### PR TITLE
Improve loading error handling

### DIFF
--- a/src/sas/sascalc/dataloader/readers/cansas_reader.py
+++ b/src/sas/sascalc/dataloader/readers/cansas_reader.py
@@ -220,8 +220,8 @@ class Reader(XMLreader):
                             return_value = self._final_cleanup(return_value)
                             output.append(return_value)
                     else:
-                        output.append("Invalid XML at: {0}".format(\
-                                                    self.find_invalid_xml()))
+                        raise RuntimeError, "Invalid XML at: {0}".format(\
+                                                    self.find_invalid_xml())
                 except:
                     # If the file does not match the schema, raise this error
                     raise RuntimeError, "%s cannot be read" % xml_file

--- a/src/sas/sasgui/guiframe/local_perspectives/data_loader/data_loader.py
+++ b/src/sas/sasgui/guiframe/local_perspectives/data_loader/data_loader.py
@@ -154,9 +154,14 @@ class Plugin(PluginBase):
             error message to be sure user knows the issue.
         """
         data_error = False
-        for error_data in item.errors:
+        if hasattr(item, 'errors'):
+            for error_data in item.errors:
+                data_error = True
+                message += "\tError: {0}\n".format(error_data)
+        else:
+            logging.error("Loader returned an invalid object:\n %s" % str(item))
             data_error = True
-            message += "\tError: {0}\n".format(error_data)
+        
         data = self.parent.create_gui_data(item, p_file)
         output[data.id] = data
         return output, message, data_error
@@ -202,6 +207,7 @@ class Plugin(PluginBase):
                                                           output,
                                                           error_message)
             except:
+                logging.error(sys.exc_value)
                 any_error = True
             if any_error or error_message != "":
                 if error_message == "":


### PR DESCRIPTION
The cansas data loader is not handling errors correctly. There are two parts to this fix:

1- If the cansas file is invalid, the loader should raise an exception. At the moment it's returning an invalid object (a list containing an error string rather than a data object with an error data member). It should simply raise an exception that will be properly logged.

2- In the event that a loader returns an invalid object, the UI object handling should still behave properly.