### PR TITLE
Ticket 824

### DIFF
--- a/src/sas/sascalc/dataloader/manipulations.py
+++ b/src/sas/sascalc/dataloader/manipulations.py
@@ -142,7 +142,7 @@ class _Slab(object):
         :param maj_min: min value on the major axis
         :return: Data1D object
         """
-        if len(data2D.detector) != 1:
+        if len(data2D.detector) > 1:
             msg = "_Slab._avg: invalid number of "
             msg += " detectors: %g" % len(data2D.detector)
             raise RuntimeError, msg
@@ -298,7 +298,7 @@ class Boxsum(object):
         :return: number of counts,
             error on number of counts, number of entries summed
         """
-        if len(data2D.detector) != 1:
+        if len(data2D.detector) > 1:
             msg = "Circular averaging: invalid number "
             msg += "of detectors: %g" % len(data2D.detector)
             raise RuntimeError, msg

--- a/src/sas/sasgui/guiframe/local_perspectives/plotting/Plotter2D.py
+++ b/src/sas/sasgui/guiframe/local_perspectives/plotting/Plotter2D.py
@@ -315,7 +315,7 @@ class ModelPanel2D(ModelPanel1D):
         wx.EVT_MENU(self, wx_id, self._onSave)
 
         slicerpop.AppendSeparator()
-        if len(self.data2D.detector) == 1:
+        if len(self.data2D.detector) <= 1:
             item_list = self.parent.get_current_context_menu(self)
             if (not item_list == None) and (not len(item_list) == 0) and\
                 self.data2D.name.split(" ")[0] != 'Residuals':


### PR DESCRIPTION
For some reason, the box slicers, box sum, annular averaging and sector averaging routines need data2d objects with one and only one detector given within the data set. I'm curious to know the reason behind this. This fix allows data sets with no detector information to use the slicers, sum and averaging.