### PR TITLE
Add OSX Build Instructions

### DIFF
--- a/mac_setup.sh
+++ b/mac_setup.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+sudo pip install Pillow
+brew tap homebrew/science
+brew install hdf5
+sudo pip install h5py
+xcode-select --install
+sudo python setup.py install


### PR DESCRIPTION
This is all that was necessary to build SasView from scratch on El Capitan. If it is suitable to merge this, I would like to update the docs to advise folks to:

1. Install homebrew
1. `source mac_setup.sh`