### PR TITLE
Ticket 876: CanSAS Nexus as a default data reader

### DIFF
--- a/src/sas/sascalc/dataloader/loader.py
+++ b/src/sas/sascalc/dataloader/loader.py
@@ -61,31 +61,32 @@ class Registry(ExtensionRegistry):
         :param format: explicit extension, to force the use
             of a particular reader
 
-        Defaults to the ascii (multi-column) reader
-        if no reader was registered for the file's
-        extension.
+        Defaults to the ascii (multi-column), cansas XML, and cansas NeXuS
+        readers if no reader was registered for the file's extension.
         """
         try:
             return super(Registry, self).load(path, format=format)
-        except:
-            try:
-                # No reader was found. Default to the ascii reader.
-                ascii_loader = ascii_reader.Reader()
-                return ascii_loader.read(path)
-            except:
-                try:
-                    cansas_loader = cansas_reader.Reader()
-                    return cansas_loader.read(path)
-                except:
-                    try:
-                        cansas_nexus_loader = cansas_reader_HDF5.Reader()
-                        return cansas_nexus_loader.read(path)
-                    except:
-                        msg = "\n\tUnknown data format: %s.\n" % path
-                        msg += "\tThe file is not a known format for SasView. "
-                        msg += "The most common formats are multi-column "
-                        msg += "ASCII, CanSAS XML, andCanSAS NeXuS."
-                        raise Exception(msg)
+        except Exception:
+            pass # try the ASCII reader
+        try:
+            ascii_loader = ascii_reader.Reader()
+            return ascii_loader.read(path)
+        except Exception:
+            pass # try the cansas XML reader
+        try:
+            cansas_loader = cansas_reader.Reader()
+            return cansas_loader.read(path)
+        except Exception:
+            pass # try the cansas NeXuS reader
+        try:
+            cansas_nexus_loader = cansas_reader_HDF5.Reader()
+            return cansas_nexus_loader.read(path)
+        except Exception:
+            # No known reader available. Give up and throw an error
+            msg = "\n\tUnknown data format: %s.\n\tThe file is not a " % path
+            msg += "known format for SasView. The most common formats are "
+            msg += "multi-column ASCII, CanSAS XML, and CanSAS NeXuS."
+            raise Exception(msg)
 
     def find_plugins(self, dir):
         """

--- a/src/sas/sascalc/dataloader/loader.py
+++ b/src/sas/sascalc/dataloader/loader.py
@@ -30,6 +30,7 @@ from sas.sascalc.data_util.registry import ExtensionRegistry
 import readers
 from readers import ascii_reader
 from readers import cansas_reader
+from readers import cansas_reader_HDF5
 
 class Registry(ExtensionRegistry):
     """
@@ -72,8 +73,12 @@ class Registry(ExtensionRegistry):
                 ascii_loader = ascii_reader.Reader()
                 return ascii_loader.read(path)
             except:
-                cansas_loader = cansas_reader.Reader()
-                return cansas_loader.read(path)
+                try:
+                    cansas_loader = cansas_reader.Reader()
+                    return cansas_loader.read(path)
+                except:
+                    cansas_nexus_loader = cansas_reader_HDF5.Reader()
+                    return cansas_nexus_loader.read(path)
 
     def find_plugins(self, dir):
         """

--- a/src/sas/sascalc/dataloader/loader.py
+++ b/src/sas/sascalc/dataloader/loader.py
@@ -77,8 +77,15 @@ class Registry(ExtensionRegistry):
                     cansas_loader = cansas_reader.Reader()
                     return cansas_loader.read(path)
                 except:
-                    cansas_nexus_loader = cansas_reader_HDF5.Reader()
-                    return cansas_nexus_loader.read(path)
+                    try:
+                        cansas_nexus_loader = cansas_reader_HDF5.Reader()
+                        return cansas_nexus_loader.read(path)
+                    except:
+                        msg = "\n\tUnknown data format: %s.\n" % path
+                        msg += "\tThe file is not a known format for SasView. "
+                        msg += "The most common formats are multi-column "
+                        msg += "ASCII, CanSAS XML, andCanSAS NeXuS."
+                        raise Exception(msg)
 
     def find_plugins(self, dir):
         """

--- a/src/sas/sascalc/dataloader/readers/cansas_reader_HDF5.py
+++ b/src/sas/sascalc/dataloader/readers/cansas_reader_HDF5.py
@@ -52,7 +52,7 @@ class Reader():
     ## List of allowed extensions
     ext = ['.h5', '.H5']
     ## Flag to bypass extension check
-    allow_all = False
+    allow_all = True
     ## List of files to return
     output = None
 


### PR DESCRIPTION
This is a pull request that can wait until after 4.1 release.

If the data file extension is not in the list of known extensions (defaults.json), this change sends the data to the cansas nexus (HDF5) reader as the 3rd and final default option before giving up. I tested loading times for 2 exact data files, but with the file extension changed. The loading times, each around 0.02 seconds, were exactly the same to the 7th decimal place.