### PR TITLE
BUG: IgorReader

### DIFF
--- a/src/sas/sascalc/dataloader/manipulations.py
+++ b/src/sas/sascalc/dataloader/manipulations.py
@@ -79,7 +79,7 @@ def reader2D_converter(data2d=None):
     :return: 1d arrays of Data2D object
 
     """
-    if data2d.data == None or data2d.x_bins == None or data2d.y_bins == None:
+    if data2d.data is None or data2d.x_bins is None or data2d.y_bins is None:
         raise ValueError, "Can't convert this data: data=None..."
     new_x = numpy.tile(data2d.x_bins, (len(data2d.y_bins), 1))
     new_y = numpy.tile(data2d.y_bins, (len(data2d.x_bins), 1))
@@ -89,7 +89,7 @@ def reader2D_converter(data2d=None):
     qx_data = new_x.flatten()
     qy_data = new_y.flatten()
     q_data = numpy.sqrt(qx_data * qx_data + qy_data * qy_data)
-    if data2d.err_data == None or numpy.any(data2d.err_data <= 0):
+    if data2d.err_data is None or numpy.any(data2d.err_data <= 0):
         new_err_data = numpy.sqrt(numpy.abs(new_data))
     else:
         new_err_data = data2d.err_data.flatten()

--- a/src/sas/sascalc/dataloader/readers/IgorReader.py
+++ b/src/sas/sascalc/dataloader/readers/IgorReader.py
@@ -12,12 +12,11 @@
 #copyright 2008, University of Tennessee
 #############################################################################
 import os
-import numpy
-import math
-#import logging
+
 from sas.sascalc.dataloader.data_info import Data2D
 from sas.sascalc.dataloader.data_info import Detector
 from sas.sascalc.dataloader.manipulations import reader2D_converter
+import numpy as np
 
 # Look for unit converter
 has_converter = True
@@ -39,213 +38,147 @@ class Reader:
     def read(self, filename=None):
         """ Read file """
         if not os.path.isfile(filename):
-            raise ValueError, \
-            "Specified file %s is not a regular file" % filename
+            raise ValueError("Specified file %s is not a regular "
+                             "file" % filename)
         
-        # Read file
-        f = open(filename, 'r')
-        buf = f.read()
-        
-        # Instantiate data object
         output = Data2D()
+
         output.filename = os.path.basename(filename)
         detector = Detector()
-        if len(output.detector) > 0:
-            print str(output.detector[0])
+        if len(output.detector):
+            print(str(output.detector[0]))
         output.detector.append(detector)
-                
-        # Get content
-        dataStarted = False
+
+        data_conv_q = data_conv_i = None
         
-        lines = buf.split('\n')
-        itot = 0
-        x = []
-        y = []
-        
-        ncounts = 0
-        
-        xmin = None
-        xmax = None
-        ymin = None
-        ymax = None
-        
-        i_x = 0
-        i_y = -1
-        i_tot_row = 0
-        
-        isInfo = False
-        isCenter = False
-       
-        data_conv_q = None
-        data_conv_i = None
-        
-        if has_converter == True and output.Q_unit != '1/A':
+        if has_converter and output.Q_unit != '1/A':
             data_conv_q = Converter('1/A')
             # Test it
             data_conv_q(1.0, output.Q_unit)
             
-        if has_converter == True and output.I_unit != '1/cm':
+        if has_converter and output.I_unit != '1/cm':
             data_conv_i = Converter('1/cm')
             # Test it
             data_conv_i(1.0, output.I_unit)
-         
-        for line in lines:
-            
-            # Find setup info line
-            if isInfo:
-                isInfo = False
-                line_toks = line.split()
-                # Wavelength in Angstrom
-                try:
-                    wavelength = float(line_toks[1])
-                except:
-                    msg = "IgorReader: can't read this file, missing wavelength"
-                    raise ValueError, msg
-                
-            #Find # of bins in a row assuming the detector is square.
-            if dataStarted == True:
-                try:
-                    value = float(line)
-                except:
-                    # Found a non-float entry, skip it
-                    continue
-                
-                # Get total bin number
-                
-            i_tot_row += 1
-        i_tot_row = math.ceil(math.sqrt(i_tot_row)) - 1
-        #print "i_tot", i_tot_row
-        size_x = i_tot_row  # 192#128
-        size_y = i_tot_row  # 192#128
-        output.data = numpy.zeros([size_x, size_y])
-        output.err_data = numpy.zeros([size_x, size_y])
-     
-        #Read Header and 2D data
-        for line in lines:
-            # Find setup info line
-            if isInfo:
-                isInfo = False
-                line_toks = line.split()
-                # Wavelength in Angstrom
-                try:
-                    wavelength = float(line_toks[1])
-                except:
-                    msg = "IgorReader: can't read this file, missing wavelength"
-                    raise ValueError, msg
-                # Distance in meters
-                try:
-                    distance = float(line_toks[3])
-                except:
-                    msg = "IgorReader: can't read this file, missing distance"
-                    raise ValueError, msg
-                
-                # Distance in meters
-                try:
-                    transmission = float(line_toks[4])
-                except:
-                    msg = "IgorReader: can't read this file, "
-                    msg += "missing transmission"
-                    raise ValueError, msg
-                                            
-            if line.count("LAMBDA") > 0:
-                isInfo = True
-                
-            # Find center info line
-            if isCenter:
-                isCenter = False
-                line_toks = line.split()
-                
-                # Center in bin number: Must substrate 1 because
-                #the index starts from 1
-                center_x = float(line_toks[0]) - 1
-                center_y = float(line_toks[1]) - 1
 
-            if line.count("BCENT") > 0:
-                isCenter = True
-                
-            # Find data start
-            if line.count("***")>0:
-                dataStarted = True
-                
-                # Check that we have all the info
-                if wavelength == None \
-                    or distance == None \
-                    or center_x == None \
-                    or center_y == None:
-                    msg = "IgorReader:Missing information in data file"
-                    raise ValueError, msg
-                
-            if dataStarted == True:
-                try:
-                    value = float(line)
-                except:
-                    # Found a non-float entry, skip it
-                    continue
-                
-                # Get bin number
-                if math.fmod(itot, i_tot_row) == 0:
-                    i_x = 0
-                    i_y += 1
-                else:
-                    i_x += 1
-                    
-                output.data[i_y][i_x] = value
-                ncounts += 1
-                
-                # Det 640 x 640 mm
-                # Q = 4pi/lambda sin(theta/2)
-                # Bin size is 0.5 cm 
-                #REmoved +1 from theta = (i_x-center_x+1)*0.5 / distance
-                # / 100.0 and 
-                #REmoved +1 from theta = (i_y-center_y+1)*0.5 /
-                # distance / 100.0
-                #ToDo: Need  complete check if the following
-                # covert process is consistent with fitting.py.
-                theta = (i_x - center_x) * 0.5 / distance / 100.0
-                qx = 4.0 * math.pi / wavelength * math.sin(theta/2.0)
+        data_row = 0
+        wavelength = distance = center_x = center_y = None
+        dataStarted = isInfo = isCenter = False
 
-                if has_converter == True and output.Q_unit != '1/A':
-                    qx = data_conv_q(qx, units=output.Q_unit)
+        with open(filename, 'r') as f:
+            for line in f:
+                data_row += 1
+                # Find setup info line
+                if isInfo:
+                    isInfo = False
+                    line_toks = line.split()
+                    # Wavelength in Angstrom
+                    try:
+                        wavelength = float(line_toks[1])
+                    except ValueError:
+                        msg = "IgorReader: can't read this file, missing wavelength"
+                        raise ValueError(msg)
+                    # Distance in meters
+                    try:
+                        distance = float(line_toks[3])
+                    except ValueError:
+                        msg = "IgorReader: can't read this file, missing distance"
+                        raise ValueError(msg)
 
-                if xmin == None or qx < xmin:
-                    xmin = qx
-                if xmax == None or qx > xmax:
-                    xmax = qx
-                
-                theta = (i_y - center_y) * 0.5 / distance / 100.0
-                qy = 4.0 * math.pi / wavelength * math.sin(theta / 2.0)
+                    # Distance in meters
+                    try:
+                        transmission = float(line_toks[4])
+                    except:
+                        msg = "IgorReader: can't read this file, "
+                        msg += "missing transmission"
+                        raise ValueError(msg)
 
-                if has_converter == True and output.Q_unit != '1/A':
-                    qy = data_conv_q(qy, units=output.Q_unit)
-                
-                if ymin == None or qy < ymin:
-                    ymin = qy
-                if ymax == None or qy > ymax:
-                    ymax = qy
-                
-                if not qx in x:
-                    x.append(qx)
-                if not qy in y:
-                    y.append(qy)
-                
-                itot += 1
-                  
-                  
+                if line.count("LAMBDA"):
+                    isInfo = True
+
+                # Find center info line
+                if isCenter:
+                    isCenter = False
+                    line_toks = line.split()
+
+                    # Center in bin number: Must subtract 1 because
+                    # the index starts from 1
+                    center_x = float(line_toks[0]) - 1
+                    center_y = float(line_toks[1]) - 1
+
+                if line.count("BCENT"):
+                    isCenter = True
+
+                # Find data start
+                if line.count("***"):
+                    # now have to continue to blank line
+                    dataStarted = True
+
+                    # Check that we have all the info
+                    if (wavelength is None
+                            or distance is None
+                            or center_x is None
+                            or center_y is None):
+                        msg = "IgorReader:Missing information in data file"
+                        raise ValueError(msg)
+
+                if dataStarted:
+                    if len(line.rstrip()):
+                        continue
+                    else:
+                        break
+
+        # The data is loaded in row major order (last index changing most
+        # rapidly). However, the original data is in column major order (first
+        # index changing most rapidly). The swap to column major order is done
+        # in reader2D_converter at the end of this method.
+        data = np.loadtxt(filename, skiprows=data_row)
+        size_x = size_y = int(np.rint(np.sqrt(data.size)))
+        output.data = np.reshape(data, (size_x, size_y))
+        output.err_data = np.zeros_like(output.data)
+
+        # Det 640 x 640 mm
+        # Q = 4 * pi/lambda * sin(theta/2)
+        # Bin size is 0.5 cm
+        # Removed +1 from theta = (i_x - center_x + 1)*0.5 / distance
+        # / 100.0 and
+        # Removed +1 from theta = (i_y - center_y + 1)*0.5 /
+        # distance / 100.0
+        # ToDo: Need  complete check if the following
+        # convert process is consistent with fitting.py.
+
+        # calculate qx, qy bin centers of each pixel in the image
+        theta = (np.arange(size_x) - center_x) * 0.5 / distance / 100.
+        qx = 4 * np.pi / wavelength * np.sin(theta/2)
+
+        theta = (np.arange(size_y) - center_y) * 0.5 / distance / 100.
+        qy = 4 * np.pi / wavelength * np.sin(theta/2)
+
+        if has_converter and output.Q_unit != '1/A':
+            qx = data_conv_q(qx, units=output.Q_unit)
+            qy = data_conv_q(qx, units=output.Q_unit)
+
+        xmax = np.max(qx)
+        xmin = np.min(qx)
+        ymax = np.max(qy)
+        ymin = np.min(qy)
+
+        # calculate edge offset in q.
         theta = 0.25 / distance / 100.0
-        xstep = 4.0 * math.pi / wavelength * math.sin(theta / 2.0)
+        xstep = 4.0 * np.pi / wavelength * np.sin(theta / 2.0)
         
         theta = 0.25 / distance / 100.0
-        ystep = 4.0 * math.pi/ wavelength * math.sin(theta / 2.0)
+        ystep = 4.0 * np.pi/ wavelength * np.sin(theta / 2.0)
         
         # Store all data ######################################
         # Store wavelength
-        if has_converter == True and output.source.wavelength_unit != 'A':
+        if has_converter and output.source.wavelength_unit != 'A':
             conv = Converter('A')
             wavelength = conv(wavelength, units=output.source.wavelength_unit)
         output.source.wavelength = wavelength
 
         # Store distance
-        if has_converter == True and detector.distance_unit != 'm':
+        if has_converter and detector.distance_unit != 'm':
             conv = Converter('m')
             distance = conv(distance, units=detector.distance_unit)
         detector.distance = distance
@@ -253,9 +186,9 @@ class Reader:
         # Store transmission
         output.sample.transmission = transmission
         
-        # Store pixel size
+        # Store pixel size (mm)
         pixel = 5.0
-        if has_converter == True and detector.pixel_size_unit != 'mm':
+        if has_converter and detector.pixel_size_unit != 'mm':
             conv = Converter('mm')
             pixel = conv(pixel, units=detector.pixel_size_unit)
         detector.pixel_size.x = pixel
@@ -266,11 +199,11 @@ class Reader:
         detector.beam_center.y = center_y * pixel
         
         # Store limits of the image (2D array)
-        xmin = xmin - xstep / 2.0
-        xmax = xmax + xstep / 2.0
-        ymin = ymin - ystep / 2.0
-        ymax = ymax + ystep / 2.0
-        if has_converter == True and output.Q_unit != '1/A':
+        xmin -= xstep / 2.0
+        xmax += xstep / 2.0
+        ymin -= ystep / 2.0
+        ymax += ystep / 2.0
+        if has_converter and output.Q_unit != '1/A':
             xmin = data_conv_q(xmin, units=output.Q_unit)
             xmax = data_conv_q(xmax, units=output.Q_unit)
             ymin = data_conv_q(ymin, units=output.Q_unit)
@@ -281,8 +214,8 @@ class Reader:
         output.ymax = ymax
         
         # Store x and y axis bin centers
-        output.x_bins = x
-        output.y_bins = y
+        output.x_bins = qx.tolist()
+        output.y_bins = qy.tolist()
         
         # Units
         if data_conv_q is not None:

--- a/test/sasdataloader/test/utest_abs_reader.py
+++ b/test/sasdataloader/test/utest_abs_reader.py
@@ -3,8 +3,10 @@
 """
 
 import unittest
-import numpy, math
-from sas.sascalc.dataloader.loader import  Loader
+import math
+import numpy as np
+from sas.sascalc.dataloader.loader import Loader
+from sas.sascalc.dataloader.readers.IgorReader import Reader as IgorReader
 from sas.sascalc.dataloader.data_info import Data1D
  
 import os.path
@@ -85,8 +87,11 @@ class hfir_reader(unittest.TestCase):
 class igor_reader(unittest.TestCase):
     
     def setUp(self):
-        self.data = Loader().load("MAR07232_rest.ASC")
-        
+        # the IgorReader should be able to read this filetype
+        # if it can't, stop here.
+        reader = IgorReader()
+        self.data = reader.read("MAR07232_rest.ASC")
+
     def test_igor_checkdata(self):
         """
             Check the data content to see whether 
@@ -107,16 +112,27 @@ class igor_reader(unittest.TestCase):
         self.assertEqual(self.data.sample.transmission, 0.84357)
         
         self.assertEqual(self.data.detector[0].beam_center_unit, 'mm')
-        center_x = (68.76-1)*5.0
-        center_y = (62.47-1)*5.0
+        center_x = (68.76 - 1)*5.0
+        center_y = (62.47 - 1)*5.0
         self.assertEqual(self.data.detector[0].beam_center.x, center_x)
         self.assertEqual(self.data.detector[0].beam_center.y, center_y)
         
         self.assertEqual(self.data.I_unit, '1/cm')
-        self.assertEqual(self.data.data[0], 0.279783)
-        self.assertEqual(self.data.data[1], 0.28951)
-        self.assertEqual(self.data.data[2], 0.167634)
-        
+        # 3 points should be suffcient to check that the data is in column
+        # major order.
+        np.testing.assert_almost_equal(self.data.data[0:3],
+                                       [0.279783, 0.28951, 0.167634])
+        np.testing.assert_almost_equal(self.data.qx_data[0:3],
+                                       [-0.01849072, -0.01821785, -0.01794498])
+        np.testing.assert_almost_equal(self.data.qy_data[0:3],
+                                       [-0.01677435, -0.01677435, -0.01677435])
+
+    def test_generic_loader(self):
+        # the generic loader should direct the file to IgorReader as well
+        data = Loader().load("MAR07232_rest.ASC")
+        self.assertEqual(data.meta_data['loader'], "IGOR 2D")
+
+
 class danse_reader(unittest.TestCase):
     
     def setUp(self):
@@ -312,9 +328,9 @@ class cansas_reader(unittest.TestCase):
     def test_writer(self):
         from sas.sascalc.dataloader.readers.cansas_reader import Reader
         r = Reader()
-        x = numpy.ones(5)
-        y = numpy.ones(5)
-        dy = numpy.ones(5)
+        x = np.ones(5)
+        y = np.ones(5)
+        dy = np.ones(5)
         
         filename = "write_test.xml"
         r.write(filename, self.data)


### PR DESCRIPTION
`IgorReader` was failing in recent versions of numpy because it was using float instead of int for indexing. This PR fixes this issue, outlined in 888.

The PR adds a smoke test to ensure that `IgorReader` can load the Igor file without complaining.

Note: it's not clear to me where in the Loader hierarchy files are closed. e.g. in `IgorReader.read` a file is opened, but it's never actually closed.