### PR TITLE
Fixing acknowledgements box

### DIFF
--- a/sasview/local_config.py
+++ b/sasview/local_config.py
@@ -86,7 +86,7 @@ _danse_url = "http://www.cacr.caltech.edu/projects/danse/release/index.html"
 _inst_url = "http://www.utk.edu"
 _corner_image = os.path.join(icon_path, "angles_flat.png")
 _welcome_image = os.path.join(icon_path, "SVwelcome.png")
-_copyright = "(c) 2009 - 2016, UTK, UMD, NIST, ORNL, ISIS, ESS, ILL, ANSTO and TU Delft"
+_copyright = "(c) 2009 - 2017, UTK, UMD, NIST, ORNL, ISIS, ESS, ILL, ANSTO and TU Delft"
 marketplace_url = "http://marketplace.sasview.org/"
 
 #edit the list of file state your plugin can read

--- a/sasview/local_config.py
+++ b/sasview/local_config.py
@@ -32,25 +32,20 @@ _acknowledgement_preamble =\
 '''To ensure the long term support and development of this software please''' +\
 ''' remember to:'''
 _acknowledgement_preamble_bullet1 =\
-'''Acknowledge its use in your publications as suggested below;'''
+'''Acknowledge its use in your publications as :'''
 _acknowledgement_preamble_bullet2 =\
-'''Reference SasView as : M. Doucet, et al. SasView Version 4.1, Zenodo''' +\
-''', 10.5281/zenodo.438138;'''
+'''Reference SasView as:'''
 _acknowledgement_preamble_bullet3 =\
-'''Reference the model you used if appropriate (see documentation for refs);'''
+'''Reference the model you used if appropriate (see documentation for refs)'''
 _acknowledgement_preamble_bullet4 =\
 '''Send us your reference for our records: developers@sasview.org'''
 _acknowledgement_publications = \
-'''This work benefited from the use of the SasView application, originally developed under NSF Award 
-DMR-0520547. SasView also contains code developed with funding from the EU Horizon 2020 programme 
-under the SINE2020 project Grant No 654000.'''
+'''This work benefited from the use of the SasView application, originally developed under NSF Award DMR-0520547. SasView also contains code developed with funding from the EU Horizon 2020 programme under the SINE2020 project Grant No 654000.'''
+_acknowledgement_citation = \
+'''M. Doucet et al. SasView Version 4.1, Zenodo, 10.5281/zenodo.438138'''
 
 _acknowledgement =  \
-'''This work was originally developed as part of the DANSE project funded by the US NSF under Award DMR-0520547, but is currently maintained 
-by a collaboration between UTK, UMD, NIST, ORNL, ISIS, ESS, ILL, ANSTO and TU Delft and the scattering community. SasView also contains code developed with funding from the 
-EU Horizon 2020 programme under the SINE2020 project (Grant No 654000).
-
-A list of individual contributors can be found at: https://github.com/orgs/SasView/people
+'''This work was originally developed as part of the DANSE project funded by the US NSF under Award DMR-0520547,\n but is currently maintained by a collaboration between UTK, UMD, NIST, ORNL, ISIS, ESS, ILL, ANSTO and TU Delft and the scattering community.\n\n SasView also contains code developed with funding from the EU Horizon 2020 programme under the SINE2020 project (Grant No 654000).\nA list of individual contributors can be found at: https://github.com/orgs/SasView/people
 '''
 
 _homepage = "http://www.sasview.org"

--- a/src/sas/sasgui/guiframe/acknowledgebox.py
+++ b/src/sas/sasgui/guiframe/acknowledgebox.py
@@ -10,6 +10,7 @@ __revision__ = "$Revision: 1193 $"
 import wx
 import wx.richtext
 import wx.lib.hyperlink
+from wx.lib.expando import ExpandoTextCtrl
 import random
 import os.path
 import os
@@ -43,9 +44,11 @@ class DialogAcknowledge(wx.Dialog):
         kwds["style"] = wx.DEFAULT_DIALOG_STYLE
         wx.Dialog.__init__(self, *args, **kwds)
 
-        self.ack = wx.TextCtrl(self, style=wx.TE_LEFT|wx.TE_MULTILINE|wx.TE_BESTWRAP|wx.TE_READONLY|wx.TE_NO_VSCROLL)
+        self.ack = ExpandoTextCtrl(self, style=wx.TE_LEFT|wx.TE_MULTILINE|wx.TE_BESTWRAP|wx.TE_READONLY|wx.TE_NO_VSCROLL)
         self.ack.SetValue(config._acknowledgement_publications)
-        self.ack.SetMinSize((-1, 55))
+        #self.ack.SetMinSize((-1, 55))
+        self.citation = ExpandoTextCtrl(self, style=wx.TE_LEFT|wx.TE_MULTILINE|wx.TE_BESTWRAP|wx.TE_READONLY|wx.TE_NO_VSCROLL)
+        self.citation.SetValue(config._acknowledgement_citation)
         self.preamble = wx.StaticText(self, -1, config._acknowledgement_preamble)
         items = [config._acknowledgement_preamble_bullet1,
                  config._acknowledgement_preamble_bullet2,
@@ -80,11 +83,12 @@ class DialogAcknowledge(wx.Dialog):
         sizer_titles = wx.BoxSizer(wx.VERTICAL)
         sizer_titles.Add(self.preamble, 0, wx.ALL|wx.EXPAND, 5)
         sizer_titles.Add(self.list1, 0, wx.ALL|wx.EXPAND, 5)
-        sizer_titles.Add(self.list2, 0, wx.ALL|wx.EXPAND, 5)
-        sizer_titles.Add(self.list3, 0, wx.ALL|wx.EXPAND, 5)
-        sizer_titles.Add(self.list4, 0, wx.ALL|wx.EXPAND, 5)
-        sizer_titles.Add(self.static_line, 0, wx.ALL|wx.EXPAND, 0)
         sizer_titles.Add(self.ack, 0, wx.ALL|wx.EXPAND, 5)
+        sizer_titles.Add(self.list2, 0, wx.ALL|wx.EXPAND, 5)
+        sizer_titles.Add(self.citation, 0, wx.ALL|wx.EXPAND, 5)
+        sizer_titles.Add(self.list3, 0, wx.ALL|wx.EXPAND, 5)
+        #sizer_titles.Add(self.static_line, 0, wx.ALL|wx.EXPAND, 0)
+        sizer_titles.Add(self.list4, 0, wx.ALL|wx.EXPAND, 5)
         sizer_main.Add(sizer_titles, -1, wx.ALL|wx.EXPAND, 5)
         self.SetAutoLayout(True)
         self.SetSizer(sizer_main)

--- a/src/sas/sasgui/guiframe/acknowledgebox.py
+++ b/src/sas/sasgui/guiframe/acknowledgebox.py
@@ -36,7 +36,6 @@ class DialogAcknowledge(wx.Dialog):
 
     Shows the current method for acknowledging SasView in
     scholarly publications.
-
     """
 
     def __init__(self, *args, **kwds):
@@ -54,10 +53,10 @@ class DialogAcknowledge(wx.Dialog):
                  config._acknowledgement_preamble_bullet2,
                  config._acknowledgement_preamble_bullet3,
                  config._acknowledgement_preamble_bullet4]
-        self.list1 = wx.StaticText(self, -1, "\t(1) " + items[0])
-        self.list2 = wx.StaticText(self, -1, "\t(2) " + items[1])
-        self.list3 = wx.StaticText(self, -1, "\t(3) " + items[2])
-        self.list4 = wx.StaticText(self, -1, "\t(4) " + items[3])
+        self.list1 = wx.StaticText(self, -1, "(1) " + items[0])
+        self.list2 = wx.StaticText(self, -1, "(2) " + items[1])
+        self.list3 = wx.StaticText(self, -1, "(3) " + items[2])
+        self.list4 = wx.StaticText(self, -1, "(4) " + items[3])
         self.static_line = wx.StaticLine(self, 0)
         self.__set_properties()
         self.__do_layout()
@@ -71,7 +70,7 @@ class DialogAcknowledge(wx.Dialog):
         self.preamble.SetFont(wx.Font(10, wx.DEFAULT, wx.NORMAL, wx.NORMAL, 0, ""))
         self.SetTitle("Acknowledging SasView")
         #Increased size of box from (525, 225), SMK, 04/10/16
-        self.SetSize((600, 300))
+        self.SetSize((600, 320))
         # end wxGlade
 
     def __do_layout(self):

--- a/src/sas/sasgui/guiframe/acknowledgebox.py
+++ b/src/sas/sasgui/guiframe/acknowledgebox.py
@@ -70,7 +70,7 @@ class DialogAcknowledge(wx.Dialog):
         self.preamble.SetFont(wx.Font(10, wx.DEFAULT, wx.NORMAL, wx.NORMAL, 0, ""))
         self.SetTitle("Acknowledging SasView")
         #Increased size of box from (525, 225), SMK, 04/10/16
-        self.SetSize((600, 320))
+        self.SetClientSize((600, 320))
         # end wxGlade
 
     def __do_layout(self):
@@ -93,6 +93,7 @@ class DialogAcknowledge(wx.Dialog):
         self.SetSizer(sizer_main)
         self.Layout()
         self.Centre()
+        #self.SetClientSize(sizer_main.GetSize())
         # end wxGlade
 
 

--- a/src/sas/sasgui/guiframe/config.py
+++ b/src/sas/sasgui/guiframe/config.py
@@ -1,19 +1,21 @@
 """
-Application settings
+    Application settings
 """
-import os
 import time
+import os
 from sas.sasgui.guiframe.gui_style import GUIFRAME
+import sas.sasview
+import logging
+
 # Version of the application
-__appname__ = "DummyView"
-__version__ = '0.0.0'
-__build__ = '1'
+__appname__ = "SasView"
+__version__ = sas.sasview.__version__
+__build__ = sas.sasview.__build__
 __download_page__ = 'https://github.com/SasView/sasview/releases'
 __update_URL__ = 'http://www.sasview.org/latestversion.json'
 
-
 # Debug message flag
-__EVT_DEBUG__ = True
+__EVT_DEBUG__ = False
 
 # Flag for automated testing
 __TEST__ = False
@@ -28,82 +30,101 @@ _do_acknowledge = True
 _do_tutorial = True
 _acknowledgement_preamble =\
 '''To ensure the long term support and development of this software please''' +\
-''' remember to do the following.'''
+''' remember to:'''
 _acknowledgement_preamble_bullet1 =\
-'''Acknowledge its use in your publications as suggested below'''
+'''Acknowledge its use in your publications as :'''
 _acknowledgement_preamble_bullet2 =\
-'''Reference the following website: http://www.sasview.org'''
+'''Reference SasView as:'''
 _acknowledgement_preamble_bullet3 =\
 '''Reference the model you used if appropriate (see documentation for refs)'''
 _acknowledgement_preamble_bullet4 =\
 '''Send us your reference for our records: developers@sasview.org'''
 _acknowledgement_publications = \
-'''This work benefited from the use of the SasView application, originally
-developed under NSF award DMR-0520547.
-'''
-_acknowledgement =  \
-'''This work originally developed as part of the DANSE project funded by the NSF
-under grant DMR-0520547, and currently maintained by NIST, UMD, ORNL, ISIS, ESS
-and ILL.
+'''This work benefited from the use of the SasView application, originally developed under NSF Award DMR-0520547. SasView also contains code developed with funding from the EU Horizon 2020 programme under the SINE2020 project Grant No 654000.'''
+_acknowledgement_citation = \
+'''M. Doucet et al. SasView Version 4.1, Zenodo, 10.5281/zenodo.438138'''
 
+_acknowledgement =  \
+'''This work was originally developed as part of the DANSE project funded by the US NSF under Award DMR-0520547,\n but is currently maintained by a collaboration between UTK, UMD, NIST, ORNL, ISIS, ESS, ILL, ANSTO and TU Delft and the scattering community.\n\n SasView also contains code developed with funding from the EU Horizon 2020 programme under the SINE2020 project (Grant No 654000).\nA list of individual contributors can be found at: https://github.com/orgs/SasView/people
 '''
+
 _homepage = "http://www.sasview.org"
-_download = "http://sourceforge.net/projects/sasview/files/"
+_download = __download_page__
 _authors = []
 _paper = "http://sourceforge.net/p/sasview/tickets/"
 _license = "mailto:help@sasview.org"
-_nsf_logo = "images/nsf_logo.png"
-_danse_logo = "images/danse_logo.png"
-_inst_logo = "images/utlogo.gif"
-_nist_logo = "images/nist_logo.png"
-_umd_logo = "images/umd_logo.png"
-_sns_logo = "images/sns_logo.png"
-_isis_logo = "images/isis_logo.png"
-_ess_logo = "images/ess_logo.png"
-_ill_logo = "images/ill_logo.png"
+
+
+icon_path = os.path.abspath(os.path.join(os.path.dirname(__file__), "images"))
+logging.info("icon path: %s" % icon_path)
+media_path = os.path.abspath(os.path.join(os.path.dirname(__file__), "media"))
+test_path = os.path.abspath(os.path.join(os.path.dirname(__file__), "test"))
+
+_nist_logo = os.path.join(icon_path, "nist_logo.png")
+_umd_logo = os.path.join(icon_path, "umd_logo.png")
+_sns_logo = os.path.join(icon_path, "sns_logo.png")
+_ornl_logo = os.path.join(icon_path, "ornl_logo.png")
+_isis_logo = os.path.join(icon_path, "isis_logo.png")
+_ess_logo = os.path.join(icon_path, "ess_logo.png")
+_ill_logo = os.path.join(icon_path, "ill_logo.png")
+_ansto_logo = os.path.join(icon_path, "ansto_logo.png")
+_tudelft_logo = os.path.join(icon_path, "tudelft_logo.png")
+_nsf_logo = os.path.join(icon_path, "nsf_logo.png")
+_danse_logo = os.path.join(icon_path, "danse_logo.png")
+_inst_logo = os.path.join(icon_path, "utlogo.gif")
 _nist_url = "http://www.nist.gov/"
 _umd_url = "http://www.umd.edu/"
 _sns_url = "http://neutrons.ornl.gov/"
+_ornl_url = "http://neutrons.ornl.gov/"
 _nsf_url = "http://www.nsf.gov"
-_danse_url = "http://www.cacr.caltech.edu/projects/danse/release/index.html"
-_inst_url = "http://www.utk.edu"
 _isis_url = "http://www.isis.stfc.ac.uk/"
 _ess_url = "http://ess-scandinavia.eu/"
 _ill_url = "http://www.ill.eu/"
-_corner_image = "images/angles_flat.png"
-_welcome_image = "images/SVwelcome.png"
-_copyright = "(c) 2008, University of Tennessee"
-#edit the lists below of file state your plugin can read
-#for sasview this how you can edit these lists
-#PLUGIN_STATE_EXTENSIONS = ['.prv','.fitv', '.inv']
-#APPLICATION_STATE_EXTENSION = '.svs'
-#PLUGINS_WLIST = ['P(r) files (*.prv)|*.prv',
-#                  'Fitting files (*.fitv)|*.fitv',
-#                  'Invariant files (*.inv)|*.inv']
-#APPLICATION_WLIST = 'SasView files (*.svs)|*.svs'
-APPLICATION_WLIST = ''
-APPLICATION_STATE_EXTENSION = None
-PLUGINS_WLIST = []
-PLUGIN_STATE_EXTENSIONS = []
-SPLASH_SCREEN_PATH = "images/danse_logo.png"
-DEFAULT_STYLE = GUIFRAME.SINGLE_APPLICATION
-SPLASH_SCREEN_WIDTH = 500
-SPLASH_SCREEN_HEIGHT = 300
-WELCOME_PANEL_ON = False
-TUTORIAL_PATH = None
-SS_MAX_DISPLAY_TIME = 1500
-PLOPANEL_WIDTH = 350
-PLOPANEL_HEIGTH = 350
-GUIFRAME_WIDTH = 1000
-GUIFRAME_HEIGHT = 800
-CONTROL_WIDTH = -1
-CONTROL_HEIGHT = -1
-SetupIconFile_win = os.path.join("images", "ball.ico")
-SetupIconFile_mac = os.path.join("images", "ball.icns")
-DefaultGroupName = "DANSE"
-OutputBaseFilename = "setupGuiFrame"
+_ansto_url = "http://www.ansto.gov.au/"
+_tudelft_url = "http://www.tnw.tudelft.nl/en/cooperation/facilities/reactor-instituut-delft/"
+_danse_url = "http://www.cacr.caltech.edu/projects/danse/release/index.html"
+_inst_url = "http://www.utk.edu"
+_corner_image = os.path.join(icon_path, "angles_flat.png")
+_welcome_image = os.path.join(icon_path, "SVwelcome.png")
+_copyright = "(c) 2009 - 2017, UTK, UMD, NIST, ORNL, ISIS, ESS, ILL, ANSTO and TU Delft"
+marketplace_url = "http://marketplace.sasview.org/"
+
+#edit the list of file state your plugin can read
+APPLICATION_WLIST = 'SasView files (*.svs)|*.svs'
+APPLICATION_STATE_EXTENSION = '.svs'
+GUIFRAME_WIDTH = 1150
+GUIFRAME_HEIGHT = 840
+PLUGIN_STATE_EXTENSIONS = ['.fitv', '.inv', '.prv', '.crf']
+PLUGINS_WLIST = ['Fitting files (*.fitv)|*.fitv',
+                 'Invariant files (*.inv)|*.inv',
+                 'P(r) files (*.prv)|*.prv',
+                 'Corfunc files (*.crf)|*.crf']
+PLOPANEL_WIDTH = 415
+PLOPANEL_HEIGTH = 370
 DATAPANEL_WIDTH = 235
 DATAPANEL_HEIGHT = 700
+SPLASH_SCREEN_PATH = os.path.join(icon_path, "SVwelcome_mini.png")
+TUTORIAL_PATH = os.path.join(media_path, "Tutorial.pdf")
+DEFAULT_STYLE = GUIFRAME.MULTIPLE_APPLICATIONS|GUIFRAME.MANAGER_ON\
+                    |GUIFRAME.CALCULATOR_ON|GUIFRAME.TOOLBAR_ON
+SPLASH_SCREEN_WIDTH = 512
+SPLASH_SCREEN_HEIGHT = 366
+SS_MAX_DISPLAY_TIME = 2000
+WELCOME_PANEL_ON = True
+WELCOME_PANEL_SHOW = False
+CLEANUP_PLOT = False
+# OPEN and SAVE project menu
+OPEN_SAVE_PROJECT_MENU = True
+#VIEW MENU
+VIEW_MENU = True
+#EDIT MENU
+EDIT_MENU = True
+
+SetupIconFile_win = os.path.join(icon_path, "ball.ico")
+SetupIconFile_mac = os.path.join(icon_path, "ball.icns")
+DefaultGroupName = "."
+OutputBaseFilename = "setupSasView"
+
 FIXED_PANEL = True
 DATALOADER_SHOW = True
 CLEANUP_PLOT = False
@@ -112,27 +133,21 @@ WELCOME_PANEL_SHOW = False
 TOOLBAR_SHOW = True
 # set a default perspective
 DEFAULT_PERSPECTIVE = 'None'
-# OPEN and SAVE project menu
-OPEN_SAVE_PROJECT_MENU = True
-CLEANUP_PLOT = False
-# OPEN and SAVE project menu
-OPEN_SAVE_PROJECT_MENU = False
-#VIEW MENU
-VIEW_MENU = False
-#EDIT MENU
-EDIT_MENU = False
-import wx.lib.newevent
-(StatusBarEvent, EVT_STATUS) = wx.lib.newevent.NewEvent()
+
+# Time out for updating sasview
+UPDATE_TIMEOUT = 2
+
+#OpenCL option
+SAS_OPENCL = None
 
 def printEVT(message):
-    """
-    :TODO - need method documentation
-    """
     if __EVT_DEBUG__:
+        """
+        :TODO - Need method doc string
+        """
         print "%g:  %s" % (time.clock(), message)
-    
+
         if __EVT_DEBUG_2_FILE__:
             out = open(__EVT_DEBUG_FILENAME__, 'a')
             out.write("%10g:  %s\n" % (time.clock(), message))
             out.close()
-            


### PR DESCRIPTION
Changed:
- control used to display text so that users can copy/paste and so it autosizes
- order of elements to be a bit more logical

Needs testing on windows before merge.

Required for 4.1 (in previous versions, the citation and acknowledgment was truncated)

Expected layout (from mac) is:

<img width="602" alt="screen shot 2017-03-25 at 23 02 02" src="https://cloud.githubusercontent.com/assets/871392/24326466/21b4d366-11af-11e7-9f50-541b74db89c5.png">