### PR TITLE
Add yacceptance

### DIFF
--- a/src/sas/sascalc/dataloader/data_info.py
+++ b/src/sas/sascalc/dataloader/data_info.py
@@ -352,8 +352,8 @@ class Sample(object):
     ## Details
     details = None
     ## SESANS zacceptance
-    zacceptance = None
-    yacceptance = None
+    zacceptance = (0,"")
+    yacceptance = (0,"")
 
     def __init__(self):
         self.position = Vector()

--- a/src/sas/sascalc/dataloader/data_info.py
+++ b/src/sas/sascalc/dataloader/data_info.py
@@ -353,6 +353,7 @@ class Sample(object):
     details = None
     ## SESANS zacceptance
     zacceptance = None
+    yacceptance = None
 
     def __init__(self):
         self.position = Vector()

--- a/src/sas/sascalc/dataloader/readers/cansas_constants.py
+++ b/src/sas/sascalc/dataloader/readers/cansas_constants.py
@@ -134,6 +134,7 @@ class CansasConstants(object):
                "children" : {"Idata" : SASDATA_IDATA,
                              "Sesans": {"storeas": "content"},
                              "zacceptance": {"storeas": "float"},
+                             "yacceptance": {"storeas": "float"},
                              "<any>" : ANY
                             }
               }

--- a/src/sas/sascalc/dataloader/readers/cansas_reader.py
+++ b/src/sas/sascalc/dataloader/readers/cansas_reader.py
@@ -291,6 +291,8 @@ class Reader(XMLreader):
                     pass
                 elif tagname == 'Sesans':
                     self.current_datainfo.isSesans = bool(data_point)
+                elif tagname == 'yacceptance':
+                    self.current_datainfo.sample.yacceptance = (data_point, unit)
                 elif tagname == 'zacceptance':
                     self.current_datainfo.sample.zacceptance = (data_point, unit)
 
@@ -1056,6 +1058,8 @@ class Reader(XMLreader):
             sesans = self.create_element("Sesans")
             sesans.text = str(datainfo.isSesans)
             node.append(sesans)
+            self.write_node(node, "yacceptance", datainfo.sample.yacceptance[0],
+                             {'unit': datainfo.sample.yacceptance[1]})
             self.write_node(node, "zacceptance", datainfo.sample.zacceptance[0],
                              {'unit': datainfo.sample.zacceptance[1]})
 


### PR DESCRIPTION
To eventually accomodate non-isotropic samples, SESANS needs a yacceptance variable to go with the zacceptance one.  