### PR TITLE
MAINT: 2to3 fix raise instances.

### DIFF
--- a/sasview/setup_mac.py
+++ b/sasview/setup_mac.py
@@ -60,7 +60,7 @@ for item in lib_locs:
     if os.path.isfile(libxml_path_test):
         libxml_path = libxml_path_test
 if libxml_path is None:
-    raise RuntimeError, "Could not find libxml2 on the system"
+    raise RuntimeError("Could not find libxml2 on the system")
 
 APP = ['sasview.py']
 DATA_FILES += ['images','test','media', 'custom_config.py', 'local_config.py']

--- a/src/sas/sascalc/calculator/BaseComponent.py
+++ b/src/sas/sascalc/calculator/BaseComponent.py
@@ -142,7 +142,7 @@ class BaseComponent:
                 qdist[0].__class__.__name__ != 'ndarray' or \
                 qdist[1].__class__.__name__ != 'ndarray':
                 msg = "evalDistribution expects a list of 2 ndarrays"
-                raise RuntimeError, msg
+                raise RuntimeError(msg)
 
             # Extract qx and qy for code clarity
             qx = qdist[0]
@@ -166,7 +166,7 @@ class BaseComponent:
         else:
             mesg = "evalDistribution is expecting an ndarray of scalar q-values"
             mesg += " or a list [qx,qy] where qx,qy are 2D ndarrays."
-            raise RuntimeError, mesg
+            raise RuntimeError(mesg)
 
 
 
@@ -227,7 +227,7 @@ class BaseComponent:
                     self.params[item] = value
                     return
 
-        raise ValueError, "Model does not contain parameter %s" % name
+        raise ValueError("Model does not contain parameter %s" % name)
 
     def getParam(self, name):
         """
@@ -249,7 +249,7 @@ class BaseComponent:
                 if item.lower()==name.lower():
                     return self.params[item]
 
-        raise ValueError, "Model does not contain parameter %s" % name
+        raise ValueError("Model does not contain parameter %s" % name)
 
     def getParamList(self):
         """
@@ -293,22 +293,22 @@ class BaseComponent:
         """
         add
         """
-        raise ValueError, "Model operation are no longer supported"
+        raise ValueError("Model operation are no longer supported")
     def __sub__(self, other):
         """
         sub
         """
-        raise ValueError, "Model operation are no longer supported"
+        raise ValueError("Model operation are no longer supported")
     def __mul__(self, other):
         """
         mul
         """
-        raise ValueError, "Model operation are no longer supported"
+        raise ValueError("Model operation are no longer supported")
     def __div__(self, other):
         """
         div
         """
-        raise ValueError, "Model operation are no longer supported"
+        raise ValueError("Model operation are no longer supported")
 
 
 def _ordered_keys(d):

--- a/src/sas/sascalc/calculator/instrument.py
+++ b/src/sas/sascalc/calculator/instrument.py
@@ -323,7 +323,7 @@ class Neutron(object):
             plt.legend(['Spectrum'], loc='best')
             plt.show()
         except:
-            raise RuntimeError, "Can't import matplotlib required to plot..."
+            raise RuntimeError("Can't import matplotlib required to plot...")
 
 
 class TOF(Neutron):

--- a/src/sas/sascalc/calculator/resolution_calculator.py
+++ b/src/sas/sascalc/calculator/resolution_calculator.py
@@ -207,7 +207,7 @@ class ResolutionCalculator(object):
 
         if wavelength == 0:
             msg = "Can't compute the resolution: the wavelength is zero..."
-            raise RuntimeError, msg
+            raise RuntimeError(msg)
         return self.intensity
 
     def compute(self, wavelength, wavelength_spread, qx_value, qy_value,
@@ -502,7 +502,7 @@ class ResolutionCalculator(object):
             y_comp = size[1] * phi_y
         # otherwise
         else:
-            raise ValueError, " Improper input..."
+            raise ValueError(" Improper input...")
         # get them squared
         sigma = x_comp * x_comp
         sigma += y_comp * y_comp
@@ -765,7 +765,7 @@ class ResolutionCalculator(object):
         : param size: [dia_value] or [x_value, y_value]
         """
         if len(size) < 1 or len(size) > 2:
-            raise RuntimeError, "The length of the size must be one or two."
+            raise RuntimeError("The length of the size must be one or two.")
         self.aperture.set_source_size(size)
 
     def set_neutron_mass(self, mass):
@@ -782,7 +782,7 @@ class ResolutionCalculator(object):
         : param size: [dia_value] or [xheight_value, yheight_value]
         """
         if len(size) < 1 or len(size) > 2:
-            raise RuntimeError, "The length of the size must be one or two."
+            raise RuntimeError("The length of the size must be one or two.")
         self.aperture.set_sample_size(size)
 
     def set_detector_pix_size(self, size):
@@ -805,7 +805,7 @@ class ResolutionCalculator(object):
         : param distance: [distance, x_offset]
         """
         if len(distance) < 1 or len(distance) > 2:
-            raise RuntimeError, "The length of the size must be one or two."
+            raise RuntimeError("The length of the size must be one or two.")
         self.aperture.set_sample_distance(distance)
 
     def set_sample2sample_distance(self, distance):
@@ -815,7 +815,7 @@ class ResolutionCalculator(object):
         : param distance: [distance, x_offset]
         """
         if len(distance) < 1 or len(distance) > 2:
-            raise RuntimeError, "The length of the size must be one or two."
+            raise RuntimeError("The length of the size must be one or two.")
         self.sample.set_distance(distance)
 
     def set_sample2detector_distance(self, distance):
@@ -825,7 +825,7 @@ class ResolutionCalculator(object):
         : param distance: [distance, x_offset]
         """
         if len(distance) < 1 or len(distance) > 2:
-            raise RuntimeError, "The length of the size must be one or two."
+            raise RuntimeError("The length of the size must be one or two.")
         self.detector.set_distance(distance)
 
     def get_all_instrument_params(self):
@@ -997,7 +997,7 @@ class ResolutionCalculator(object):
             pix_x_size = detector_pix_size[0]
             pix_y_size = detector_pix_size[1]
         else:
-            raise ValueError, " Input value format error..."
+            raise ValueError(" Input value format error...")
         # Sample to detector distance = sample slit to detector
         # minus sample offset
         sample2detector_distance = self.sample2detector_distance[0] - \

--- a/src/sas/sascalc/calculator/sas_gen.py
+++ b/src/sas/sascalc/calculator/sas_gen.py
@@ -31,7 +31,7 @@ def mag2sld(mag, v_unit=None):
     elif v_unit == "mT":
         factor = MFACTOR_MT
     else:
-        raise ValueError, "Invalid valueunit"
+        raise ValueError("Invalid valueunit")
     sld_m = factor * mag
     return sld_m
 
@@ -171,14 +171,14 @@ class GenSAS(BaseComponent):
         if x.__class__.__name__ == 'list':
             if len(x[1]) > 0:
                 msg = "Not a 1D."
-                raise ValueError, msg
+                raise ValueError(msg)
             i_out = np.zeros_like(x[0])
             # 1D I is found at y =0 in the 2D pattern
             out = self._gen(x[0], [], i_out)
             return out
         else:
             msg = "Q must be given as list of qx's and qy's"
-            raise ValueError, msg
+            raise ValueError(msg)
 
     def runXY(self, x=0.0):
         """
@@ -193,7 +193,7 @@ class GenSAS(BaseComponent):
             return out
         else:
             msg = "Q must be given as list of qx's and qy's"
-            raise ValueError, msg
+            raise ValueError(msg)
 
     def evalDistribution(self, qdist):
         """
@@ -211,7 +211,7 @@ class GenSAS(BaseComponent):
         else:
             mesg = "evalDistribution is expecting an ndarray of "
             mesg += "a list [qx,qy] where qx,qy are arrays."
-            raise RuntimeError, mesg
+            raise RuntimeError(mesg)
 
 class OMF2SLD(object):
     """
@@ -312,17 +312,17 @@ class OMF2SLD(object):
         """
         msg = "Error: Inconsistent data length."
         if len(self.pos_x) != length:
-            raise ValueError, msg
+            raise ValueError(msg)
         if len(self.pos_y) != length:
-            raise ValueError, msg
+            raise ValueError(msg)
         if len(self.pos_z) != length:
-            raise ValueError, msg
+            raise ValueError(msg)
         if len(self.mx) != length:
-            raise ValueError, msg
+            raise ValueError(msg)
         if len(self.my) != length:
-            raise ValueError, msg
+            raise ValueError(msg)
         if len(self.mz) != length:
-            raise ValueError, msg
+            raise ValueError(msg)
 
     def remove_null_points(self, remove=False, recenter=False):
         """
@@ -412,7 +412,7 @@ class OMFReader(object):
                     if meshunit.count("m") < 1:
                         msg = "Error: \n"
                         msg += "We accept only m as meshunit"
-                        raise ValueError, msg
+                        raise ValueError(msg)
                 if s_line[0].lower().count("xbase") > 0:
                     xbase = s_line[1].lstrip()
                 if s_line[0].lower().count("ybase") > 0:
@@ -482,7 +482,7 @@ class OMFReader(object):
         except:
             msg = "%s is not supported: \n" % path
             msg += "We accept only Text format OMF file."
-            raise RuntimeError, msg
+            raise RuntimeError(msg)
 
 class PDBReader(object):
     """
@@ -602,7 +602,7 @@ class PDBReader(object):
             output.sld_unit = '1/A^(2)'
             return output
         except:
-            raise RuntimeError, "%s is not a sld file" % path
+            raise RuntimeError("%s is not a sld file" % path)
 
     def write(self, path, data):
         """
@@ -694,7 +694,7 @@ class SLDReader(object):
                 output.set_pixel_volumes(vol_pix)
             return output
         except:
-            raise RuntimeError, "%s is not a sld file" % path
+            raise RuntimeError("%s is not a sld file" % path)
 
     def write(self, path, data):
         """
@@ -703,9 +703,9 @@ class SLDReader(object):
         :Param data: MagSLD data object
         """
         if path is None:
-            raise ValueError, "Missing the file path."
+            raise ValueError("Missing the file path.")
         if data is None:
-            raise ValueError, "Missing the data to save."
+            raise ValueError("Missing the data to save.")
         x_val = data.pos_x
         y_val = data.pos_y
         z_val = data.pos_z

--- a/src/sas/sascalc/corfunc/corfunc_calculator.py
+++ b/src/sas/sascalc/corfunc/corfunc_calculator.py
@@ -79,7 +79,7 @@ class CorfuncCalculator(object):
             return
         # Only process data of the class Data1D
         if not issubclass(data.__class__, Data1D):
-            raise ValueError, "Data must be of the type DataLoader.Data1D"
+            raise ValueError("Data must be of the type DataLoader.Data1D")
 
         # Prepare the data
         new_data = Data1D(x=data.x, y=data.y)
@@ -150,7 +150,7 @@ class CorfuncCalculator(object):
         else:
             err = ("Incorrect transform type supplied, must be 'fourier'",
                 " or 'hilbert'")
-            raise ValueError, err
+            raise ValueError(err)
 
         self._transform_thread.queue()
 

--- a/src/sas/sascalc/data_util/nxsunit.py
+++ b/src/sas/sascalc/data_util/nxsunit.py
@@ -188,7 +188,7 @@ class Converter(object):
             raise KeyError("%s not in %s"%(units,possible_units))
 
 def _check(expect,get):
-    if expect != get: raise ValueError, "Expected %s but got %s"%(expect,get)
+    if expect != get: raise ValueError("Expected %s but got %s"%(expect,get))
      #print expect,"==",get
 
 def test():

--- a/src/sas/sascalc/data_util/odict.py
+++ b/src/sas/sascalc/data_util/odict.py
@@ -611,7 +611,7 @@ class OrderedDict(dict):
         TypeError: pop expected at most 2 arguments, got 3
         """
         if len(args) > 1:
-            raise TypeError, ('pop expected at most 2 arguments, got %s' %
+            raise TypeError('pop expected at most 2 arguments, got %s' %
                 (len(args) + 1))
         if key in self:
             val = self[key]

--- a/src/sas/sascalc/data_util/registry.py
+++ b/src/sas/sascalc/data_util/registry.py
@@ -104,7 +104,7 @@ class ExtensionRegistry(object):
             loaders = L
         # Raise an error if there are no matching extensions
         if len(loaders) == 0:
-            raise ValueError, "Unknown file type for "+path
+            raise ValueError("Unknown file type for "+path)
         # All done
         return loaders
     def load(self, path, format=None):
@@ -158,12 +158,12 @@ def test():
     # Make sure the case of all loaders failing is correct
     try:  reg.load('hello.cx2')
     except CxError: pass # correct failure
-    else: raise AssertError,"Incorrect error on load failure"
+    else: raise AssertError("Incorrect error on load failure")
     # Make sure the case of no loaders fails correctly
     try: reg.load('hello.missing')
     except ValueError,msg:
         assert str(msg)=="Unknown file type for hello.missing",'Message: <%s>'%(msg)
-    else: raise AssertError,"No error raised for missing extension"
+    else: raise AssertError("No error raised for missing extension")
     assert reg.formats() == ['new_cx']
     assert reg.extensions() == ['.cx','.cx.gz','.cx1','.cx1.gz','.cx2','.gz']
     # make sure that it supports multiple '.' in filename

--- a/src/sas/sascalc/dataloader/data_info.py
+++ b/src/sas/sascalc/dataloader/data_info.py
@@ -714,7 +714,7 @@ class Data1D(plottable_1D, DataInfo):
                 self.x_unit = '1/A'
                 self.y_unit = '1/cm'
         except: # the data is not recognized/supported, and the user is notified
-            raise(TypeError, 'data not recognized, check documentation for supported 1D data formats')
+            raise TypeError
 
     def __str__(self):
         """
@@ -794,13 +794,13 @@ class Data1D(plottable_1D, DataInfo):
             if len(self.x) != len(other.x) or \
                 len(self.y) != len(other.y):
                 msg = "Unable to perform operation: data length are not equal"
-                raise ValueError, msg
+                raise ValueError(msg)
             # Here we could also extrapolate between data points
             TOLERANCE = 0.01
             for i in range(len(self.x)):
                 if math.fabs((self.x[i] - other.x[i])/self.x[i]) > TOLERANCE:
                     msg = "Incompatible data sets: x-values do not match"
-                    raise ValueError, msg
+                    raise ValueError(msg)
 
             # Check that the other data set has errors, otherwise
             # create zero vector
@@ -874,7 +874,7 @@ class Data1D(plottable_1D, DataInfo):
         """
         if not isinstance(other, Data1D):
             msg = "Unable to perform operation: different types of data set"
-            raise ValueError, msg
+            raise ValueError(msg)
         return True
 
     def _perform_union(self, other):
@@ -946,7 +946,7 @@ class Data2D(plottable_2D, DataInfo):
         self.x_bins = []
 
         if len(self.detector) > 0:
-            raise RuntimeError, "Data2D: Detector bank already filled at init"
+            raise RuntimeError("Data2D: Detector bank already filled at init")
 
     def __str__(self):
         _str = "%s\n" % DataInfo.__str__(self)
@@ -1018,14 +1018,14 @@ class Data2D(plottable_2D, DataInfo):
                 len(self.qx_data) != len(other.qx_data) or \
                 len(self.qy_data) != len(other.qy_data):
                 msg = "Unable to perform operation: data length are not equal"
-                raise ValueError, msg
+                raise ValueError(msg)
             for ind in range(len(self.data)):
                 if math.fabs((self.qx_data[ind] - other.qx_data[ind])/self.qx_data[ind]) > TOLERANCE:
                     msg = "Incompatible data sets: qx-values do not match: %s %s" % (self.qx_data[ind], other.qx_data[ind])
-                    raise ValueError, msg
+                    raise ValueError(msg)
                 if math.fabs((self.qy_data[ind] - other.qy_data[ind])/self.qy_data[ind]) > TOLERANCE:
                     msg = "Incompatible data sets: qy-values do not match: %s %s" % (self.qy_data[ind], other.qy_data[ind])
-                    raise ValueError, msg
+                    raise ValueError(msg)
 
             # Check that the scales match
             err_other = other.err_data
@@ -1106,7 +1106,7 @@ class Data2D(plottable_2D, DataInfo):
         """
         if not isinstance(other, Data2D):
             msg = "Unable to perform operation: different types of data set"
-            raise ValueError, msg
+            raise ValueError(msg)
         return True
 
     def _perform_union(self, other):

--- a/src/sas/sascalc/dataloader/loader.py
+++ b/src/sas/sascalc/dataloader/loader.py
@@ -294,7 +294,7 @@ class Registry(ExtensionRegistry):
             writers = L
         # Raise an error if there are no matching extensions
         if len(writers) == 0:
-            raise ValueError, "Unknown file type for " + path
+            raise ValueError("Unknown file type for " + path)
         # All done
         return writers
 

--- a/src/sas/sascalc/dataloader/manipulations.py
+++ b/src/sas/sascalc/dataloader/manipulations.py
@@ -80,7 +80,7 @@ def reader2D_converter(data2d=None):
 
     """
     if data2d.data is None or data2d.x_bins is None or data2d.y_bins is None:
-        raise ValueError, "Can't convert this data: data=None..."
+        raise ValueError("Can't convert this data: data=None...")
     new_x = numpy.tile(data2d.x_bins, (len(data2d.y_bins), 1))
     new_y = numpy.tile(data2d.y_bins, (len(data2d.x_bins), 1))
     new_y = new_y.swapaxes(0, 1)
@@ -145,7 +145,7 @@ class _Slab(object):
         if len(data2D.detector) > 1:
             msg = "_Slab._avg: invalid number of "
             msg += " detectors: %g" % len(data2D.detector)
-            raise RuntimeError, msg
+            raise RuntimeError(msg)
 
         # Get data
         data = data2D.data[numpy.isfinite(data2D.data)]
@@ -167,7 +167,7 @@ class _Slab(object):
                 y_min = self.y_min
             nbins = int(math.ceil((self.y_max - y_min) / self.bin_width))
         else:
-            raise RuntimeError, "_Slab._avg: unrecognized axis %s" % str(maj)
+            raise RuntimeError("_Slab._avg: unrecognized axis %s" % str(maj))
 
         x = numpy.zeros(nbins)
         y = numpy.zeros(nbins)
@@ -228,7 +228,7 @@ class _Slab(object):
 
         if not idx.any():
             msg = "Average Error: No points inside ROI to average..."
-            raise ValueError, msg
+            raise ValueError(msg)
         return Data1D(x=x[idx], y=y[idx], dy=err_y[idx])
 
 
@@ -301,7 +301,7 @@ class Boxsum(object):
         if len(data2D.detector) > 1:
             msg = "Circular averaging: invalid number "
             msg += "of detectors: %g" % len(data2D.detector)
-            raise RuntimeError, msg
+            raise RuntimeError(msg)
         # Get data
         data = data2D.data[numpy.isfinite(data2D.data)]
         err_data = data2D.err_data[numpy.isfinite(data2D.data)]
@@ -463,7 +463,7 @@ class CircularAverage(object):
         #q_data_max = numpy.max(q_data)
         if len(data2D.q_data) is None:
             msg = "Circular averaging: invalid q_data: %g" % data2D.q_data
-            raise RuntimeError, msg
+            raise RuntimeError(msg)
 
         # Build array of Q intervals
         nbins = int(math.ceil((self.r_max - self.r_min) / self.bin_width))
@@ -487,7 +487,7 @@ class CircularAverage(object):
 
             ## No need to calculate the frac when all data are within range
             if self.r_min >= self.r_max:
-                raise ValueError, "Limit Error: min > max"
+                raise ValueError("Limit Error: min > max")
 
             if self.r_min <= q_value and q_value <= self.r_max:
                 frac = 1
@@ -538,7 +538,7 @@ class CircularAverage(object):
 
         if not idx.any():
             msg = "Average Error: No points inside ROI to average..."
-            raise ValueError, msg
+            raise ValueError(msg)
 
         return Data1D(x=x[idx], y=y[idx], dy=err_y[idx], dx=d_x)
 
@@ -579,7 +579,7 @@ class Ring(object):
         :return: Data1D object
         """
         if data2D.__class__.__name__ not in ["Data2D", "plottable_2D"]:
-            raise RuntimeError, "Ring averaging only take plottable_2D objects"
+            raise RuntimeError("Ring averaging only take plottable_2D objects")
 
         Pi = math.pi
 
@@ -639,7 +639,7 @@ class Ring(object):
 
         if not idx.any():
             msg = "Average Error: No points inside ROI to average..."
-            raise ValueError, msg
+            raise ValueError(msg)
         #elif len(phi_bins[idx])!= self.nbins_phi:
         #    print "resulted",self.nbins_phi- len(phi_bins[idx])
         #,"empty bin(s) due to tight binning..."
@@ -764,7 +764,7 @@ class _Sector(object):
         :return: Data1D object
         """
         if data2D.__class__.__name__ not in ["Data2D", "plottable_2D"]:
-            raise RuntimeError, "Ring averaging only take plottable_2D objects"
+            raise RuntimeError("Ring averaging only take plottable_2D objects")
         Pi = math.pi
 
         # Get the all data & info
@@ -930,7 +930,7 @@ class _Sector(object):
             d_x = None
         if not idx.any():
             msg = "Average Error: No points inside sector of ROI to average..."
-            raise ValueError, msg
+            raise ValueError(msg)
         #elif len(y[idx])!= self.nbins:
         #    print "resulted",self.nbins- len(y[idx]),
         #"empty bin(s) due to tight binning..."
@@ -1006,7 +1006,7 @@ class Ringcut(object):
         :return: index array in the range
         """
         if data2D.__class__.__name__ not in ["Data2D", "plottable_2D"]:
-            raise RuntimeError, "Ring cut only take plottable_2D objects"
+            raise RuntimeError("Ring cut only take plottable_2D objects")
 
         # Get data
         qx_data = data2D.qx_data
@@ -1054,7 +1054,7 @@ class Boxcut(object):
            with Trues where the data points are inside ROI, otherwise Falses
         """
         if data2D.__class__.__name__ not in ["Data2D", "plottable_2D"]:
-            raise RuntimeError, "Boxcut take only plottable_2D objects"
+            raise RuntimeError("Boxcut take only plottable_2D objects")
         # Get qx_ and qy_data
         qx_data = data2D.qx_data
         qy_data = data2D.qy_data
@@ -1105,7 +1105,7 @@ class Sectorcut(object):
         with Trues where the data points are inside ROI, otherwise Falses
         """
         if data2D.__class__.__name__ not in ["Data2D", "plottable_2D"]:
-            raise RuntimeError, "Sectorcut take only plottable_2D objects"
+            raise RuntimeError("Sectorcut take only plottable_2D objects")
         Pi = math.pi
         # Get data
         qx_data = data2D.qx_data

--- a/src/sas/sascalc/dataloader/readers/abs_reader.py
+++ b/src/sas/sascalc/dataloader/readers/abs_reader.py
@@ -49,7 +49,7 @@ class Reader:
                 try:
                     input_f = open(path,'r')
                 except:
-                    raise  RuntimeError, "abs_reader: cannot open %s" % path
+                    raise  RuntimeError("abs_reader: cannot open %s" % path)
                 buff = input_f.read()
                 lines = buff.split('\n')
                 x  = np.zeros(0)
@@ -98,7 +98,7 @@ class Reader:
                         except:
                             #goes to ASC reader
                             msg = "abs_reader: cannot open %s" % path
-                            raise  RuntimeError, msg
+                            raise  RuntimeError(msg)
                         
                         # Distance in meters
                         try:
@@ -113,7 +113,7 @@ class Reader:
                         except:
                             #goes to ASC reader
                             msg = "abs_reader: cannot open %s" % path
-                            raise  RuntimeError, msg
+                            raise  RuntimeError(msg)
                         # Transmission
                         try:
                             output.sample.transmission = float(line_toks[4])
@@ -222,11 +222,11 @@ class Reader:
                 # Sanity check
                 if not len(y) == len(dy):
                     msg = "abs_reader: y and dy have different length"
-                    raise ValueError, msg
+                    raise ValueError(msg)
                 # If the data length is zero, consider this as
                 # though we were not able to read the file.
                 if len(x) == 0:
-                    raise ValueError, "ascii_reader: could not load file"
+                    raise ValueError("ascii_reader: could not load file")
                 
                 output.x = x[x != 0]
                 output.y = y[x != 0]
@@ -245,5 +245,5 @@ class Reader:
                 output.meta_data['loader'] = self.type_name
                 return output
         else:
-            raise RuntimeError, "%s is not a file" % path
+            raise RuntimeError("%s is not a file" % path)
         return None

--- a/src/sas/sascalc/dataloader/readers/ascii_reader.py
+++ b/src/sas/sascalc/dataloader/readers/ascii_reader.py
@@ -63,7 +63,7 @@ class Reader:
                     # characters that breaks the open operation
                     input_f = open(path,'rb')
                 except:
-                    raise  RuntimeError, "ascii_reader: cannot open %s" % path
+                    raise  RuntimeError("ascii_reader: cannot open %s" % path)
                 buff = input_f.read()
                 lines = buff.splitlines()
 
@@ -172,18 +172,18 @@ class Reader:
                 input_f.close()
                 if not is_data:
                     msg = "ascii_reader: x has no data"
-                    raise RuntimeError, msg
+                    raise RuntimeError(msg)
                 # Sanity check
                 if has_error_dy == True and not len(ty) == len(tdy):
                     msg = "ascii_reader: y and dy have different length"
-                    raise RuntimeError, msg
+                    raise RuntimeError(msg)
                 if has_error_dx == True and not len(tx) == len(tdx):
                     msg = "ascii_reader: y and dy have different length"
-                    raise RuntimeError, msg
+                    raise RuntimeError(msg)
                 # If the data length is zero, consider this as
                 # though we were not able to read the file.
                 if len(tx) == 0:
-                    raise RuntimeError, "ascii_reader: could not load file"
+                    raise RuntimeError("ascii_reader: could not load file")
 
                 #Let's re-order the data to make cal.
                 # curve look better some cases
@@ -221,11 +221,11 @@ class Reader:
                 # Store loading process information
                 output.meta_data['loader'] = self.type_name
                 if len(output.x) < 1:
-                    raise RuntimeError, "%s is empty" % path
+                    raise RuntimeError("%s is empty" % path)
                 return output
 
         else:
-            raise RuntimeError, "%s is not a file" % path
+            raise RuntimeError("%s is not a file" % path)
         return None
 
     def splitline(self, line):

--- a/src/sas/sascalc/dataloader/readers/cansas_reader.py
+++ b/src/sas/sascalc/dataloader/readers/cansas_reader.py
@@ -1478,7 +1478,7 @@ class Reader(XMLreader):
                             if optional:
                                 logger.info(err_mess)
                             else:
-                                raise ValueError, err_mess
+                                raise ValueError(err_mess)
                     else:
                         err_mess = "CanSAS reader: unrecognized %s unit [%s];"\
                         % (variable, units)
@@ -1487,7 +1487,7 @@ class Reader(XMLreader):
                         if optional:
                             logger.info(err_mess)
                         else:
-                            raise ValueError, err_mess
+                            raise ValueError(err_mess)
                 else:
                     exec "storage.%s = value" % variable
             else:

--- a/src/sas/sascalc/dataloader/readers/danse_reader.py
+++ b/src/sas/sascalc/dataloader/readers/danse_reader.py
@@ -55,7 +55,7 @@ class Reader:
             try:
                 datafile = open(filename, 'r')
             except:
-                raise  RuntimeError,"danse_reader cannot open %s" % (filename)
+                raise  RuntimeError("danse_reader cannot open %s" % (filename))
         
             # defaults
             # wavelength in Angstrom
@@ -270,7 +270,7 @@ class Reader:
            
             if not fversion >= 1.0:
                 msg = "Danse_reader can't read this file %s" % filename
-                raise ValueError, msg
+                raise ValueError(msg)
             else:
                 logger.info("Danse_reader Reading %s \n" % filename)
             

--- a/src/sas/sascalc/dataloader/readers/hfir1d_reader.py
+++ b/src/sas/sascalc/dataloader/readers/hfir1d_reader.py
@@ -48,7 +48,7 @@ class Reader(object):
                 try:
                     input_f = open(path,'r')
                 except:
-                    raise  RuntimeError, "hfir1d_reader: cannot open %s" % path
+                    raise  RuntimeError("hfir1d_reader: cannot open %s" % path)
                 buff = input_f.read()
                 lines = buff.split('\n')
                 x = np.zeros(0)
@@ -98,15 +98,15 @@ class Reader(object):
                 # Sanity check
                 if not len(y) == len(dy):
                     msg = "hfir1d_reader: y and dy have different length"
-                    raise RuntimeError, msg
+                    raise RuntimeError(msg)
                 if not len(x) == len(dx):
                     msg = "hfir1d_reader: x and dx have different length"
-                    raise RuntimeError, msg
+                    raise RuntimeError(msg)
 
                 # If the data length is zero, consider this as
                 # though we were not able to read the file.
                 if len(x) == 0:
-                    raise RuntimeError, "hfir1d_reader: could not load file"
+                    raise RuntimeError("hfir1d_reader: could not load file")
                
                 output.x = x
                 output.y = y
@@ -125,5 +125,5 @@ class Reader(object):
                 output.meta_data['loader'] = self.type_name
                 return output
         else:
-            raise RuntimeError, "%s is not a file" % path
+            raise RuntimeError("%s is not a file" % path)
         return None

--- a/src/sas/sascalc/dataloader/readers/nexus_reader.py
+++ b/src/sas/sascalc/dataloader/readers/nexus_reader.py
@@ -34,7 +34,7 @@ class Reader:
         except:
             msg = "Error reading Nexus file: Nexus package is missing.\n"
             msg += "  Get it from http://http://www.nexusformat.org/"
-            raise RuntimeError, msg
+            raise RuntimeError(msg)
         
         # Instantiate data object
         output = Data2D()

--- a/src/sas/sascalc/dataloader/readers/red2d_reader.py
+++ b/src/sas/sascalc/dataloader/readers/red2d_reader.py
@@ -69,8 +69,7 @@ class Reader:
     def read(self, filename=None):
         """ Read file """
         if not os.path.isfile(filename):
-            raise ValueError, \
-            "Specified file %s is not a regular file" % filename
+            raise ValueError("Specified file %s is not a regular file" % filename)
 
         # Read file
         f = open(filename, 'r')
@@ -231,7 +230,7 @@ class Reader:
             data_point = data_array.reshape(row_num, col_num).transpose()
         except:
             msg = "red2d_reader: Can't read this file: Not a proper file format"
-            raise ValueError, msg
+            raise ValueError(msg)
         ## Get the all data: Let's HARDcoding; Todo find better way
         # Defaults
         dqx_data = np.zeros(0)

--- a/src/sas/sascalc/dataloader/readers/sesans_reader.py
+++ b/src/sas/sascalc/dataloader/readers/sesans_reader.py
@@ -56,7 +56,7 @@ class Reader:
                     # characters that brakes the open operation
                     input_f = open(path,'rb')
                 except:
-                    raise  RuntimeError, "sesans_reader: cannot open %s" % path
+                    raise  RuntimeError("sesans_reader: cannot open %s" % path)
                 buff = input_f.read()
                 lines = buff.splitlines()
                 x  = np.zeros(0)
@@ -157,11 +157,11 @@ class Reader:
                 output.vars = varheader
 
                 if len(output.x) < 1:
-                    raise RuntimeError, "%s is empty" % path
+                    raise RuntimeError("%s is empty" % path)
                 return output
 
         else:
-            raise RuntimeError, "%s is not a file" % path
+            raise RuntimeError("%s is not a file" % path)
         return None
 
     def _unit_conversion(self, value, value_unit, default_unit):

--- a/src/sas/sascalc/dataloader/readers/tiff_reader.py
+++ b/src/sas/sascalc/dataloader/readers/tiff_reader.py
@@ -43,7 +43,7 @@ class Reader:
             Image._initialized=2
         except:
             msg = "tiff_reader: could not load file. Missing Image module."
-            raise RuntimeError, msg
+            raise RuntimeError(msg)
         
         # Instantiate data object
         output = Data2D()
@@ -53,7 +53,7 @@ class Reader:
         try:
             im = Image.open(filename)
         except:
-            raise  RuntimeError, "cannot open %s"%(filename)
+            raise  RuntimeError("cannot open %s"%(filename))
         data = im.getdata()
 
         # Initiazed the output data object

--- a/src/sas/sascalc/file_converter/cansas_writer.py
+++ b/src/sas/sascalc/file_converter/cansas_writer.py
@@ -31,7 +31,7 @@ class CansasWriter(CansasReader):
         """
         valid_class = all([issubclass(data.__class__, Data1D) for data in frame_data])
         if not valid_class:
-            raise RuntimeError, ("The cansas writer expects an array of "
+            raise RuntimeError("The cansas writer expects an array of "
                 "Data1D instances")
 
         # Get PIs and create root element

--- a/src/sas/sascalc/fit/AbstractFitEngine.py
+++ b/src/sas/sascalc/fit/AbstractFitEngine.py
@@ -249,7 +249,7 @@ class FitData1D(Data1D):
         if np.size(self.dy) != np.size(fx):
             msg = "FitData1D: invalid error array "
             msg += "%d <> %d" % (np.shape(self.dy), np.size(fx))
-            raise RuntimeError, msg
+            raise RuntimeError(msg)
         return (self.y[self.idx] - fx[self.idx]) / self.dy[self.idx], fx[self.idx]
             
     def residuals_deriv(self, model, pars=[]):

--- a/src/sas/sascalc/fit/Loader.py
+++ b/src/sas/sascalc/fit/Loader.py
@@ -56,9 +56,9 @@ class Load:
                     print "READ ERROR", line
             # Sanity check
             if not len(self.x) == len(self.dx):
-                raise ValueError, "x and dx have different length"
+                raise ValueError("x and dx have different length")
             if not len(self.y) == len(self.dy):
-                raise ValueError, "y and dy have different length"
+                raise ValueError("y and dy have different length")
             
             
     def get_values(self):

--- a/src/sas/sascalc/fit/MultiplicationModel.py
+++ b/src/sas/sascalc/fit/MultiplicationModel.py
@@ -244,7 +244,7 @@ class MultiplicationModel(BaseComponent):
                     self.params[item] = value
                     return
 
-        raise ValueError, "Model does not contain parameter %s" % name
+        raise ValueError("Model does not contain parameter %s" % name)
 
 
     def _set_fixed_params(self):

--- a/src/sas/sascalc/fit/expression.py
+++ b/src/sas/sascalc/fit/expression.py
@@ -236,7 +236,7 @@ def order_dependencies(pairs):
         independent = right - left
         if independent == emptyset:
             cycleset = ", ".join(str(s) for s in left)
-            raise ValueError,"Cyclic dependencies amongst %s"%cycleset
+            raise ValueError("Cyclic dependencies amongst %s"%cycleset)
 
         # The possibly resolvable items are those that depend on the independents
         dependent = set([a for a,b in pairs if b in independent])
@@ -264,10 +264,10 @@ def _check(msg,pairs):
     if set(n) != items or len(n) != len(items):
         n.sort()
         items = list(items); items.sort()
-        raise Exception,"%s expect %s to contain %s for %s"%(msg,n,items,pairs)
+        raise Exception("%s expect %s to contain %s for %s"%(msg,n,items,pairs))
     for lo,hi in pairs:
         if lo in n and hi in n and n.index(lo) >= n.index(hi):
-            raise Exception,"%s expect %s before %s in %s for %s"%(msg,lo,hi,n,pairs)
+            raise Exception("%s expect %s before %s in %s for %s"%(msg,lo,hi,n,pairs))
 
 def test_deps():
     import numpy as np
@@ -287,7 +287,7 @@ def test_deps():
     pairs = [(1,4),(4,3),(4,5),(5,1)]
     try: n = order_dependencies(pairs)
     except ValueError: pass
-    else: raise Exception,"test3 expect ValueError exception for %s"%(pairs,)
+    else: raise Exception("test3 expect ValueError exception for %s"%(pairs,))
 
     # large test for gross speed check
     A = np.random.randint(4000,size=(1000,2))

--- a/src/sas/sascalc/fit/pluginmodel.py
+++ b/src/sas/sascalc/fit/pluginmodel.py
@@ -34,7 +34,7 @@ class Model1DPlugin(BaseComponent):
             y_val = x[0]*math.sin(x[1])
             return self.function(x_val)*self.function(y_val)
         elif x.__class__.__name__ == 'tuple':
-            raise ValueError, "Tuples are not allowed as input to BaseComponent models"
+            raise ValueError("Tuples are not allowed as input to BaseComponent models")
         else:
             return self.function(x)
 
@@ -51,7 +51,7 @@ class Model1DPlugin(BaseComponent):
         if x.__class__.__name__ == 'list':
             return self.function(x[0])*self.function(x[1])
         elif x.__class__.__name__ == 'tuple':
-            raise ValueError, "Tuples are not allowed as input to BaseComponent models"
+            raise ValueError("Tuples are not allowed as input to BaseComponent models")
         else:
             return self.function(x)
 

--- a/src/sas/sascalc/invariant/invariant.py
+++ b/src/sas/sascalc/invariant/invariant.py
@@ -423,7 +423,7 @@ class InvariantCalculator(object):
         """
         if not issubclass(data.__class__, LoaderData1D):
             #Process only data that inherited from DataLoader.Data_info.Data1D
-            raise ValueError, "Data must be of type DataLoader.Data1D"
+            raise ValueError("Data must be of type DataLoader.Data1D")
         #from copy import deepcopy
         new_data = (self._scale * data) - self._background
 
@@ -483,7 +483,7 @@ class InvariantCalculator(object):
         if len(data.x) <= 1 or len(data.y) <= 1 or len(data.x) != len(data.y):
             msg = "Length x and y must be equal"
             msg += " and greater than 1; got x=%s, y=%s" % (len(data.x), len(data.y))
-            raise ValueError, msg
+            raise ValueError(msg)
         else:
             # Take care of smeared data
             if self._smeared is None:
@@ -532,7 +532,7 @@ class InvariantCalculator(object):
             (data.dy is not None and (len(data.dy) != len(data.y))):
             msg = "Length of data.x and data.y must be equal"
             msg += " and greater than 1; got x=%s, y=%s" % (len(data.x), len(data.y))
-            raise ValueError, msg
+            raise ValueError(msg)
         else:
             #Create error for data without dy error
             if data.dy is None:
@@ -741,16 +741,16 @@ class InvariantCalculator(object):
         """
         range = range.lower()
         if range not in ['high', 'low']:
-            raise ValueError, "Extrapolation range should be 'high' or 'low'"
+            raise ValueError("Extrapolation range should be 'high' or 'low'")
         function = function.lower()
         if function not in ['power_law', 'guinier']:
             msg = "Extrapolation function should be 'guinier' or 'power_law'"
-            raise ValueError, msg
+            raise ValueError(msg)
 
         if range == 'high':
             if function != 'power_law':
                 msg = "Extrapolation only allows a power law at high Q"
-                raise ValueError, msg
+                raise ValueError(msg)
             self._high_extrapolation_npts = npts
             self._high_extrapolation_power = power
             self._high_extrapolation_power_fitted = power
@@ -851,14 +851,14 @@ class InvariantCalculator(object):
         :note: volume fraction must have no unit
         """
         if contrast <= 0:
-            raise ValueError, "The contrast parameter must be greater than zero"
+            raise ValueError("The contrast parameter must be greater than zero")
 
         # Make sure Q star is up to date
         self.get_qstar(extrapolation)
 
         if self._qstar <= 0:
             msg = "Invalid invariant: Invariant Q* must be greater than zero"
-            raise RuntimeError, msg
+            raise RuntimeError(msg)
 
         # Compute intermediate constant
         k = 1.e-8 * self._qstar / (2 * (math.pi * math.fabs(float(contrast))) ** 2)
@@ -868,7 +868,7 @@ class InvariantCalculator(object):
         # Compute volume fraction
         if discrim < 0:
             msg = "Could not compute the volume fraction: negative discriminant"
-            raise RuntimeError, msg
+            raise RuntimeError(msg)
         elif discrim == 0:
             return 1 / 2
         else:
@@ -880,7 +880,7 @@ class InvariantCalculator(object):
             elif 0 <= volume2 and volume2 <= 1:
                 return volume2
             msg = "Could not compute the volume fraction: inconsistent results"
-            raise RuntimeError, msg
+            raise RuntimeError(msg)
 
     def get_qstar_with_error(self, extrapolation=None):
         """

--- a/src/sas/sascalc/pr/fit/AbstractFitEngine.py
+++ b/src/sas/sascalc/pr/fit/AbstractFitEngine.py
@@ -249,7 +249,7 @@ class FitData1D(Data1D):
         if np.size(self.dy) != np.size(fx):
             msg = "FitData1D: invalid error array "
             msg += "%d <> %d" % (np.shape(self.dy), np.size(fx))
-            raise RuntimeError, msg
+            raise RuntimeError(msg)
         return (self.y[self.idx] - fx[self.idx]) / self.dy[self.idx], fx[self.idx]
             
     def residuals_deriv(self, model, pars=[]):

--- a/src/sas/sascalc/pr/fit/Loader.py
+++ b/src/sas/sascalc/pr/fit/Loader.py
@@ -56,9 +56,9 @@ class Load:
                     print "READ ERROR", line
             # Sanity check
             if not len(self.x) == len(self.dx):
-                raise ValueError, "x and dx have different length"
+                raise ValueError("x and dx have different length")
             if not len(self.y) == len(self.dy):
-                raise ValueError, "y and dy have different length"
+                raise ValueError("y and dy have different length")
             
             
     def get_values(self):

--- a/src/sas/sascalc/pr/fit/expression.py
+++ b/src/sas/sascalc/pr/fit/expression.py
@@ -236,7 +236,7 @@ def order_dependencies(pairs):
         independent = right - left
         if independent == emptyset:
             cycleset = ", ".join(str(s) for s in left)
-            raise ValueError,"Cyclic dependencies amongst %s"%cycleset
+            raise ValueError("Cyclic dependencies amongst %s"%cycleset)
 
         # The possibly resolvable items are those that depend on the independents
         dependent = set([a for a,b in pairs if b in independent])
@@ -264,10 +264,10 @@ def _check(msg,pairs):
     if set(n) != items or len(n) != len(items):
         n.sort()
         items = list(items); items.sort()
-        raise Exception,"%s expect %s to contain %s for %s"%(msg,n,items,pairs)
+        raise Exception("%s expect %s to contain %s for %s"%(msg,n,items,pairs))
     for lo,hi in pairs:
         if lo in n and hi in n and n.index(lo) >= n.index(hi):
-            raise Exception,"%s expect %s before %s in %s for %s"%(msg,lo,hi,n,pairs)
+            raise Exception("%s expect %s before %s in %s for %s"%(msg,lo,hi,n,pairs))
 
 def test_deps():
     import numpy as np
@@ -287,7 +287,7 @@ def test_deps():
     pairs = [(1,4),(4,3),(4,5),(5,1)]
     try: n = order_dependencies(pairs)
     except ValueError: pass
-    else: raise Exception,"test3 expect ValueError exception for %s"%(pairs,)
+    else: raise Exception("test3 expect ValueError exception for %s"%(pairs,))
 
     # large test for gross speed check
     A = np.random.randint(4000,size=(1000,2))

--- a/src/sas/sascalc/pr/invertor.py
+++ b/src/sas/sascalc/pr/invertor.py
@@ -147,7 +147,7 @@ class Invertor(Cinvertor):
             if 0.0 in value:
                 msg = "Invertor: one of your q-values is zero. "
                 msg += "Delete that entry before proceeding"
-                raise ValueError, msg
+                raise ValueError(msg)
             return self.set_x(value)
         elif name == 'y':
             return self.set_y(value)
@@ -158,7 +158,7 @@ class Invertor(Cinvertor):
             if value <= 0.0:
                 msg = "Invertor: d_max must be greater than zero."
                 msg += "Correct that entry before proceeding"
-                raise ValueError, msg
+                raise ValueError(msg)
             return self.set_dmax(value)
         elif name == 'q_min':
             if value is None:
@@ -180,7 +180,7 @@ class Invertor(Cinvertor):
             elif value == False:
                 return self.set_has_bck(0)
             else:
-                raise ValueError, "Invertor: has_bck can only be True or False"
+                raise ValueError("Invertor: has_bck can only be True or False")
 
         return Cinvertor.__setattr__(self, name, value)
 
@@ -324,7 +324,7 @@ class Invertor(Cinvertor):
         # First, check that the current data is valid
         if self.is_valid() <= 0:
             msg = "Invertor.invert: Data array are of different length"
-            raise RuntimeError, msg
+            raise RuntimeError(msg)
 
         p = np.ones(nfunc)
         t_0 = time.time()
@@ -357,7 +357,7 @@ class Invertor(Cinvertor):
         # First, check that the current data is valid
         if self.is_valid() <= 0:
             msg = "Invertor.invert: Data arrays are of different length"
-            raise RuntimeError, msg
+            raise RuntimeError(msg)
 
         p = np.ones(nfunc)
         t_0 = time.time()
@@ -441,7 +441,7 @@ class Invertor(Cinvertor):
 
         if self.is_valid() < 0:
             msg = "Invertor: invalid data; incompatible data lengths."
-            raise RuntimeError, msg
+            raise RuntimeError(msg)
 
         self.nfunc = nfunc
         # a -- An M x N matrix.
@@ -466,7 +466,7 @@ class Invertor(Cinvertor):
         try:
             self._get_matrix(nfunc, nq, a, b)
         except:
-            raise RuntimeError, "Invertor: could not invert I(Q)\n  %s" % sys.exc_value
+            raise RuntimeError("Invertor: could not invert I(Q)\n  %s" % sys.exc_value)
 
         # Perform the inversion (least square fit)
         c, chi2, _, _ = lstsq(a, b)
@@ -750,7 +750,7 @@ class Invertor(Cinvertor):
 
             except:
                 msg = "Invertor.from_file: corrupted file\n%s" % sys.exc_value
-                raise RuntimeError, msg
+                raise RuntimeError(msg)
         else:
             msg = "Invertor.from_file: '%s' is not a file" % str(path)
-            raise RuntimeError, msg
+            raise RuntimeError(msg)

--- a/src/sas/sasgui/guiframe/data_processor.py
+++ b/src/sas/sasgui/guiframe/data_processor.py
@@ -906,20 +906,20 @@ class Notebook(nb, PanelBase):
                 if c != col:
                     msg = "Edit axis doesn't understand this selection.\n"
                     msg += "Please select only one column"
-                    raise ValueError, msg
+                    raise ValueError(msg)
             for (_, cell_col) in grid.selected_cells:
                 if cell_col != col:
                     msg = "Cannot use cells from different columns for "
                     msg += "this operation.\n"
                     msg += "Please select elements of the same col.\n"
-                    raise ValueError, msg
+                    raise ValueError(msg)
 
             # Finally check the highlighted cell if any cells missing
             self.get_highlighted_row(True)
         else:
             msg = "No item selected.\n"
             msg += "Please select only one column or one cell"
-            raise ValueError, msg
+            raise ValueError(msg)
         return grid.selected_cells
 
     def get_highlighted_row(self, is_number=True):
@@ -1323,7 +1323,7 @@ class GridPanel(SPanel):
         try:
             if sentence.strip() == "":
                 msg = "Select column values for x axis"
-                raise ValueError, msg
+                raise ValueError(msg)
         except:
             msg = "X axis value error."
             wx.PostEvent(self.parent.parent, StatusEvent(status=msg, info="error"))
@@ -1342,7 +1342,7 @@ class GridPanel(SPanel):
         try:
             if sentence.strip() == "":
                 msg = "select value for y axis"
-                raise ValueError, msg
+                raise ValueError(msg)
         except:
             msg = "Y axis value error."
             wx.PostEvent(self.parent.parent, StatusEvent(status=msg, info="error"))

--- a/src/sas/sasgui/guiframe/gui_manager.py
+++ b/src/sas/sasgui/guiframe/gui_manager.py
@@ -2612,7 +2612,7 @@ class ViewerFrame(PARENT_FRAME):
                         data.filename
             wx.PostEvent(self, StatusEvent(status=msg,
                                            info="error"))
-            raise ValueError, msg
+            raise ValueError(msg)
         # text = str(data)
         text = data.__str__()
         text += 'Data Min Max:\n'

--- a/src/sas/sasgui/guiframe/local_perspectives/plotting/SectorSlicer.py
+++ b/src/sas/sasgui/guiframe/local_perspectives/plotting/SectorSlicer.py
@@ -234,7 +234,7 @@ class SectorInteractor(_BaseInteractor):
         if math.fabs(self.left_line.phi) != math.fabs(self.right_line.phi):
             msg = "Phi left and phi right are different"
             msg += " %f, %f" % (self.left_line.phi, self.right_line.phi)
-            raise ValueError, msg
+            raise ValueError(msg)
         params["Phi [deg]"] = self.main_line.theta * 180 / math.pi
         params["Delta_Phi [deg]"] = math.fabs(self.left_line.phi * 180 / math.pi)
         params["nbins"] = self.nbins

--- a/src/sas/sasgui/guiframe/local_perspectives/plotting/binder.py
+++ b/src/sas/sasgui/guiframe/local_perspectives/plotting/binder.py
@@ -186,8 +186,8 @@ class BindArtist(object):
         """
         # Check that the trigger is valid
         if trigger not in self._actions:
-            raise ValueError, "%s invalid --- valid triggers are %s" \
-                % (trigger, ", ".join(self.events))
+            raise ValueError("%s invalid --- valid triggers are %s" \
+                % (trigger, ", ".join(self.events)))
         # Register the trigger callback
         self._actions[trigger][artist] = action
         # print "==> added",artist,[artist],"to",trigger,":",
@@ -202,7 +202,7 @@ class BindArtist(object):
         to figure, and to 'all' if the event is not processed.
         """
         if action not in self.events:
-            raise ValueError, "Trigger expects " + ", ".join(self.events)
+            raise ValueError("Trigger expects " + ", ".join(self.events))
         # Tag the event with modifiers
         for mod in ('alt', 'control', 'shift', 'meta'):
             setattr(ev, mod, getattr(self, mod))

--- a/src/sas/sasgui/guiframe/local_perspectives/plotting/boxSlicer.py
+++ b/src/sas/sasgui/guiframe/local_perspectives/plotting/boxSlicer.py
@@ -151,7 +151,7 @@ class BoxInteractor(_BaseInteractor):
         if self.averager is None:
             if new_slab is None:
                 msg = "post data:cannot average , averager is empty"
-                raise ValueError, msg
+                raise ValueError(msg)
             self.averager = new_slab
         if self.direction == "X":
             if self.fold:
@@ -167,7 +167,7 @@ class BoxInteractor(_BaseInteractor):
             bin_width = (y_max + y_low) / self.nbins
         else:
             msg = "post data:no Box Average direction was supplied"
-            raise ValueError, msg
+            raise ValueError(msg)
         # # Average data2D given Qx or Qy
         box = self.averager(x_min=x_min, x_max=x_max, y_min=y_min, y_max=y_max,
                             bin_width=bin_width)

--- a/src/sas/sasgui/guiframe/local_perspectives/plotting/plotting.py
+++ b/src/sas/sasgui/guiframe/local_perspectives/plotting/plotting.py
@@ -198,7 +198,7 @@ class Plugin(PluginBase):
             return  new_panel
 
         msg = "1D Panel of group ID %s could not be created" % str(group_id)
-        raise ValueError, msg
+        raise ValueError(msg)
 
     def create_2d_panel(self, data, group_id):
         """
@@ -216,7 +216,7 @@ class Plugin(PluginBase):
             new_panel.frame = win
             return new_panel
         msg = "2D Panel of group ID %s could not be created" % str(group_id)
-        raise ValueError, msg
+        raise ValueError(msg)
 
     def update_panel(self, data, panel):
         """
@@ -236,7 +236,7 @@ class Plugin(PluginBase):
             msg = "Cannot add %s" % str(data.name)
             msg += " to panel %s\n" % str(panel.window_caption)
             msg += "Please edit %s's units, labels" % str(data.name)
-            raise ValueError, msg
+            raise ValueError(msg)
         else:
             if panel.group_id not in data.list_group_id:
                 data.list_group_id.append(panel.group_id)

--- a/src/sas/sasgui/guiframe/local_perspectives/plotting/sector_mask.py
+++ b/src/sas/sasgui/guiframe/local_perspectives/plotting/sector_mask.py
@@ -174,7 +174,7 @@ class SectorMask(_BaseInteractor):
             msg = "Phi left and phi right are "
             msg += "different %f, %f" % (self.left_line.phi,
                                          self.right_line.phi)
-            raise ValueError, msg
+            raise ValueError(msg)
         params["Phi"] = self.main_line.theta
         params["Delta_Phi"] = math.fabs(self.left_line.phi)
         return params

--- a/src/sas/sasgui/guiframe/plugin_base.py
+++ b/src/sas/sasgui/guiframe/plugin_base.py
@@ -276,7 +276,7 @@ class PluginBase(object):
             related to available theory state
         """
         msg = "%s plugin: does not support import theory" % str(self.sub_menu)
-        raise ValueError, msg
+        raise ValueError(msg)
 
     def on_set_state_helper(self, event):
         """

--- a/src/sas/sasgui/perspectives/calculator/resolution_calculator_panel.py
+++ b/src/sas/sasgui/perspectives/calculator/resolution_calculator_panel.py
@@ -1081,7 +1081,7 @@ class ResolutionCalculatorPanel(ScrolledPanel):
             else:
                 msg = "The numbers must be one or two (separated by ',')..."
                 self._status_info(msg, 'stop')
-                raise RuntimeError, msg
+                raise RuntimeError(msg)
 
         return new_string
 

--- a/src/sas/sasgui/perspectives/calculator/slit_length_calculator_panel.py
+++ b/src/sas/sasgui/perspectives/calculator/slit_length_calculator_panel.py
@@ -261,7 +261,7 @@ class SlitLengthCalculatorPanel(wx.Panel, PanelBase):
             y = data.y
             if x == [] or  x is None or y == [] or y is None:
                 msg = "The current data is empty please check x and y"
-                raise ValueError, msg
+                raise ValueError(msg)
             slit_length_calculator = SlitlengthCalculator()
             slit_length_calculator.set_data(x=x, y=y)
             slit_length = slit_length_calculator.calculate_slit_length()

--- a/src/sas/sasgui/perspectives/corfunc/corfunc_state.py
+++ b/src/sas/sasgui/perspectives/corfunc/corfunc_state.py
@@ -283,7 +283,7 @@ class Reader(CansasReader):
             basename = os.path.basename(path)
             root, ext = os.path.splitext(basename)
             if not ext.lower() in self.ext:
-                raise IOError, "{} is not a supported file type".format(ext)
+                raise IOError("{} is not a supported file type".format(ext))
             tree = etree.parse(path, parser=etree.ETCompatXMLParser())
             root = tree.getroot()
             entry_list = root.xpath('/ns:SASroot/ns:SASentry',
@@ -299,7 +299,7 @@ class Reader(CansasReader):
         else:
             # File not found
             msg = "{} is not a valid file path or doesn't exist".format(path)
-            raise IOError, msg
+            raise IOError(msg)
 
         if len(output) == 0:
             return None
@@ -323,7 +323,7 @@ class Reader(CansasReader):
         elif not (isinstance(datainfo, Data1D) or isinstance(datainfo, LoaderData1D)):
             msg = ("The CanSAS writer expects a Data1D instance. {} was "
                 "provided").format(datainfo.__class__.__name__)
-            raise RuntimeError, msg
+            raise RuntimeError(msg)
         if datainfo.title is None or datainfo.title == '':
             datainfo.title = datainfo.name
         if datainfo.run_name is None or datainfo.run_name == '':

--- a/src/sas/sasgui/perspectives/fitting/fit_thread.py
+++ b/src/sas/sasgui/perspectives/fitting/fit_thread.py
@@ -53,7 +53,7 @@ class FitThread(CalcThread):
             CalcThread.isquit(self)
         except KeyboardInterrupt:
             msg = "Fitting: terminated by the user."
-            raise KeyboardInterrupt, msg
+            raise KeyboardInterrupt(msg)
 
     def compute(self):
         """

--- a/src/sas/sasgui/perspectives/fitting/fitpage.py
+++ b/src/sas/sasgui/perspectives/fitting/fitpage.py
@@ -1846,7 +1846,7 @@ class FitPage(BasicPage):
                                 data.filename
                     wx.PostEvent(self._manager.parent, StatusEvent(status=msg,
                                                info="error"))
-                    raise ValueError, msg
+                    raise ValueError(msg)
 
             else:
                 qmin = 0
@@ -1858,7 +1858,7 @@ class FitPage(BasicPage):
                                 data.filename
                     wx.PostEvent(self._manager.parent, StatusEvent(status=msg,
                                                info="error"))
-                    raise ValueError, msg
+                    raise ValueError(msg)
                 # Maximum value of data
                 qmax = math.sqrt(x * x + y * y)
                 npts = len(data.data)
@@ -2097,7 +2097,7 @@ class FitPage(BasicPage):
         # make sure stop button to fit button all the time
         self._on_fit_complete()
         if out is None or not np.isfinite(chisqr):
-            raise ValueError, "Fit error occured..."
+            raise ValueError("Fit error occured...")
 
         is_modified = False
         has_error = False
@@ -2172,7 +2172,7 @@ class FitPage(BasicPage):
                             has_error = True
                 i += 1
             else:
-                raise ValueError, "onsetValues: Invalid parameters..."
+                raise ValueError("onsetValues: Invalid parameters...")
         # Show error title when any errors displayed
         if has_error:
             if not self.text2_3.IsShown():

--- a/src/sas/sasgui/perspectives/fitting/fitpanel.py
+++ b/src/sas/sasgui/perspectives/fitting/fitpanel.py
@@ -124,7 +124,7 @@ class FitPanel(nb, PanelBase):
         """
         if uid not in self.opened_pages:
             msg = "Fitpanel cannot find ID: %s in self.opened_pages" % str(uid)
-            raise ValueError, msg
+            raise ValueError(msg)
         else:
             return self.opened_pages[uid]
 
@@ -388,7 +388,7 @@ class FitPanel(nb, PanelBase):
         Delete the given data
         """
         if data.__class__.__name__ != "list":
-            raise ValueError, "Fitpanel delete_data expect list of id"
+            raise ValueError("Fitpanel delete_data expect list of id")
         else:
             for page in self.opened_pages.values():
                 pos = self.GetPageIndex(page)

--- a/src/sas/sasgui/perspectives/fitting/fitting.py
+++ b/src/sas/sasgui/perspectives/fitting/fitting.py
@@ -1231,7 +1231,7 @@ class Plugin(PluginBase):
         """
         panel = self.plot_panel
         if panel is None:
-            raise ValueError, "Fitting:_onSelect: NonType panel"
+            raise ValueError("Fitting:_onSelect: NonType panel")
         Plugin.on_perspective(self, event=event)
         self.select_data(panel)
 

--- a/src/sas/sasgui/perspectives/fitting/model_thread.py
+++ b/src/sas/sasgui/perspectives/fitting/model_thread.py
@@ -64,7 +64,7 @@ class Calc2D(CalcThread):
 
         if self.data is None:
             msg = "Compute Calc2D receive data = %s.\n" % str(self.data)
-            raise ValueError, msg
+            raise ValueError(msg)
 
         # Define matrix where data will be plotted
         radius = np.sqrt((self.data.qx_data * self.data.qx_data) + \

--- a/src/sas/sasgui/perspectives/fitting/models.py
+++ b/src/sas/sasgui/perspectives/fitting/models.py
@@ -141,7 +141,7 @@ class ReportProblem:
         type, value, tb = sys.exc_info()
         if type is not None and issubclass(type, py_compile.PyCompileError):
             print "Problem with", repr(value)
-            raise type, value, tb
+            raise type(value).with_traceback(tb)
         return 1
 
 report_problem = ReportProblem()

--- a/src/sas/sasgui/perspectives/fitting/pagestate.py
+++ b/src/sas/sasgui/perspectives/fitting/pagestate.py
@@ -1013,7 +1013,7 @@ class PageState(object):
         if file is not None:
             msg = "PageState no longer supports non-CanSAS"
             msg += " format for fitting files"
-            raise RuntimeError, msg
+            raise RuntimeError(msg)
 
         if node.get('version'):
             # Get the version for model conversion purposes
@@ -1309,7 +1309,7 @@ class Reader(CansasReader):
 
             else:
                 self.call_back(format=ext)
-                raise RuntimeError, "%s is not a file" % path
+                raise RuntimeError("%s is not a file" % path)
 
             # Return output consistent with the loader's api
             if len(output) == 0:

--- a/src/sas/sasgui/perspectives/invariant/invariant.py
+++ b/src/sas/sasgui/perspectives/invariant/invariant.py
@@ -132,7 +132,7 @@ class Plugin(PluginBase):
         if not issubclass(data.__class__, Data1D):
             name = data.__class__.__name__
             msg = "Invariant use only Data1D got: [%s] " % str(name)
-            raise ValueError, msg
+            raise ValueError(msg)
         self.compute_helper(data=data)
 
     def set_data(self, data_list=None):
@@ -239,7 +239,7 @@ class Plugin(PluginBase):
         else:
             msg = "invariant.save_file: the data being saved is"
             msg += " not a sas.sascalc.dataloader.data_info.Data1D object"
-            raise RuntimeError, msg
+            raise RuntimeError(msg)
 
     def set_state(self, state=None, datainfo=None):
         """
@@ -257,7 +257,7 @@ class Plugin(PluginBase):
             if data is None:
                 msg = "invariant.set_state: datainfo parameter cannot"
                 msg += " be None in standalone mode"
-                raise RuntimeError, msg
+                raise RuntimeError(msg)
             # Make sure the user sees the invariant panel after loading
             # self.parent.set_perspective(self.perspective)
             self.on_perspective(event=None)
@@ -319,7 +319,7 @@ class Plugin(PluginBase):
             new_plot.symbol = GUIFRAME_ID.CURVE_SYMBOL_NUM
         else:
             msg = "Scale can not be zero."
-            raise ValueError, msg
+            raise ValueError(msg)
         if len(new_plot.x) == 0:
             return
 

--- a/src/sas/sasgui/perspectives/invariant/invariant_panel.py
+++ b/src/sas/sasgui/perspectives/invariant/invariant_panel.py
@@ -317,12 +317,12 @@ class InvariantPanel(ScrolledPanel, PanelBase):
         """
         background = self.background_tcl.GetValue().lstrip().rstrip()
         if background == "":
-            raise ValueError, "Need a background"
+            raise ValueError("Need a background")
         if check_float(self.background_tcl):
             return float(background)
         else:
             msg = "Receive invalid value for background : %s" % (background)
-            raise ValueError, msg
+            raise ValueError(msg)
 
     def get_scale(self):
         """
@@ -330,16 +330,16 @@ class InvariantPanel(ScrolledPanel, PanelBase):
         """
         scale = self.scale_tcl.GetValue().lstrip().rstrip()
         if scale == "":
-            raise ValueError, "Need a background"
+            raise ValueError("Need a background")
         if check_float(self.scale_tcl):
             if float(scale) <= 0.0:
                 self.scale_tcl.SetBackgroundColour("pink")
                 self.scale_tcl.Refresh()
                 msg = "Receive invalid value for scale: %s" % (scale)
-                raise ValueError, msg
+                raise ValueError(msg)
             return float(scale)
         else:
-            raise ValueError, "Receive invalid value for scale : %s" % (scale)
+            raise ValueError("Receive invalid value for scale : %s" % (scale))
 
     def get_contrast(self):
         """
@@ -864,7 +864,7 @@ class InvariantPanel(ScrolledPanel, PanelBase):
             _, _, current_state, comp_state = self.state.bookmark_list[int(num)]
         except:
             logger.error(sys.exc_value)
-            raise ValueError, "No such bookmark exists"
+            raise ValueError("No such bookmark exists")
 
         # set the parameters
         for key in comp_state:

--- a/src/sas/sasgui/perspectives/invariant/invariant_state.py
+++ b/src/sas/sasgui/perspectives/invariant/invariant_state.py
@@ -364,7 +364,7 @@ class InvariantState(object):
         if file is not None:
             msg = "InvariantSate no longer supports non-CanSAS"
             msg += " format for invariant files"
-            raise RuntimeError, msg
+            raise RuntimeError(msg)
 
         if node.get('version')\
             and node.get('version') == '1.0':
@@ -738,7 +738,7 @@ class Reader(CansasReader):
                         sas_entry.filename = invstate.file
                         output.append(sas_entry)
         else:
-            raise RuntimeError, "%s is not a file" % path
+            raise RuntimeError("%s is not a file" % path)
 
         # Return output consistent with the loader's api
         if len(output) == 0:
@@ -784,7 +784,7 @@ class Reader(CansasReader):
         elif not issubclass(datainfo.__class__, sas.sascalc.dataloader.data_info.Data1D):
             msg = "The cansas writer expects a Data1D"
             msg += " instance: %s" % str(datainfo.__class__.__name__)
-            raise RuntimeError, msg
+            raise RuntimeError(msg)
         # make sure title and data run is filled up.
         if datainfo.title is None or datainfo.title == '':
             datainfo.title = datainfo.name

--- a/src/sas/sasgui/perspectives/pr/inversion_panel.py
+++ b/src/sas/sasgui/perspectives/pr/inversion_panel.py
@@ -853,7 +853,7 @@ class InversionControl(ScrolledPanel, PanelBase):
                 message = "Number of function terms should be smaller "
                 message += "than the number of points"
                 wx.PostEvent(self._manager.parent, StatusEvent(status=message))
-                raise ValueError, message
+                raise ValueError(message)
             self.nfunc_ctl.SetBackgroundColour(wx.WHITE)
             self.nfunc_ctl.Refresh()
         except:

--- a/src/sas/sasgui/perspectives/pr/inversion_state.py
+++ b/src/sas/sasgui/perspectives/pr/inversion_state.py
@@ -234,7 +234,7 @@ class InversionState(object):
         if file is not None:
             msg = "InversionState no longer supports non-CanSAS"
             msg += " format for P(r) files"
-            raise RuntimeError, msg
+            raise RuntimeError(msg)
 
         if node.get('version') and node.get('version') == '1.0':
 
@@ -477,7 +477,7 @@ class Reader(CansasReader):
                         sas_entry.filename = prstate.file
                         output.append(sas_entry)
         else:
-            raise RuntimeError, "%s is not a file" % path
+            raise RuntimeError("%s is not a file" % path)
 
         # Return output consistent with the loader's api
         if len(output) == 0:
@@ -521,7 +521,7 @@ class Reader(CansasReader):
         elif not issubclass(datainfo.__class__, Data1D):
             msg = "The cansas writer expects a Data1D "
             msg += "instance: %s" % str(datainfo.__class__.__name__)
-            raise RuntimeError, msg
+            raise RuntimeError(msg)
 
         # Create basic XML document
         doc, sasentry = self._to_xml_doc(datainfo)

--- a/src/sas/sasgui/perspectives/pr/pr.py
+++ b/src/sas/sasgui/perspectives/pr/pr.py
@@ -148,7 +148,7 @@ class Plugin(PluginBase):
             if data is None:
                 msg = "Pr.set_state: datainfo parameter cannot "
                 msg += "be None in standalone mode"
-                raise RuntimeError, msg
+                raise RuntimeError(msg)
 
             # Ensuring that plots are coordinated correctly
             t = time.localtime(data.meta_data['prstate'].timestamp)
@@ -449,7 +449,7 @@ class Plugin(PluginBase):
         dataread = data
         # Notify the user if we could not read the file
         if dataread is None:
-            raise RuntimeError, "Invalid data"
+            raise RuntimeError("Invalid data")
 
         x = None
         y = None
@@ -469,7 +469,7 @@ class Plugin(PluginBase):
             else:
                 if dataread is None:
                     return x, y, err
-                raise RuntimeError, "This tool can only read 1D data"
+                raise RuntimeError("This tool can only read 1D data")
 
         self._current_file_data.x = x
         self._current_file_data.y = y
@@ -848,11 +848,11 @@ class Plugin(PluginBase):
             except:
                 status = "Problem reading data: %s" % sys.exc_value
                 wx.PostEvent(self.parent, StatusEvent(status=status))
-                raise RuntimeError, status
+                raise RuntimeError(status)
 
             # If the file contains nothing, just return
             if pr is None:
-                raise RuntimeError, "Loaded data is invalid"
+                raise RuntimeError("Loaded data is invalid")
 
             self.pr = pr
 
@@ -902,7 +902,7 @@ class Plugin(PluginBase):
         else:
             msg = "pr.save_data: the data being saved is not a"
             msg += " sas.data_info.Data1D object"
-            raise RuntimeError, msg
+            raise RuntimeError(msg)
 
     def setup_plot_inversion(self, alpha, nfunc, d_max, q_min=None, q_max=None,
                              bck=False, height=0, width=0):

--- a/src/sas/sasgui/perspectives/simulation/ShapeAdapter.py
+++ b/src/sas/sasgui/perspectives/simulation/ShapeAdapter.py
@@ -86,7 +86,7 @@ class ShapeVisitor:
             
             self.sim_canvas._model_changed()
         else:
-            raise ValueError, "SimShapeVisitor: Wrong class for visited object"
+            raise ValueError("SimShapeVisitor: Wrong class for visited object")
         
         
         
@@ -114,7 +114,7 @@ class ShapeVisitor:
             
             self.sim_canvas._model_changed()
         else:
-            raise ValueError, "SimShapeVisitor: Wrong class for visited object"
+            raise ValueError("SimShapeVisitor: Wrong class for visited object")
         
     
     def update(self, volCanvas, shape):
@@ -129,5 +129,5 @@ class ShapeVisitor:
             self.sim_canvas = volCanvas
             shape.accept_update(self)
         else:
-            raise ValueError, "ShapeAdapter: Shape [%s] not in list" % shape.name
+            raise ValueError("ShapeAdapter: Shape [%s] not in list" % shape.name)
 

--- a/src/sas/sasgui/plottools/LineModel.py
+++ b/src/sas/sasgui/plottools/LineModel.py
@@ -81,7 +81,7 @@ class LineModel(object):
                                 self._line(x[0] * math.sin(x[1]))
         elif x.__class__.__name__ == 'tuple':
             msg = "Tuples are not allowed as input to BaseComponent models"
-            raise ValueError, msg
+            raise ValueError(msg)
         else:
             return self._line(x)
 
@@ -103,6 +103,6 @@ class LineModel(object):
             return self._line(x[0]) * self._line(x[1])
         elif x.__class__.__name__ == 'tuple':
             msg = "Tuples are not allowed as input to BaseComponent models"
-            raise ValueError, msg
+            raise ValueError(msg)
         else:
             return self._line(x)

--- a/src/sas/sasgui/plottools/binder.py
+++ b/src/sas/sasgui/plottools/binder.py
@@ -186,8 +186,8 @@ class BindArtist(object):
         """
         # Check that the trigger is valid
         if trigger not in self._actions:
-            raise ValueError, "%s invalid --- valid triggers are %s"\
-                 % (trigger, ", ".join(self.events))
+            raise ValueError("%s invalid --- valid triggers are %s"\
+                 % (trigger, ", ".join(self.events)))
 
         # Register the trigger callback
         self._actions[trigger][artist] = action
@@ -202,7 +202,7 @@ class BindArtist(object):
         to figure, and to 'all' if the event is not processed.
         """
         if action not in self.events:
-            raise ValueError, "Trigger expects " + ", ".join(self.events)
+            raise ValueError("Trigger expects " + ", ".join(self.events))
 
         # Tag the event with modifiers
         for mod in ('alt', 'control', 'shift', 'meta'):

--- a/src/sas/sasgui/plottools/convert_units.py
+++ b/src/sas/sasgui/plottools/convert_units.py
@@ -41,12 +41,12 @@ def convert_unit(power, unit):
                         else:
                             unit = toks[0] + "^{" + str(powerer) + "}"
                 else:
-                    raise ValueError, "missing } in unit expression"
+                    raise ValueError("missing } in unit expression")
         else:  # no powerer
             if  power != 1:
                 unit = "(" + unit + ")" + "^{" + str(power) + "}"
     else:
-        raise ValueError, "empty unit ,enter a powerer different from zero"
+        raise ValueError("empty unit ,enter a powerer different from zero")
     return unit
 
 

--- a/src/sas/sasgui/plottools/fitDialog.py
+++ b/src/sas/sasgui/plottools/fitDialog.py
@@ -670,7 +670,7 @@ class LinearFit(wx.Dialog):
             if x > 0:
                 return x
             else:
-                raise ValueError, "cannot compute log of a negative number"
+                raise ValueError("cannot compute log of a negative number")
 
     def floatInvTransform(self, x):
         """
@@ -733,7 +733,7 @@ class LinearFit(wx.Dialog):
             float(xmax)
         except:
             msg = "LinearFit.set_fit_region: fit range must be floats"
-            raise ValueError, msg
+            raise ValueError(msg)
         self.xminFit.SetValue(format_number(xmin))
         self.xmaxFit.SetValue(format_number(xmax))
 

--- a/src/sas/sasgui/plottools/plottables.py
+++ b/src/sas/sasgui/plottools/plottables.py
@@ -385,7 +385,7 @@ class Transform(object):
         user, along with an indication of which plottable was at fault.
 
         """
-        raise NotImplemented, "Not a valid transform"
+        raise NotImplemented("Not a valid transform")
 
     # Related issues
     # ==============
@@ -685,17 +685,17 @@ class View(object):
             if dx is not None and not len(dx) == 0 and not len(x) == len(dx):
                 msg = "Plottable.View: Given x and dx are not"
                 msg += " of the same length"
-                raise ValueError, msg
+                raise ValueError(msg)
             # Check length of y array
             if not len(y) == len(x):
                 msg = "Plottable.View: Given y "
                 msg += "and x are not of the same length"
-                raise ValueError, msg
+                raise ValueError(msg)
 
             if dy is not None and not len(dy) == 0 and not len(y) == len(dy):
                 msg = "Plottable.View: Given y and dy are not of the same "
                 msg += "length: len(y)=%s, len(dy)=%s" % (len(y), len(dy))
-                raise ValueError, msg
+                raise ValueError(msg)
             self.x = []
             self.y = []
             if has_err_x:
@@ -730,15 +730,15 @@ class View(object):
             if not len(self.x) == len(self.y):
                 msg = "Plottable.View: transformed x "
                 msg += "and y are not of the same length"
-                raise ValueError, msg
+                raise ValueError(msg)
             if has_err_x and not (len(self.x) == len(self.dx)):
                 msg = "Plottable.View: transformed x and dx"
                 msg += " are not of the same length"
-                raise ValueError, msg
+                raise ValueError(msg)
             if has_err_y and not (len(self.y) == len(self.dy)):
                 msg = "Plottable.View: transformed y"
                 msg += " and dy are not of the same length"
-                raise ValueError, msg
+                raise ValueError(msg)
             # Check that negative values are not plot on x and y axis for
             # log10 transformation
             self.check_data_logX()
@@ -1104,7 +1104,7 @@ class Theory1D(Plottable):
         """
         Plottable.__init__(self)
         msg = "Theory1D is no longer supported, please use Data1D and change symbol.\n"
-        raise DeprecationWarning, msg
+        raise DeprecationWarning(msg)
 
 class Fit1D(Plottable):
     """

--- a/src/sas/sasgui/plottools/transform.py
+++ b/src/sas/sasgui/plottools/transform.py
@@ -23,7 +23,7 @@ def toX_pos(x, y=None):
 
     """
     if not x > 0:
-        raise ValueError, "Transformation only accepts positive values."
+        raise ValueError("Transformation only accepts positive values.")
     else:
         return x
 
@@ -49,7 +49,7 @@ def fromX2(x, y=None):
 
     """
     if not x >= 0:
-        raise ValueError, "square root of a negative value "
+        raise ValueError("square root of a negative value ")
     else:
         return math.sqrt(x)
 
@@ -75,7 +75,7 @@ def fromX4(x, y=None):
 
     """
     if not x >= 0:
-        raise ValueError, "double square root of a negative value "
+        raise ValueError("double square root of a negative value ")
     else:
         return math.sqrt(math.sqrt(x))
 
@@ -89,7 +89,7 @@ def toLogX(x, y=None):
 
     """
     if not x > 0:
-        raise ValueError, "Log(x)of a negative value "
+        raise ValueError("Log(x)of a negative value ")
     else:
         return math.log(x)
 
@@ -99,7 +99,7 @@ def toOneOverX(x, y=None):
     if x != 0:
         return 1 / x
     else:
-        raise ValueError, "cannot divide by zero"
+        raise ValueError("cannot divide by zero")
 
 
 def toOneOverSqrtX(y, x=None):
@@ -108,7 +108,7 @@ def toOneOverSqrtX(y, x=None):
     if y > 0:
         return 1 / math.sqrt(y)
     else:
-        raise ValueError, "transform.toOneOverSqrtX: cannot be computed"
+        raise ValueError("transform.toOneOverSqrtX: cannot be computed")
 
 
 def toLogYX2(y, x):
@@ -117,7 +117,7 @@ def toLogYX2(y, x):
     if (y * (x ** 2)) > 0:
         return math.log(y * (x ** 2))
     else:
-        raise ValueError, "transform.toLogYX2: cannot be computed"
+        raise ValueError("transform.toLogYX2: cannot be computed")
 
 
 def toLogYX4(y, x):
@@ -126,7 +126,7 @@ def toLogYX4(y, x):
     if (math.pow(x, 4) * y) > 0:
         return math.log(math.pow(x, 4) * y)
     else:
-        raise ValueError, "transform.toLogYX4: input error"
+        raise ValueError("transform.toLogYX4: input error")
 
 
 def toYX4(y, x):
@@ -148,7 +148,7 @@ def toLogXY(y, x):
 
     """
     if not (x * y) > 0:
-        raise ValueError, "Log(X*Y)of a negative value "
+        raise ValueError("Log(X*Y)of a negative value ")
     else:
         return math.log(x * y)
 
@@ -210,7 +210,7 @@ def errFromX2(x, y=None, dx=None, dy=None):
         return math.fabs(err)
     else:
         msg = "transform.errFromX2: can't compute error of negative x"
-        raise ValueError, msg
+        raise ValueError(msg)
 
 
 def errToX4(x, y=None, dx=None, dy=None):
@@ -244,7 +244,7 @@ def errFromX4(x, y=None, dx=None, dy=None):
         return math.fabs(err)
     else:
         msg = "transform.errFromX4: can't compute error of negative x"
-        raise ValueError, msg
+        raise ValueError(msg)
 
 
 def errToLog10X(x, y=None, dx=None, dy=None):
@@ -263,11 +263,11 @@ def errToLog10X(x, y=None, dx=None, dy=None):
     if not (x - dx) > 0:
         msg = "Transformation does not accept"
         msg += " point that are consistent with zero."
-        raise ValueError, msg
+        raise ValueError(msg)
     if x != 0:
         dx = dx / (x * math.log(10))
     else:
-        raise ValueError, "errToLogX: divide by zero"
+        raise ValueError("errToLogX: divide by zero")
     return dx
 
 
@@ -286,7 +286,7 @@ def errToLogX(x, y=None, dx=None, dy=None):
     if x != 0:
         dx = dx / x
     else:
-        raise ValueError, "errToLogX: divide by zero"
+        raise ValueError("errToLogX: divide by zero")
     return dx
 
 
@@ -311,7 +311,7 @@ def errToLogXY(x, y, dx=None, dy=None):
     if not (x - dx) > 0 or not (y - dy) > 0:
         msg = "Transformation does not accept point "
         msg += " that are consistent with zero."
-        raise ValueError, msg
+        raise ValueError(msg)
     if x != 0 and y != 0:
         if dx is None:
             dx = 0
@@ -319,7 +319,7 @@ def errToLogXY(x, y, dx=None, dy=None):
             dy = 0
         err = (dx / x) ** 2 + (dy / y) ** 2
     else:
-        raise ValueError, "cannot compute this error"
+        raise ValueError("cannot compute this error")
 
     return math.sqrt(math.fabs(err))
 
@@ -334,7 +334,7 @@ def errToLogYX2(y, x, dy=None, dx=None):
     if not (x - dx) > 0 or not (y - dy) > 0:
         msg = "Transformation does not accept point"
         msg += " that are consistent with zero."
-        raise ValueError, msg
+        raise ValueError(msg)
     if x > 0 and y > 0:
         if dx is None:
             dx = 0
@@ -342,7 +342,7 @@ def errToLogYX2(y, x, dy=None, dx=None):
             dy = 0
         err = (2.0 * dx / x) ** 2 + (dy / y) ** 2
     else:
-        raise ValueError, "cannot compute this error"
+        raise ValueError("cannot compute this error")
     return math.sqrt(math.fabs(err))
 
 
@@ -356,7 +356,7 @@ def errOneOverX(x, y=None, dx=None, dy=None):
             dx = 0
         err = dx / x ** 2
     else:
-        raise ValueError, "Cannot compute this error"
+        raise ValueError("Cannot compute this error")
     return math.fabs(err)
 
 
@@ -370,7 +370,7 @@ def errOneOverSqrtX(x, y=None, dx=None, dy=None):
             dx = 0
         err = -1 / 2 * math.pow(x, -3.0 / 2.0) * dx
     else:
-        raise ValueError, "Cannot compute this error"
+        raise ValueError("Cannot compute this error")
     return math.fabs(err)
 
 
@@ -386,7 +386,7 @@ def errToLogYX4(y, x, dy=None, dx=None):
     if (not (x - dx) > 0) or (not (y - dy) > 0):
         msg = "Transformation does not accept point "
         msg += " that are consistent with zero."
-        raise ValueError, msg
+        raise ValueError(msg)
     if dx is None:
         dx = 0
     if dy is None:

--- a/test/sasdataloader/plugins/test_reader.py
+++ b/test/sasdataloader/plugins/test_reader.py
@@ -37,7 +37,7 @@ class Reader:
                 try:
                     input_f =  open(path,'r')
                 except :
-                    raise  RuntimeError, "ascii_reader: cannot open %s" % path
+                    raise  RuntimeError("ascii_reader: cannot open %s" % path)
                 buff = input_f.read()
                 lines = buff.split('\n')
                 x  = np.zeros(0)
@@ -52,7 +52,7 @@ class Reader:
                 output.x = x
                 return output
         else:
-            raise RuntimeError, "%s is not a file" % path
+            raise RuntimeError("%s is not a file" % path)
         return None
     
 if __name__ == "__main__": 

--- a/test/sasdataloader/test/utest_abs_reader.py
+++ b/test/sasdataloader/test/utest_abs_reader.py
@@ -274,7 +274,7 @@ class cansas_reader(unittest.TestCase):
                 _found2 = True
                 
         if _found1==False or _found2==False:
-            raise RuntimeError, "Could not find all data %s %s" % (_found1, _found2) 
+            raise RuntimeError("Could not find all data %s %s" % (_found1, _found2)) 
             
         # Detector
         self.assertEqual(self.data.detector[0].name, "fictional hybrid")
@@ -320,7 +320,7 @@ class cansas_reader(unittest.TestCase):
                     _found_term1 = True
                     
         if _found_term1==False or _found_term2==False:
-            raise RuntimeError, "Could not find all process terms %s %s" % (_found_term1, _found_term2) 
+            raise RuntimeError("Could not find all process terms %s %s" % (_found_term1, _found_term2)) 
             
         
         

--- a/test/sasrealspace/test/utest_oriented.py
+++ b/test/sasrealspace/test/utest_oriented.py
@@ -241,7 +241,7 @@ class TestEllipsoid(unittest.TestCase):
             self.assert_( math.fabs(sim_val/ana_val-1.0)<0.05 )
         except:
             print "Error", ana_val, sim_val, sim_val/ana_val
-            raise sys.exc_type, sys.exc_value
+            raise sys.exc_type(sys.exc_value)
 
 class TestCoreShell(unittest.TestCase):
     """ Tests for oriented (2D) systems """
@@ -395,7 +395,7 @@ class TestRunMethods(unittest.TestCase):
             self.assert_( math.fabs(sim_val/ana_val-1.0)<0.05 )
         except:
             print "Error", ana_val, sim_val, sim_val/ana_val
-            raise sys.exc_type, sys.exc_value
+            raise sys.exc_type(sys.exc_value)
 
     def testRunXY_float(self):
         """ Testing ellipsoid along X """
@@ -407,7 +407,7 @@ class TestRunMethods(unittest.TestCase):
             self.assert_( math.fabs(sim_val/ana_val-1.0)<0.05 )
         except:
             print "Error", ana_val, sim_val, sim_val/ana_val
-            raise sys.exc_type, sys.exc_value
+            raise sys.exc_type(sys.exc_value)
 
     def testRun_float(self):
         """ Testing ellipsoid along X """
@@ -419,7 +419,7 @@ class TestRunMethods(unittest.TestCase):
             self.assert_( math.fabs(sim_val/ana_val-1.0)<0.05 )
         except:
             print "Error", ana_val, sim_val, sim_val/ana_val
-            raise sys.exc_type, sys.exc_value
+            raise sys.exc_type(sys.exc_value)
 
     def testRun_list(self):
         """ Testing ellipsoid along X """
@@ -431,7 +431,7 @@ class TestRunMethods(unittest.TestCase):
             self.assert_( math.fabs(sim_val/ana_val-1.0)<0.05 )
         except:
             print "Error", ana_val, sim_val, sim_val/ana_val
-            raise sys.exc_type, sys.exc_value
+            raise sys.exc_type(sys.exc_value)
 
 class TestParamChange(unittest.TestCase):
     """ Tests for oriented (2D) systems """


### PR DESCRIPTION
Raising errors as `raise ValueError, msg` is now deprecated in favour of `raise ValueError(msg)`. This PR has used the `2to3 -w -f raise *.py` on each of these files to make these changes. I'm not sure if I've missed any. The changes were automated. I did not inspect each change.