### PR TITLE
fixes #865

### DIFF
--- a/src/sas/sasgui/perspectives/fitting/fitpage.py
+++ b/src/sas/sasgui/perspectives/fitting/fitpage.py
@@ -1238,7 +1238,6 @@ class FitPage(BasicPage):
             custom_model = CUSTOM_MODEL
             mod_cat = self.categorybox.GetStringSelection()
             if mod_cat == custom_model:
-                ################This is where the model dies###############
                 temp_id = self.model.id
                 temp = self.parent.update_model_list()
                 for v in self.parent.model_dictionary.values():

--- a/src/sas/sasgui/perspectives/fitting/fitpage.py
+++ b/src/sas/sasgui/perspectives/fitting/fitpage.py
@@ -1238,7 +1238,12 @@ class FitPage(BasicPage):
             custom_model = CUSTOM_MODEL
             mod_cat = self.categorybox.GetStringSelection()
             if mod_cat == custom_model:
+                ################This is where the model dies###############
+                temp_id = self.model.id
                 temp = self.parent.update_model_list()
+                for v in self.parent.model_dictionary.values():
+                    if v.id == temp_id:
+                        self.model = v()
                 if temp:
                     self.model_list_box = temp
                     current_val = self.formfactorbox.GetLabel()

--- a/src/sas/sasgui/perspectives/fitting/models.py
+++ b/src/sas/sasgui/perspectives/fitting/models.py
@@ -318,8 +318,8 @@ class ModelManagerBase:
         new models were added else return empty dictionary
         """
         new_plugins = self.findModels()
-        if len(new_plugins) > 0:
-            for name, plug in  new_plugins.iteritems():
+        if new_plugins:
+            for name, plug in  new_plugins.items():
                 self.stored_plugins[name] = plug
                 self.plugins.append(plug)
                 self.model_dictionary[name] = plug

--- a/src/sas/sasgui/perspectives/fitting/models.py
+++ b/src/sas/sasgui/perspectives/fitting/models.py
@@ -320,10 +320,9 @@ class ModelManagerBase:
         new_plugins = self.findModels()
         if len(new_plugins) > 0:
             for name, plug in  new_plugins.iteritems():
-                if name not in self.stored_plugins.keys():
-                    self.stored_plugins[name] = plug
-                    self.plugins.append(plug)
-                    self.model_dictionary[name] = plug
+                self.stored_plugins[name] = plug
+                self.plugins.append(plug)
+                self.model_dictionary[name] = plug
             self.model_combobox.set_list("Plugin Models", self.plugins)
             return self.model_combobox.get_list()
         else:


### PR DESCRIPTION
I've tracked the namespace bug down to a single function call and I've managed to write a work around, but I'm at a bit of a loss as to what exactly is causing the bug.

If you look at the original code, you can call self.model.calculate_Iq() before line 1241 and get your Iq value back.  If you call it after line 1241, then you run into the namespace issue.  Debugging further than that is problematic because

a) self.model is not in scope within the function, so it' impossible to tell where it's being corrupted
b) the model loaded BY update_model_list is not corrupted.  In fact, this is a necessary component of the work around.

What this code does is store the ID of the (currently functional) model before calling self.parent.update_model_list().  It then calls the update and, somehow, corrupts the model.  When then find that model ID in the update model dictionary and use that valid model for the rest of the routine.