### PR TITLE
Improve model reloading bug

### DIFF
--- a/src/sas/sasgui/perspectives/fitting/fitpage.py
+++ b/src/sas/sasgui/perspectives/fitting/fitpage.py
@@ -1238,7 +1238,6 @@ class FitPage(BasicPage):
             custom_model = CUSTOM_MODEL
             mod_cat = self.categorybox.GetStringSelection()
             if mod_cat == custom_model:
-                ################This is where the model dies###############
                 temp_id = self.model.id
                 temp = self.parent.update_model_list()
                 for v in self.parent.model_dictionary.values():

--- a/src/sas/sasgui/perspectives/fitting/fitpage.py
+++ b/src/sas/sasgui/perspectives/fitting/fitpage.py
@@ -1235,9 +1235,8 @@ class FitPage(BasicPage):
             new_event = PageInfoEvent(page=self)
             wx.PostEvent(self.parent, new_event)
             # update list of plugins if new plugin is available
-            custom_model = CUSTOM_MODEL
             mod_cat = self.categorybox.GetStringSelection()
-            if mod_cat == custom_model:
+            if mod_cat == CUSTOM_MODEL:
                 temp_id = self.model.id
                 temp = self.parent.update_model_list()
                 for v in self.parent.model_dictionary.values():

--- a/src/sas/sasgui/perspectives/fitting/fitpage.py
+++ b/src/sas/sasgui/perspectives/fitting/fitpage.py
@@ -1242,6 +1242,7 @@ class FitPage(BasicPage):
                 for v in self.parent.model_dictionary.values():
                     if v.id == temp_id:
                         self.model = v()
+                        break
                 if temp:
                     self.model_list_box = temp
                     current_val = self.formfactorbox.GetLabel()

--- a/src/sas/sasgui/perspectives/fitting/fitpage.py
+++ b/src/sas/sasgui/perspectives/fitting/fitpage.py
@@ -1238,7 +1238,12 @@ class FitPage(BasicPage):
             custom_model = CUSTOM_MODEL
             mod_cat = self.categorybox.GetStringSelection()
             if mod_cat == custom_model:
+                ################This is where the model dies###############
+                temp_id = self.model.id
                 temp = self.parent.update_model_list()
+                for v in self.parent.model_dictionary.values():
+                    if v.id == temp_id:
+                        self.model = v()
                 if temp:
                     self.model_list_box = temp
                     current_val = self.formfactorbox.GetLabel()

--- a/src/sas/sasgui/perspectives/fitting/models.py
+++ b/src/sas/sasgui/perspectives/fitting/models.py
@@ -318,8 +318,8 @@ class ModelManagerBase:
         new models were added else return empty dictionary
         """
         new_plugins = self.findModels()
-        if len(new_plugins) > 0:
-            for name, plug in  new_plugins.iteritems():
+        if new_plugins:
+            for name, plug in  new_plugins.items():
                 self.stored_plugins[name] = plug
                 self.plugins.append(plug)
                 self.model_dictionary[name] = plug

--- a/src/sas/sasgui/perspectives/fitting/models.py
+++ b/src/sas/sasgui/perspectives/fitting/models.py
@@ -320,10 +320,9 @@ class ModelManagerBase:
         new_plugins = self.findModels()
         if len(new_plugins) > 0:
             for name, plug in  new_plugins.iteritems():
-                if name not in self.stored_plugins.keys():
-                    self.stored_plugins[name] = plug
-                    self.plugins.append(plug)
-                    self.model_dictionary[name] = plug
+                self.stored_plugins[name] = plug
+                self.plugins.append(plug)
+                self.model_dictionary[name] = plug
             self.model_combobox.set_list("Plugin Models", self.plugins)
             return self.model_combobox.get_list()
         else:

--- a/src/sas/sasgui/perspectives/fitting/models.py
+++ b/src/sas/sasgui/perspectives/fitting/models.py
@@ -319,6 +319,7 @@ class ModelManagerBase:
         return a dictionary of model if
         new models were added else return empty dictionary
         """
+        self.plugins = []
         new_plugins = self.findModels()
         if new_plugins:
             for name, plug in  new_plugins.items():

--- a/src/sas/sasgui/perspectives/fitting/models.py
+++ b/src/sas/sasgui/perspectives/fitting/models.py
@@ -259,7 +259,9 @@ class ModelManagerBase:
         """
         temp = {}
         if self.is_changed():
-            return  _findModels(dir)
+            temp =  _findModels(dir)
+            self.last_time_dir_modified = time.time()
+            return temp
         logging.info("plugin model : %s" % str(temp))
         return temp
 
@@ -306,7 +308,7 @@ class ModelManagerBase:
         plugin_dir = find_plugins_dir()
         if os.path.isdir(plugin_dir):
             temp = os.path.getmtime(plugin_dir)
-            if  self.last_time_dir_modified != temp:
+            if  self.last_time_dir_modified < temp:
                 is_modified = True
                 self.last_time_dir_modified = temp
 

--- a/src/sas/sasgui/perspectives/fitting/models.py
+++ b/src/sas/sasgui/perspectives/fitting/models.py
@@ -17,6 +17,7 @@ import shutil
 from sas.sascalc.fit.pluginmodel import Model1DPlugin
 from sas.sasgui.guiframe.CategoryInstaller import CategoryInstaller
 from sasmodels.sasview_model import load_custom_model, load_standard_models
+from sas.sasgui.perspectives.fitting.fitpage import CUSTOM_MODEL
 
 
 PLUGIN_DIR = 'plugin_models'
@@ -326,7 +327,7 @@ class ModelManagerBase:
                 self.stored_plugins[name] = plug
                 self.plugins.append(plug)
                 self.model_dictionary[name] = plug
-            self.model_combobox.set_list("Plugin Models", self.plugins)
+            self.model_combobox.set_list(CUSTOM_MODEL, self.plugins)
             return self.model_combobox.get_list()
         else:
             return {}


### PR DESCRIPTION
There was an awkward bug where, if a plugin model was modified (so that the .py and the .pyc were out of sync), it would cause an error message until the user reloaded the models.