### PR TITLE
Find models tidy

### DIFF
--- a/src/sas/sasgui/perspectives/fitting/models.py
+++ b/src/sas/sasgui/perspectives/fitting/models.py
@@ -173,7 +173,7 @@ def _findModels(dir):
         return {}
 
     plugin_log("looking for models in: %s" % str(dir))
-    #compile_file(dir)  #always recompile the folder plugin
+    # compile_file(dir)  #always recompile the folder plugin
     logger.info("plugin model dir: %s" % str(dir))
 
     plugins = {}
@@ -190,8 +190,8 @@ def _findModels(dir):
                 msg += "\nwhile accessing model in %r" % path
                 plugin_log(msg)
                 logger.warning("Failed to load plugin %r. See %s for details"
-                                % (path, PLUGIN_LOG))
-            
+                               % (path, PLUGIN_LOG))
+
     return plugins
 
 

--- a/src/sas/sasgui/perspectives/fitting/models.py
+++ b/src/sas/sasgui/perspectives/fitting/models.py
@@ -160,7 +160,7 @@ def compile_file(dir):
     return None
 
 
-def _findModels(dir):
+def _findModels():
     """
     Find custom models
     """
@@ -261,7 +261,7 @@ class ModelManagerBase:
         """
         temp = {}
         if self.is_changed():
-            return  _findModels(dir)
+            return  _findModels()
         logger.info("plugin model : %s" % str(temp))
         return temp
 
@@ -336,7 +336,7 @@ class ModelManagerBase:
         return a dictionary of model
         """
         self.plugins = []
-        new_plugins = _findModels(dir)
+        new_plugins = _findModels()
         for name, plug in  new_plugins.iteritems():
             for stored_name, stored_plug in self.stored_plugins.iteritems():
                 if name == stored_name:

--- a/src/sas/sasgui/perspectives/fitting/models.py
+++ b/src/sas/sasgui/perspectives/fitting/models.py
@@ -160,7 +160,7 @@ def compile_file(dir):
     return None
 
 
-def _findModels():
+def _find_models():
     """
     Find custom models
     """
@@ -261,7 +261,7 @@ class ModelManagerBase:
         """
         temp = {}
         if self.is_changed():
-            return  _findModels()
+            return  _find_models()
         logger.info("plugin model : %s" % str(temp))
         return temp
 
@@ -336,7 +336,7 @@ class ModelManagerBase:
         return a dictionary of model
         """
         self.plugins = []
-        new_plugins = _findModels()
+        new_plugins = _find_models()
         for name, plug in  new_plugins.iteritems():
             for stored_name, stored_plug in self.stored_plugins.iteritems():
                 if name == stored_name:

--- a/src/sas/sasgui/perspectives/fitting/models.py
+++ b/src/sas/sasgui/perspectives/fitting/models.py
@@ -165,22 +165,22 @@ def _findModels():
     Find custom models
     """
     # List of plugin objects
-    dir = find_plugins_dir()
+    directory = find_plugins_dir()
     # Go through files in plug-in directory
-    if not os.path.isdir(dir):
-        msg = "SasView couldn't locate Model plugin folder %r." % dir
+    if not os.path.isdir(directory):
+        msg = "SasView couldn't locate Model plugin folder %r." % directory
         logger.warning(msg)
         return {}
 
-    plugin_log("looking for models in: %s" % str(dir))
-    # compile_file(dir)  #always recompile the folder plugin
-    logger.info("plugin model dir: %s" % str(dir))
+    plugin_log("looking for models in: %s" % str(directory))
+    # compile_file(directory)  #always recompile the folder plugin
+    logger.info("plugin model dir: %s" % str(directory))
 
     plugins = {}
-    for filename in os.listdir(dir):
+    for filename in os.listdir(directory):
         name, ext = os.path.splitext(filename)
         if ext == '.py' and not name == '__init__':
-            path = os.path.abspath(os.path.join(dir, filename))
+            path = os.path.abspath(os.path.join(directory, filename))
             try:
                 model = load_custom_model(path)
                 model.name = PLUGIN_NAME_BASE + model.name


### PR DESCRIPTION
Some minor tidying of the _findModels function.  The main concern was the `dir` parameter on the function call, which

a) was never used
b) shadowed the dir builtin, making the function harder to debug