### PR TITLE
Ticket 861

### DIFF
--- a/src/sas/sasgui/perspectives/fitting/basepage.py
+++ b/src/sas/sasgui/perspectives/fitting/basepage.py
@@ -1840,7 +1840,6 @@ class BasicPage(ScrolledPanel, PanelBase):
         for models in list:
             if models.name != "NoStructure":
                 mlist.append((models.name, models))
-
         # Sort the models
         mlist_sorted = sorted(mlist)
         for item in mlist_sorted:

--- a/src/sas/sasgui/perspectives/fitting/fitpage.py
+++ b/src/sas/sasgui/perspectives/fitting/fitpage.py
@@ -1155,8 +1155,15 @@ class FitPage(BasicPage):
                     or event.GetEventObject() == self.multifactorbox:
                 copy_flag = self.get_copy_params()
                 is_poly_enabled = self.enable_disp.GetValue()
-
-        self._on_select_model_helper()
+        try:
+            self._on_select_model_helper()
+        except Exception as e:
+            evt = StatusEvent(status=e.message, info="error")
+            wx.PostEvent(self._manager.parent, evt)
+            # Set S(Q) to None
+            self.structurebox.SetSelection(0)
+            self._on_select_model()
+            return
         self.set_model_param_sizer(self.model)
         if self.model is None:
             self._set_bookmark_flag(False)

--- a/src/sas/sasgui/perspectives/fitting/fitting.py
+++ b/src/sas/sasgui/perspectives/fitting/fitting.py
@@ -356,6 +356,10 @@ class Plugin(PluginBase):
                                 page.formfactorbox.SetLabel(new_val)
                             else:
                                 page.formfactorbox.SetLabel(current_val)
+                        if hasattr(page, 'structurebox'):
+                            page.structurebox.Clear()
+                            page._populate_box(page.structurebox,
+                                page.model_list_box["Structure Factors"])
         except:
             logger.error("update_custom_combo: %s", sys.exc_value)
 

--- a/src/sas/sasgui/perspectives/fitting/fitting.py
+++ b/src/sas/sasgui/perspectives/fitting/fitting.py
@@ -360,9 +360,7 @@ class Plugin(PluginBase):
                             selected_name = page.structurebox.GetStringSelection()
 
                             page.structurebox.Clear()
-                            page._populate_box(page.structurebox,
-                                page.model_list_box["Structure Factors"])
-                            page.structurebox.Insert("None", 0, None)
+                            page.initialize_combox()
 
                             index = page.structurebox.FindString(selected_name)
                             if index == -1:

--- a/src/sas/sasgui/perspectives/fitting/fitting.py
+++ b/src/sas/sasgui/perspectives/fitting/fitting.py
@@ -357,9 +357,18 @@ class Plugin(PluginBase):
                             else:
                                 page.formfactorbox.SetLabel(current_val)
                         if hasattr(page, 'structurebox'):
+                            selected_name = page.structurebox.GetStringSelection()
+
                             page.structurebox.Clear()
                             page._populate_box(page.structurebox,
                                 page.model_list_box["Structure Factors"])
+                            page.structurebox.Insert("None", 0, None)
+
+                            index = page.structurebox.FindString(selected_name)
+                            if index == -1:
+                                index = 0
+                            page.structurebox.SetSelection(index)
+                            page._on_select_model()
         except:
             logger.error("update_custom_combo: %s", sys.exc_value)
 

--- a/src/sas/sasgui/perspectives/fitting/models.py
+++ b/src/sas/sasgui/perspectives/fitting/models.py
@@ -298,12 +298,15 @@ class ModelManagerBase:
         self.plugins = self.stored_plugins.values()
         for name, plug in self.stored_plugins.iteritems():
             self.model_dictionary[name] = plug
-            if plug.is_structure_factor:
+            # TODO: Remove 'hasattr' statements when old style plugin models
+            # are no longer supported. All sasmodels models will have
+            # the required attributes.
+            if hasattr(plug, 'is_structure_factor') and plug.is_structure_factor:
                 self.struct_list.append(plug)
                 self.plugins.remove(plug)
-            elif plug.is_form_factor:
+            elif hasattr(plug, 'is_form_factor') and plug.is_form_factor:
                 self.multiplication_factor.append(plug)
-            if plug.is_multiplicity_model:
+            if hasattr(plug, 'is_multiplicity_model') and plug.is_multiplicity_model:
                 self.multi_func_list.append(plug)
 
         self._get_multifunc_models()


### PR DESCRIPTION
Allows users to define structure factor models by adding `structure_factor = True` to an 'advanced' custom model.py file. Similarly, form factor models can be defined by adding `form_factor = True`

Fixes ticket [#861](http://trac.sasview.org/ticket/861)