### PR TITLE
Ticket 1013 - Reset FileReader class state on every data load

### DIFF
--- a/src/sas/sascalc/dataloader/file_reader_base_class.py
+++ b/src/sas/sascalc/dataloader/file_reader_base_class.py
@@ -53,7 +53,6 @@ class FileReader(object):
 
         :param filepath: The full or relative path to a file to be loaded
         """
-        self.reset_state()
         if os.path.isfile(filepath):
             basename, extension = os.path.splitext(os.path.basename(filepath))
             self.extension = extension.lower()
@@ -85,7 +84,9 @@ class FileReader(object):
             self.handle_error_message(msg)
 
         # Return a list of parsed entries that data_loader can manage
-        return self.output
+        final_data = self.output
+        self.reset_state()
+        return final_data
 
     def reset_state(self):
         """

--- a/src/sas/sascalc/dataloader/file_reader_base_class.py
+++ b/src/sas/sascalc/dataloader/file_reader_base_class.py
@@ -53,6 +53,7 @@ class FileReader(object):
 
         :param filepath: The full or relative path to a file to be loaded
         """
+        self.reset_state()
         if os.path.isfile(filepath):
             basename, extension = os.path.splitext(os.path.basename(filepath))
             self.extension = extension.lower()
@@ -85,6 +86,15 @@ class FileReader(object):
 
         # Return a list of parsed entries that data_loader can manage
         return self.output
+
+    def reset_state(self):
+        """
+        Resets the class state to a base case when loading a new data file so previous
+        data files do not appear a second time
+        """
+        self.current_datainfo = None
+        self.current_dataset = None
+        self.output = []
 
     def nextline(self):
         """

--- a/src/sas/sascalc/dataloader/readers/cansas_reader.py
+++ b/src/sas/sascalc/dataloader/readers/cansas_reader.py
@@ -67,9 +67,7 @@ class Reader(XMLreader):
         Resets the class state to a base case when loading a new data file so previous
         data files do not appear a second time
         """
-        self.current_datainfo = None
-        self.current_dataset = None
-        self.current_data1d = None
+        super(Reader, self).reset_state()
         self.data = []
         self.process = Process()
         self.transspectrum = TransmissionSpectrum()
@@ -78,7 +76,6 @@ class Reader(XMLreader):
         self.detector = Detector()
         self.names = []
         self.cansas_defaults = {}
-        self.output = []
         self.ns_list = None
         self.logging = []
         self.encoding = None

--- a/src/sas/sascalc/dataloader/readers/cansas_reader_HDF5.py
+++ b/src/sas/sascalc/dataloader/readers/cansas_reader_HDF5.py
@@ -64,7 +64,7 @@ class Reader(FileReader):
         :return: List of Data1D/2D objects and/or a list of errors.
         """
         # Reinitialize when loading a new data file to reset all class variables
-        self.reset_class_variables()
+        self.reset_state()
 
         filename = self.f_open.name
         self.f_open.close() # IO handled by h5py
@@ -100,18 +100,16 @@ class Reader(FileReader):
                             self.output = []
                             raise FileContentsException("Fewer than 5 data points found.")
 
-    def reset_class_variables(self):
+    def reset_state(self):
         """
         Create the reader object and define initial states for class variables
         """
-        self.current_datainfo = None
-        self.current_dataset = None
+        super(Reader, self).reset_state()
         self.data1d = []
         self.data2d = []
         self.raw_data = None
         self.errors = set()
         self.logging = []
-        self.output = []
         self.parent_class = u''
         self.detector = Detector()
         self.collimation = Collimation()

--- a/test/sasdataloader/test/utest_abs_reader.py
+++ b/test/sasdataloader/test/utest_abs_reader.py
@@ -19,8 +19,8 @@ class abs_reader(unittest.TestCase):
 
     def setUp(self):
         reader = AbsReader()
-        data = reader.read("jan08002.ABS")
-        self.data= data[0]
+        self.data_list = reader.read("jan08002.ABS")
+        self.data = self.data_list[0]
 
     def test_abs_checkdata(self):
         """
@@ -75,8 +75,8 @@ class DanseReaderTests(unittest.TestCase):
 
     def setUp(self):
         reader = DANSEReader()
-        data = reader.read("MP_New.sans")
-        self.data = data[0]
+        self.data_list = reader.read("MP_New.sans")
+        self.data = self.data_list[0]
 
     def test_checkdata(self):
         """
@@ -86,6 +86,7 @@ class DanseReaderTests(unittest.TestCase):
             Data1D defaults changed. Otherwise the
             tests won't pass
         """
+        self.assertEqual(len(self.data_list), 1)
         self.assertEqual(self.data.filename, "MP_New.sans")
         self.assertEqual(self.data.meta_data['loader'], "DANSE")
 
@@ -113,6 +114,7 @@ class DanseReaderTests(unittest.TestCase):
     def test_generic_loader(self):
         # the generic loader should work as well
         data = Loader().load("MP_New.sans")
+        self.assertEqual(len(data), 1)
         self.assertEqual(data[0].meta_data['loader'], "DANSE")
 
 
@@ -120,12 +122,13 @@ class cansas_reader(unittest.TestCase):
 
     def setUp(self):
         reader = CANSASReader()
-        data = reader.read("cansas1d.xml")
-        self.data = data[0]
+        self.data_list = reader.read("cansas1d.xml")
+        self.data = self.data_list[0]
 
     def test_generic_loader(self):
         # the generic loader should work as well
         data = Loader().load("cansas1d.xml")
+        self.assertEqual(len(data), 1)
         self.assertEqual(data[0].meta_data['loader'], "CanSAS XML 1D")
 
     def test_cansas_checkdata(self):
@@ -140,6 +143,7 @@ class cansas_reader(unittest.TestCase):
             Data1D defaults changed. Otherwise the
             tests won't pass
         """
+        self.assertEqual(len(self.data_list), 1)
         self.assertEqual(self.data.run[0], "1234")
         self.assertEqual(self.data.meta_data['loader'], "CanSAS XML 1D")
 
@@ -280,6 +284,7 @@ class cansas_reader(unittest.TestCase):
         r.write(filename, self.data)
         data = Loader().load(filename)
         self.data = data[0]
+        self.assertEqual(len(data), 1)
         self.assertEqual(self.data.filename, filename)
         self._checkdata()
         if os.path.isfile(filename):
@@ -293,6 +298,7 @@ class cansas_reader(unittest.TestCase):
         filename = "cansas1d_units.xml"
         data = CANSASReader().read(filename)
         self.data = data[0]
+        self.assertEqual(len(data), 1)
         self.assertEqual(self.data.filename, filename)
         self._checkdata()
 
@@ -304,6 +310,7 @@ class cansas_reader(unittest.TestCase):
         filename = "cansas1d_badunits.xml"
         data = CANSASReader().read(filename)
         self.data = data[0]
+        self.assertEqual(len(data), 1)
         self.assertEqual(self.data.filename, filename)
         # The followed should not have been loaded
         self.assertAlmostEqual(self.data.sample.thickness, 0.00103)
@@ -320,6 +327,8 @@ class cansas_reader(unittest.TestCase):
         filename = "cansas1d_slit.xml"
         data = CANSASReader().read(filename)
         self.data = data[0]
+        self.assertEqual(len(data), 1)
+        self.assertEqual(len(self.data_list), 1)
         self.assertEqual(self.data.filename, filename)
         self.assertEqual(self.data.run[0], "1234")
 

--- a/test/sasdataloader/test/utest_ascii.py
+++ b/test/sasdataloader/test/utest_ascii.py
@@ -28,6 +28,11 @@ class ABSReaderTests(unittest.TestCase):
             Test .ABS file loaded as ascii
         """
         # The length of the data is 10
+        self.assertEqual(len(self.f1_list), 1)
+        self.assertEqual(len(self.f2_list), 1)
+        self.assertEqual(len(self.f3_list), 1)
+        self.assertEqual(len(self.f4_list), 1)
+        self.assertEqual(len(self.f5_list), 1)
         self.assertEqual(len(self.f1.x), 10)
         self.assertEqual(self.f1.x[0],0.002618)
         self.assertEqual(self.f1.x[9],0.0497)

--- a/test/sasdataloader/test/utest_averaging.py
+++ b/test/sasdataloader/test/utest_averaging.py
@@ -103,7 +103,8 @@ class DataInfoTests(unittest.TestCase):
     def setUp(self):
         filepath = os.path.join(os.path.dirname(
             os.path.realpath(__file__)), 'MAR07232_rest.h5')
-        self.data = Loader().load(filepath)[0]
+        self.data_list = Loader().load(filepath)
+        self.data = self.data_list[0]
 
     def test_ring(self):
         """
@@ -118,8 +119,10 @@ class DataInfoTests(unittest.TestCase):
         o = r(self.data)
         filepath = os.path.join(os.path.dirname(
             os.path.realpath(__file__)), 'ring_testdata.txt')
-        answer = Loader().load(filepath)[0]
+        answer_list = Loader().load(filepath)
+        answer = answer_list[0]
 
+        self.assertEqual(len(answer_list), 1)
         for i in range(r.nbins_phi - 1):
             self.assertAlmostEqual(o.x[i + 1], answer.x[i], 4)
             self.assertAlmostEqual(o.y[i + 1], answer.y[i], 4)

--- a/test/sasdataloader/test/utest_generic_file_reader_class.py
+++ b/test/sasdataloader/test/utest_generic_file_reader_class.py
@@ -16,31 +16,37 @@ logger = logging.getLogger(__name__)
 class GenericFileReaderTests(unittest.TestCase):
 
     def setUp(self):
-        self.reader = FileReader()
+        self.reader = TestFileReader()
         self.bad_file = "ACB123.txt"
         self.good_file = "123ABC.txt"
-        self.msg = "Unable to find file at: {}\n".format(self.bad_file)
-        self.msg += "Please check your file path and try again."
-        x = np.zeros(0)
-        y = np.zeros(0)
-        self.reader.current_dataset = plottable_1D(x, y)
-        self.reader.current_datainfo = DataInfo()
-        self.reader.send_to_output()
 
     def test_bad_file_path(self):
         output = self.reader.read(self.bad_file)
-        self.assertEqual(len(output[0].errors), 1)
-        self.assertEqual(output[0].errors[0], self.msg)
+        self.assertEqual(output, [])
 
     def test_good_file_path(self):
-        f_open = open(self.good_file, 'w')
-        f_open.close()
+        f = open(self.good_file, 'w')
+        f.write('123ABC exists!')
+        f.close()
         output = self.reader.read(self.good_file)
-        self.assertEqual(len(output[0].errors), 1)
-        self.assertEqual(output[0].errors[0], self.msg)
+        self.assertEqual(len(output), 1)
+        self.assertEqual(output[0].meta_data["blah"], '123ABC exists!')
 
     def tearDown(self):
         if os.path.isfile(self.bad_file):
             os.remove(self.bad_file)
         if os.path.isfile(self.good_file):
             os.remove(self.good_file)
+
+class TestFileReader(FileReader):
+    def get_file_contents(self):
+        """
+        Reader specific class to access the contents of the file
+        All reader classes that inherit from FileReader must implement
+        """
+        x = np.zeros(0)
+        y = np.zeros(0)
+        self.current_dataset = plottable_1D(x,y)
+        self.current_datainfo = DataInfo()
+        self.current_datainfo.meta_data["blah"] = self.nextline()
+        self.send_to_output()

--- a/test/sasdataloader/test/utest_red2d_reader.py
+++ b/test/sasdataloader/test/utest_red2d_reader.py
@@ -13,13 +13,15 @@ class abs_reader(unittest.TestCase):
 
     def setUp(self):
         self.loader = Loader()
+        self.data_list = self.loader.load("exp18_14_igor_2dqxqy.dat")
 
     def test_checkdata(self):
         """
             Test .DAT file loaded as IGOR/DAT 2D Q_map
         """
-        f = self.loader.load("exp18_14_igor_2dqxqy.dat")[0]
+        f = self.data_list[0]
         # The length of the data is 10
+        self.assertEqual(len(self.data_list), 1)
         self.assertEqual(len(f.qx_data),  36864)
         self.assertEqual(f.qx_data[0],-0.03573497)
         self.assertEqual(f.qx_data[36863],0.2908819)

--- a/test/sasdataloader/test/utest_sesans.py
+++ b/test/sasdataloader/test/utest_sesans.py
@@ -21,6 +21,7 @@ class sesans_reader(unittest.TestCase):
         file = Loader().load("sesans_examples/sphere2micron.ses")
         f = file[0]
         # self.assertEqual(f, 5)
+        self.assertEqual(len(file), 1)
         self.assertEqual(len(f.x), 40)
         self.assertEqual(f.x[0], 391.56)
         self.assertEqual(f.x[-1], 46099)
@@ -38,6 +39,7 @@ class sesans_reader(unittest.TestCase):
         """
         file = self.loader("sesans_examples/sphere_isis.ses")
         f = file[0]
+        self.assertEqual(len(file), 1)
         self.assertEqual(len(f.x), 57)
         self.assertEqual(f.x[-1], 19303.4)
         self.assertEqual(f.source.wavelength[-1], 13.893668)


### PR DESCRIPTION
I added a reset_state class variable to the FileReader class that empties class variable output every time a new read is initiated. I also added unit tests to be sure the proper number of data sets are being returned from each reader. This should resolve issue [1013](http://trac.sasview.org/ticket/1013).