### PR TITLE
consistent $-math expression for sasmodels and sasview, now allowing 1-$\sigma$

### DIFF
--- a/docs/sphinx-docs/source/_extensions/dollarmath.py
+++ b/docs/sphinx-docs/source/_extensions/dollarmath.py
@@ -10,7 +10,7 @@ semicolon).
 """
 
 import re
-_dollar = re.compile(r"(?:^|(?<=\s))[$]([^\n]*?)(?<![\\])[$](?:$|(?=\s|[.,;:?\\()]))")
+_dollar = re.compile(r"(?:^|(?<=\s|[-(]))[$]([^\n]*?)(?<![\\])[$](?:$|(?=\s|[-.,;:?\\)]))")
 _notdollar = re.compile(r"\\[$]")
 
 def replace_dollar(content):


### PR DESCRIPTION
The new orientation docs use ```$x$-$y$-$z$```, etc., instead of ```$x$\ -\ $y$\ -\ $z$```, so the sasmodels docs that are included in sasview will not render correctly without this patch.