### PR TITLE
Fix entry point to point to new run_gui function

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -427,7 +427,7 @@ setup(
     zip_safe=False,
     entry_points={
         'console_scripts': [
-            "sasview = sas.sasview.sasview:run",
+            "sasview = sas.sasview.sasview:run_gui",
         ]
     },
     cmdclass={'build_ext': build_ext_subclass,


### PR DESCRIPTION
The current entry point defined by `setup.py` has not caught up with the change to the function name for the entry point:

```
$ sasview
Traceback (most recent call last):
  File "/usr/bin/sasview", line 11, in <module>
    load_entry_point('sasview==4.2.0', 'console_scripts', 'sasview')()
  File "…/lib/python2.7/site-packages/pkg_resources/__init__.py", line 564, in load_entry_point
    return get_distribution(dist).load_entry_point(group, name)
  File …/lib/python2.7/site-packages/pkg_resources/__init__.py", line 2662, in load_entry_point
    return ep.load()
  File …/lib/python2.7/site-packages/pkg_resources/__init__.py", line 2316, in load
    return self.resolve()
  File "…/lib/python2.7/site-packages/pkg_resources/__init__.py", line 2326, in resolve
    raise ImportError(str(exc))
ImportError: 'module' object has no attribute 'run'
```

with the egg containing in `sasview-4.2.0.egg-info/entry_points.txt`:

```
[console_scripts]
sasview = sas.sasview.sasview:run
```
This patch replaces `run` with `run_gui` in the entry point.
