### PR TITLE
Remove unused pylint import in test

### DIFF
--- a/test/fileconverter/test/utest_nxcansas_writer.py
+++ b/test/fileconverter/test/utest_nxcansas_writer.py
@@ -2,7 +2,6 @@ from sas.sascalc.file_converter.nxcansas_writer import NXcanSASWriter
 from sas.sascalc.dataloader.loader import Loader
 
 import os
-import pylint
 import unittest
 import warnings
 


### PR DESCRIPTION
`pylint` is unused so there's no need to have it installed to be able to run these tests.