### PR TITLE
Fix location of image in sasview-api docs

### DIFF
--- a/src/sas/sasgui/guiframe/data_processor.py
+++ b/src/sas/sasgui/guiframe/data_processor.py
@@ -13,7 +13,7 @@ The organization of the classes goes as:
 
 .. note:: Path to image is: /sasview/src/sas/sasgui/guiframe/media/BatchGridClassLayout.png
 
-.. image:: ../../user/sasgui/guiframe/BatchGridClassLayout.png
+.. image:: ../../../../../src/sas/sasgui/guiframe/media/BatchGridClassLayout.png
    :align: center
 
 """


### PR DESCRIPTION
Updating the location of the BatchGridClass.png image permits sphinx to generate the PDF once more. (A slightly prettier relative path might also be possible...)