### PR TITLE
Make tests work from any directory and functional without special runner script

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+norecursedirs=test/sasrealspace test/calculatorview
+addopts=--ignore test/utest_sasview.py
+python_files='u*py'

--- a/src/sas/sascalc/dataloader/file_reader_base_class.py
+++ b/src/sas/sascalc/dataloader/file_reader_base_class.py
@@ -26,12 +26,6 @@ else:
         return s.decode() if isinstance(s, bytes) else s
 
 class FileReader(object):
-    # List of Data1D and Data2D objects to be sent back to data_loader
-    output = []
-    # Current plottable_(1D/2D) object being loaded in
-    current_dataset = None
-    # Current DataInfo object being loaded in
-    current_datainfo = None
     # String to describe the type of data this reader can load
     type_name = "ASCII"
     # Wildcards to display
@@ -42,10 +36,18 @@ class FileReader(object):
     allow_all = False
     # Able to import the unit converter
     has_converter = True
-    # Open file handle
-    f_open = None
     # Default value of zero
     _ZERO = 1e-16
+
+    def __init__(self):
+        # List of Data1D and Data2D objects to be sent back to data_loader
+        self.output = []
+        # Current plottable_(1D/2D) object being loaded in
+        self.current_dataset = None
+        # Current DataInfo object being loaded in
+        self.current_datainfo = None
+        # Open file handle
+        self.f_open = None
 
     def read(self, filepath):
         """

--- a/test/corfunc/test/utest_corfunc.py
+++ b/test/corfunc/test/utest_corfunc.py
@@ -3,6 +3,7 @@ Unit Tests for CorfuncCalculator class
 """
 from __future__ import division, print_function
 
+import os.path
 import unittest
 import time
 
@@ -10,6 +11,10 @@ import numpy as np
 
 from sas.sascalc.corfunc.corfunc_calculator import CorfuncCalculator
 from sas.sascalc.dataloader.data_info import Data1D
+
+
+def find(filename):
+    return os.path.join(os.path.dirname(__file__), filename)
 
 
 class TestCalculator(unittest.TestCase):
@@ -30,7 +35,7 @@ class TestCalculator(unittest.TestCase):
         self.calculator.background = 0.3
         self.extrapolation = None
         self.transformation = None
-        self.results = [np.loadtxt(filename+"_out.txt").T[2]
+        self.results = [np.loadtxt(find(filename+"_out.txt")).T[2]
                         for filename in ("gamma1", "gamma3", "idf")]
 
     def extrapolate(self):
@@ -109,7 +114,7 @@ class TestCalculator(unittest.TestCase):
 
 
 def load_data(filename="98929.txt"):
-    data = np.loadtxt(filename, dtype=np.float64)
+    data = np.loadtxt(find(filename), dtype=np.float64)
     q = data[:,0]
     iq = data[:,1]
     return Data1D(x=q, y=iq)

--- a/test/fileconverter/test/utest_nxcansas_writer.py
+++ b/test/fileconverter/test/utest_nxcansas_writer.py
@@ -2,20 +2,26 @@ from sas.sascalc.file_converter.nxcansas_writer import NXcanSASWriter
 from sas.sascalc.dataloader.loader import Loader
 
 import os
+import os.path
 import unittest
 import warnings
 
 warnings.simplefilter("ignore")
+
+
+def find(filename):
+    return os.path.join(os.path.dirname(__file__), filename)
+
 
 class nxcansas_writer(unittest.TestCase):
 
     def setUp(self):
         self.loader = Loader()
         self.writer = NXcanSASWriter()
-        self.read_file_1d = "cansas1d.xml"
-        self.write_file_1d = "export1d.h5"
-        self.read_file_2d = "exp18_14_igor_2dqxqy.dat"
-        self.write_file_2d = "export2d.h5"
+        self.read_file_1d = find("cansas1d.xml")
+        self.write_file_1d = find("export1d.h5")
+        self.read_file_2d = find("exp18_14_igor_2dqxqy.dat")
+        self.write_file_2d = find("export2d.h5")
 
         self.data_1d = self.loader.load(self.read_file_1d)[0]
 

--- a/test/pr_inversion/test/utest_explorer.py
+++ b/test/pr_inversion/test/utest_explorer.py
@@ -2,16 +2,22 @@
     Unit tests for DistExplorer class
 """
 
+import os.path
 import unittest, math, numpy
 from utest_invertor import load
 from sas.sascalc.pr.invertor import Invertor
 from sas.sascalc.pr.distance_explorer import DistExplorer
-        
+
+
+def find(filename):
+    return os.path.join(os.path.dirname(__file__), filename)
+
+
 class TestExplorer(unittest.TestCase):
             
     def setUp(self):
         self.invertor = Invertor()
-        x, y, err = load('sphere_80.txt')
+        x, y, err = load(find('sphere_80.txt'))
         
         # Choose the right d_max...
         self.invertor.d_max = 160.0

--- a/test/pr_inversion/test/utest_invertor.py
+++ b/test/pr_inversion/test/utest_invertor.py
@@ -9,10 +9,15 @@ from __future__ import print_function
 
 
 import os
+import os.path
 import unittest
 import math
 import numpy
 from sas.sascalc.pr.invertor import Invertor
+
+
+def find(filename):
+    return os.path.join(os.path.dirname(__file__), filename)
 
 
 class TestFiguresOfMerit(unittest.TestCase):
@@ -27,7 +32,7 @@ class TestFiguresOfMerit(unittest.TestCase):
         for i in range(self.ntest):
             self.x_in[i] = 1.0*(i+1)
        
-        x, y, err = load("sphere_80.txt")
+        x, y, err = load(find("sphere_80.txt"))
 
         # Choose the right d_max...
         self.invertor.d_max = 160.0
@@ -191,7 +196,7 @@ class TestBasicComponent(unittest.TestCase):
         """
             Test an inversion for which we know the answer
         """
-        x, y, err = load("sphere_80.txt")
+        x, y, err = load(find("sphere_80.txt"))
 
         # Choose the right d_max...
         self.invertor.d_max = 160.0
@@ -246,7 +251,7 @@ class TestBasicComponent(unittest.TestCase):
         """
             Test an inversion for which we know the answer
         """
-        x, y, err = load("sphere_80.txt")
+        x, y, err = load(find("sphere_80.txt"))
 
         # Choose the right d_max...
         self.invertor.d_max = 160.0
@@ -311,7 +316,7 @@ class TestBasicComponent(unittest.TestCase):
         """
             Test error condition where a point has q=0
         """
-        x, y, err = load("sphere_80.txt")
+        x, y, err = load(find("sphere_80.txt"))
         x[0] = 0.0
         
         # Choose the right d_max...
@@ -328,7 +333,7 @@ class TestBasicComponent(unittest.TestCase):
         """
             Test error condition where a point has q<0
         """
-        x, y, err = load("sphere_80.txt")
+        x, y, err = load(find("sphere_80.txt"))
         x[0] = -0.2
         
         # Choose the right d_max...
@@ -352,7 +357,7 @@ class TestBasicComponent(unittest.TestCase):
         """
             Test error condition where a point has q<0
         """
-        x, y, err = load("sphere_80.txt")
+        x, y, err = load(find("sphere_80.txt"))
         y[0] = 0.0
         
         # Choose the right d_max...
@@ -373,7 +378,7 @@ class TestBasicComponent(unittest.TestCase):
             raise
         
     def no_test_time(self):
-        x, y, err = load("sphere_80.txt")
+        x, y, err = load(find("sphere_80.txt"))
 
         # Choose the right d_max...
         self.invertor.d_max = 160.0
@@ -405,7 +410,7 @@ class TestBasicComponent(unittest.TestCase):
             self.assertEqual(self.x_in[i], clone.x[i])
         
     def test_save(self):
-        x, y, err = load("sphere_80.txt")
+        x, y, err = load(find("sphere_80.txt"))
 
         # Choose the right d_max...
         self.invertor.d_max = 160.0
@@ -463,7 +468,7 @@ class TestErrorConditions(unittest.TestCase):
         """
             Test an inversion for which we know the answer
         """
-        x, y, err = load("data_error_1.txt")
+        x, y, err = load(find("data_error_1.txt"))
 
         # Choose the right d_max...
         self.invertor.d_max = 160.0
@@ -481,7 +486,7 @@ class TestErrorConditions(unittest.TestCase):
         """
             Have zero as an error should raise an exception
         """
-        x, y, err = load("data_error_2.txt")
+        x, y, err = load(find("data_error_2.txt"))
 
         # Set data
         self.invertor.x   = x
@@ -494,7 +499,7 @@ class TestErrorConditions(unittest.TestCase):
         """
             Test an inversion for which we know the answer
         """
-        x, y, err = load("data_error_1.txt")
+        x, y, err = load(find("data_error_1.txt"))
 
         # Set data
         self.invertor.x   = x
@@ -510,7 +515,7 @@ class TestErrorConditions(unittest.TestCase):
             One of the q-values is zero.
             An exception should be raised.
         """
-        x, y, err = load("data_error_3.txt")
+        x, y, err = load(find("data_error_3.txt"))
 
         # Set data
         self.assertRaises(ValueError, self.invertor.__setattr__, 'x', x)
@@ -520,7 +525,7 @@ class TestErrorConditions(unittest.TestCase):
             One of the I(q) points has a value of zero
             Should not complain or crash.
         """
-        x, y, err = load("data_error_4.txt")
+        x, y, err = load(find("data_error_4.txt"))
 
         # Set data
         self.invertor.x   = x
@@ -534,7 +539,7 @@ class TestErrorConditions(unittest.TestCase):
             One q value is negative.
             Makes not sense, but should not complain or crash.
         """
-        x, y, err = load("data_error_5.txt")
+        x, y, err = load(find("data_error_5.txt"))
 
         # Set data
         self.invertor.x   = x
@@ -548,7 +553,7 @@ class TestErrorConditions(unittest.TestCase):
             One I(q) value is negative.
             Makes not sense, but should not complain or crash.
         """
-        x, y, err = load("data_error_6.txt")
+        x, y, err = load(find("data_error_6.txt"))
 
         # Set data
         self.invertor.x   = x

--- a/test/sascalculator/test/utest_sas_gen.py
+++ b/test/sascalculator/test/utest_sas_gen.py
@@ -1,11 +1,17 @@
 """
 Unit tests for the sas_gen
 """
+
+import os.path
 import warnings
 warnings.simplefilter("ignore")
 
 import unittest
 from sas.sascalc.calculator import sas_gen
+
+
+def find(filename):
+    return os.path.join(os.path.dirname(__file__), filename)
 
 
 class sas_gen_test(unittest.TestCase):
@@ -19,7 +25,7 @@ class sas_gen_test(unittest.TestCase):
         """
         Test .sld file loaded
         """
-        f = self.sldloader.read("sld_file.sld")
+        f = self.sldloader.read(find("sld_file.sld"))
         self.assertEqual(f.pos_x[0], -40.5)
         self.assertEqual(f.pos_y[0], -13.5)
         self.assertEqual(f.pos_z[0], -13.5)
@@ -28,7 +34,7 @@ class sas_gen_test(unittest.TestCase):
         """
         Test .pdb file loaded
         """
-        f = self.pdbloader.read("c60.pdb")
+        f = self.pdbloader.read(find("c60.pdb"))
         self.assertEqual(f.pos_x[0], -0.733)
         self.assertEqual(f.pos_y[0], -1.008)
         self.assertEqual(f.pos_z[0], 3.326)
@@ -37,7 +43,7 @@ class sas_gen_test(unittest.TestCase):
         """
         Test .omf file loaded
         """
-        f = self.omfloader.read("A_Raw_Example-1.omf")
+        f = self.omfloader.read(find("A_Raw_Example-1.omf"))
         output = sas_gen.OMF2SLD()
         output.set_data(f)
         self.assertEqual(f.mx[0], 0)

--- a/test/sascalculator/test/utest_slit_length_calculator.py
+++ b/test/sascalculator/test/utest_slit_length_calculator.py
@@ -2,10 +2,15 @@
     Unit tests for slit_length_calculator
 """
 
+import os.path
 import unittest
 from sas.sascalc.dataloader.readers.ascii_reader import Reader
 from sas.sascalc.calculator.slit_length_calculator import SlitlengthCalculator \
     as calculator
+
+
+def find(filename):
+    return os.path.join(os.path.dirname(__file__), filename)
 
 
 class SlitCalculator(unittest.TestCase):
@@ -18,7 +23,7 @@ class SlitCalculator(unittest.TestCase):
         """
             Test slit_length_calculator"
         """
-        list = self.reader.read("beam profile.DAT")
+        list = self.reader.read(find("beam profile.DAT"))
         self.assertTrue(len(list) == 1)
         f = list[0]
         cal = calculator()

--- a/test/sasdataloader/test/utest_abs_reader.py
+++ b/test/sasdataloader/test/utest_abs_reader.py
@@ -15,11 +15,15 @@ from sas.sascalc.dataloader.data_info import Data1D
 import os.path
 
 
+def find(filename):
+    return os.path.join(os.path.dirname(__file__), filename)
+
+
 class abs_reader(unittest.TestCase):
 
     def setUp(self):
         reader = AbsReader()
-        self.data_list = reader.read("jan08002.ABS")
+        self.data_list = reader.read(find("jan08002.ABS"))
         self.data = self.data_list[0]
 
     def test_abs_checkdata(self):
@@ -30,7 +34,7 @@ class abs_reader(unittest.TestCase):
             Data1D defaults changed. Otherwise the
             tests won't pass
         """
-        self.assertEqual(self.data.filename, "jan08002.ABS")
+        self.assertEqual(os.path.basename(self.data.filename), "jan08002.ABS")
         self.assertEqual(self.data.meta_data['loader'], "IGOR 1D")
 
         self.assertEqual(self.data.source.wavelength_unit, 'A')
@@ -68,14 +72,14 @@ class abs_reader(unittest.TestCase):
 
     def test_generic_loader(self):
         # the generic loader should work as well
-        data = Loader().load("jan08002.ABS")
+        data = Loader().load(find("jan08002.ABS"))
         self.assertEqual(data[0].meta_data['loader'], "IGOR 1D")
 
 class DanseReaderTests(unittest.TestCase):
 
     def setUp(self):
         reader = DANSEReader()
-        self.data_list = reader.read("MP_New.sans")
+        self.data_list = reader.read(find("MP_New.sans"))
         self.data = self.data_list[0]
 
     def test_checkdata(self):
@@ -87,7 +91,7 @@ class DanseReaderTests(unittest.TestCase):
             tests won't pass
         """
         self.assertEqual(len(self.data_list), 1)
-        self.assertEqual(self.data.filename, "MP_New.sans")
+        self.assertEqual(os.path.basename(self.data.filename), "MP_New.sans")
         self.assertEqual(self.data.meta_data['loader'], "DANSE")
 
         self.assertEqual(self.data.source.wavelength_unit, 'A')
@@ -113,7 +117,7 @@ class DanseReaderTests(unittest.TestCase):
 
     def test_generic_loader(self):
         # the generic loader should work as well
-        data = Loader().load("MP_New.sans")
+        data = Loader().load(find("MP_New.sans"))
         self.assertEqual(len(data), 1)
         self.assertEqual(data[0].meta_data['loader'], "DANSE")
 
@@ -122,17 +126,17 @@ class cansas_reader(unittest.TestCase):
 
     def setUp(self):
         reader = CANSASReader()
-        self.data_list = reader.read("cansas1d.xml")
+        self.data_list = reader.read(find("cansas1d.xml"))
         self.data = self.data_list[0]
 
     def test_generic_loader(self):
         # the generic loader should work as well
-        data = Loader().load("cansas1d.xml")
+        data = Loader().load(find("cansas1d.xml"))
         self.assertEqual(len(data), 1)
         self.assertEqual(data[0].meta_data['loader'], "CanSAS XML 1D")
 
     def test_cansas_checkdata(self):
-        self.assertEqual(self.data.filename, "cansas1d.xml")
+        self.assertEqual(os.path.basename(self.data.filename), "cansas1d.xml")
         self._checkdata()
 
     def _checkdata(self):
@@ -281,8 +285,8 @@ class cansas_reader(unittest.TestCase):
         r = CANSASReader()
 
         filename = "write_test.xml"
-        r.write(filename, self.data)
-        data = Loader().load(filename)
+        r.write(find(filename), self.data)
+        data = Loader().load(find(filename))
         self.data = data[0]
         self.assertEqual(len(data), 1)
         self.assertEqual(self.data.filename, filename)
@@ -296,7 +300,7 @@ class cansas_reader(unittest.TestCase):
             Note that not all units are available.
         """
         filename = "cansas1d_units.xml"
-        data = CANSASReader().read(filename)
+        data = CANSASReader().read(find(filename))
         self.data = data[0]
         self.assertEqual(len(data), 1)
         self.assertEqual(self.data.filename, filename)
@@ -308,7 +312,7 @@ class cansas_reader(unittest.TestCase):
             Note that not all units are available.
         """
         filename = "cansas1d_badunits.xml"
-        data = CANSASReader().read(filename)
+        data = CANSASReader().read(find(filename))
         self.data = data[0]
         self.assertEqual(len(data), 1)
         self.assertEqual(self.data.filename, filename)
@@ -325,7 +329,7 @@ class cansas_reader(unittest.TestCase):
             Check slit data
         """
         filename = "cansas1d_slit.xml"
-        data = CANSASReader().read(filename)
+        data = CANSASReader().read(find(filename))
         self.data = data[0]
         self.assertEqual(len(data), 1)
         self.assertEqual(len(self.data_list), 1)

--- a/test/sasdataloader/test/utest_ascii.py
+++ b/test/sasdataloader/test/utest_ascii.py
@@ -1,6 +1,8 @@
 """
     Unit tests for the ascii (n-column) reader
 """
+
+import os.path
 import warnings
 warnings.simplefilter("ignore")
 
@@ -8,19 +10,23 @@ import unittest
 from sas.sascalc.dataloader.loader import Loader
 
 
+def find(filename):
+    return os.path.join(os.path.dirname(__file__), filename)
+
+
 class ABSReaderTests(unittest.TestCase):
     
     def setUp(self):
         self.loader = Loader()
-        self.f1_list = self.loader.load("ascii_test_1.txt")
+        self.f1_list = self.loader.load(find("ascii_test_1.txt"))
         self.f1 = self.f1_list[0]
-        self.f2_list = self.loader.load("ascii_test_2.txt")
+        self.f2_list = self.loader.load(find("ascii_test_2.txt"))
         self.f2 = self.f2_list[0]
-        self.f3_list = self.loader.load("ascii_test_3.txt")
+        self.f3_list = self.loader.load(find("ascii_test_3.txt"))
         self.f3 = self.f3_list[0]
-        self.f4_list = self.loader.load("ascii_test_4.abs")
+        self.f4_list = self.loader.load(find("ascii_test_4.abs"))
         self.f4 = self.f4_list[0]
-        self.f5_list = self.loader.load("ascii_test_5.txt")
+        self.f5_list = self.loader.load(find("ascii_test_5.txt"))
         self.f5 = self.f5_list[0]
 
     def test_checkdata(self):
@@ -98,7 +104,7 @@ class ABSReaderTests(unittest.TestCase):
         # Test .ABS file loaded as ascii
         f = None
         try:
-            f = self.loader.load("ascii_test_6.txt")
+            f = self.loader.load(find("ascii_test_6.txt"))
         # The length of the data is 5
         except:
             self.assertEqual(f, None)

--- a/test/sasdataloader/test/utest_averaging.py
+++ b/test/sasdataloader/test/utest_averaging.py
@@ -14,6 +14,10 @@ from sas.sascalc.dataloader.manipulations import (Boxavg, Boxsum,
                                                   reader2D_converter)
 
 
+def find(filename):
+    return os.path.join(os.path.dirname(__file__), filename)
+
+
 class Averaging(unittest.TestCase):
     """
         Test averaging manipulations on a flat distribution
@@ -101,8 +105,7 @@ class Averaging(unittest.TestCase):
 class DataInfoTests(unittest.TestCase):
 
     def setUp(self):
-        filepath = os.path.join(os.path.dirname(
-            os.path.realpath(__file__)), 'MAR07232_rest.h5')
+        filepath = find('MAR07232_rest.h5')
         self.data_list = Loader().load(filepath)
         self.data = self.data_list[0]
 
@@ -117,8 +120,7 @@ class DataInfoTests(unittest.TestCase):
         ##r.nbins_phi = 20
 
         o = r(self.data)
-        filepath = os.path.join(os.path.dirname(
-            os.path.realpath(__file__)), 'ring_testdata.txt')
+        filepath = find('ring_testdata.txt')
         answer_list = Loader().load(filepath)
         answer = answer_list[0]
 
@@ -139,8 +141,7 @@ class DataInfoTests(unittest.TestCase):
 
         o = r(self.data)
 
-        filepath = os.path.join(os.path.dirname(
-            os.path.realpath(__file__)), 'avg_testdata.txt')
+        filepath = find('avg_testdata.txt')
         answer = Loader().load(filepath)[0]
         for i in range(r.nbins_phi):
             self.assertAlmostEqual(o.x[i], answer.x[i], 4)
@@ -175,8 +176,7 @@ class DataInfoTests(unittest.TestCase):
         r.fold = False
         o = r(self.data)
 
-        filepath = os.path.join(os.path.dirname(
-            os.path.realpath(__file__)), 'slabx_testdata.txt')
+        filepath = find('slabx_testdata.txt')
         answer = Loader().load(filepath)[0]
         for i in range(len(o.x)):
             self.assertAlmostEqual(o.x[i], answer.x[i], 4)
@@ -194,8 +194,7 @@ class DataInfoTests(unittest.TestCase):
         r.fold = False
         o = r(self.data)
 
-        filepath = os.path.join(os.path.dirname(
-            os.path.realpath(__file__)), 'slaby_testdata.txt')
+        filepath = find('slaby_testdata.txt')
         answer = Loader().load(filepath)[0]
         for i in range(len(o.x)):
             self.assertAlmostEqual(o.x[i], answer.x[i], 4)
@@ -221,8 +220,7 @@ class DataInfoTests(unittest.TestCase):
                       nbins=nbins)
         o = r(self.data)
 
-        filepath = os.path.join(os.path.dirname(
-            os.path.realpath(__file__)), 'ring_testdata.txt')
+        filepath = find('ring_testdata.txt')
         answer = Loader().load(filepath)[0]
         for i in range(len(o.x)):
             self.assertAlmostEqual(o.x[i], answer.x[i], 4)
@@ -239,8 +237,7 @@ class DataInfoTests(unittest.TestCase):
         r.nbins_phi = 20
         o = r(self.data)
 
-        filepath = os.path.join(os.path.dirname(
-            os.path.realpath(__file__)), 'sectorphi_testdata.txt')
+        filepath = find('sectorphi_testdata.txt')
         answer = Loader().load(filepath)[0]
         for i in range(len(o.x)):
             self.assertAlmostEqual(o.x[i], answer.x[i], 4)
@@ -257,8 +254,7 @@ class DataInfoTests(unittest.TestCase):
         r.nbins_phi = 20
         o = r(self.data)
 
-        filepath = os.path.join(os.path.dirname(
-            os.path.realpath(__file__)), 'sectorq_testdata.txt')
+        filepath = find('sectorq_testdata.txt')
         answer = Loader().load(filepath)[0]
         for i in range(len(o.x)):
             self.assertAlmostEqual(o.x[i], answer.x[i], 4)

--- a/test/sasdataloader/test/utest_cansas.py
+++ b/test/sasdataloader/test/utest_cansas.py
@@ -30,25 +30,30 @@ warnings.simplefilter("ignore")
 CANSAS_FORMAT = CansasConstants.CANSAS_FORMAT
 CANSAS_NS = CansasConstants.CANSAS_NS
 
+
+def find(filename):
+    return os.path.join(os.path.dirname(__file__), filename)
+
+
 class cansas_reader_xml(unittest.TestCase):
 
     def setUp(self):
         self.loader = Loader()
-        self.xml_valid = "cansas_test_modified.xml"
-        self.xml_invalid = "cansas_test.xml"
-        self.cansas1d_badunits = "cansas1d_badunits.xml"
-        self.cansas1d = "cansas1d.xml"
-        self.cansas1d_slit = "cansas1d_slit.xml"
-        self.cansas1d_units = "cansas1d_units.xml"
-        self.cansas1d_notitle = "cansas1d_notitle.xml"
-        self.isis_1_0 = "ISIS_1_0.xml"
-        self.isis_1_1 = "ISIS_1_1.xml"
-        self.isis_1_1_notrans = "ISIS_1_1_notrans.xml"
-        self.isis_1_1_doubletrans = "ISIS_1_1_doubletrans.xml"
-        self.schema_1_0 = "cansas1d_v1_0.xsd"
-        self.schema_1_1 = "cansas1d_v1_1.xsd"
-        self.write_1_0_filename = "isis_1_0_write_test.xml"
-        self.write_1_1_filename = "isis_1_1_write_test.xml"
+        self.xml_valid = find("cansas_test_modified.xml")
+        self.xml_invalid = find("cansas_test.xml")
+        self.cansas1d_badunits = find("cansas1d_badunits.xml")
+        self.cansas1d = find("cansas1d.xml")
+        self.cansas1d_slit = find("cansas1d_slit.xml")
+        self.cansas1d_units = find("cansas1d_units.xml")
+        self.cansas1d_notitle = find("cansas1d_notitle.xml")
+        self.isis_1_0 = find("ISIS_1_0.xml")
+        self.isis_1_1 = find("ISIS_1_1.xml")
+        self.isis_1_1_notrans = find("ISIS_1_1_notrans.xml")
+        self.isis_1_1_doubletrans = find("ISIS_1_1_doubletrans.xml")
+        self.schema_1_0 = find("cansas1d_v1_0.xsd")
+        self.schema_1_1 = find("cansas1d_v1_1.xsd")
+        self.write_1_0_filename = find("isis_1_0_write_test.xml")
+        self.write_1_1_filename = find("isis_1_1_write_test.xml")
 
     def get_number_of_entries(self, dictionary, name, i):
         if dictionary.get(name) is not None:
@@ -253,10 +258,10 @@ class cansas_reader_hdf5(unittest.TestCase):
 
     def setUp(self):
         self.loader = Loader()
-        self.datafile_basic = "simpleexamplefile.h5"
-        self.datafile_multiplesasentry = "cansas_1Dand2D_samedatafile.h5"
-        self.datafile_multiplesasdata = "cansas_1Dand2D_samesasentry.h5"
-        self.datafile_multiplesasdata_multiplesasentry = "cansas_1Dand2D_multiplesasentry_multiplesasdata.h5"
+        self.datafile_basic = find("simpleexamplefile.h5")
+        self.datafile_multiplesasentry = find("cansas_1Dand2D_samedatafile.h5")
+        self.datafile_multiplesasdata = find("cansas_1Dand2D_samesasentry.h5")
+        self.datafile_multiplesasdata_multiplesasentry = find("cansas_1Dand2D_multiplesasentry_multiplesasdata.h5")
 
     def test_real_data(self):
         self.data = self.loader.load(self.datafile_basic)

--- a/test/sasdataloader/test/utest_extension_registry.py
+++ b/test/sasdataloader/test/utest_extension_registry.py
@@ -12,15 +12,20 @@ from sas.sascalc.dataloader.loader import Registry as Loader
 
 logger = logging.getLogger(__name__)
 
+
+def find(filename):
+    return os.path.join(os.path.dirname(__file__), filename)
+
+
 class ExtensionRegistryTests(unittest.TestCase):
 
     def setUp(self):
-        self.valid_file = "valid_cansas_xml.xml"
-        self.valid_file_wrong_known_ext = "valid_cansas_xml.txt"
-        self.valid_file_wrong_unknown_ext = "valid_cansas_xml.xyz"
+        self.valid_file = find("valid_cansas_xml.xml")
+        self.valid_file_wrong_known_ext = find("valid_cansas_xml.txt")
+        self.valid_file_wrong_unknown_ext = find("valid_cansas_xml.xyz")
         shutil.copyfile(self.valid_file, self.valid_file_wrong_known_ext)
         shutil.copyfile(self.valid_file, self.valid_file_wrong_unknown_ext)
-        self.invalid_file = "cansas1d_notitle.xml"
+        self.invalid_file = find("cansas1d_notitle.xml")
 
         self.loader = Loader()
 

--- a/test/sasdataloader/test/utest_generic_file_reader_class.py
+++ b/test/sasdataloader/test/utest_generic_file_reader_class.py
@@ -13,12 +13,16 @@ from sas.sascalc.dataloader.file_reader_base_class import FileReader
 logger = logging.getLogger(__name__)
 
 
+def find(filename):
+    return os.path.join(os.path.dirname(__file__), filename)
+
+
 class GenericFileReaderTests(unittest.TestCase):
 
     def setUp(self):
         self.reader = TestFileReader()
-        self.bad_file = "ACB123.txt"
-        self.good_file = "123ABC.txt"
+        self.bad_file = find("ACB123.txt")
+        self.good_file = find("123ABC.txt")
 
     def test_bad_file_path(self):
         output = self.reader.read(self.bad_file)

--- a/test/sasdataloader/test/utest_red2d_reader.py
+++ b/test/sasdataloader/test/utest_red2d_reader.py
@@ -9,11 +9,16 @@ from sas.sascalc.dataloader.loader import  Loader
 
 import os.path
 
+
+def find(filename):
+    return os.path.join(os.path.dirname(__file__), filename)
+
+
 class abs_reader(unittest.TestCase):
 
     def setUp(self):
         self.loader = Loader()
-        self.data_list = self.loader.load("exp18_14_igor_2dqxqy.dat")
+        self.data_list = self.loader.load(find("exp18_14_igor_2dqxqy.dat"))
 
     def test_checkdata(self):
         """

--- a/test/sasdataloader/test/utest_sesans.py
+++ b/test/sasdataloader/test/utest_sesans.py
@@ -2,11 +2,17 @@
     Unit tests for the SESANS .ses reader
 """
 
+import os.path
 import unittest
 from sas.sascalc.dataloader.loader_exceptions import FileContentsException,\
     DefaultReaderException
 from sas.sascalc.dataloader.readers.sesans_reader import Reader
 from sas.sascalc.dataloader.loader import  Loader
+
+
+def find(filename):
+    return os.path.join(os.path.dirname(__file__), filename)
+
 
 class sesans_reader(unittest.TestCase):
 
@@ -18,7 +24,7 @@ class sesans_reader(unittest.TestCase):
         """
             Test .SES in the full loader to make sure that the file type is correctly accepted
         """
-        file = Loader().load("sesans_examples/sphere2micron.ses")
+        file = Loader().load(find("sesans_examples/sphere2micron.ses"))
         f = file[0]
         # self.assertEqual(f, 5)
         self.assertEqual(len(file), 1)
@@ -37,7 +43,7 @@ class sesans_reader(unittest.TestCase):
         """
             Test .SES loading on a TOF dataset
         """
-        file = self.loader("sesans_examples/sphere_isis.ses")
+        file = self.loader(find("sesans_examples/sphere_isis.ses"))
         f = file[0]
         self.assertEqual(len(file), 1)
         self.assertEqual(len(f.x), 57)
@@ -55,7 +61,7 @@ class sesans_reader(unittest.TestCase):
         self.assertRaises(
             FileContentsException,
             self.loader,
-            "sesans_examples/sesans_no_data.ses")
+            find("sesans_examples/sesans_no_data.ses"))
 
     def test_sesans_no_spin_echo_unit(self):
         """
@@ -64,7 +70,7 @@ class sesans_reader(unittest.TestCase):
         self.assertRaises(
             FileContentsException,
             self.loader,
-            "sesans_examples/no_spin_echo_unit.ses")
+            find("sesans_examples/no_spin_echo_unit.ses"))
 
     def test_sesans_future_version(self):
         """
@@ -73,7 +79,7 @@ class sesans_reader(unittest.TestCase):
         self.assertRaises(
             FileContentsException,
             self.loader,
-            "sesans_examples/next_gen.ses")
+            find("sesans_examples/next_gen.ses"))
 
     def test_sesans_mandatory_headers(self):
         """
@@ -82,7 +88,7 @@ class sesans_reader(unittest.TestCase):
         self.assertRaises(
             FileContentsException,
             self.loader,
-            "sesans_examples/no_wavelength.ses")
+            find("sesans_examples/no_wavelength.ses"))
 
     def test_sesans_columns_match_headers(self):
         """
@@ -91,7 +97,7 @@ class sesans_reader(unittest.TestCase):
         self.assertRaises(
             FileContentsException,
             self.loader,
-            "sesans_examples/too_many_headers.ses")
+            find("sesans_examples/too_many_headers.ses"))
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/sasguiframe/test/utest_manipulations.py
+++ b/test/sasguiframe/test/utest_manipulations.py
@@ -14,10 +14,14 @@ from sas.sasgui.guiframe.dataFitting import Data1D
 from sas.sasgui.guiframe.dataFitting import Data2D
 
 
+def find(filename):
+    return os.path.join(os.path.dirname(__file__), filename)
+
+
 class DataInfoTests(unittest.TestCase):
 
     def setUp(self):
-        data = Loader().load("cansas1d.xml")
+        data = Loader().load(find("cansas1d.xml"))
         self.data = data[0]
 
     def test_clone1D(self):
@@ -34,7 +38,7 @@ class DataInfoTests(unittest.TestCase):
 class Theory1DTests(unittest.TestCase):
 
     def setUp(self):
-        data = Loader().load("cansas1d.xml")
+        data = Loader().load(find("cansas1d.xml"))
         self.data = data[0]
 
     def test_clone_theory1D(self):

--- a/test/sasinvariant/test/utest_data_handling.py
+++ b/test/sasinvariant/test/utest_data_handling.py
@@ -7,6 +7,8 @@ See the license text in license.txt
 
 copyright 2010, University of Tennessee
 """
+
+import os.path
 import unittest
 import math
 import numpy as np
@@ -14,7 +16,12 @@ from sas.sascalc.dataloader.loader import  Loader
 from sas.sascalc.dataloader.data_info import Data1D
 
 from sas.sascalc.invariant import invariant
-    
+
+
+def find(filename):
+    return os.path.join(os.path.dirname(__file__), filename)
+
+
 class TestLinearFit(unittest.TestCase):
     """
         Test Line fit 
@@ -93,7 +100,7 @@ class TestInvariantCalculator(unittest.TestCase):
         Test main functionality of the Invariant calculator
     """
     def setUp(self):
-        data = Loader().load("latex_smeared_slit.xml")
+        data = Loader().load(find("latex_smeared_slit.xml"))
         self.data = data[0]
         self.data.dxl = None
         
@@ -675,4 +682,3 @@ class TestDataExtraHighSlitPowerLaw(unittest.TestCase):
         for i in range(len(self.data.x[start:])):
             value  = math.fabs(test_y[i]- temp[i])/temp[i]
             self.assert_(value < 0.001)                
-                      

--- a/test/sasinvariant/test/utest_use_cases.py
+++ b/test/sasinvariant/test/utest_use_cases.py
@@ -3,9 +3,15 @@
   
 """
 #TODO: there's no test for smeared extrapolation
+
+import os.path
 import unittest
 from sas.sascalc.dataloader.loader import  Loader
 from sas.sascalc.invariant import invariant
+
+
+def find(filename):
+    return os.path.join(os.path.dirname(__file__), filename)
 
 
 class Data1D:
@@ -17,7 +23,7 @@ class TestLineFit(unittest.TestCase):
         Test Line fit 
     """
     def setUp(self):
-        self.data_list = Loader().load("linefittest.txt")
+        self.data_list = Loader().load(find("linefittest.txt"))
         self.data = self.data_list[0]
 
     def test_fit_line_data(self):
@@ -56,7 +62,7 @@ class TestLineFitNoweight(unittest.TestCase):
         Test Line fit without weight(dy data)
     """
     def setUp(self):
-        self.data_list = Loader().load("linefittest_no_weight.txt")
+        self.data_list = Loader().load(find("linefittest_no_weight.txt"))
         self.data = self.data_list[0]
 
     def skip_test_fit_line_data_no_weight(self):
@@ -95,7 +101,7 @@ class TestInvPolySphere(unittest.TestCase):
         Test unsmeared data for invariant computation
     """
     def setUp(self):
-        self.data_list = Loader().load("PolySpheres.txt")
+        self.data_list = Loader().load(find("PolySpheres.txt"))
         self.data = self.data_list[0]
 
     def test_wrong_data(self):
@@ -277,7 +283,7 @@ class TestInvPinholeSmear(unittest.TestCase):
     """
     def setUp(self):
         # data with smear info
-        list = Loader().load("latex_smeared.xml")
+        list = Loader().load(find("latex_smeared.xml"))
         self.data_q_smear = list[0]
 
     def test_use_case_1(self):


### PR DESCRIPTION
Test resources are in the same directory (or a child directory) of the test code, so the code can locate the resources itself rather than relying on the tests being run from a certain location. This PR adds a trivial function to find the necessary data files for the tests.

Making the tests more robust to the current working directory allows the tests to be used against installed code rather than the current checkout. These changes also allow automated test discovery to work and so tools like `py.test` can run all (or a selection of) tests at once, without the need for a custom test runner script; a `pytest.ini` configuration is included to facilitate this. For example, in the Debian packaging, we can now run the tests against the compiled version by running nothing more than `py.test`.

(This PR builds on top of #122 and so the commit in that PR will be shown here too)