### PR TITLE
Allow models to have mixed case filenames in help

### DIFF
--- a/src/sas/sasgui/perspectives/fitting/basepage.py
+++ b/src/sas/sasgui/perspectives/fitting/basepage.py
@@ -2811,7 +2811,7 @@ class BasicPage(ScrolledPanel, PanelBase):
 
         if self.model is not None:
             name = self.formfactorbox.GetValue()
-            _TreeLocation = 'user/models/' + name.lower()+'.html'
+            _TreeLocation = 'user/models/%s.html' % name
             _doc_viewer = DocumentationWindow(self, wx.ID_ANY, _TreeLocation,
                                               "", name + " Help")
         else:


### PR DESCRIPTION
sasmodels contains filenames that are not all lowercase ([unified_power_Rg.py](https://github.com/SasView/sasmodels/blob/master/sasmodels/models/unified_power_Rg.py)) and so the HTML help pages generated for this model are also mixed case (unified_power_Rg.html). The current code forces the filename for the HTML help file to lowercase means that the help for this model will not be found.

```
2018-01-09 09:38:41,256 : INFO : root (kernelpy.py:36) :: load python model unified_power_Rg
2018-01-09 09:38:44,161 : ERROR : sas.sasgui.guiframe.documentation_window (documentation_window.py:102) :: Could not find Sphinx documentation at /usr/lib/python2.7/dist-packages/sas/sasview/doc/user/models/unified_power_rg.html -- has it been built?
```

```
$ ls -l /usr/lib/python2.7/dist-packages/sas/sasview/doc/user/models/
...
-rw-r--r-- 1 root root  9639 Jan  7 12:46 unified_power_Rg.html
...
```

This can either be fixed by renaming the file in sasmodels (and requiring that all models are always lowercase filenames which would need to be enforced in the test suite), or by dropping the conversion to lowercase. I can't see any reason to want to convert to lowercase and the commit that added that code does not say why it was considered necessary. Dropping the call to `lower()` seems like the right approach.

http://bugs.debian.org/886715