### PR TITLE
Take Angsgtrom symbol out of mathrm

### DIFF
--- a/docs/sphinx-docs/source/conf.py
+++ b/docs/sphinx-docs/source/conf.py
@@ -223,7 +223,7 @@ LATEX_PREAMBLE=r"""
 \usepackage[utf8]{inputenc}      % Allow unicode symbols in text
 \newcommand{\lt}{<}              % HTML needs \lt rather than <
 \newcommand{\gt}{>}              % HTML needs \gt rather than >
-\renewcommand{\AA}{\mathrm{\r{A}}} % Allow \AA in math mode
+\renewcommand{\AA}{\text{\r{A}}} % Allow \AA in math mode
 \DeclareUnicodeCharacter {212B} {\AA}                  % Angstrom
 \DeclareUnicodeCharacter {00B7} {\ensuremath{\cdot}}   % cdot
 \DeclareUnicodeCharacter {00B0} {\ensuremath{^\circ}}  % degrees


### PR DESCRIPTION
mathrm only works in math mode, but we want to be able to use the
angstrom symbol everywhere