### PR TITLE
Fix loading of projects with the Uniform distribution

### DIFF
--- a/src/sas/sasgui/perspectives/fitting/basepage.py
+++ b/src/sas/sasgui/perspectives/fitting/basepage.py
@@ -2678,7 +2678,7 @@ class BasicPage(ScrolledPanel, PanelBase):
                        disp_func.type)
             except ValueError:
                 pass  # Fall through to default class
-        return POLYDISPERSITY_MODELS.keys().index('gaussian'), 'gaussian'
+        return (list(POLYDISPERSITY_MODELS).index('gaussian'), 'gaussian')
 
     def on_reset_clicked(self, event):
         """

--- a/src/sas/sasgui/perspectives/fitting/basepage.py
+++ b/src/sas/sasgui/perspectives/fitting/basepage.py
@@ -1366,12 +1366,12 @@ class BasicPage(ScrolledPanel, PanelBase):
                     [state.values, state.weights]
             except Exception:
                 logger.error(traceback.format_exc())
-            selection = self._find_polyfunc_selection(disp_model)
+            index, selection = self._find_polyfunc_selection(disp_model)
             for list in self.fittable_param:
                 if list[1] == key and list[7] is not None:
-                    list[7].SetSelection(selection)
+                    list[7].SetSelection(index)
                     # For the array disp_model, set the values and weights
-                    if selection == 1:
+                    if selection == 'array':
                         disp_model.set_weights(self.values[key],
                                                self.weights[key])
                         try:
@@ -1384,7 +1384,7 @@ class BasicPage(ScrolledPanel, PanelBase):
                         except Exception:
                             logger.error(traceback.format_exc())
             # For array, disable all fixed params
-            if selection == 1:
+            if selection == 'array':
                 for item in self.fixed_param:
                     if item[1].split(".")[0] == key.split(".")[0]:
                         # try it and pass it for the orientation for 1D
@@ -2667,17 +2667,18 @@ class BasicPage(ScrolledPanel, PanelBase):
 
     def _find_polyfunc_selection(self, disp_func=None):
         """
-        FInd Comboox selection from disp_func
+        Find Combobox selection from disp_func
 
         :param disp_function: dispersion distr. function
         """
         # Find the selection
         if disp_func is not None:
             try:
-                return POLYDISPERSITY_MODELS.values().index(disp_func.__class__)
+                index = POLYDISPERSITY_MODELS.values().index(disp_func.__class__)
+                return index, POLYDISPERSITY_MODELS.keys()[index]
             except ValueError:
                 pass  # Fall through to default class
-        return POLYDISPERSITY_MODELS.keys().index('gaussian')
+        return POLYDISPERSITY_MODELS.keys().index('gaussian'), 'gaussian'
 
     def on_reset_clicked(self, event):
         """

--- a/src/sas/sasgui/perspectives/fitting/basepage.py
+++ b/src/sas/sasgui/perspectives/fitting/basepage.py
@@ -2674,8 +2674,8 @@ class BasicPage(ScrolledPanel, PanelBase):
         # Find the selection
         if disp_func is not None:
             try:
-                index = POLYDISPERSITY_MODELS.values().index(disp_func.__class__)
-                return index, POLYDISPERSITY_MODELS.keys()[index]
+                return (list(POLYDISPERSITY_MODELS).index(disp_func.type),
+                       disp_func.type)
             except ValueError:
                 pass  # Fall through to default class
         return POLYDISPERSITY_MODELS.keys().index('gaussian'), 'gaussian'


### PR DESCRIPTION
This PR fixes the issue with loading projects saved using the Uniform distribution introduced in the boltzmann sasmodels branch. The project loader was using the index of the distribution combobox to check for a distribution array. The Uniform distribution was put into the position the Array distribution used to hold causing the issue seen in [ticket 1018](http://trac.sasview.org/ticket/1018#comment:5).

This PR is tied to [sasmodels PR59](https://github.com/SasView/sasmodels/pull/59).