### PR TITLE
Ticket 1068: Throw an explicit error message when a pixel space data set is sent to the loader.

### DIFF
--- a/src/sas/sascalc/dataloader/loader.py
+++ b/src/sas/sascalc/dataloader/loader.py
@@ -54,7 +54,7 @@ class Registry(ExtensionRegistry):
         self.wildcards = ['All (*.*)|*.*']
 
         # Deprecated extensions
-        self.deprecated_extensions = ['.asc', '.ASC', '.nxs', '.NXS']
+        self.deprecated_extensions = ['.asc', '.nxs']
 
         # Creation time, for testing
         self._created = time.time()
@@ -75,10 +75,14 @@ class Registry(ExtensionRegistry):
         """
         # Gets set to a string if the file has an associated reader that fails
         msg_from_reader = None
-        extlist = [ext for ext in self.deprecated_extensions if path.endswith(ext)]
+        extlist = [ext for ext in self.deprecated_extensions if
+                   path.lower().endswith(ext)]
         if extlist:
-            msg = ("\rThe file you are attempting to load, {}, is no "
-                   "longer loadable into SasView. Please use data in Q space."
+            msg = ("\rThe file you are attempting to load, {}, is no longer "
+                   "loadable by SasView. The file extension suggests the data "
+                   "set is in pixel space. SasView will no longer reduce raw da"
+                   "ta sets. Please provide fully reduced data in Q space. No a"
+                   "ttempt to load the data has been made."
                    .format(path))
             raise RuntimeError(msg)
         try:

--- a/src/sas/sascalc/dataloader/loader.py
+++ b/src/sas/sascalc/dataloader/loader.py
@@ -53,6 +53,9 @@ class Registry(ExtensionRegistry):
         # List of wildcards
         self.wildcards = ['All (*.*)|*.*']
 
+        # Deprecated extensions
+        self.deprecated_extensions = ['.asc', '.ASC', '.nxs', '.NXS']
+
         # Creation time, for testing
         self._created = time.time()
 
@@ -72,6 +75,12 @@ class Registry(ExtensionRegistry):
         """
         # Gets set to a string if the file has an associated reader that fails
         msg_from_reader = None
+        extlist = [ext for ext in self.deprecated_extensions if path.endswith(ext)]
+        if extlist:
+            msg = ("\rThe file you are attempting to load, {}, is no "
+                   "longer loadable into SasView. Please use data in Q space."
+                   .format(path))
+            raise RuntimeError(msg)
         try:
             return super(Registry, self).load(path, format=format)
         #except Exception: raise  # for debugging, don't use fallback loader


### PR DESCRIPTION
An explicit error message is thrown when the data loader sees a data set read previously by the IgorReader (.asc) or NexusReader (.nxs). The error is immediately thrown and no data loading operations are attempted.