### PR TITLE
Ticket 930 chi squared documentation updating to clarify we use reduced chi2

### DIFF
--- a/src/sas/sasgui/perspectives/fitting/fitpage.py
+++ b/src/sas/sasgui/perspectives/fitting/fitpage.py
@@ -364,7 +364,7 @@ class FitPage(BasicPage):
 
         # StaticText for chi2, N(for fitting), Npts + Log/linear spacing
         self.tcChi = BGTextCtrl(self, wx.ID_ANY, "-", size=(75, 20), style=0)
-        self.tcChi.SetToolTipString("Chi2/Npts(Fit)")
+        self.tcChi.SetToolTipString("Chi2/DOF (DOF=Npts-Npar fitted)")
         self.Npts_fit = BGTextCtrl(self, wx.ID_ANY, "-", size=(75, 20), style=0)
         self.Npts_fit.SetToolTipString(
             " Npts : number of points selected for fitting")
@@ -390,7 +390,7 @@ class FitPage(BasicPage):
         self.points_sizer.Add(wx.StaticText(self, wx.ID_ANY, 'Npts    '))
         self.points_sizer.Add(self.pointsbox)
 
-        box_description_1 = wx.StaticText(self, wx.ID_ANY, '   Chi2/Npts')
+        box_description_1 = wx.StaticText(self, wx.ID_ANY, 'Reduced Chi2')
         box_description_2 = wx.StaticText(self, wx.ID_ANY, 'Npts(Fit)')
 
         # StaticText for smear

--- a/src/sas/sasgui/perspectives/fitting/media/fitting_help.rst
+++ b/src/sas/sasgui/perspectives/fitting/media/fitting_help.rst
@@ -442,8 +442,9 @@ corresponding uncertainties on the optimised values.
    fitted parameters, or the model is relatively insensitive to the value of
    that particular parameter.
 
-In the bottom left corner of the *Fit Page* is a box displaying the normalised
-value of the statistical $\chi^2$ parameter returned by the optimiser.
+In the bottom left corner of the *Fit Page* is a box displaying a normalised
+value of the statistical $\chi^2$ parameter (the reduced $\chi^2$,
+See :ref:`Assessing_Fit_Quality`) returned by the optimiser.
 
 Now check the box for another model parameter and click *Fit* again. Repeat this
 process until all relevant parameters are checked and have been optimised. As
@@ -468,7 +469,7 @@ This mode is an extension of the :ref:`Single_Fit_Mode` that allows for some
 relatively extensive constraints between fitted parameters in a single *FitPage*
 or between several *FitPage*'s (eg, to constrain all fitted parameters to be the
 same in a contrast series of *FitPages* except for the solvent sld parameter,
-contrain the length to be twice that of the radius in a single *FitPage*,
+constrain the length to be twice that of the radius in a single *FitPage*,
 fix the radius of the sphere in one *FitPage* to be the same as the radius of
 the cylinder in a second *FitPage*, etc).
 

--- a/src/sas/sasgui/perspectives/fitting/media/fitting_help.rst
+++ b/src/sas/sasgui/perspectives/fitting/media/fitting_help.rst
@@ -431,25 +431,25 @@ data and minimizes the values of the residuals.
 
 Change the default values of the model parameters by hand until the theory line
 starts to represent the experimental data. Then check the tick boxes alongside
-the 'background' and the 'scale' parameters. Click the *Fit* button. SasView
+the 'background' and 'scale' parameters. Click the *Fit* button. SasView
 will optimise the values of the 'background' and 'scale' and also display the
 corresponding uncertainties on the optimised values.
 
 .. note::
-   If a parameter uncertainty is unrealistically large, or if it displays as
-   NaN either the model is a poor representation of the data, the parameter in
-   question is either highly correlated with one or more other fitted parameters
-   or at least that the model is relatively insensitive to the value of that
-   particular parameter.
+   If the uncertainty on a fitted parameter is unrealistically large, or if it
+   displays as NaN, the model is most likely a poor representation of the data,
+   the parameter in question is highly correlated with one or more of the other
+   fitted parameters, or the model is relatively insensitive to the value of
+   that particular parameter.
 
 In the bottom left corner of the *Fit Page* is a box displaying the normalised
 value of the statistical $\chi^2$ parameter returned by the optimiser.
 
 Now check the box for another model parameter and click *Fit* again. Repeat this
-process until most or all parameters are checked and have been optimised. As the
-fit of the theory to the experimental data improves, the value of 'Reduced Chi2'
-will decrease. A good model fit should produce values of Reduced Chi2 close
-close to one, and certainly <100. See :ref:`Assessing_Fit_Quality`.
+process until all relevant parameters are checked and have been optimised. As
+the fit of the theory to the experimental data improves, the value of 'Reduced
+Chi2' will decrease. A good model fit should produce values of Reduced Chi2
+close to one, and certainly << 100. See :ref:`Assessing_Fit_Quality`.
 
 SasView has a number of different optimisers (see the section :ref:`Fitting_Options`).
 The DREAM optimiser is the most sophisticated, but may not necessarily be the best
@@ -464,9 +464,13 @@ Simultaneous Fit Mode
 *NB: Before proceeding, ensure that the Single Mode radio button at the bottom of*
 *the Data Explorer is checked (see the section* :ref:`Loading_data` *).*
 
-This mode is an extension of the :ref:`Single_Fit_Mode` that fits two or more data
-sets *to the same model* simultaneously. If necessary it is possible to constrain
-fit parameters between data sets (eg, to fix a background level, or radius, etc).
+This mode is an extension of the :ref:`Single_Fit_Mode` that allows for some
+relatively extensive constraints between fitted parameters in a single *FitPage*
+or between several *FitPage*'s (eg, to constrain all fitted parameters to be the
+same in a contrast series of *FitPages* except for the solvent sld parameter,
+contrain the length to be twice that of the radius in a single *FitPage*,
+fix the radius of the sphere in one *FitPage* to be the same as the radius of
+the cylinder in a second *FitPage*, etc).
 
 If the data to be fit are in multiple files, load each file, then select each file
 in the *Data Explorer*, and *Send To Fitting*. If multiple data sets are in one file,
@@ -503,28 +507,11 @@ them in the first place!).
 To tie parameters between the data sets with constraints, check the 'yes' radio button
 next to *Add Constraint?* in the *Fit Constraints* box.
 
+To constrain all identically named parameters to fit *simultaneously* to the
+same value across all the *Fitpages* use the *Easy Setup* drop-down buttons in
+the *Const & Simul Fit* page.
+
 *NB: You can only constrain parameters that are set to refine.*
-
-When ready, click the *Fit* button on the *Const & Simul Fit* page, NOT the *Fit*
-button on the individual *FitPage*'s.
-
-Simultaneous Fits without Constraints
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-The results of the model-fitting will be returned to each of the individual
-*FitPage*'s.
-
-Note that the Reduced Chi2 value returned is the SUM of the Reduced Chi2 of
-each fit. To see the Reduced Chi2 value for a specific *FitPage*, click the 
-*Compute* button at the bottom of that *FitPage* to recalculate. Note that in
-doing so the degrees of freedome will be set to Npts.
-See :ref:`Assessing_Fit_Quality`.
-
-Simultaneous Fits with Constraints
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-Use the *Easy Setup* drop-down buttons in the *Const & Simul Fit* page to set
-up constraints between *FitPage*'s.
 
 Constraints will generally be of the form
 
@@ -539,15 +526,19 @@ A 'free-form' constraint box is also provided.
 
 Many constraints can be entered for a single fit.
 
+When ready, click the *Fit* button on the *Const & Simul Fit* page, NOT the *Fit*
+button on the individual *FitPage*'s.
+
 The results of the model-fitting will be returned to each of the individual
 *FitPage*'s.
 
 Note that the Reduced Chi2 value returned is the SUM of the Reduced Chi2 of
 each fit. To see the Reduced Chi2 value for a specific *FitPage*, click the 
 *Compute* button at the bottom of that *FitPage* to recalculate. Note that in
-doing so the degrees of freedome will be set to Npts.
+doing so the degrees of freedom will be set to Npts.
 See :ref:`Assessing_Fit_Quality`.  Moreover in the case of constraints the
-degrees of freedom are less than one might think do to those constraints.
+degrees of freedom are less than one might think due to those constraints.
+
 .. ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ
 
 .. _Batch_Fit_Mode:
@@ -772,5 +763,8 @@ finding the peak.
 
 .. ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ
 
-.. note::  This help document was last changed by Paul Butler, 10 September
-   2017
+.*Document History*
+
+| 2017-09-10 Paul Butler
+| 2017-09-15 Steve King
+| 2018-03-05 Paul Butler

--- a/src/sas/sasgui/perspectives/fitting/media/fitting_help.rst
+++ b/src/sas/sasgui/perspectives/fitting/media/fitting_help.rst
@@ -425,27 +425,30 @@ window, and a second graph window will appear displaying the residuals (the
 difference between the experimental data and the theory) at the same X-data values.
 See :ref:`Assessing_Fit_Quality`.
 
-The objective of model-fitting is to find a *physically-plausible* model, and set
-of model parameters, that generate a theory that reproduces the experimental data
-and gives residual values as close to zero as possible.
+The objective of model-fitting is to find a *physically-plausible* model, and
+set of model parameters, that generate a theory that reproduces the experimental
+data and minimizes the values of the residuals.
 
 Change the default values of the model parameters by hand until the theory line
-starts to represent the experimental data. Then uncheck the tick boxes alongside
-all parameters *except* the 'background' and the 'scale'. Click the *Fit* button.
-SasView will optimise the values of the 'background' and 'scale' and also display
-the corresponding uncertainties on the optimised values.
+starts to represent the experimental data. Then check the tick boxes alongside
+the 'background' and the 'scale' parameters. Click the *Fit* button. SasView
+will optimise the values of the 'background' and 'scale' and also display the
+corresponding uncertainties on the optimised values.
 
-*NB: If no uncertainty is shown it generally means that the model is not very*
-*dependent on the corresponding parameter (or that one or more parameters are*
-*'correlated').*
+.. note::
+   If a parameter uncertainty is unrealistically large, or if it displays as
+   NaN either the model is a poor representation of the data, the parameter in
+   question is either highly correlated with one or more other fitted parameters
+   or at least that the model is relatively insensitive to the value of that
+   particular parameter.
 
-In the bottom left corner of the *Fit Page* is a box displaying the normalised value
-of the statistical $\chi^2$ parameter returned by the optimiser.
+In the bottom left corner of the *Fit Page* is a box displaying the normalised
+value of the statistical $\chi^2$ parameter returned by the optimiser.
 
 Now check the box for another model parameter and click *Fit* again. Repeat this
 process until most or all parameters are checked and have been optimised. As the
-fit of the theory to the experimental data improves the value of 'chi2/Npts' will
-decrease. A good model fit should easily produce values of 'chi2/Npts' that are
+fit of the theory to the experimental data improves, the value of 'Reduced Chi2'
+will decrease. A good model fit should produce values of Reduced Chi2 close
 close to one, and certainly <100. See :ref:`Assessing_Fit_Quality`.
 
 SasView has a number of different optimisers (see the section :ref:`Fitting_Options`).
@@ -511,9 +514,11 @@ Simultaneous Fits without Constraints
 The results of the model-fitting will be returned to each of the individual
 *FitPage*'s.
 
-Note that the chi2/Npts value returned is the SUM of the chi2/Npts of each fit. To
-see the chi2/Npts value for a specific *FitPage*, click the *Compute* button at the
-bottom of that *FitPage* to recalculate. Also see :ref:`Assessing_Fit_Quality`.
+Note that the Reduced Chi2 value returned is the SUM of the Reduced Chi2 of
+each fit. To see the Reduced Chi2 value for a specific *FitPage*, click the 
+*Compute* button at the bottom of that *FitPage* to recalculate. Note that in
+doing so the degrees of freedome will be set to Npts.
+See :ref:`Assessing_Fit_Quality`.
 
 Simultaneous Fits with Constraints
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -537,10 +542,12 @@ Many constraints can be entered for a single fit.
 The results of the model-fitting will be returned to each of the individual
 *FitPage*'s.
 
-Note that the chi2/Npts value returned is the SUM of the chi2/Npts of each fit. To
-see the chi2/Npts value for a specific *FitPage*, click the *Compute* button at the
-bottom of that *FitPage* to recalculate. Also see :ref:`Assessing_Fit_Quality`.
-
+Note that the Reduced Chi2 value returned is the SUM of the Reduced Chi2 of
+each fit. To see the Reduced Chi2 value for a specific *FitPage*, click the 
+*Compute* button at the bottom of that *FitPage* to recalculate. Note that in
+doing so the degrees of freedome will be set to Npts.
+See :ref:`Assessing_Fit_Quality`.  Moreover in the case of constraints the
+degrees of freedom are less than one might think do to those constraints.
 .. ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ
 
 .. _Batch_Fit_Mode:

--- a/src/sas/sasgui/perspectives/fitting/media/residuals_help.rst
+++ b/src/sas/sasgui/perspectives/fitting/media/residuals_help.rst
@@ -26,19 +26,21 @@ Chi2
 ^^^^
 
 $\chi^2$ is a statistical parameter that quantifies the differences between
-an observed data set and an expected dataset (or 'theory').
-
-When showing the a model with the data, *SasView* displays this parameter
-normalized to the number of data points, $N_\mathrm{pts}$ such that
+an observed data set and an expected dataset (or 'theory') calculated as
 
 .. math::
 
-  \chi^2_N
-  =  \sum[(Y_i - \mathrm{theory}_i)^2 / \mathrm{error}_i^2] / N_\mathrm{pts}
+  \chi^2
+  =  \sum[(Y_i - \mathrm{theory}_i)^2 / \mathrm{error}_i^2]
 
-When performing a fit, *SasView* instead displays the reduced $\chi^2_R$,
-which takes into account the number of fitting parameters $N_\mathrm{par}$
-(to calculate the number of 'degrees of freedom'). This is computed as
+Fitting typically minimizes the value of $\chi^2$.  However, for assessing the
+quality of the model and its "fit" this parameter is not terribly helpful on its
+own.  Thus *SasView* instead displays a normalized version of this parameter,
+using the traditional reduced $\chi^2_R$.  This is the $\chi^2$ divided by the
+degrees of freedom (or DOF). The DOF is simply the number of data points being
+considered reduced by the number of free (i.e. fitted) parameters. Note that
+model parameters that are kept fixed do *not* contribute to the DOF (they are
+not"free". This reduced value is then given as
 
 .. math::
 
@@ -46,8 +48,15 @@ which takes into account the number of fitting parameters $N_\mathrm{par}$
   =  \sum[(Y_i - \mathrm{theory}_i)^2 / \mathrm{error}_i^2]
   / [N_\mathrm{pts} - N_\mathrm{par}]
 
-The normalized $\chi^2_N$ and the reduced $\chi^2_R$ are very close to each
-other when $N_\mathrm{pts} \gg N_\mathrm{par}$.
+where $N_\mathrm{par}$ is the number of *fitted* parameters. Note that this
+means the displayed value will vary depending on the number of parameters used
+in the fit.  In particular, when doing a calculation without a fit (e.g.
+manually changing a parameter) the DOF will now equal $N_\mathrm{pts}$ and the
+$\chi^2_R$ will be the smallest possible for that combination of model, data
+set and set of parameter values.
+
+When $N_\mathrm{pts} \gg N_\mathrm{par}$ as it should for proper fitting, the
+value of the reduced $\chi^2_R$ will not change very much.
 
 For a good fit, $\chi^2_R$ tends to 1.
 

--- a/src/sas/sasgui/perspectives/fitting/media/residuals_help.rst
+++ b/src/sas/sasgui/perspectives/fitting/media/residuals_help.rst
@@ -33,14 +33,14 @@ an observed data set and an expected dataset (or 'theory') calculated as
   \chi^2
   =  \sum[(Y_i - \mathrm{theory}_i)^2 / \mathrm{error}_i^2]
 
-Fitting typically minimizes the value of $\chi^2$.  However, for assessing the
-quality of the model and its "fit" this parameter is not terribly helpful on its
-own.  Thus *SasView* instead displays a normalized version of this parameter,
-using the traditional reduced $\chi^2_R$.  This is the $\chi^2$ divided by the
-degrees of freedom (or DOF). The DOF is simply the number of data points being
-considered reduced by the number of free (i.e. fitted) parameters. Note that
-model parameters that are kept fixed do *not* contribute to the DOF (they are
-not"free". This reduced value is then given as
+Fitting typically minimizes the value of $\chi^2$.  For assessing the quality of
+the model and its "fit" however, *SasView* displays the traditional reduced
+$\chi^2_R$ which normalizes this parameter by dividing it by the number of
+degrees of freedom (or DOF). The DOF is the number of data points being
+considered, $N_\mathrm{pts}$, reduced by the number of free (i.e. fitted)
+parameters, $N_\mathrm{par}$. Note that model parameters that are kept fixed do
+*not* contribute to the DOF (they are not "free"). This reduced value is then
+given as
 
 .. math::
 
@@ -48,12 +48,11 @@ not"free". This reduced value is then given as
   =  \sum[(Y_i - \mathrm{theory}_i)^2 / \mathrm{error}_i^2]
   / [N_\mathrm{pts} - N_\mathrm{par}]
 
-where $N_\mathrm{par}$ is the number of *fitted* parameters. Note that this
-means the displayed value will vary depending on the number of parameters used
-in the fit.  In particular, when doing a calculation without a fit (e.g.
-manually changing a parameter) the DOF will now equal $N_\mathrm{pts}$ and the
-$\chi^2_R$ will be the smallest possible for that combination of model, data
-set and set of parameter values.
+Note that this means the displayed value will vary depending on the number of
+parameters used in the fit. In particular, when doing a calculation without a
+fit (e.g. manually changing a parameter) the DOF will now equal $N_\mathrm{pts}$
+and the $\chi^2_R$ will be the smallest possible for that combination of model,
+data set, and set of parameter values.
 
 When $N_\mathrm{pts} \gg N_\mathrm{par}$ as it should for proper fitting, the
 value of the reduced $\chi^2_R$ will not change very much.
@@ -98,3 +97,4 @@ be meaningless.
 
 | 2015-06-08 Steve King
 | 2017-09-28 Paul Kienzle
+| 2018-03-04 Paul Butler


### PR DESCRIPTION
Besides updating the documentation in residual_help which was already close and that in fitting_help which was less so, the section on simultaneous fitting was also updated since it referred to chi^2.

closes #930