### PR TITLE
Ticket 1052: Allow custom models to be used in sum|multi models

### DIFF
--- a/src/sas/sascalc/fit/models.py
+++ b/src/sas/sascalc/fit/models.py
@@ -97,6 +97,7 @@ def find_plugins_dir():
     # TODO: should we be checking for new default models every time?
     # TODO: restore support for default plugins
     #initialize_plugins_dir(path)
+    os.environ['PLUGIN_MODEL_DIR'] = path
     return path
 
 

--- a/src/sas/sascalc/fit/models.py
+++ b/src/sas/sascalc/fit/models.py
@@ -97,7 +97,6 @@ def find_plugins_dir():
     # TODO: should we be checking for new default models every time?
     # TODO: restore support for default plugins
     #initialize_plugins_dir(path)
-    os.environ['PLUGIN_MODEL_DIR'] = path
     return path
 
 

--- a/src/sas/sasgui/perspectives/calculator/model_editor.py
+++ b/src/sas/sasgui/perspectives/calculator/model_editor.py
@@ -390,6 +390,7 @@ class TextDialog(wx.Dialog):
             color = 'red'
         self._msg_box.SetLabel(msg)
         self._msg_box.SetForegroundColour(color)
+        self._set_model_list()
         if self.parent.parent is not None:
             from sas.sasgui.guiframe.events import StatusEvent
             wx.PostEvent(self.parent.parent, StatusEvent(status=msg,
@@ -431,6 +432,8 @@ class TextDialog(wx.Dialog):
 
         if len(main_list) > 1:
             main_list.sort()
+        self.model1.Clear()
+        self.model2.Clear()
         for idx in range(len(main_list)):
             self.model1.Append(str(main_list[idx]), idx)
             self.model2.Append(str(main_list[idx]), idx)


### PR DESCRIPTION
I created a new environment variable PLUGIN_MODEL_DIR set in sasview and used in sasmodels to find the plugin directory. As a bonus, the Sum|Multi window model combo boxes are updated when a new plugin model is created.

This depends on [sasmodels PR 63](https://github.com/SasView/sasmodels/pull/63).