### PR TITLE
Fix finding of test resource

### DIFF
--- a/test/sascalculator/test/utest_sas_gen.py
+++ b/test/sascalculator/test/utest_sas_gen.py
@@ -59,7 +59,7 @@ class sas_gen_test(unittest.TestCase):
         """
         Test that the calculator calculates.
         """
-        f = self.omfloader.read("A_Raw_Example-1.omf")
+        f = self.omfloader.read(find("A_Raw_Example-1.omf"))
         omf2sld = sas_gen.OMF2SLD()
         omf2sld.set_data(f)
         model = sas_gen.GenSAS()


### PR DESCRIPTION
A newly added test missed the call to `find()`, breaking the use of pytest.

(Would you be open to using pytest to run the tests on travis? Is there any functionality that `utest_sasview.py` provides that a simple call to pytest doesn't? Example of this failure being caught on travis at https://travis-ci.org/llimeht/sasview/jobs/351702734 )