### PR TITLE
Removing save button from OSX

### DIFF
--- a/src/sas/sascalc/fit/pagestate.py
+++ b/src/sas/sascalc/fit/pagestate.py
@@ -1375,7 +1375,7 @@ FEET_1 = \
 <br><font size='4' >Data: "%s"</font><br>
 """
 FEET_2 = \
-"""<img src="%s" width="540"></img>
+"""<img src="%s"></img>
 """
 FEET_2_unix = \
 """<img src="%s" width="540"></img>

--- a/src/sas/sascalc/fit/pagestate.py
+++ b/src/sas/sascalc/fit/pagestate.py
@@ -645,6 +645,8 @@ class PageState(object):
                     # parsing "data : File:     filename [mmm dd hh:mm]"
                     name = value.split(':', 1)[1].strip()
                     file_value = "File name:" + name
+                    if len(file_value) > 50:
+                        file_value = "File name:.."+file_value[-40:]
                     file_name = CENTRE % file_value
                     if len(title) == 0:
                         title = name + " [" + repo_time + "]"
@@ -1367,7 +1369,7 @@ FEET_1 = \
 <br><font size='4' >Data: "%s"</font><br>
 """
 FEET_2 = \
-"""<img src="%s" ></img>
+"""<img src="%s" width="540"></img>
 """
 FEET_3 = \
 """</center>

--- a/src/sas/sascalc/fit/pagestate.py
+++ b/src/sas/sascalc/fit/pagestate.py
@@ -645,8 +645,11 @@ class PageState(object):
                     # parsing "data : File:     filename [mmm dd hh:mm]"
                     name = value.split(':', 1)[1].strip()
                     file_value = "File name:" + name
-                    if len(file_value) > 50:
-                        file_value = "File name:.."+file_value[-40:]
+                    #Truncating string so print doesn't complain of being outside margins
+                    if sys.platform != "win32":
+                        MAX_STRING_LENGHT = 50
+                        if len(file_value) > MAX_STRING_LENGHT:
+                            file_value = "File name:.."+file_value[-MAX_STRING_LENGHT+10:]
                     file_name = CENTRE % file_value
                     if len(title) == 0:
                         title = name + " [" + repo_time + "]"
@@ -722,8 +725,11 @@ class PageState(object):
         # get the strings for report
         html_str, text_str, title = self._get_report_string()
         # Allow 2 figures to append
-        image_links = [FEET_2%fig for fig in fig_urls]
-
+        #Constraining image width for OSX and linux, so print doesn't complain of being outside margins
+        if sys.platform == "win32":
+            image_links = [FEET_2%fig for fig in fig_urls]
+        else:
+            image_links = [FEET_2_unix%fig for fig in fig_urls]
         # final report html strings
         report_str = html_str + ELINE.join(image_links)
         report_str += FEET_3
@@ -1369,6 +1375,9 @@ FEET_1 = \
 <br><font size='4' >Data: "%s"</font><br>
 """
 FEET_2 = \
+"""<img src="%s" width="540"></img>
+"""
+FEET_2_unix = \
 """<img src="%s" width="540"></img>
 """
 FEET_3 = \

--- a/src/sas/sascalc/fit/pagestate.py
+++ b/src/sas/sascalc/fit/pagestate.py
@@ -724,7 +724,7 @@ class PageState(object):
 
         # final report html strings
         report_str = html_str + ELINE.join(image_links)
-
+        report_str += FEET_3
         return report_str, text_str
 
     def _to_xml_helper(self, thelist, element, newdoc):

--- a/src/sas/sasgui/guiframe/report_dialog.py
+++ b/src/sas/sasgui/guiframe/report_dialog.py
@@ -26,7 +26,7 @@ else:
 
 class BaseReportDialog(wx.Dialog):
 
-    def __init__(self, report_list, *args, **kwds):
+    def __init__(self, report_list, imgRAM, fig_urls, *args, **kwds):
         """
         Initialization. The parameters added to Dialog are:
 
@@ -36,6 +36,10 @@ class BaseReportDialog(wx.Dialog):
         super(BaseReportDialog, self).__init__(*args, **kwds)
         kwds["image"] = 'Dynamic Image'
 
+        #MemoryFSHandle for storing images
+        self.imgRAM = imgRAM
+        #Images location in urls
+        self.fig_urls = fig_urls
         # title
         self.SetTitle("Report")
         # size
@@ -74,11 +78,10 @@ class BaseReportDialog(wx.Dialog):
                           id=button_print.GetId())
         hbox.Add(button_print)
 
-        if sys.platform == "win32":
-            button_save = wx.Button(self, wx.NewId(), "Save")
-            button_save.SetToolTipString("Save this report.")
-            button_save.Bind(wx.EVT_BUTTON, self.onSave, id=button_save.GetId())
-            hbox.Add(button_save)
+        button_save = wx.Button(self, wx.NewId(), "Save")
+        button_save.SetToolTipString("Save this report.")
+        button_save.Bind(wx.EVT_BUTTON, self.onSave, id=button_save.GetId())
+        hbox.Add(button_save)
 
         # panel for report page
         vbox = wx.BoxSizer(wx.VERTICAL)
@@ -111,11 +114,15 @@ class BaseReportDialog(wx.Dialog):
         printh = html.HtmlEasyPrinting(name="Printing", parentWindow=self)
         printh.PrintText(self.report_html)
 
+
     def OnClose(self, event=None):
         """
         Close the Dialog
         : event: Close button event
         """
+        for fig in self.fig_urls:
+            self.imgRAM.RemoveFile(fig)
+
         self.Close()
 
     def HTML2PDF(self, data, filename):

--- a/src/sas/sasgui/guiframe/report_dialog.py
+++ b/src/sas/sasgui/guiframe/report_dialog.py
@@ -77,11 +77,12 @@ class BaseReportDialog(wx.Dialog):
         button_print.Bind(wx.EVT_BUTTON, self.onPrint,
                           id=button_print.GetId())
         hbox.Add(button_print)
-
-        button_save = wx.Button(self, wx.NewId(), "Save")
-        button_save.SetToolTipString("Save this report.")
-        button_save.Bind(wx.EVT_BUTTON, self.onSave, id=button_save.GetId())
-        hbox.Add(button_save)
+        
+        if sys.platform == "win32":
+            button_save = wx.Button(self, wx.NewId(), "Save")
+            button_save.SetToolTipString("Save this report.")
+            button_save.Bind(wx.EVT_BUTTON, self.onSave, id=button_save.GetId())
+            hbox.Add(button_save)
 
         # panel for report page
         vbox = wx.BoxSizer(wx.VERTICAL)

--- a/src/sas/sasgui/guiframe/report_dialog.py
+++ b/src/sas/sasgui/guiframe/report_dialog.py
@@ -78,7 +78,7 @@ class BaseReportDialog(wx.Dialog):
                           id=button_print.GetId())
         hbox.Add(button_print)
 
-        if sys.platform == "win32":
+        if sys.platform != "darwin":
             button_save = wx.Button(self, wx.NewId(), "Save")
             button_save.SetToolTipString("Save this report.")
             button_save.Bind(wx.EVT_BUTTON, self.onSave, id=button_save.GetId())

--- a/src/sas/sasgui/guiframe/report_dialog.py
+++ b/src/sas/sasgui/guiframe/report_dialog.py
@@ -74,10 +74,11 @@ class BaseReportDialog(wx.Dialog):
                           id=button_print.GetId())
         hbox.Add(button_print)
 
-        button_save = wx.Button(self, wx.NewId(), "Save")
-        button_save.SetToolTipString("Save this report.")
-        button_save.Bind(wx.EVT_BUTTON, self.onSave, id=button_save.GetId())
-        hbox.Add(button_save)
+        if sys.platform == "win32":
+            button_save = wx.Button(self, wx.NewId(), "Save")
+            button_save.SetToolTipString("Save this report.")
+            button_save.Bind(wx.EVT_BUTTON, self.onSave, id=button_save.GetId())
+            hbox.Add(button_save)
 
         # panel for report page
         vbox = wx.BoxSizer(wx.VERTICAL)

--- a/src/sas/sasgui/guiframe/report_dialog.py
+++ b/src/sas/sasgui/guiframe/report_dialog.py
@@ -77,7 +77,7 @@ class BaseReportDialog(wx.Dialog):
         button_print.Bind(wx.EVT_BUTTON, self.onPrint,
                           id=button_print.GetId())
         hbox.Add(button_print)
-        
+
         if sys.platform == "win32":
             button_save = wx.Button(self, wx.NewId(), "Save")
             button_save.SetToolTipString("Save this report.")

--- a/src/sas/sasgui/perspectives/fitting/basepage.py
+++ b/src/sas/sasgui/perspectives/fitting/basepage.py
@@ -640,10 +640,9 @@ class BasicPage(ScrolledPanel, PanelBase):
 
         # get the strings for report
         report_str, text_str = self.state.report(fig_urls=refs)
-
         # Show the dialog
         report_list = [report_str, text_str, images]
-        dialog = ReportDialog(report_list, None, wx.ID_ANY, "")
+        dialog = ReportDialog(report_list, imgRAM, refs, None, wx.ID_ANY, "")
         dialog.Show()
 
     def _build_plots_for_report(self, figs, canvases):
@@ -676,7 +675,6 @@ class BasicPage(ScrolledPanel, PanelBase):
             name = 'img_fit%s.png' % ind
             refs.append('memory:' + name)
             imgRAM.AddFile(name, canvas.bitmap, wx.BITMAP_TYPE_PNG)
-
             # append figs
             images.append(fig)
 


### PR DESCRIPTION
Simply disabling saving functionality for OSX due to issues with generating empty pdf files. 