### PR TITLE
Drop incorrect version req on pyparsing

### DIFF
--- a/build_tools/requirements.txt
+++ b/build_tools/requirements.txt
@@ -2,7 +2,7 @@
 # Commented items are generally easier to install separately.
 pylint
 unittest-xml-reporting==1.10.0
-pyparsing==1.5.5
+pyparsing>=2.0
 html5lib==0.95
 reportlab==2.5
 lxml==2.3

--- a/setup.py
+++ b/setup.py
@@ -401,7 +401,7 @@ package_data['sas.sasview'] = ['images/*',
 packages.append("sas.sasview")
 
 required = [
-    'bumps>=0.7.5.9', 'periodictable>=1.5.0', 'pyparsing<2.0.0',
+    'bumps>=0.7.5.9', 'periodictable>=1.5.0', 'pyparsing>=2.0.0',
 
     # 'lxml>=2.2.2',
     'lxml', 'h5py',


### PR DESCRIPTION
matplotlib has a minimum version of pyparsing ("Matplotlib requires pyparsing>=2.0.1;") that is considerably greater than and also incompatible with the 1.5.5 that pyparsing is currently pinned to. Travis currently installs 1.5.5 and 1.5.7 and 2.2.0 within the system via apt, conda and pip. 

This patch fixes up the sasview requirement so that matplotlib and sasview are co-installable, possibly addressing the pyparsing issues described in #143.

(As a general rule, avoiding `==` dependencies is really important for maintaining the ability to install the required packages. Use of `>=` to ensure a particular feature is available or a particular bug is fixed is best. Most maintainers are of dependencies will work to ensure that API compatibility is maintained, at least across minor and micro releases so `==` is overkill.)