### PR TITLE
Fix imports for matplotlib 2.2.2

### DIFF
--- a/src/sas/sasgui/perspectives/calculator/resolution_calculator_panel.py
+++ b/src/sas/sasgui/perspectives/calculator/resolution_calculator_panel.py
@@ -17,7 +17,7 @@ import logging
 #Use the WxAgg back end. The Wx one takes too long to render
 matplotlib.use('WXAgg')
 from matplotlib.backends.backend_wxagg import FigureCanvasWxAgg as FigureCanvas
-from matplotlib.backends.backend_wxagg import NavigationToolbar2Wx as Toolbar
+from matplotlib.backends.backend_wxagg import NavigationToolbar2WxAgg as Toolbar
 from matplotlib.backend_bases import FigureManagerBase
 # Wx-Pylab magic for displaying plots within an application's window.
 from matplotlib import _pylab_helpers


### PR DESCRIPTION
The wx backend no longer eposes both NavigationToolbar2WxAgg and
NavigationToolbar2Wx. Since the resolution calculator still used the Wx
name not the WxAgg name, it could not be imported, and neither could any
of sas.sasgui.perspectives.fitting. The ImportError in the SasView constructor
(sas/sasview/sasview.py:67, import sas.sasgui.perspectives.fitting fails)
leaves the GUI pretty messy and fitting is not possible.