### PR TITLE
Fix race condition in test

### DIFF
--- a/test/corfunc/test/utest_corfunc.py
+++ b/test/corfunc/test/utest_corfunc.py
@@ -73,14 +73,16 @@ class TestCalculator(unittest.TestCase):
         # Transform is performed asynchronously; give it time to run
         while True:
             time.sleep(0.001)
-            if not self.calculator.transform_isrunning():
+            if (not self.calculator.transform_isrunning() and
+                self.transformation is not None):
                 break
 
-    def transform_callback(self, transforms):
-        transform1, transform3, idf = transforms
+        transform1, transform3, idf = self.transformation
         self.assertIsNotNone(transform1)
         self.assertAlmostEqual(transform1.y[0], 1)
         self.assertAlmostEqual(transform1.y[-1], 0, 5)
+
+    def transform_callback(self, transforms):
         self.transformation = transforms
 
     def extract_params(self):


### PR DESCRIPTION
`transform_isrunning()` returns `False` both before the calculation has started and also after the calculation has finished. The test of the transformation was only considering the latter case and so was regularly failing on the reproducible-builds.org test infrastructure. (This patch has been in place for a couple of months without failure.)

There is, perhaps, a broader discussion about whether the `transform_isrunning()` should return `False` when the calculation is yet to start (`complete` or `completed` would be a better test), but I don't know the wider implications of that suggestion throughout the code.