### PR TITLE
Ticket 1069: Fix for orphaned error boxes

### DIFF
--- a/src/sas/sasgui/perspectives/fitting/basepage.py
+++ b/src/sas/sasgui/perspectives/fitting/basepage.py
@@ -2551,6 +2551,7 @@ class BasicPage(ScrolledPanel, PanelBase):
             self._update_paramv_on_fit()
             # draw
             self._draw_model()
+            self.Layout()
             self.Refresh()
         except Exception:
             logger.error(traceback.format_exc())

--- a/src/sas/sasgui/perspectives/fitting/fitpage.py
+++ b/src/sas/sasgui/perspectives/fitting/fitpage.py
@@ -707,7 +707,7 @@ class FitPage(BasicPage):
                         ix = 3
                         ctl2 = wx.TextCtrl(self, wx.ID_ANY,
                                            size=(_BOX_WIDTH / 1.3, 20),
-                                           style=0)
+                                           style=wx.TE_READONLY)
 
                         self.sizer4_4.Add(ctl2, (iy, ix), (1, 1),
                                           wx.EXPAND | wx.ADJUST_MINSIZE, 0)
@@ -1997,6 +1997,7 @@ class FitPage(BasicPage):
 
         self.on_smear_helper()
         self.on_set_focus(None)
+        self.Layout()
         self.Refresh()
         # update model plot with new data information
         if flag:
@@ -2892,7 +2893,8 @@ class FitPage(BasicPage):
                         text2.Hide()
                     ix += 1
                     ctl2 = wx.TextCtrl(self, wx.ID_ANY,
-                                       size=(_BOX_WIDTH / 1.2, 20), style=0)
+                                       size=(_BOX_WIDTH / 1.2, 20),
+                                       style=wx.TE_READONLY)
                     sizer.Add(ctl2, (iy, ix), (1, 1),
                               wx.EXPAND | wx.ADJUST_MINSIZE, 0)
                     if not self.is_mac:

--- a/src/sas/sasgui/perspectives/fitting/fitpage.py
+++ b/src/sas/sasgui/perspectives/fitting/fitpage.py
@@ -705,9 +705,8 @@ class FitPage(BasicPage):
                             text2.Hide()
 
                         ix = 3
-                        ctl2 = wx.TextCtrl(self, wx.ID_ANY,
-                                           size=(_BOX_WIDTH / 1.3, 20),
-                                           style=wx.TE_READONLY)
+                        ctl2 = BGTextCtrl(self, wx.ID_ANY,
+                                           size=(_BOX_WIDTH / 1.3, 20))
 
                         self.sizer4_4.Add(ctl2, (iy, ix), (1, 1),
                                           wx.EXPAND | wx.ADJUST_MINSIZE, 0)
@@ -2892,9 +2891,8 @@ class FitPage(BasicPage):
                     if not self.is_mac:
                         text2.Hide()
                     ix += 1
-                    ctl2 = wx.TextCtrl(self, wx.ID_ANY,
-                                       size=(_BOX_WIDTH / 1.2, 20),
-                                       style=wx.TE_READONLY)
+                    ctl2 = BGTextCtrl(self, wx.ID_ANY,
+                                       size=(_BOX_WIDTH / 1.2, 20))
                     sizer.Add(ctl2, (iy, ix), (1, 1),
                               wx.EXPAND | wx.ADJUST_MINSIZE, 0)
                     if not self.is_mac:


### PR DESCRIPTION
This fixes the issue with the orphaned error boxes that show up on the top-left of the fit page when first assigning data (not in the ticket) as well as when the polydispersity distribution is changed. Also, I made the error value read-only. They appear similar to other values, but cannot be edited now.