### PR TITLE
SASVIEW-957 logging changes

### DIFF
--- a/src/sas/logger_config.py
+++ b/src/sas/logger_config.py
@@ -7,8 +7,6 @@ import os.path
 
 import pkg_resources
 
-import sas.qtgui.Utilities.LocalConfig as LocalConfig
-
 '''
 Module that manages the global logging
 '''
@@ -30,9 +28,6 @@ class SetupLogger(object):
             logging.captureWarnings(True)
             logger = logging.getLogger(self.name)
 
-        # use this as a final override if the need arises
-        logging.disable(LocalConfig.DISABLE_LOGGING)
-
         return logger
 
     def config_development(self):
@@ -42,9 +37,6 @@ class SetupLogger(object):
         logger = logging.getLogger(self.name)
         self._update_all_logs_to_debug(logger)
         logging.captureWarnings(True)
-
-        # use this as a final override if the need arises
-        logging.disable(LocalConfig.DISABLE_LOGGING)
 
         return logger
 

--- a/src/sas/logger_config.py
+++ b/src/sas/logger_config.py
@@ -7,6 +7,7 @@ import os.path
 
 import pkg_resources
 
+import sas.qtgui.Utilities.LocalConfig as LocalConfig
 
 '''
 Module that manages the global logging
@@ -28,6 +29,10 @@ class SetupLogger(object):
             self._read_config_file()
             logging.captureWarnings(True)
             logger = logging.getLogger(self.name)
+
+        # use this as a final override if the need arises
+        logging.disable(LocalConfig.DISABLE_LOGGING)
+
         return logger
 
     def config_development(self):
@@ -37,6 +42,10 @@ class SetupLogger(object):
         logger = logging.getLogger(self.name)
         self._update_all_logs_to_debug(logger)
         logging.captureWarnings(True)
+
+        # use this as a final override if the need arises
+        logging.disable(LocalConfig.DISABLE_LOGGING)
+
         return logger
 
     def _read_config_file(self):
@@ -48,11 +57,9 @@ class SetupLogger(object):
         This updates all loggers and respective handlers to DEBUG
         '''
         for handler in logger.handlers or logger.parent.handlers:
-            #handler.setLevel(logging.DEBUG)
-            handler.setLevel(logging.WARNING)
+            handler.setLevel(logging.DEBUG)
         for name, _ in logging.Logger.manager.loggerDict.items():
-            #logging.getLogger(name).setLevel(logging.DEBUG)
-            logging.getLogger(name).setLevel(logging.WARNING)
+            logging.getLogger(name).setLevel(logging.DEBUG)
 
     def _find_config_file(self, filename="logging.ini"):
         '''

--- a/src/sas/logging.ini
+++ b/src/sas/logging.ini
@@ -11,7 +11,8 @@ keys=simple,detailed
 [formatter_simple]
 #format=%(asctime)s - %(name)s - %(levelname)s - %(message)s
 #format=%(asctime)s - %(levelname)s : %(name)s:%(pathname)s:%(lineno)4d: %(message)s
-format=%(asctime)s - %(levelname)s : %(name)s:%(lineno)4d: %(message)s
+#format=%(asctime)s - %(levelname)s : %(name)s:%(lineno)4d: %(message)s
+format=%(asctime)s - %(levelname)s: %(message)s
 datefmt=%H:%M:%S
 
 [formatter_detailed]

--- a/src/sas/qtgui/MainWindow/GuiManager.py
+++ b/src/sas/qtgui/MainWindow/GuiManager.py
@@ -12,7 +12,7 @@ from PyQt5.QtCore import Qt, QLocale, QUrl
 from twisted.internet import reactor
 # General SAS imports
 from sas.qtgui.Utilities.ConnectionProxy import ConnectionProxy
-from sas.qtgui.Utilities.SasviewLogger import XStream
+from sas.qtgui.Utilities.SasviewLogger import setup_qt_logging
 
 import sas.qtgui.Utilities.LocalConfig as LocalConfig
 import sas.qtgui.Utilities.GuiUtils as GuiUtils
@@ -85,8 +85,8 @@ class GuiManager(object):
         self.addWidgets()
 
         # Fork off logging messages to the Log Window
-        XStream.stdout().messageWritten.connect(self.listWidget.insertPlainText)
-        XStream.stderr().messageWritten.connect(self.listWidget.insertPlainText)
+        handler = setup_qt_logging()
+        handler.messageWritten.connect(self.listWidget.insertPlainText)
 
         # Log the start of the session
         logging.info(" --- SasView session started ---")

--- a/src/sas/qtgui/MainWindow/GuiManager.py
+++ b/src/sas/qtgui/MainWindow/GuiManager.py
@@ -86,7 +86,7 @@ class GuiManager(object):
 
         # Fork off logging messages to the Log Window
         handler = setup_qt_logging()
-        handler.messageWritten.connect(self.listWidget.insertPlainText)
+        handler.messageWritten.connect(self.appendLog)
 
         # Log the start of the session
         logging.info(" --- SasView session started ---")
@@ -268,6 +268,11 @@ class GuiManager(object):
         Set the status bar text
         """
         self.statusLabel.setText(text)
+
+    def appendLog(self, msg):
+        """Appends a message to the list widget in the Log Explorer. Use this
+        instead of listWidget.insertPlainText() to facilitate auto-scrolling"""
+        self.listWidget.append(msg.strip())
 
     def createGuiData(self, item, p_file=None):
         """

--- a/src/sas/qtgui/MainWindow/MainWindow.py
+++ b/src/sas/qtgui/MainWindow/MainWindow.py
@@ -10,9 +10,6 @@ from PyQt5.QtGui import QPixmap
 from sas.qtgui.UI import main_resources_rc
 from .UI.MainWindowUI import Ui_MainWindow
 
-# Initialize logging
-import sas.qtgui.Utilities.SasviewLogger
-
 class MainSasViewWindow(QMainWindow, Ui_MainWindow):
     # Main window of the application
     def __init__(self, parent=None):

--- a/src/sas/qtgui/Perspectives/Fitting/FittingWidget.py
+++ b/src/sas/qtgui/Perspectives/Fitting/FittingWidget.py
@@ -106,9 +106,6 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         # Globals
         self.initializeGlobals()
 
-        # Set up desired logging level
-        logging.disable(LocalConfig.DISABLE_LOGGING)
-
         # data index for the batch set
         self.data_index = 0
         # Main Data[12]D holders

--- a/src/sas/qtgui/Utilities/LocalConfig.py
+++ b/src/sas/qtgui/Utilities/LocalConfig.py
@@ -135,14 +135,11 @@ DEFAULT_PERSPECTIVE = 'None'
 # Default threading model
 USING_TWISTED = True
 
-# Logging levels to disable, if any
-DISABLE_LOGGING = logging.DEBUG
-
 # Time out for updating sasview
 UPDATE_TIMEOUT = 2
 
 # Logging levels to disable, if any
-DISABLE_LOGGING = logging.DEBUG
+DISABLE_LOGGING = logging.NOTSET
 
 def printEVT(message):
     """

--- a/src/sas/qtgui/Utilities/SasviewLogger.py
+++ b/src/sas/qtgui/Utilities/SasviewLogger.py
@@ -5,111 +5,33 @@ import logging
 from PyQt5.QtCore import *
 
 
-class XStream(QObject):
-    """
-    Imitates, loosely, an `io.TextIOWrapper` class in order to intercept
-    messages going to stdout and stderr.
-
-    To intercept messages to stdout, use:
-
-    .. code-block:: python
-       XStream.stdout().messageWritten.mySignalHandler()
-
-    All messages to stdout will now also be emitted to your handler. Use
-    `XStream.stderr()` in the same way to intercept stderr messages.
-
-    An additional function, `XStream.write_log()`, emits a message only to the
-    messageWritten signal, and not the stdout or stderr streams. It is intended
-    for separation of log handling between console and Qt, as reflected in the
-    name.
-    """
-    _stdout = None
-    _stderr = None
-    messageWritten = pyqtSignal(str)
-
-    _real_stream = None
-
-    def flush(self):
-        pass
-
-    def fileno(self):
-        return -1
-
-    def write(self, msg):
-        """
-        'msg' is emitted in the messageWritten signal, and is also written to
-        the original stream. This means stdout/stderr messages have been
-        redirected to a custom location (e.g. in-widget), but also reach
-        console output.
-
-        :param msg: message to write
-        :return: None
-        """
-        if(not self.signalsBlocked()):
-            self.messageWritten.emit(str(msg))
-        self._real_stream.write(msg)
-
-    def write_log(self, msg):
-        """
-        'msg' is only emitted in the messageWritten signal, not in the original
-        stdout/stderr stream, for the purposes of logging. Use in, e.g. a
-        custom logging handler's emit() function.
-
-        :param msg: message to write
-        :return: None
-        """
-        if(not self.signalsBlocked()):
-            self.messageWritten.emit(str(msg))
-
-    @staticmethod
-    def stdout():
-        """
-        Creates imitation of sys.stdout.
-        :return: An XStream instance that interfaces exactly like sys.stdout,
-                 but, has redirection capabilities through the
-                 messageWritten(str) signal.
-        """
-        if(not XStream._stdout):
-            XStream._stdout = XStream()
-            XStream._stdout._real_stream = sys.stdout
-            sys.stdout = XStream._stdout
-        return XStream._stdout
-
-    @staticmethod
-    def stderr():
-        """
-        Creates imitation of sys.stderr.
-        :return: An XStream instance that interfaces exactly like sys.stderr,
-                 but, has redirection capabilities through the
-                 messageWritten(str) signal.
-        """
-        if(not XStream._stderr):
-            XStream._stderr = XStream()
-            XStream._stderr._real_stream = sys.stderr
-            sys.stderr = XStream._stderr
-        return XStream._stderr
-
-
-class QtHandler(logging.Handler):
+class QtHandler(QObject, logging.Handler):
     """
     Version of logging handler "emitting" the message to custom stdout()
     """
+    messageWritten = pyqtSignal(str)
+
     def __init__(self):
+        QObject.__init__(self)
         logging.Handler.__init__(self)
 
     def emit(self, record):
         record = self.format(record)
         if record:
-            XStream.stdout().write_log('%s\n'%record)
+            self.messageWritten.emit('%s\n'%record)
 
 
-# Define the default logger
-logger = logging.getLogger()
+def setup_qt_logging():
+    # Define the default logger
+    logger = logging.getLogger()
 
-# Add the qt-signal logger
-handler = QtHandler()
-handler.setFormatter(logging.Formatter(
-    fmt="%(asctime)s - %(levelname)s: %(message)s",
-    datefmt="%H:%M:%S"
-))
-logger.addHandler(handler)
+    # Add the qt-signal logger
+    handler = QtHandler()
+    handler.setFormatter(logging.Formatter(
+        fmt="%(asctime)s - %(levelname)s: %(message)s",
+        datefmt="%H:%M:%S"
+    ))
+    handler.setLevel(logging.DEBUG)
+    logger.addHandler(handler)
+
+    return handler

--- a/src/sas/qtgui/Utilities/SasviewLogger.py
+++ b/src/sas/qtgui/Utilities/SasviewLogger.py
@@ -31,7 +31,6 @@ def setup_qt_logging():
         fmt="%(asctime)s - %(levelname)s: %(message)s",
         datefmt="%H:%M:%S"
     ))
-    handler.setLevel(logging.DEBUG)
     logger.addHandler(handler)
 
     return handler

--- a/src/sas/qtgui/Utilities/SasviewLogger.py
+++ b/src/sas/qtgui/Utilities/SasviewLogger.py
@@ -6,9 +6,28 @@ from PyQt5.QtCore import *
 
 
 class XStream(QObject):
+    """
+    Imitates, loosely, an `io.TextIOWrapper` class in order to intercept
+    messages going to stdout and stderr.
+
+    To intercept messages to stdout, use:
+
+    .. code-block:: python
+       XStream.stdout().messageWritten.mySignalHandler()
+
+    All messages to stdout will now also be emitted to your handler. Use
+    `XStream.stderr()` in the same way to intercept stderr messages.
+
+    An additional function, `XStream.write_log()`, emits a message only to the
+    messageWritten signal, and not the stdout or stderr streams. It is intended
+    for separation of log handling between console and Qt, as reflected in the
+    name.
+    """
     _stdout = None
     _stderr = None
     messageWritten = pyqtSignal(str)
+
+    _real_stream = None
 
     def flush(self):
         pass
@@ -17,27 +36,63 @@ class XStream(QObject):
         return -1
 
     def write(self, msg):
+        """
+        'msg' is emitted in the messageWritten signal, and is also written to
+        the original stream. This means stdout/stderr messages have been
+        redirected to a custom location (e.g. in-widget), but also reach
+        console output.
+
+        :param msg: message to write
+        :return: None
+        """
+        if(not self.signalsBlocked()):
+            self.messageWritten.emit(str(msg))
+        self._real_stream.write(msg)
+
+    def write_log(self, msg):
+        """
+        'msg' is only emitted in the messageWritten signal, not in the original
+        stdout/stderr stream, for the purposes of logging. Use in, e.g. a
+        custom logging handler's emit() function.
+
+        :param msg: message to write
+        :return: None
+        """
         if(not self.signalsBlocked()):
             self.messageWritten.emit(str(msg))
 
     @staticmethod
     def stdout():
+        """
+        Creates imitation of sys.stdout.
+        :return: An XStream instance that interfaces exactly like sys.stdout,
+                 but, has redirection capabilities through the
+                 messageWritten(str) signal.
+        """
         if(not XStream._stdout):
             XStream._stdout = XStream()
+            XStream._stdout._real_stream = sys.stdout
             sys.stdout = XStream._stdout
         return XStream._stdout
 
     @staticmethod
     def stderr():
+        """
+        Creates imitation of sys.stderr.
+        :return: An XStream instance that interfaces exactly like sys.stderr,
+                 but, has redirection capabilities through the
+                 messageWritten(str) signal.
+        """
         if(not XStream._stderr):
             XStream._stderr = XStream()
+            XStream._stderr._real_stream = sys.stderr
             sys.stderr = XStream._stderr
         return XStream._stderr
 
+
 class QtHandler(logging.Handler):
     """
-    Version of logging handler
-    "emitting" the message to custom stdout()
+    Version of logging handler "emitting" the message to custom stdout()
     """
     def __init__(self):
         logging.Handler.__init__(self)
@@ -45,18 +100,16 @@ class QtHandler(logging.Handler):
     def emit(self, record):
         record = self.format(record)
         if record:
-            XStream.stdout().write('%s\n'%record)
+            XStream.stdout().write_log('%s\n'%record)
 
 
 # Define the default logger
 logger = logging.getLogger()
 
-# Add the file handler
-logging.basicConfig(level=logging.INFO,
-                    format='%(asctime)s %(levelname)s %(message)s',
-                    filename=os.path.join(os.path.expanduser("~"),
-                                          'sasview.log'))
 # Add the qt-signal logger
 handler = QtHandler()
-handler.setFormatter(logging.Formatter("%(levelname)s: %(message)s"))
+handler.setFormatter(logging.Formatter(
+    fmt="%(asctime)s - %(levelname)s: %(message)s",
+    datefmt="%H:%M:%S"
+))
 logger.addHandler(handler)

--- a/src/sas/qtgui/Utilities/UnitTesting/SasviewLoggerTest.py
+++ b/src/sas/qtgui/Utilities/UnitTesting/SasviewLoggerTest.py
@@ -10,7 +10,6 @@ from PyQt5.QtWidgets import *
 import sas.qtgui.path_prepare
 
 # Local
-from sas.qtgui.Utilities.SasviewLogger import XStream
 from sas.qtgui.Utilities.SasviewLogger import QtHandler
 
 if not QApplication.instance():
@@ -22,9 +21,9 @@ class SasviewLoggerTest(unittest.TestCase):
         Prepare the logger
         """
         self.logger = logging.getLogger(__name__)
-        handler = QtHandler()
-        handler.setFormatter(logging.Formatter("%(levelname)s: %(message)s"))
-        self.logger.addHandler(handler)
+        self.handler = QtHandler()
+        self.handler.setFormatter(logging.Formatter("%(levelname)s: %(message)s"))
+        self.logger.addHandler(self.handler)
         self.logger.setLevel(logging.DEBUG)
 
         self.outHandlerGui=QTextBrowser()
@@ -34,17 +33,14 @@ class SasviewLoggerTest(unittest.TestCase):
         """
         Test redirection of all levels of logging
         """
-        # Attach the listeners
-        XStream.stderr().messageWritten.connect( self.outHandlerGui.insertPlainText )
-        XStream.stdout().messageWritten.connect( self.outHandlerGui.insertPlainText )
+        # Attach the listener
+        self.handler.messageWritten.connect(self.outHandlerGui.insertPlainText)
 
         # Send the signals
         self.logger.debug('debug message')
         self.logger.info('info message')
         self.logger.warning('warning message')
         self.logger.error('error message')
-        sys.stdout.write('with stdout')
-        sys.stderr.write('with stderr')
 
         out=self.outHandlerGui.toPlainText()
 
@@ -53,8 +49,6 @@ class SasviewLoggerTest(unittest.TestCase):
         self.assertIn('INFO: info message', out)
         self.assertIn('WARNING: warning message', out)
         self.assertIn('ERROR: error message', out)
-        self.assertIn('with stdout', out)
-        self.assertIn('with stderr', out)
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
In summary:
* disable generic stdout/stderr redirection to Log Explorer, to make program output more permanent in the event of a crash
* all logs are still propagated to the Log Explorer, console, and log file (with separate handlers)
* minor fixes (Log Explorer auto-scroll, log levels no longer changing in different places)

for JIRA users, please see: <https://jira.esss.lu.se/browse/SASVIEW-957>
for trac users, please see: <http://trac.sasview.org/ticket/1123>