### PR TITLE
Batch slicer documentation - 1139

### DIFF
--- a/src/sas/sasgui/guiframe/local_perspectives/plotting/parameters_panel_slicer.py
+++ b/src/sas/sasgui/guiframe/local_perspectives/plotting/parameters_panel_slicer.py
@@ -250,9 +250,19 @@ class SlicerParameterPanel(wx.Dialog):
             self.Bind(wx.EVT_BUTTON, self.on_batch_slicer)
             self.bck.Add(self.batch_slicer_button, (iy, ix), (1, 1),
                          wx.LEFT | wx.EXPAND | wx.ADJUST_MINSIZE, 15)
+            # Help button
+
+            self.bt_help = wx.Button(self, wx.NewId(), "HELP")
+            self.bt_help.SetToolTipString(
+                "Help for the slicer parameters and batch slicing.")
+            self.bck.Add(self.bt_help, (iy, 1), (1, 1),
+                         wx.ALIGN_RIGHT | wx.ADJUST_MINSIZE, 15)
+            wx.EVT_BUTTON(self, self.bt_help.GetId(), self.on_help)
+
             iy += 1
             self.bck.Add((5, 5), (iy, ix), (1, 1),
                          wx.LEFT | wx.EXPAND | wx.ADJUST_MINSIZE, 5)
+
         self.bck.Layout()
         self.bck.Fit(self)
         self.parent.GetSizer().Layout()
@@ -534,3 +544,16 @@ class SlicerParameterPanel(wx.Dialog):
         for key in params:
             self.default_value += "_{0}".format(key).split(" [")[0]
             self.default_value += "-{:.2f}".format(params[key])
+
+    def on_help(self, event=None):
+        """
+        Opens a help window for the slicer parameters/batch slicing window
+        :param event:
+        :return:
+        """
+        from sas.sasgui.guiframe.documentation_window import DocumentationWindow
+
+        _TreeLocation = "user/sasgui/guiframe/graph_help.html"
+        _doc_viewer = DocumentationWindow(self, wx.ID_ANY, _TreeLocation,
+                                          "#d-data-averaging",
+                                          "Data Explorer Help")

--- a/src/sas/sasgui/guiframe/media/graph_help.rst
+++ b/src/sas/sasgui/guiframe/media/graph_help.rst
@@ -265,6 +265,7 @@ chosen dataset, or to change the dataset label that appears in the plot legend
 box.
 
 .. ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ
+.. _d_data_averaging:
 
 2D data averaging
 -----------------
@@ -300,8 +301,9 @@ the size of the data.*
 
 Alternatively, once a 'slicer' is active you can also select the region to
 average by bringing back the *Dataset Menu* and selecting *Edit Slicer
-Parameters*. A dialog window will appear in which you can enter values to
-define a region or select the number of points to plot (*nbins*).
+Parameters and Batch Fitting*. A dialog window will appear in which you can
+enter values to define a region, select the number of points to plot (*nbins*),
+or apply the slicer to any or all other 2D data plots.
 
 A separate plot window will also have appeared, displaying the requested
 average.
@@ -314,6 +316,32 @@ Selecting *Box Sum* automatically brings up the 'Slicer Parameters' dialog in
 order to display the average numerically, rather than graphically.
 
 To remove a 'slicer', bring back the *Dataset menu* and select *Clear Slicer*.
+
+Batch Slicing
+^^^^^^^^^^^^^
+
+An existing slicer can be applied to multiple data plots by opening the 'Slicer
+Parameters' window by bringing back the *Dataset Menu* and selecting *Edit
+Slicer Parameters and Batch Fitting*. At the bottom of the window, batch slicing
+options are available.
+
+Select the data plots you want to apply the slicer. All data plots are selected
+by default. The resulting 1d data for all slicers can be saved as a text file
+and then sent to fitting by selecting the 'Auto save generated 1D' check box.
+Sending data to the fitting perspective requires the data be saved.
+
+Once the auto save check box is selected, you can select where the files are
+saved. The file name for the saved data is the file name from the original data
+set, plus what is in the 'Append to file name' field. The default value in the
+append to field includes the names and values for all of the slicer parameters.
+
+Three options for fitting are available. The first is to not send the data to
+a fit page. The second is to send each slice to individual fit page. The last
+is to send all sliced data to a batch fit.
+
+Clicking the 'Apply Slicer to Selected Plots' will then run through each of plot
+and create a slicer for that plot with the exact parameters as the slicer from
+the plot used to open the 'Slicer Parameters' popup window.
 
 Unmasked circular average
 ^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/src/sas/sasgui/guiframe/media/graph_help.rst
+++ b/src/sas/sasgui/guiframe/media/graph_help.rst
@@ -320,28 +320,31 @@ To remove a 'slicer', bring back the *Dataset menu* and select *Clear Slicer*.
 Batch Slicing
 ^^^^^^^^^^^^^
 
-An existing slicer can be applied to multiple data plots by opening the 'Slicer
-Parameters' window by bringing back the *Dataset Menu* and selecting *Edit
-Slicer Parameters and Batch Fitting*. At the bottom of the window, batch slicing
-options are available.
+A slicer can be applied to any or all existing 2D data plots using the 'Slicer
+Parameters' window. To open the window, select *Edit Slicer Parameters and Batch
+Fitting* in the *Dataset Menu* (see Invoking_the_dataset_menu_). Batch slicing
+options are available at the bottom of the window.
 
-Select the data plots you want to apply the slicer. All data plots are selected
+Select the 2D plots you want to apply the slicer. All 2D plots are selected
 by default. The resulting 1d data for all slicers can be saved as a text file
-and then sent to fitting by selecting the 'Auto save generated 1D' check box.
+and then sent to fitting by selecting the *Auto save generated 1D* check box.
 Sending data to the fitting perspective requires the data be saved.
 
 Once the auto save check box is selected, you can select where the files are
-saved. The file name for the saved data is the file name from the original data
-set, plus what is in the 'Append to file name' field. The default value in the
-append to field includes the names and values for all of the slicer parameters.
+saved. The file name for the saved data is the slicer name plus the file name
+of the original data set, plus what is in the *Append to file name* field. The
+default value in the append to field includes the names and values for all of
+the slicer parameters.
 
-Three options for fitting are available. The first is to not send the data to
-a fit page. The second is to send each slice to individual fit page. The last
-is to send all sliced data to a batch fit.
+The batch of slices can be sent to fitting if desired, with three options
+available. The first is to not fit the data, the second is to send the
+slices to individual fit pages, and the third is to send all sliced data to a
+single batch fit window.
 
-Clicking the 'Apply Slicer to Selected Plots' will then run through each of plot
-and create a slicer for that plot with the exact parameters as the slicer from
-the plot used to open the 'Slicer Parameters' popup window.
+Clicking *Apply Slicer to Selected Plots* will create a slicer for each selected
+plot with the parameters entered in the 'Slicer Parameters' window. Depending on
+the options selected the data may then be saved, loaded as separate data sets in
+the data manager panel, and finally sent to fitting.
 
 Unmasked circular average
 ^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/src/sas/sasgui/guiframe/media/graph_help.rst
+++ b/src/sas/sasgui/guiframe/media/graph_help.rst
@@ -325,8 +325,8 @@ Parameters' window. To open the window, select *Edit Slicer Parameters and Batch
 Fitting* in the *Dataset Menu* (see Invoking_the_dataset_menu_). Batch slicing
 options are available at the bottom of the window.
 
-Select the 2D plots you want to apply the slicer. All 2D plots are selected
-by default. The resulting 1d data for all slicers can be saved as a text file
+Select the 2D plots you want to apply the slicer to. All 2D plots are selected
+by default. The resulting 1D data for all slicers can be saved as a text file
 and then sent to fitting by selecting the *Auto save generated 1D* check box.
 Sending data to the fitting perspective requires the data be saved.
 


### PR DESCRIPTION
Documentation for batch slicing added in 4.2b. A help button was added to the slicer parameters window that should link to the 2D data averaging section, but anchors are currently broken as outlined in [Trac ticket 1104](http://trac.sasview.org/ticket/1104).