### PR TITLE
Use Q_mean from ABS files to match Igor analysis

### DIFF
--- a/src/sas/sascalc/dataloader/readers/abs_reader.py
+++ b/src/sas/sascalc/dataloader/readers/abs_reader.py
@@ -170,7 +170,7 @@ class Reader(FileReader):
                 toks = line.split()
 
                 try:
-                    _x = float(toks[0])
+                    _x = float(toks[4])
                     _y = float(toks[1])
                     _dy = float(toks[2])
                     _dx = float(toks[3])

--- a/test/sasdataloader/test/utest_abs_reader.py
+++ b/test/sasdataloader/test/utest_abs_reader.py
@@ -52,9 +52,9 @@ class abs_reader(unittest.TestCase):
         self.assertEqual(self.data.detector[0].beam_center.y, center_y)
 
         self.assertEqual(self.data.y_unit, 'cm^{-1}')
-        self.assertEqual(self.data.x[0], 0.002618)
-        self.assertEqual(self.data.x[1], 0.007854)
-        self.assertEqual(self.data.x[2], 0.01309)
+        self.assertEqual(self.data.x[0], 0.008082)
+        self.assertEqual(self.data.x[1], 0.0275)
+        self.assertEqual(self.data.x[2], 0.02762)
         self.assertEqual(self.data.x[126], 0.5828)
 
         self.assertEqual(self.data.y[0], 0.02198)


### PR DESCRIPTION
Igor analysis uses the Q_mean from ABS files when analyzing the data. The Q_mean diverges from Q closer to the beam stop as outlined in a paper by John Barker. This is related to the issue in [ticket 1102](http://trac.sasview.org/ticket/1102).