### PR TITLE
Beta Load Project Issue Fix

### DIFF
--- a/src/sas/sascalc/fit/pagestate.py
+++ b/src/sas/sascalc/fit/pagestate.py
@@ -12,6 +12,7 @@ Class that holds a fit page state
 # copyright 2009, University of Tennessee
 ################################################################################
 import time
+import re
 import os
 import sys
 import copy
@@ -961,8 +962,8 @@ class PageState(object):
 
         if node.get('version'):
             # Get the version for model conversion purposes
-            self.version = tuple(int(e) for e in
-                                 str.split(node.get('version'), "."))
+            x = re.sub('[^\d.]', '', node.get('version'))
+            self.version = tuple(int(e) for e in str.split(x, "."))
             # The tuple must be at least 3 items long
             while len(self.version) < 3:
                 ver_list = list(self.version)


### PR DESCRIPTION
Saved projects hold the SasView version number in them for backward compatibility checks. The version is  put into a tuple of integers as (major, minor, point) e.g. (4, 1, 2). Adding '-beta' caused the int conversion to fail. This fix removes all non numeric characters from the version number when loading the project.

If desired, I can also remove the non-numeric characters when saving projects, but that isn't included in this PR as of yet.