### PR TITLE
SASVIEW-971: Constraining an S(Q) param to its current value crashes the app

### DIFF
--- a/src/sas/qtgui/Perspectives/Fitting/FittingUtilities.py
+++ b/src/sas/qtgui/Perspectives/Fitting/FittingUtilities.py
@@ -150,9 +150,10 @@ def addSimpleParametersToModel(parameters, is2D):
     return item
 
 def markParameterDisabled(model, row):
-    """Given the QModel row number, format to show it is not available for
-    fitting"""
-    items = [model.item(row, c) for c in range(5)]
+    """Given the QModel row number, format to show it is not available for fitting"""
+
+    # If an error column is present, there are a total of 6 columns.
+    items = [model.item(row, c) for c in range(6)]
 
     model.blockSignals(True)
 
@@ -160,7 +161,6 @@ def markParameterDisabled(model, row):
         if item is None:
             continue
         item.setEditable(False)
-        item.setSelectable(False)
         item.setCheckable(False)
 
     item = items[0]

--- a/src/sas/qtgui/Perspectives/Fitting/FittingUtilities.py
+++ b/src/sas/qtgui/Perspectives/Fitting/FittingUtilities.py
@@ -149,6 +149,30 @@ def addSimpleParametersToModel(parameters, is2D):
         item.append([item1, item2, item4, item5, item6])
     return item
 
+def markParameterDisabled(model, row):
+    """Given the QModel row number, format to show it is not available for
+    fitting"""
+    items = [model.item(row, c) for c in range(5)]
+
+    model.blockSignals(True)
+
+    for item in items:
+        if item is None:
+            continue
+        item.setEditable(False)
+        item.setSelectable(False)
+        item.setCheckable(False)
+
+    item = items[0]
+
+    font = QtGui.QFont()
+    font.setItalic(True)
+    item.setFont(font)
+    item.setForeground(QtGui.QBrush(QtGui.QColor(100, 100, 100)))
+    item.setToolTip("This parameter cannot be fitted.")
+
+    model.blockSignals(False)
+
 def addCheckedListToModel(model, param_list):
     """
     Add a QItem to model. Makes the QItem checkable

--- a/src/sas/qtgui/Perspectives/Fitting/FittingWidget.py
+++ b/src/sas/qtgui/Perspectives/Fitting/FittingWidget.py
@@ -1969,8 +1969,7 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         new_rows = FittingUtilities.addSimpleParametersToModel(structure_parameters, self.is2D)
         for row in new_rows:
             self._model_model.appendRow(row)
-            # disable fitting of parameters not listed in self.kernel_module
-            # (probably radius_effective)
+            # disable fitting of parameters not listed in self.kernel_module (probably radius_effective)
             if row[0].text() not in self.kernel_module.params.keys():
                 row_num = self._model_model.rowCount() - 1
                 FittingUtilities.markParameterDisabled(self._model_model, row_num)

--- a/src/sas/qtgui/Perspectives/Fitting/FittingWidget.py
+++ b/src/sas/qtgui/Perspectives/Fitting/FittingWidget.py
@@ -14,10 +14,10 @@ from PyQt5 import QtCore
 from PyQt5 import QtGui
 from PyQt5 import QtWidgets
 
-from sasmodels import product
 from sasmodels import generate
 from sasmodels import modelinfo
 from sasmodels.sasview_model import load_standard_models
+from sasmodels.sasview_model import MultiplicationModel
 from sasmodels.weights import MODELS as POLYDISPERSITY_MODELS
 
 from sas.sascalc.fit.BumpsFitting import BumpsFit as Fit
@@ -1960,13 +1960,21 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         """
         structure_module = generate.load_kernel_module(structure_factor)
         structure_parameters = modelinfo.make_parameter_table(getattr(structure_module, 'parameters', []))
-        structure_kernel = self.models[structure_factor]()
 
-        self.kernel_module._model_info = product.make_product_info(self.kernel_module._model_info, structure_kernel._model_info)
+        structure_kernel = self.models[structure_factor]()
+        form_kernel = self.kernel_module
+
+        self.kernel_module = MultiplicationModel(form_kernel, structure_kernel)
 
         new_rows = FittingUtilities.addSimpleParametersToModel(structure_parameters, self.is2D)
         for row in new_rows:
             self._model_model.appendRow(row)
+            # disable fitting of parameters not listed in self.kernel_module
+            # (probably radius_effective)
+            if row[0].text() not in self.kernel_module.params.keys():
+                row_num = self._model_model.rowCount() - 1
+                FittingUtilities.markParameterDisabled(self._model_model, row_num)
+
         # Update the counter used for multishell display
         self._last_model_row = self._model_model.rowCount()
 


### PR DESCRIPTION
Fixes for:

- [SASVIEW-960](https://jira.esss.lu.se/browse/SASVIEW-960) &ndash; Cannot fit any S(Q) params if using P(Q)S(Q) model
- [SASVIEW-971](https://jira.esss.lu.se/browse/SASVIEW-971) &ndash; Constraining an S(Q) param to its current value crashes the app

Beforehand, only the `model_info` structures were being updated when the user selected a S(Q); without updating the `kernel_module` object (which is really a `SasviewModel` object), the application could not access the S(Q) parameters for fitting or constraints.

----

Additionally, any parameters in the table which are not found in the kernel module's parameter list (i.e. they cannot be currently fitted &ndash; this is exclusively `radius_effective`, at the moment) are now greyed-out in the table, and cannot be checked, selected or edited. This is a temporary measure; at some point `radius_effective` will be toggle-able as either a fitting or internally calculated parameter.