### PR TITLE
Load data for slit size calculator - 1132

### DIFF
--- a/src/sas/sasgui/perspectives/calculator/slit_length_calculator_panel.py
+++ b/src/sas/sasgui/perspectives/calculator/slit_length_calculator_panel.py
@@ -247,6 +247,8 @@ class SlitLengthCalculatorPanel(wx.Panel, PanelBase):
         """
             Complete the loading and compute the slit size
         """
+        if isinstance(data, list):
+            data = data[0]
         if data is None or data.__class__.__name__ == 'Data2D':
             if self.parent.parent is None:
                 return


### PR DESCRIPTION
As of 4.2-beta, all data loaded into SasView is returned as a list to allow for any number of data sets to be loaded simultaneously. The calculator perspective expected a Data1D object instead of a list, causing the issue outlined in [ticket 1132](http://trac.sasview.org/ticket/1132).