### PR TITLE
Added dependency required for pyopencl on win64 - ticket 1131

### DIFF
--- a/installers/setup_exe.py
+++ b/installers/setup_exe.py
@@ -286,6 +286,7 @@ if msvcrtdll:
 packages = [
     'matplotlib', 'scipy', 'encodings', 'comtypes', 'h5py',
     'win32com', 'xhtml2pdf', 'bumps', 'sasmodels', 'sas',
+    'pkg_resources'
     ]
 packages.extend([
     'reportlab',

--- a/src/sas/sasgui/perspectives/fitting/gpu_options.py
+++ b/src/sas/sasgui/perspectives/fitting/gpu_options.py
@@ -138,6 +138,9 @@ class GpuOptions(wx.Dialog):
         self.Bind(wx.EVT_BUTTON, self.on_help, help_btn)
 
         test_text = wx.StaticText(self, -1, "WARNING: Running tests can take a few minutes!")
+        test_text2 = wx.StaticText(self, -1, "NOTE: No test will run if No OpenCL is checked")
+        test_text.SetForegroundColour(wx.RED)
+        self.vbox.Add(test_text2, 0, wx.LEFT|wx.EXPAND|wx.ADJUST_MINSIZE, 10)
         self.vbox.Add(test_text, 0, wx.LEFT|wx.EXPAND|wx.ADJUST_MINSIZE, 10)
 
         btn_sizer = wx.BoxSizer(wx.HORIZONTAL)


### PR DESCRIPTION
Added dependency on pkg_resources to setup_exe.py in order for pyopencl to find the correct path to the include directory.