### PR TITLE
Ticket 1163 plus come docs

### DIFF
--- a/src/sas/sasgui/perspectives/calculator/media/slit_calculator_help.rst
+++ b/src/sas/sasgui/perspectives/calculator/media/slit_calculator_help.rst
@@ -14,7 +14,7 @@ This tool enables X-ray users to calculate the slit size (FWHM/2) for smearing
 based on their half beam profile data.
 
 *NOTE! Whilst it may have some more generic applicability, the calculator has
-only been tested with beam profile data from Anton-Paar SAXSess:sup:`TM` software.*
+only been tested with beam profile data from Anton-Paar SAXSess\ :sup:`TM` software.*
 
 .. ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ
 

--- a/src/sas/sasgui/perspectives/calculator/model_editor.py
+++ b/src/sas/sasgui/perspectives/calculator/model_editor.py
@@ -42,11 +42,11 @@ logger = logging.getLogger(__name__)
 
 if sys.platform.count("win32") > 0:
     FONT_VARIANT = 0
-    PNL_WIDTH = 450
+    PNL_WIDTH = 500
     PNL_HEIGHT = 320
 else:
     FONT_VARIANT = 1
-    PNL_WIDTH = 590
+    PNL_WIDTH = 655
     PNL_HEIGHT = 350
 M_NAME = 'Model'
 EDITOR_WIDTH = 800
@@ -494,18 +494,25 @@ class TextDialog(wx.Dialog):
         """
         Choose the equation to use depending on whether we now have
         a sum or multiply model then create the appropriate string
+        
+        for the sum model the result will be:
+        scale_factor * (scale1 * model_1 + scale2 * model_2) + background
+        while for ghe multiply model it will just be:
+        scale_factor * (model_1* model_2) + background
         """
         name = ''
         if operator == '*':
             name = 'Multi'
-            factor = 'background'
+            factor_1 = ''
+            factor_2 = ''
         else:
             name = 'Sum'
-            factor = 'scale_factor'
+            factor_1 = 'scale_1 * '
+            factor_2 = 'scale_2 * '
 
         self._operator = operator
-        self.explanation = ("  Plugin_model = scale_factor * (model_1 {} "
-            "model_2) + background").format(operator)
+        self.explanation = ("  Plugin_model = scale_factor * ({}model_1 {} "
+            "{}model_2) + background").format(factor_1,operator,factor_2)
         self.explanationctr.SetLabel(self.explanation)
         self.name = name + M_NAME
 

--- a/src/sas/sasgui/perspectives/calculator/model_editor.py
+++ b/src/sas/sasgui/perspectives/calculator/model_editor.py
@@ -46,7 +46,7 @@ if sys.platform.count("win32") > 0:
     PNL_HEIGHT = 320
 else:
     FONT_VARIANT = 1
-    PNL_WIDTH = 655
+    PNL_WIDTH = 590
     PNL_HEIGHT = 350
 M_NAME = 'Model'
 EDITOR_WIDTH = 800

--- a/src/sas/sasgui/perspectives/calculator/model_editor.py
+++ b/src/sas/sasgui/perspectives/calculator/model_editor.py
@@ -46,7 +46,7 @@ if sys.platform.count("win32") > 0:
     PNL_HEIGHT = 320
 else:
     FONT_VARIANT = 1
-    PNL_WIDTH = 590
+    PNL_WIDTH = 500
     PNL_HEIGHT = 350
 M_NAME = 'Model'
 EDITOR_WIDTH = 800

--- a/src/sas/sasgui/perspectives/calculator/model_editor.py
+++ b/src/sas/sasgui/perspectives/calculator/model_editor.py
@@ -497,7 +497,7 @@ class TextDialog(wx.Dialog):
         
         for the sum model the result will be:
         scale_factor * (scale1 * model_1 + scale2 * model_2) + background
-        while for ghe multiply model it will just be:
+        while for the multiply model it will just be:
         scale_factor * (model_1* model_2) + background
         """
         name = ''


### PR DESCRIPTION
Fixes the help string for sum model as per ticket #1163.  Also attempted to fix problem with lack of superscript on TM in the slit calculator which was not formatted correctly.  It is now formatted correctly as demonstrated with online sphinx markup editor however my build system does not seem to handle it.  I will try a PR build to see if it is our sphinx setup or my system.

Also note that it seems that substitution is not working for this sphinx build.