### PR TITLE
SASVIEW-966: Organise parameter table by model component

### DIFF
--- a/src/sas/qtgui/Perspectives/Fitting/FittingUtilities.py
+++ b/src/sas/qtgui/Perspectives/Fitting/FittingUtilities.py
@@ -123,19 +123,35 @@ def addParametersToModel(parameters, kernel_module, is2D):
         item.append([item1, item2, item3, item4, item5])
     return item
 
-def addSimpleParametersToModel(parameters, is2D):
+def addSimpleParametersToModel(parameters, is2D, parameters_original=None):
     """
     Update local ModelModel with sasmodel parameters
+    parameters_original: list of parameters before any tagging on their IDs, e.g. for product model
+    (so that those are the display names; see below)
     """
     if is2D:
         params = [p for p in parameters.kernel_parameters if p.type != 'magnetic']
     else:
         params = parameters.iq_parameters
+
+    if parameters_original:
+        # 'parameters_original' contains the parameters as they are to be DISPLAYED, while 'parameters'
+        # contains the parameters as they were renamed; this is for handling name collisions in product model.
+        # The 'real name' of the parameter will be stored in the item's user data.
+        if is2D:
+            params_orig = [p for p in parameters_original.kernel_parameters if p.type != 'magnetic']
+        else:
+            params_orig = parameters_original.iq_parameters
+    else:
+        # no difference in names anyway
+        params_orig = params
+
     item = []
-    for param in params:
+    for param, param_orig in zip(params, params_orig):
         # Create the top level, checkable item
-        item_name = param.name
+        item_name = param_orig.name
         item1 = QtGui.QStandardItem(item_name)
+        item1.setData(param.name, QtCore.Qt.UserRole)
         item1.setCheckable(True)
         item1.setEditable(False)
         # Param values

--- a/src/sas/qtgui/Perspectives/Fitting/FittingUtilities.py
+++ b/src/sas/qtgui/Perspectives/Fitting/FittingUtilities.py
@@ -258,12 +258,15 @@ def addErrorPolyHeadersToModel(model):
     poly_header_error_tooltips.insert(2, error_tooltip)
     model.header_tooltips = copy.copy(poly_header_error_tooltips)
 
-def addShellsToModel(parameters, model, index):
+def addShellsToModel(parameters, model, index, row_num=None):
     """
-    Find out multishell parameters and update the model with the requested number of them
+    Find out multishell parameters and update the model with the requested number of them.
+    Inserts them after the row at row_num, if not None; otherwise, appends to end.
+    Returns a list of lists of QStandardItem objects.
     """
     multishell_parameters = getIterParams(parameters)
 
+    rows = []
     for i in range(index):
         for par in multishell_parameters:
             # Create the name: <param>[<i>], e.g. "sld1" for parameter "sld[n]"
@@ -290,7 +293,16 @@ def addShellsToModel(parameters, model, index):
             item3 = QtGui.QStandardItem(str(par.limits[0]))
             item4 = QtGui.QStandardItem(str(par.limits[1]))
             item5 = QtGui.QStandardItem(par.units)
-            model.appendRow([item1, item2, item3, item4, item5])
+            row = [item1, item2, item3, item4, item5]
+            rows.append(row)
+
+            if row_num is None:
+                model.appendRow(row)
+            else:
+                model.insertRow(row_num, row)
+                row_num += 1
+
+    return rows
 
 def calculateChi2(reference_data, current_data):
     """

--- a/src/sas/qtgui/Perspectives/Fitting/FittingUtilities.py
+++ b/src/sas/qtgui/Perspectives/Fitting/FittingUtilities.py
@@ -159,7 +159,7 @@ def addSimpleParametersToModel(parameters, is2D, parameters_original=None):
         item2 = QtGui.QStandardItem(str(param.default))
         item4 = QtGui.QStandardItem(str(param.limits[0]))
         item5 = QtGui.QStandardItem(str(param.limits[1]))
-        item6 = QtGui.QStandardItem(param.units)
+        item6 = QtGui.QStandardItem(str(param.units))
         item6.setEditable(False)
         item.append([item1, item2, item4, item5, item6])
     return item

--- a/src/sas/qtgui/Perspectives/Fitting/FittingUtilities.py
+++ b/src/sas/qtgui/Perspectives/Fitting/FittingUtilities.py
@@ -181,6 +181,22 @@ def addCheckedListToModel(model, param_list):
     item_list[0].setCheckable(True)
     model.appendRow(item_list)
 
+def addHeadingRowToModel(model, name):
+    """adds a non-interactive top-level row to the model"""
+    header_row = [QtGui.QStandardItem() for i in range(5)]
+    header_row[0].setText(name)
+
+    font = header_row[0].font()
+    font.setBold(True)
+    header_row[0].setFont(font)
+
+    for item in header_row:
+        item.setEditable(False)
+        item.setCheckable(False)
+        item.setSelectable(False)
+
+    model.appendRow(header_row)
+
 def addHeadersToModel(model):
     """
     Adds predefined headers to the model

--- a/src/sas/qtgui/Perspectives/Fitting/FittingWidget.py
+++ b/src/sas/qtgui/Perspectives/Fitting/FittingWidget.py
@@ -1722,8 +1722,7 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         Take func and throw it inside the magnet model row loop
         """
         for row_i in range(self._magnet_model.rowCount()):
-            if self.isCheckable(row_i):
-                func(row_i)
+            func(row_i)
 
     def updateMagnetModelFromList(self, param_dict):
         """

--- a/src/sas/qtgui/Perspectives/Fitting/FittingWidget.py
+++ b/src/sas/qtgui/Perspectives/Fitting/FittingWidget.py
@@ -2065,7 +2065,7 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
 
         # Add a header
         header_row = [QtGui.QStandardItem() for i in range(5)]
-        header_row[0].setText(self.kernel_module._model_info.composition[1][1].name)
+        header_row[0].setText(structure_kernel._model_info.name)
         font = header_row[0].font()
         font.setBold(True)
         header_row[0].setFont(font)

--- a/src/sas/qtgui/Perspectives/Fitting/FittingWidget.py
+++ b/src/sas/qtgui/Perspectives/Fitting/FittingWidget.py
@@ -2030,6 +2030,19 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
 
         self.shell_names = self.shellNamesList()
 
+        # Add a header
+        header_row = [QtGui.QStandardItem() for i in range(5)]
+        header_row[0].setText(self.kernel_module.name)
+        font = header_row[0].font()
+        font.setBold(True)
+        header_row[0].setFont(font)
+        for item in header_row:
+            item.setEditable(False)
+            item.setCheckable(False)
+            item.setSelectable(False)
+
+        self._model_model.appendRow(header_row)
+
         # Update the QModel
         new_rows = FittingUtilities.addParametersToModel(self.model_parameters, self.kernel_module, self.is2D)
 
@@ -2049,6 +2062,19 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         form_kernel = self.kernel_module
 
         self.kernel_module = MultiplicationModel(form_kernel, structure_kernel)
+
+        # Add a header
+        header_row = [QtGui.QStandardItem() for i in range(5)]
+        header_row[0].setText(self.kernel_module._model_info.composition[1][1].name)
+        font = header_row[0].font()
+        font.setBold(True)
+        header_row[0].setFont(font)
+        for item in header_row:
+            item.setEditable(False)
+            item.setCheckable(False)
+            item.setSelectable(False)
+
+        self._model_model.appendRow(header_row)
 
         new_rows = FittingUtilities.addSimpleParametersToModel(structure_parameters, self.is2D)
         for row in new_rows:

--- a/src/sas/qtgui/Perspectives/Fitting/UnitTesting/FittingWidgetTest.py
+++ b/src/sas/qtgui/Perspectives/Fitting/UnitTesting/FittingWidgetTest.py
@@ -588,9 +588,12 @@ class FittingWidgetTest(unittest.TestCase):
         self.widget.cbModel.setCurrentIndex(model_index)
 
         # Assure we have the combobox available
-        last_row = self.widget._last_model_row
-        func_index = self.widget._model_model.index(last_row-1, 1)
+        cbox_row = self.widget._n_shells_row
+        func_index = self.widget._model_model.index(cbox_row, 1)
         self.assertIsInstance(self.widget.lstParams.indexWidget(func_index), QtWidgets.QComboBox)
+
+        # get number of rows before changing shell count
+        last_row = self.widget._model_model.rowCount()
 
         # Change the combo box index
         self.widget.lstParams.indexWidget(func_index).setCurrentIndex(3)

--- a/src/sas/qtgui/Perspectives/Fitting/UnitTesting/FittingWidgetTest.py
+++ b/src/sas/qtgui/Perspectives/Fitting/UnitTesting/FittingWidgetTest.py
@@ -253,8 +253,8 @@ class FittingWidgetTest(unittest.TestCase):
         structure_index = self.widget.cbStructureFactor.findText('squarewell')
         self.widget.cbStructureFactor.setCurrentIndex(structure_index)
 
-        # We have 4 more rows now
-        self.assertEqual(self.widget._model_model.rowCount(), rowcount+5)
+        # We have 3 more param rows now (radius_effective is removed), and a new heading
+        self.assertEqual(self.widget._model_model.rowCount(), rowcount+4)
 
         # Switch models
         self.widget.cbModel.setCurrentIndex(0)
@@ -273,7 +273,7 @@ class FittingWidgetTest(unittest.TestCase):
         # Choose the last factor
         last_index = self.widget.cbStructureFactor.count()
         self.widget.cbStructureFactor.setCurrentIndex(last_index-1)
-        # Do we have all the rows?
+        # Do we have all the rows (incl. radius_effective & heading row)?
         self.assertEqual(self.widget._model_model.rowCount(), 5)
 
         # Are the command buttons properly enabled?


### PR DESCRIPTION
These changes update the main param table:

- Subheadings for P(Q) and S(Q) are added to make the origin of each parameter clear
- radius_effective is no longer shown (if using sasmodels master) because it is not manipulable yet
- Duplicate parameter names from different models (i.e. if P(Q) and S(Q) each have a parameter with the same name) are no longer displayed with the conjured suffix '_S' (the subheadings make it clear which is which)