### PR TITLE
Ticket 1164 slit calculator docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,11 +33,6 @@ Thumbs.db
 # doc build
 /docs/sphinx-docs/build
 /docs/sphinx-docs/source-temp
-/docs/sphinx-docs/source/dev/api
-/docs/sphinx-docs/source/user/guiframe
-/docs/sphinx-docs/source/user/models
-/docs/sphinx-docs/source/user/sasview
-/docs/sphinx-docs/source/user/perspectives
 /docs/sphinx-docs/katex*.zip
 /docs/sphinx-docs/node_modules
 /docs/sphinx-docs/node-package.json

--- a/docs/sphinx-docs/build_sphinx.py
+++ b/docs/sphinx-docs/build_sphinx.py
@@ -7,23 +7,18 @@ http://sphinx-doc.org/invocation.html
 """
 from __future__ import print_function
 
-import subprocess
+import sys
 import os
 from os.path import join as joinpath, abspath, dirname, isdir, exists, relpath
-import sys
-import fnmatch
 import shutil
+import subprocess
 import imp
-
 from glob import glob
 from distutils.dir_util import copy_tree
 from distutils.util import get_platform
 from distutils.spawn import find_executable
 
-from shutil import copy
-from os import listdir
-
-platform = '.%s-%s'%(get_platform(),sys.version[:3])
+PLATFORM = '.%s-%s'%(get_platform(), sys.version[:3])
 
 # sphinx paths
 SPHINX_ROOT = dirname(abspath(__file__))
@@ -34,7 +29,7 @@ SPHINX_PERSPECTIVES = joinpath(SPHINX_SOURCE, "user", "sasgui", "perspectives")
 # sasview paths
 SASVIEW_ROOT = joinpath(SPHINX_ROOT, '..', '..')
 SASVIEW_DOCS = joinpath(SPHINX_ROOT, "source")
-SASVIEW_BUILD = abspath(joinpath(SASVIEW_ROOT, "build", "lib"+platform))
+SASVIEW_BUILD = abspath(joinpath(SASVIEW_ROOT, "build", "lib"+PLATFORM))
 SASVIEW_MEDIA_SOURCE = joinpath(SASVIEW_ROOT, "src", "sas")
 SASVIEW_DOC_TARGET = joinpath(SASVIEW_BUILD, "doc")
 SASVIEW_API_TARGET = joinpath(SPHINX_SOURCE, "dev", "sasview-api")
@@ -64,17 +59,15 @@ run = imp.load_source('run', joinpath(SASVIEW_ROOT, 'run.py'))
 run.prepare()
 
 def inplace_change(filename, old_string, new_string):
-# Thanks to http://stackoverflow.com/questions/4128144/replace-string-within-file-contents
-        s=open(filename).read()
-        if old_string in s:
-                print('Changing "{old_string}" to "{new_string}"'.format(**locals()))
-                s=s.replace(old_string, new_string)
-                f=open(filename, 'w')
-                f.write(s)
-                f.flush()
-                f.close()
-        else:
-                print('No occurences of "{old_string}" found.'.format(**locals()))
+    # Thanks to http://stackoverflow.com/questions/4128144/replace-string-within-file-contents
+    s = open(filename).read()
+    if old_string in s:
+        print('Changing "{old_string}" to "{new_string}"'.format(**locals()))
+        s = s.replace(old_string, new_string)
+        with open(filename, 'w') as f:
+            f.write(s)
+    else:
+        print('No occurences of "{old_string}" found.'.format(**locals()))
 
 def _remove_dir(dir_path):
     """Removes the given directory."""
@@ -240,8 +233,8 @@ def fetch_katex(version, destination="_static"):
                 fd_out.write(fd_in.read())
         finally:
             fd_in.close()
-    with ZipFile(cache_path) as zip:
-        zip.extractall(destination)
+    with ZipFile(cache_path) as archive:
+        archive.extractall(destination)
 
 def convert_katex():
     print("=== Preprocess HTML, converting latex to html ===")

--- a/docs/sphinx-docs/source/conf.py
+++ b/docs/sphinx-docs/source/conf.py
@@ -10,6 +10,7 @@
 #
 # All configuration values have a default; values that are commented out
 # serve to show the default.
+from __future__ import print_function
 
 import sys, os, collections
 
@@ -21,8 +22,8 @@ platform = '.%s-%s'%(get_platform(),sys.version[:3])
 build_lib = os.path.abspath('../../../build/lib'+platform)
 sys.path.insert(0, build_lib)
 sys.path.insert(0, os.path.abspath('_extensions')) # for sphinx extensions
-print "-- path --"
-print "\n".join(sys.path)
+print("-- path --")
+print("\n".join(sys.path))
 
 # -- General configuration -----------------------------------------------------
 

--- a/docs/sphinx-docs/source/rst_prolog
+++ b/docs/sphinx-docs/source/rst_prolog
@@ -1,3 +1,5 @@
+.. TODO: This file is ignored!  Prolog comes from sasmodels/doc/rst_prolog.
+
 .. Set up some substitutions to make life easier...
 
 .. |Ang| unicode:: U+212B

--- a/src/sas/sasgui/perspectives/calculator/media/slit_calculator_help.rst
+++ b/src/sas/sasgui/perspectives/calculator/media/slit_calculator_help.rst
@@ -13,8 +13,8 @@ Description
 This tool enables X-ray users to calculate the slit size (FWHM/2) for smearing
 based on their half beam profile data.
 
-*NOTE! Whilst it may have some more generic applicability, the calculator has
-only been tested with beam profile data from Anton-Paar SAXSess\ :sup:`TM` software.*
+NOTE! Whilst it may have some more generic applicability, the calculator has
+only been tested with beam profile data from Anton-Paar SAXSess\ :sup:`TM` software.
 
 .. ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ
 
@@ -31,9 +31,9 @@ Using the tool
 3) Once a data is loaded, the slit size is automatically computed and displayed
    in the tool window.
 
-*NOTE! The beam profile file does not carry any information about the units of
-the Q data. This calculator assumes the data has units of 1/\ |Ang|\ . If the
-data is not in these units it must be manually converted beforehand.*
+NOTE! The beam profile file does not carry any information about the units of
+the Q data. This calculator assumes the data has units of 1/|Ang|. If the
+data is not in these units it must be manually converted beforehand.
 
 .. ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ
 


### PR DESCRIPTION
Fix the problem with sphinx superscript and substitution (Ticket [1164](http://trac.sasview.org/ticket/1164)) in an emphasized environment by removing the emphasis.

Not the best solution.  May want to try the most recent version of sphinx under python 3 to see if this problem has already been fixed upstream.  

Other option is to turn off emphasis for the superscript and the substitution.