### PR TITLE
SASVIEW-1032: Support for fixed-choice model parameters, e.g structure_factor_mode

### DIFF
--- a/src/sas/qtgui/Perspectives/Fitting/AssociatedComboBox.py
+++ b/src/sas/qtgui/Perspectives/Fitting/AssociatedComboBox.py
@@ -1,0 +1,38 @@
+from PyQt5 import QtGui, QtWidgets
+
+
+class AssociatedComboBox(QtWidgets.QComboBox):
+    """Just a regular combo box, but associated with a particular QStandardItem so that it can be used to display and
+    select an item's current text and a restricted list of other possible text.
+
+    When the combo box's current text is changed, the change is immediately reflected in the associated item; either
+    the text itself is set as the item's data, or the current index is used; see constructor."""
+    item = None  # type: QtGui.QStandardItem
+
+    def __init__(self, item, idx_as_value=False, parent=None):
+        # type: (QtGui.QStandardItem, bool, QtWidgets.QWidget) -> None
+        """
+        Initialize widget. idx_as_value indicates whether to use the combo box's current index (otherwise, current text)
+        as the associated item's new data.
+        """
+        super(AssociatedComboBox, self).__init__(parent)
+        self.item = item
+
+        if idx_as_value:
+            self.currentIndexChanged[int].connect(self._onIndexChanged)
+        else:
+            self.currentTextChanged.connect(self._onTextChanged)
+
+    def _onTextChanged(self, text):
+        # type: (str) -> None
+        """
+        Callback for combo box's currentTextChanged. Set associated item's data to the new text.
+        """
+        self.item.setText(text)
+
+    def _onIndexChanged(self, idx):
+        # type: (int) -> None
+        """
+        Callback for combo box's currentIndexChanged. Set associated item's data to the new index.
+        """
+        self.item.setText(str(idx))

--- a/src/sas/qtgui/Perspectives/Fitting/FittingUtilities.py
+++ b/src/sas/qtgui/Perspectives/Fitting/FittingUtilities.py
@@ -169,6 +169,8 @@ def addParametersToModel(parameters, kernel_module, is2D, model=None, view=None)
 def addSimpleParametersToModel(parameters, is2D, model=None, view=None):
     """
     Update local ModelModel with sasmodel parameters (non-dispersed, non-magnetic)
+    Actually appends to model, if model and view params are not None.
+    Always returns list of lists of QStandardItems.
     """
     if is2D:
         params = [p for p in parameters.kernel_parameters if p.type != 'magnetic']
@@ -285,6 +287,8 @@ def addErrorPolyHeadersToModel(model):
 def addShellsToModel(parameters, model, index, view=None):
     """
     Find out multishell parameters and update the model with the requested number of them
+    Always appends to model. If view param is not None, supports fixed-choice params.
+    Returns list of lists of QStandardItems.
     """
     multishell_parameters = getIterParams(parameters)
 

--- a/src/sas/qtgui/Perspectives/Fitting/FittingUtilities.py
+++ b/src/sas/qtgui/Perspectives/Fitting/FittingUtilities.py
@@ -270,7 +270,7 @@ def addErrorPolyHeadersToModel(model):
     poly_header_error_tooltips.insert(2, error_tooltip)
     model.header_tooltips = copy.copy(poly_header_error_tooltips)
 
-def addShellsToModel(parameters, model, index):
+def addShellsToModel(parameters, model, view, index):
     """
     Find out multishell parameters and update the model with the requested number of them
     """
@@ -293,7 +293,7 @@ def addShellsToModel(parameters, model, index):
                     item1_2 = QtGui.QStandardItem(str(p.default))
                     item1_3 = QtGui.QStandardItem(str(p.limits[0]))
                     item1_4 = QtGui.QStandardItem(str(p.limits[1]))
-                    item1_5 = QtGui.QStandardItem(p.units)
+                    item1_5 = QtGui.QStandardItem(str(p.units))
                     poly_item.appendRow([item1_1, item1_2, item1_3, item1_4, item1_5])
                     break
                 item1.appendRow([poly_item])
@@ -301,8 +301,17 @@ def addShellsToModel(parameters, model, index):
             item2 = QtGui.QStandardItem(str(par.default))
             item3 = QtGui.QStandardItem(str(par.limits[0]))
             item4 = QtGui.QStandardItem(str(par.limits[1]))
-            item5 = QtGui.QStandardItem(par.units)
-            model.appendRow([item1, item2, item3, item4, item5])
+            item5 = QtGui.QStandardItem(str(par.units))
+            item5.setEditable(False)
+
+            # Check if fixed-choice (returns combobox, if so, also makes some items uneditable)
+            row = [item1, item2, item3, item4, item5]
+            cbox = createFixedChoiceComboBox(par, row)
+
+            # Append to the model and use the combobox, if required
+            model.appendRow(row)
+            if cbox is not None:
+                view.setIndexWidget(item2.index(), cbox)
 
 def calculateChi2(reference_data, current_data):
     """

--- a/src/sas/qtgui/Perspectives/Fitting/FittingUtilities.py
+++ b/src/sas/qtgui/Perspectives/Fitting/FittingUtilities.py
@@ -74,11 +74,11 @@ def createFixedChoiceComboBox(param, item_row):
     # implementation is not yet concrete; there are several possible indicators that the parameter is fixed-choice.
     # TODO: (when the sasmodels implementation is concrete, clean this up)
     choices = None
-    if type(param.choices) is list and len(param.choices) > 0:
+    if isinstance(param.choices, (list, tuple)) and len(param.choices) > 0:
         # The choices property is concrete in sasmodels, probably will use this
         choices = param.choices
-    elif type(param.units) is list:
-        choices = param.units
+    elif isinstance(param.units, (list, tuple)):
+        choices = [str(x) for x in param.units]
 
     cbox = None
     if choices is not None:

--- a/src/sas/qtgui/Perspectives/Fitting/FittingWidget.py
+++ b/src/sas/qtgui/Perspectives/Fitting/FittingWidget.py
@@ -2050,11 +2050,11 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
 
         # Update the QModel
         FittingUtilities.addParametersToModel(
-                self._model_model,
-                self.lstParams,
                 self.model_parameters,
                 self.kernel_module,
-                self.is2D)
+                self.is2D,
+                self._model_model,
+                self.lstParams)
 
         # Update the counter used for multishell display
         self._last_model_row = self._model_model.rowCount()
@@ -2075,10 +2075,10 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
 
         # Update the QModel
         FittingUtilities.addSimpleParametersToModel(
-                self._model_model,
-                self.lstParams,
                 structure_parameters,
-                self.is2D)
+                self.is2D,
+                self._model_model,
+                self.lstParams)
 
         # Any parameters removed from the structure factor when producing the product model, e.g. radius_effective, must
         # be disabled (greyed out, etc.)
@@ -2711,8 +2711,8 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         FittingUtilities.addShellsToModel(
                 self.model_parameters,
                 self._model_model,
-                self.lstParams,
-                index)
+                index,
+                self.lstParams)
 
         self.current_shell_displayed = index
 

--- a/src/sas/qtgui/Perspectives/Fitting/FittingWidget.py
+++ b/src/sas/qtgui/Perspectives/Fitting/FittingWidget.py
@@ -2096,36 +2096,37 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         if structure_factor is None or structure_factor=="None":
             return
 
-        s_kernel = self.models[structure_factor]()
-        p_kernel = self.kernel_module
+        if self.kernel_module is None:
+            # Structure factor is the only selected model; build it and show all its params
+            self.kernel_module = self.models[structure_factor]()
+            s_params = self.kernel_module._model_info.parameters
+            s_params_orig = s_params
 
-        # if p_kernel is None:
-        #     # Not a product model, just S(Q)
-        #     self.kernel_module = s_kernel
-        #     params = modelinfo.ParameterTable(self.kernel_module._model_info.parameters.kernel_parameters)
-        #     FittingUtilities.addSimpleParametersToModel(params, self.is2D)
-        # else:
-        p_pars_len = len(p_kernel._model_info.parameters.kernel_parameters)
-        s_pars_len = len(s_kernel._model_info.parameters.kernel_parameters)
-
-        self.kernel_module = MultiplicationModel(p_kernel, s_kernel)
-        all_params = self.kernel_module._model_info.parameters.kernel_parameters
-        all_param_names = [param.name for param in all_params]
-
-        # S(Q) params from the product model are not necessarily the same as those from the S(Q) model; any
-        # conflicting names with P(Q) params will cause a rename
-
-        if "radius_effective_mode" in all_param_names:
-            # Show all parameters
-            s_params = modelinfo.ParameterTable(all_params[p_pars_len:p_pars_len+s_pars_len])
-            s_params_orig = modelinfo.ParameterTable(s_kernel._model_info.parameters.kernel_parameters)
         else:
-            # Ensure radius_effective is not displayed
-            s_params_orig = modelinfo.ParameterTable(s_kernel._model_info.parameters.kernel_parameters[1:])
-            if "radius_effective" in all_param_names:
-                s_params = modelinfo.ParameterTable(all_params[p_pars_len+1:p_pars_len+s_pars_len])
+            s_kernel = self.models[structure_factor]()
+            p_kernel = self.kernel_module
+
+            p_pars_len = len(p_kernel._model_info.parameters.kernel_parameters)
+            s_pars_len = len(s_kernel._model_info.parameters.kernel_parameters)
+
+            self.kernel_module = MultiplicationModel(p_kernel, s_kernel)
+            all_params = self.kernel_module._model_info.parameters.kernel_parameters
+            all_param_names = [param.name for param in all_params]
+
+            # S(Q) params from the product model are not necessarily the same as those from the S(Q) model; any
+            # conflicting names with P(Q) params will cause a rename
+
+            if "radius_effective_mode" in all_param_names:
+                # Show all parameters
+                s_params = modelinfo.ParameterTable(all_params[p_pars_len:p_pars_len+s_pars_len])
+                s_params_orig = modelinfo.ParameterTable(s_kernel._model_info.parameters.kernel_parameters)
             else:
-                s_params = modelinfo.ParameterTable(all_params[p_pars_len:p_pars_len+s_pars_len-1])
+                # Ensure radius_effective is not displayed
+                s_params_orig = modelinfo.ParameterTable(s_kernel._model_info.parameters.kernel_parameters[1:])
+                if "radius_effective" in all_param_names:
+                    s_params = modelinfo.ParameterTable(all_params[p_pars_len+1:p_pars_len+s_pars_len])
+                else:
+                    s_params = modelinfo.ParameterTable(all_params[p_pars_len:p_pars_len+s_pars_len-1])
 
         # Add heading row
         FittingUtilities.addHeadingRowToModel(self._model_model, structure_factor)

--- a/src/sas/qtgui/Perspectives/Fitting/FittingWidget.py
+++ b/src/sas/qtgui/Perspectives/Fitting/FittingWidget.py
@@ -2708,7 +2708,12 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         if remove_rows > 1:
             self._model_model.removeRows(last_row, remove_rows)
 
-        FittingUtilities.addShellsToModel(self.model_parameters, self._model_model, index)
+        FittingUtilities.addShellsToModel(
+                self.model_parameters,
+                self._model_model,
+                self.lstParams,
+                index)
+
         self.current_shell_displayed = index
 
         # Update relevant models

--- a/src/sas/qtgui/Perspectives/Fitting/FittingWidget.py
+++ b/src/sas/qtgui/Perspectives/Fitting/FittingWidget.py
@@ -2049,10 +2049,13 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         self.shell_names = self.shellNamesList()
 
         # Update the QModel
-        new_rows = FittingUtilities.addParametersToModel(self.model_parameters, self.kernel_module, self.is2D)
+        FittingUtilities.addParametersToModel(
+                self._model_model,
+                self.lstParams,
+                self.model_parameters,
+                self.kernel_module,
+                self.is2D)
 
-        for row in new_rows:
-            self._model_model.appendRow(row)
         # Update the counter used for multishell display
         self._last_model_row = self._model_model.rowCount()
 
@@ -2070,13 +2073,19 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
 
         self.kernel_module = MultiplicationModel(form_kernel, structure_kernel)
 
-        new_rows = FittingUtilities.addSimpleParametersToModel(structure_parameters, self.is2D)
-        for row in new_rows:
-            self._model_model.appendRow(row)
-            # disable fitting of parameters not listed in self.kernel_module (probably radius_effective)
-            if row[0].text() not in self.kernel_module.params.keys():
-                row_num = self._model_model.rowCount() - 1
-                FittingUtilities.markParameterDisabled(self._model_model, row_num)
+        # Update the QModel
+        FittingUtilities.addSimpleParametersToModel(
+                self._model_model,
+                self.lstParams,
+                structure_parameters,
+                self.is2D)
+
+        # Any parameters removed from the structure factor when producing the product model, e.g. radius_effective, must
+        # be disabled (greyed out, etc.)
+        for r in range(self._last_model_row, self._model_model.rowCount()):
+            param_name = self._model_model.item(r, 0).text()
+            if param_name not in self.kernel_module.params.keys():
+                FittingUtilities.markParameterDisabled(self._model_model, r)
 
         # Update the counter used for multishell display
         self._last_model_row = self._model_model.rowCount()


### PR DESCRIPTION
This introduces support for fixed-choice parameters in models (including structure factors).

There are currently no built-in models (to my knowledge) that attempt to include fixed-choice parameters, but sasmodels contains the functionality.

This does not include support for parameters added to product models by sasmodels (see SASVIEW-1034); this will be introduced in a subsequent patch, bringing us very close to beta approximation support.