### PR TITLE
Ticket 1166: Fix for report generation issue

### DIFF
--- a/src/sas/sasgui/guiframe/report_dialog.py
+++ b/src/sas/sasgui/guiframe/report_dialog.py
@@ -6,6 +6,7 @@ import wx
 import logging
 import sys
 import wx.html as html
+from sas.sasgui.guiframe.report_image_handler import ReportImageHandler
 
 logger = logging.getLogger(__name__)
 
@@ -69,6 +70,8 @@ class BaseReportDialog(wx.Dialog):
         # buttons
         button_close = wx.Button(self, wx.ID_OK, "Close")
         button_close.SetToolTipString("Close this report window.")
+        button_close.Bind(wx.EVT_BUTTON, self.onClose,
+                          id=button_close.GetId())
         hbox.Add(button_close)
         button_close.SetFocus()
 
@@ -116,15 +119,15 @@ class BaseReportDialog(wx.Dialog):
         printh.PrintText(self.report_html)
 
 
-    def OnClose(self, event=None):
+    def onClose(self, event=None):
         """
         Close the Dialog
         : event: Close button event
         """
         for fig in self.fig_urls:
-            self.imgRAM.RemoveFile(fig)
+            ReportImageHandler.remove_figure(fig)
 
-        self.Close()
+        self.Destroy()
 
     def HTML2PDF(self, data, filename):
         """

--- a/src/sas/sasgui/guiframe/report_image_handler.py
+++ b/src/sas/sasgui/guiframe/report_image_handler.py
@@ -2,7 +2,8 @@ import wx
 
 
 class ReportImageHandler:
-
+    # Singleton class that manages all report plot images
+    # To call the handler, call the static method set_figs
 
     class _ReportImageHandler:
 
@@ -13,6 +14,13 @@ class ReportImageHandler:
             self.indices = []
 
         def set_figs(self, figs, bitmaps, perspective):
+            """
+            Save figures and images to memory and return refernces
+            :param figs: A list of matplotlib Figures
+            :param bitmaps: A list of bitmaps
+            :param perspective: A String with the perspective name
+            :return: A tuple of a list of Figures and a list of memory refs
+            """
             imgs = []
             refs = []
             if figs is None or len(figs) == 0:
@@ -33,6 +41,12 @@ class ReportImageHandler:
             return imgs, refs
 
         def create_unique_name(self, perspective, index=None):
+            """
+            Create a unique key for each item in memory
+            :param perspective: The perspective name as a string
+            :param index: The base index used for incrementing the name
+            :return: A unique file name not currently in use
+            """
             if not index:
                 index = len(self.indices)
             if index in self.indices:
@@ -42,9 +56,10 @@ class ReportImageHandler:
                 name = 'img_{}_{:03d}.png'.format(str(perspective), index)
             return name
 
-
     instance = None
 
-    def __init__(self):
+    @staticmethod
+    def set_figs(figs, bitmaps, perspective):
         if not ReportImageHandler.instance:
             ReportImageHandler.instance = ReportImageHandler._ReportImageHandler()
+        return ReportImageHandler.instance.set_figs(figs, bitmaps, perspective)

--- a/src/sas/sasgui/guiframe/report_image_handler.py
+++ b/src/sas/sasgui/guiframe/report_image_handler.py
@@ -1,0 +1,50 @@
+import wx
+
+
+class ReportImageHandler:
+
+
+    class _ReportImageHandler:
+
+        def __init__(self):
+            self.img_holder = wx.MemoryFSHandler()
+            wx.FileSystem.AddHandler(wx.MemoryFSHandler())
+            self.refs = {}
+            self.indices = []
+
+        def set_figs(self, figs, bitmaps, perspective):
+            imgs = []
+            refs = []
+            if figs is None or len(figs) == 0:
+                figs = [None]
+            for fig in figs:
+                if fig is not None:
+                    ind = figs.index(fig)
+                    bitmap = bitmaps[ind]
+
+                # name of the fig
+                name = self.create_unique_name(perspective)
+                # AddFile, image can be retrieved with 'memory:filename'
+                ref = 'memory:' + name
+                self.refs[ref] = fig
+                self.img_holder.AddFile(name, bitmap, wx.BITMAP_TYPE_PNG)
+                refs.append(ref)
+                imgs.append(fig)
+            return imgs, refs
+
+        def create_unique_name(self, perspective, index=None):
+            if not index:
+                index = len(self.indices)
+            if index in self.indices:
+                name = self.create_unique_name(index + 1)
+            else:
+                self.indices.append(index)
+                name = 'img_{}_{:03d}.png'.format(str(perspective), index)
+            return name
+
+
+    instance = None
+
+    def __init__(self):
+        if not ReportImageHandler.instance:
+            ReportImageHandler.instance = ReportImageHandler._ReportImageHandler()

--- a/src/sas/sasgui/guiframe/report_image_handler.py
+++ b/src/sas/sasgui/guiframe/report_image_handler.py
@@ -1,4 +1,7 @@
 import wx
+import logging
+
+logger = logging.getLogger(__name__)
 
 
 class ReportImageHandler:
@@ -8,8 +11,8 @@ class ReportImageHandler:
     class _ReportImageHandler:
 
         def __init__(self):
-            self.img_holder = wx.MemoryFSHandler()
             wx.FileSystem.AddHandler(wx.MemoryFSHandler())
+            self.img_holder = wx.MemoryFSHandler()
             self.refs = {}
             self.indices = []
 
@@ -59,7 +62,20 @@ class ReportImageHandler:
     instance = None
 
     @staticmethod
+    def check_for_empty_instance():
+        if ReportImageHandler.instance is None:
+            ReportImageHandler.instance = \
+                ReportImageHandler._ReportImageHandler()
+
+    @staticmethod
     def set_figs(figs, bitmaps, perspective):
-        if not ReportImageHandler.instance:
-            ReportImageHandler.instance = ReportImageHandler._ReportImageHandler()
+        ReportImageHandler.check_for_empty_instance()
         return ReportImageHandler.instance.set_figs(figs, bitmaps, perspective)
+
+    @staticmethod
+    def remove_figure(fig_url):
+        try:
+            ReportImageHandler.check_for_empty_instance()
+            ReportImageHandler.instance.refs.pop(fig_url)
+        except Exception as e:
+            logger.warn(e)

--- a/src/sas/sasgui/perspectives/fitting/basepage.py
+++ b/src/sas/sasgui/perspectives/fitting/basepage.py
@@ -651,14 +651,12 @@ class BasicPage(ScrolledPanel, PanelBase):
         Build image state that wx.html understand
         by plotting, putting it into wx.FileSystem image object
         """
-
-        img_handler = ReportImageHandler()
         bitmaps = []
         for canvas in canvases:
             bitmaps.append(canvas.bitmap)
-        imgs, refs = img_handler.instance.set_figs(figs, bitmaps, 'fit')
+        imgs, refs = ReportImageHandler.set_figs(figs, bitmaps, 'fit')
 
-        return img_handler.instance.img_holder, imgs, refs
+        return ReportImageHandler.instance, imgs, refs
 
     def on_save(self, event):
         """

--- a/src/sas/sasgui/perspectives/fitting/basepage.py
+++ b/src/sas/sasgui/perspectives/fitting/basepage.py
@@ -30,6 +30,7 @@ from sas.sascalc.fit.pagestate import PageState
 from sas.sascalc.fit.models import PLUGIN_NAME_BASE
 
 from sas.sasgui.guiframe.panel_base import PanelBase
+from sas.sasgui.guiframe.report_image_handler import ReportImageHandler
 from sas.sasgui.guiframe.utils import format_number, check_float, IdList, \
     check_int
 from sas.sasgui.guiframe.events import PanelOnFocusEvent
@@ -650,36 +651,14 @@ class BasicPage(ScrolledPanel, PanelBase):
         Build image state that wx.html understand
         by plotting, putting it into wx.FileSystem image object
         """
-        images = []
-        refs = []
 
-        # For no figures in the list, prepare empty plot
-        if figs is None or len(figs) == 0:
-            figs = [None]
+        img_handler = ReportImageHandler()
+        bitmaps = []
+        for canvas in canvases:
+            bitmaps.append(canvas.bitmap)
+        imgs, refs = img_handler.instance.set_figs(figs, bitmaps, 'fit')
 
-        # Loop over the list of figures
-        # use wx.MemoryFSHandler
-        imgRAM = wx.MemoryFSHandler()
-        for fig in figs:
-            if fig is not None:
-                ind = figs.index(fig)
-                canvas = canvases[ind]
-
-            # store the image in wx.FileSystem Object
-            wx.FileSystem.AddHandler(wx.MemoryFSHandler())
-
-            # index of the fig
-            ind = figs.index(fig)
-
-            # AddFile, image can be retrieved with 'memory:filename'
-            name = 'img_fit%s.png' % ind
-            refs.append('memory:' + name)
-            imgRAM.AddFile(name, canvas.bitmap, wx.BITMAP_TYPE_PNG)
-            # append figs
-            images.append(fig)
-
-        return imgRAM, images, refs
-
+        return img_handler.instance.img_holder, imgs, refs
 
     def on_save(self, event):
         """

--- a/src/sas/sasgui/perspectives/fitting/report_dialog.py
+++ b/src/sas/sasgui/perspectives/fitting/report_dialog.py
@@ -73,14 +73,17 @@ class ReportDialog(BaseReportDialog):
 
         # save figures
         pictures = []
-        for num in range(self.nimages):
-            pic_name = basename + '_img%s.png' % num
+        i = 0
+        for url in self.fig_urls:
+            append_me = url.split(':')[1]
+            pic_name = basename + '_{}'.format(append_me)
             # save the image for use with pdf writer
-            self.report_list[2][num].savefig(pic_name)
+            self.report_list[2][i].savefig(pic_name)
             pictures.append(pic_name)
+            i += 1
 
         # translate png references int html from in-memory name to on-disk name
-        html = self.report_html.replace("memory:img_fit", basename+'_img')
+        html = self.report_html.replace("memory:", basename+'_')
 
         #set file extensions
         img_ext = []

--- a/src/sas/sasgui/perspectives/invariant/invariant_panel.py
+++ b/src/sas/sasgui/perspectives/invariant/invariant_panel.py
@@ -23,6 +23,7 @@ from sas.sasgui.perspectives.invariant.invariant_widgets import InvTextCtrl
 from sas.sasgui.perspectives.invariant.invariant_state import InvariantState as IState
 from sas.sasgui.guiframe.panel_base import PanelBase
 from sas.sasgui.guiframe.documentation_window import DocumentationWindow
+from sas.sasgui.guiframe.report_image_handler import ReportImageHandler
 
 logger = logging.getLogger(__name__)
 
@@ -782,7 +783,7 @@ class InvariantPanel(ScrolledPanel, PanelBase):
         report_text_str = self.state.__str__()
         report_img = self.state.image
         report_list = [report_html_str, report_text_str, report_img]
-        imgRAM = self.state.img_handler
+        imgRAM = ReportImageHandler.instance.img_holder
         refs = [self.state.wximgbmp]
         dialog = ReportDialog(report_list, imgRAM, refs, None, wx.ID_ANY, "")
         dialog.Show()

--- a/src/sas/sasgui/perspectives/invariant/invariant_panel.py
+++ b/src/sas/sasgui/perspectives/invariant/invariant_panel.py
@@ -782,7 +782,9 @@ class InvariantPanel(ScrolledPanel, PanelBase):
         report_text_str = self.state.__str__()
         report_img = self.state.image
         report_list = [report_html_str, report_text_str, report_img]
-        dialog = ReportDialog(report_list, None, -1, "")
+        imgRAM = self.state.img_handler
+        refs = [self.state.wximgbmp]
+        dialog = ReportDialog(report_list, imgRAM, refs, None, wx.ID_ANY, "")
         dialog.Show()
 
     def get_state_by_num(self, state_num=None):

--- a/src/sas/sasgui/perspectives/invariant/invariant_state.py
+++ b/src/sas/sasgui/perspectives/invariant/invariant_state.py
@@ -611,8 +611,7 @@ class InvariantState(object):
         # get the dynamic image for the htmlwindow
         wximgbmp = wx.BitmapFromImage(wximg)
         # store the image in wx.FileSystem Object
-        self.img_handler = ReportImageHandler()
-        imgs, refs = self.img_handler.instance.set_figs([fig], [wximgbmp], 'inv')
+        imgs, refs = ReportImageHandler.set_figs([fig], [wximgbmp], 'inv')
 
         self.wximgbmp = refs[0]
         self.image = imgs[0]

--- a/src/sas/sasgui/perspectives/invariant/invariant_state.py
+++ b/src/sas/sasgui/perspectives/invariant/invariant_state.py
@@ -11,6 +11,7 @@ import sas.sascalc.dataloader
 # from xml.dom.minidom import parse
 from lxml import etree
 from sas.sascalc.dataloader.readers.cansas_reader import Reader as CansasReader
+from sas.sasgui.guiframe.report_image_handler import ReportImageHandler
 from sas.sascalc.dataloader.readers.cansas_reader import get_content
 from sas.sasgui.guiframe.utils import format_number
 from sas.sasgui.guiframe.gui_style import GUIFRAME_ID
@@ -610,14 +611,11 @@ class InvariantState(object):
         # get the dynamic image for the htmlwindow
         wximgbmp = wx.BitmapFromImage(wximg)
         # store the image in wx.FileSystem Object
-        wx.FileSystem.AddHandler(wx.MemoryFSHandler())
-        # use wx.MemoryFSHandler
-        self.imgRAM = wx.MemoryFSHandler()
-        # AddFile, image can be retrieved with 'memory:filename'
-        self.imgRAM.AddFile('img_inv.png', wximgbmp, wx.BITMAP_TYPE_PNG)
+        self.img_handler = ReportImageHandler()
+        imgs, refs = self.img_handler.instance.set_figs([fig], [wximgbmp], 'inv')
 
-        self.wximgbmp = 'memory:img_inv.png'
-        self.image = fig
+        self.wximgbmp = refs[0]
+        self.image = imgs[0]
 
 class Reader(CansasReader):
     """

--- a/src/sas/sasgui/perspectives/invariant/report_dialog.py
+++ b/src/sas/sasgui/perspectives/invariant/report_dialog.py
@@ -40,7 +40,7 @@ class ReportDialog(BaseReportDialog):
         self.SetTitle("Report: Invariant computaion")
 
         # put image path in the report string
-        self.report_html = self.report_list[0] % "memory:img_inv.png"
+        self.report_html = self.report_list[0] % self.fig_urls[0]
         # layout
         self._setup_layout()
 


### PR DESCRIPTION
This is a fix for the issue outlined in [1166](http://trac.sasview.org/ticket/1166). The issue stems from a memory clash when new reports are generated. Images of plots are stored in virtual memory when generating reports, but the same memory space(s) and file name(s) are used without ensuring the space is free prior to creating new reports and images. Release 4.1.2 and earlier also experience issues, but not in such obvious ways as to the beta release. In 4.1.2, when opening multiple reports without closing any of them, the image(s) from the most recently opened report are saved in the PDFs, regardless of which report is saved, because the old images are wiped from memory and replaced with the latest ones.

To fix this, I moved the file handler from the fitting perspective to its own class in guiframe.  ensure any new image stored in memory has a unique name, and attempt to free up memory when reports are closed. The file handler is now used by the fitting and invariant perspectives.

I have tested this locally, with multiple reports open simultaneously and all save appropriately, for the fitting and invariant perspective. No unit tests were added.

This is a semi-large change for a beta, but report generation is quite broken.

refs #1166