### PR TITLE
SASVIEW-1033: Support for sasmodels' new 'lazy' intermediate results

### DIFF
--- a/src/sas/qtgui/Perspectives/Fitting/FittingLogic.py
+++ b/src/sas/qtgui/Perspectives/Fitting/FittingLogic.py
@@ -166,7 +166,7 @@ class FittingLogic(object):
         elapsed, index, model, \
         data, update_chisqr, source, \
         unsmeared_output, unsmeared_data, unsmeared_error, \
-        pq_values, sq_values = return_data
+        intermediate_results = return_data
 
         return self._create1DPlot(tab_id, x, y, model, data)
 
@@ -223,17 +223,12 @@ class FittingLogic(object):
         elapsed, index, model, \
         data, update_chisqr, source, \
         unsmeared_output, unsmeared_data, unsmeared_error, \
-        pq_values, sq_values = return_data
+        intermediate_results = return_data
 
-        pq_plot = None
-        sq_plot = None
-
-        if pq_values is not None:
-            pq_plot = self._create1DPlot(tab_id, x, pq_values, model, data, component="P(Q)")
-        if sq_values is not None:
-            sq_plot = self._create1DPlot(tab_id, x, sq_values, model, data, component="S(Q)")
-
-        return pq_plot, sq_plot
+        plots = []
+        for name, result in intermediate_results.items():
+            plots.append(self._create1DPlot(tab_id, x, result, model, data, component=name))
+        return plots
 
     def computeDataRange(self):
         """

--- a/src/sas/qtgui/Perspectives/Fitting/FittingWidget.py
+++ b/src/sas/qtgui/Perspectives/Fitting/FittingWidget.py
@@ -2345,17 +2345,11 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
             self.communicate.deleteIntermediateTheoryPlotsSignal.emit(self.kernel_module.id)
 
         # Create plots for intermediate product data
-        pq_data, sq_data = self.logic.new1DProductPlots(return_data, self.tab_id)
-        if pq_data is not None:
-            pq_data.symbol = "Line"
-            self.createNewIndex(pq_data)
-            # self.communicate.plotUpdateSignal.emit([pq_data])
-            new_plots.append(pq_data)
-        if sq_data is not None:
-            sq_data.symbol = "Line"
-            self.createNewIndex(sq_data)
-            # self.communicate.plotUpdateSignal.emit([sq_data])
-            new_plots.append(sq_data)
+        plots = self.logic.new1DProductPlots(return_data, self.tab_id)
+        for plot in plots:
+            plot.symbol = "Line"
+            self.createNewIndex(plot)
+            new_plots.append(plot)
 
         # Update/generate plots
         for plot in new_plots:

--- a/src/sas/qtgui/Perspectives/Fitting/UnitTesting/FittingLogicTest.py
+++ b/src/sas/qtgui/Perspectives/Fitting/UnitTesting/FittingLogicTest.py
@@ -102,7 +102,7 @@ class FittingLogicTest(unittest.TestCase):
                        0, True, 0.0, 1, data,
                        data, False, None,
                        None, None, None,
-                       None, None)
+                       None)
 
         new_plot = self.logic.new1DPlot(return_data=return_data, tab_id=0)
 


### PR DESCRIPTION
This sasmodels feature is implemented in the branch beta_approx and (I assume) is relatively stable; SasViewModel._intermediate_results is a callable which, when called, returns a dict of intermediate results, keyed by name.

Support is retained for sasmodels master, whereby P(Q) and S(Q) data are specifically returned directly.

Note the conflict with PR #169 (easy to resolve but notable)