### PR TITLE
SASVIEW-1034: Support for parameters injected into the product model by sasmodels

### DIFF
--- a/src/sas/qtgui/Perspectives/Fitting/FittingWidget.py
+++ b/src/sas/qtgui/Perspectives/Fitting/FittingWidget.py
@@ -2096,6 +2096,20 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
                 row_num = self._model_model.rowCount() - 1
                 FittingUtilities.markParameterDisabled(self._model_model, row_num)
 
+        # grab list of params injected by sasmodels.product
+        # (only supporting sasmodels master until ESS_GUI merge!!!)
+        num_p_params = len(form_kernel._model_info.parameters.kernel_parameters)
+        num_s_params = len(structure_kernel._model_info.parameters.kernel_parameters)
+        product_params = modelinfo.ParameterTable(
+                self.kernel_module._model_info.parameters.kernel_parameters[num_p_params+num_s_params-1:])
+        product_rows = FittingUtilities.addSimpleParametersToModel(product_params, self.is2D)
+
+        # product params should go at the top of the list, below scale & background
+        row_num = 2
+        for row in product_rows:
+            self._model_model.insertRow(row_num, row)
+            row_num += 1
+
         # Update the counter used for multishell display
         self._last_model_row = self._model_model.rowCount()
 


### PR DESCRIPTION
In sasmodels dev branches, sasmodels' product.py will inject parameters into the product model that are not a part of either P(Q) nor S(Q), e.g. structure_factor_mode, radius_effective_mode.

These parameters are placed in the parameter table above the P(Q)- and S(Q)-specific parameters and headings.