### PR TITLE
FittingWidget: showing also new plots on recalc conditionally

### DIFF
--- a/src/sas/qtgui/MainWindow/DataExplorer.py
+++ b/src/sas/qtgui/MainWindow/DataExplorer.py
@@ -574,7 +574,7 @@ class DataExplorerWindow(DroppableDataLoadWidget):
         # groups plots which move into an own window
         new_plots = dict(int = [], res = [], pd = [])
         for item, plot in plots.items():
-            if self.updatePlot(plot) and filename != plot.name:
+            if (self.updatePlot(plot) and filename != plot.name) or plot.hidden:
                 continue
             # Don't plot intermediate results, e.g. P(Q), S(Q)
             match = GuiUtils.theory_plot_ID_pattern.match(plot.id)
@@ -582,7 +582,8 @@ class DataExplorerWindow(DroppableDataLoadWidget):
             # result, if present (e.g. "[P(Q)]")
             if match and match.groups()[1] != None:
                 continue
-            # Don't include plots from different fitpages, but always include the original data
+            # Don't include plots from different fitpages,
+            # but always include the original data
             if fitpage_name in plot.name or filename == plot.name:
                 # 'sophisticated' test to generate standalone plot for residuals
                 # this should be done by some kind of grouping by lists

--- a/src/sas/qtgui/MainWindow/DataExplorer.py
+++ b/src/sas/qtgui/MainWindow/DataExplorer.py
@@ -94,7 +94,7 @@ class DataExplorerWindow(DroppableDataLoadWidget):
         self.communicator.fileReadSignal.connect(self.loadFromURL)
         self.communicator.activeGraphsSignal.connect(self.updateGraphCount)
         self.communicator.activeGraphName.connect(self.updatePlotName)
-        self.communicator.plotUpdateSignal.connect(self.updatePlot)
+        self.communicator.plotUpdateSignal.connect(self.displayData)
         self.communicator.maskEditorSignal.connect(self.showEditDataMask)
         self.communicator.extMaskEditorSignal.connect(self.extShowEditDataMask)
         self.communicator.changeDataExplorerTabSignal.connect(self.changeTabs)
@@ -571,37 +571,47 @@ class DataExplorerWindow(DroppableDataLoadWidget):
         plots = GuiUtils.plotsFromFilename(filename, model)
         # Each fitpage contains the name based on fit widget number
         fitpage_name = "" if id is None else "M"+str(id)
-        new_plots = []
+        # groups plots which move into an own window
+        new_plots = dict(int = [], res = [], pd = [])
         for item, plot in plots.items():
             if self.updatePlot(plot) and filename != plot.name:
                 continue
             # Don't plot intermediate results, e.g. P(Q), S(Q)
             match = GuiUtils.theory_plot_ID_pattern.match(plot.id)
-            # 2nd match group contains the identifier for the intermediate result, if present (e.g. "[P(Q)]")
+            # 2nd match group contains the identifier for the intermediate
+            # result, if present (e.g. "[P(Q)]")
             if match and match.groups()[1] != None:
                 continue
             # Don't include plots from different fitpages, but always include the original data
             if fitpage_name in plot.name or filename == plot.name:
                 # 'sophisticated' test to generate standalone plot for residuals
+                # this should be done by some kind of grouping by lists
+                # which helps to indicate which go into a single plot window
                 if 'esiduals' in plot.title:
-                    plot.yscale='linear'
-                    self.plotData([(item, plot)])
+                    plot.yscale = 'linear'
+                    new_plots['res'].append((item, plot))
+                elif 'olydispersity' in plot.title:
+                    plot.yscale = 'linear'
+                    new_plots['pd'].append((item, plot))
                 else:
-                    new_plots.append((item, plot))
+                    new_plots['int'].append((item, plot))
 
-        if new_plots:
-            self.plotData(new_plots)
+        # create entirely new plots for those which could not be updated
+        for plots in new_plots.values():
+            if len(plots):
+                self.plotData(plots)
 
     def displayData(self, data_list, id=None):
         """
         Forces display of charts for the given data set
         """
-        plot_to_show = data_list[0]
-        # passed plot is used ONLY to figure out its title,
-        # so all the charts related by it can be pulled from 
-        # the data explorer indices.
-        filename = plot_to_show.filename
-        self.displayFile(filename=filename, is_data=plot_to_show.is_data, id=id)
+        for plot_to_show in data_list:
+            # may there be duplicates? list(OrderedDict.fromkeys(data_list))
+            # passed plot is used ONLY to figure out its title,
+            # so all the charts related by it can be pulled from
+            # the data explorer indices.
+            filename = plot_to_show.filename
+            self.displayFile(filename=filename, is_data=plot_to_show.is_data, id=id)
 
     def addDataPlot2D(self, plot_set, item):
         """

--- a/src/sas/qtgui/Perspectives/Fitting/FittingWidget.py
+++ b/src/sas/qtgui/Perspectives/Fitting/FittingWidget.py
@@ -1087,11 +1087,19 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         else:
             return True
 
+    def updateDataVisibility(self, updateOnly):
+        self.dataUpdateOnly = updateOnly
+        for dataitem in self.all_data:
+            data = GuiUtils.dataFromItem(dataitem)
+            data.hidden = self.dataUpdateOnly
+            self.updateModelIndex(data)
+
     def updateData(self):
         """
         Helper function for recalculation of data used in plotting
         """
         # Update the chart
+        self.updateDataVisibility(True)
         if self.data_is_loaded:
             self.cmdPlot.setText("Show Plot")
             self.calculateQGridForModel()
@@ -1812,11 +1820,11 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         # Regardless of previous state, this should now be `plot show` functionality only
         self.cmdPlot.setText("Show Plot")
         # Force data recalculation so existing charts are updated
-        self.showPlot()
+#        self.showPlot()
         # This is an important processEvent.
         # This allows charts to be properly updated in order
         # of plots being applied.
-        QtWidgets.QApplication.processEvents()
+#        QtWidgets.QApplication.processEvents()
         self.recalculatePlotData()
 
     def onSmearingOptionsUpdate(self):
@@ -2269,6 +2277,9 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         """
         Create a model or theory index with passed Data1D/Data2D
         """
+        # set some flag which decides if new plots should be created or
+        # just existing ones updated, selectively hiding indiv. plot will also work
+        fitted_data.hidden = getattr(self, 'dataUpdateOnly', True)
         if self.data_is_loaded:
             if not fitted_data.name:
                 name = self.nameForFittedData(self.data.filename)
@@ -2439,6 +2450,8 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
 
         for plot in new_plots:
             self.communicate.plotUpdateSignal.emit([plot])
+        # enable plots to be shown next time if updateData() wasn't called
+        self.updateDataVisibility(False)
 
     def complete2D(self, return_data):
         """


### PR DESCRIPTION
A proposal on updating and creating new plots directly after (threaded) recalculation - prevents showPlot() to interfere with updatePlot() and thus plotting outdated data which will get overwritten by calc results anyway. Perhaps more streamlined this way, saves resources on the long run (when the UI grows).

New plots show up conditionally only, based on a flag. Data1D.hidden is used here, because it seems to not being used so far. This would also allow individual hide/show settings by the user on a per plot basis. It's tricky to update the data plot which is created only once, outside of any recalc action, that's what  updateDataVisibility() is for.

- cherry-picked from ESS_GUI_poly_plot branch to keep discussion separate, but included there as well and therefore, it might be best to agree on this proposal first before merging the poly_plot changes