### PR TITLE
SASVIEW-1052: Let user choose if radius_effective is computed from form factor, or free/fittable

### DIFF
--- a/src/sas/qtgui/Perspectives/Fitting/FittingLogic.py
+++ b/src/sas/qtgui/Perspectives/Fitting/FittingLogic.py
@@ -212,10 +212,23 @@ class FittingLogic(object):
         """
         plots = []
         for name, result in return_data['intermediate_results'].items():
+            if not isinstance(result, np.ndarray):
+                continue
             plots.append(self._create1DPlot(tab_id, return_data['x'], result,
                          return_data['model'], return_data['data'],
                          component=name))
         return plots
+
+    def getScalarIntermediateResults(self, return_data):
+        """
+        Returns a dict of scalar-only intermediate results from the return data.
+        """
+        res = {}
+        for name, int_res in return_data["intermediate_results"].items():
+            if isinstance(int_res, np.ndarray):
+                continue
+            res[name] = int_res
+        return res
 
     def computeDataRange(self):
         """

--- a/src/sas/qtgui/Perspectives/Fitting/FittingWidget.py
+++ b/src/sas/qtgui/Perspectives/Fitting/FittingWidget.py
@@ -2593,35 +2593,7 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
             self.communicate.plotUpdateSignal.emit([plot])
 
         # Update radius_effective if relevant
-        def updateRadiusEffective():
-            ER_mode_row = self.getRowFromName("radius_effective_mode")
-            if ER_mode_row is None:
-                return
-            try:
-                ER_mode = int(self._model_model.item(ER_mode_row, 1).text())
-            except ValueError:
-                logging.error("radius_effective_mode was set to an invalid value.")
-                return
-            if ER_mode < 1:
-                # does not need updating if it is not being computed
-                return
-
-            ER_row = self.getRowFromName("radius_effective")
-            if ER_row is None:
-                return
-
-            scalar_results = self.logic.getScalarIntermediateResults(return_data)
-            ER_value = scalar_results.get("effective_radius") # note name of key
-            if ER_value is None:
-                return
-            # ensure the model does not recompute when updating the value
-            self._model_model.blockSignals(True)
-            self._model_model.item(ER_row, 1).setText(str(ER_value))
-            self._model_model.blockSignals(False)
-            # ensure the view is updated immediately
-            self._model_model.layoutChanged.emit()
-
-        updateRadiusEffective()
+        self.updateRadiusEffective(return_data)
 
     def complete2D(self, return_data):
         """
@@ -2640,6 +2612,38 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         # Update/generate plots
         for plot in new_plots:
             self.communicate.plotUpdateSignal.emit([plot])
+
+    def updateRadiusEffective(self, return_data):
+        """
+        Given return data from sasmodels, update the effective radius parameter in the GUI table with the new
+        calculated value as returned by sasmodels (if the value was returned).
+        """
+        ER_mode_row = self.getRowFromName("radius_effective_mode")
+        if ER_mode_row is None:
+            return
+        try:
+            ER_mode = int(self._model_model.item(ER_mode_row, 1).text())
+        except ValueError:
+            logging.error("radius_effective_mode was set to an invalid value.")
+            return
+        if ER_mode < 1:
+            # does not need updating if it is not being computed
+            return
+
+        ER_row = self.getRowFromName("radius_effective")
+        if ER_row is None:
+            return
+
+        scalar_results = self.logic.getScalarIntermediateResults(return_data)
+        ER_value = scalar_results.get("effective_radius") # note name of key
+        if ER_value is None:
+            return
+        # ensure the model does not recompute when updating the value
+        self._model_model.blockSignals(True)
+        self._model_model.item(ER_row, 1).setText(str(ER_value))
+        self._model_model.blockSignals(False)
+        # ensure the view is updated immediately
+        self._model_model.layoutChanged.emit()
 
     def calculateResiduals(self, fitted_data):
         """

--- a/src/sas/qtgui/Perspectives/Fitting/FittingWidget.py
+++ b/src/sas/qtgui/Perspectives/Fitting/FittingWidget.py
@@ -2593,7 +2593,7 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
             self.communicate.plotUpdateSignal.emit([plot])
 
         # Update radius_effective if relevant
-        self.updateRadiusEffective(return_data)
+        self.updateEffectiveRadius(return_data)
 
     def complete2D(self, return_data):
         """
@@ -2613,7 +2613,7 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         for plot in new_plots:
             self.communicate.plotUpdateSignal.emit([plot])
 
-    def updateRadiusEffective(self, return_data):
+    def updateEffectiveRadius(self, return_data):
         """
         Given return data from sasmodels, update the effective radius parameter in the GUI table with the new
         calculated value as returned by sasmodels (if the value was returned).


### PR DESCRIPTION
([See JIRA issue](https://jira.esss.lu.se/browse/SASVIEW-1052).)

The radius_effective_mode functionality was merged into sasmodels' beta_approx branch, so it is as stable as the rest of the beta approximation-related features which I have already merged into ESS_GUI. Therefore this should be merged in too.

In summary, the value of radius_effective_mode is checked, and the radius_effective parameter is made editable/non-editable appropriately. Additionally, when a model has been evaluated and radius_effective has been calculated in the model and passed back as an intermediate result, it is placed into the parameter table so the user can view it.