### PR TITLE
Ticket 1183: Don't clear parameters on structure box content reset

### DIFF
--- a/src/sas/sasgui/perspectives/fitting/fitting.py
+++ b/src/sas/sasgui/perspectives/fitting/fitting.py
@@ -376,7 +376,7 @@ class Plugin(PluginBase):
                         if index == -1:
                             index = 0
                         page.structurebox.SetSelection(index)
-                        page._on_select_model()
+                        page._on_select_model(keep_pars=True)
         except Exception:
             logger.error("update_custom_combo: %s", sys.exc_value)
 


### PR DESCRIPTION
See [Ticket #1183](http://trac.sasview.org/ticket/1183).

When model reload triggered, all models with structure factor boxes had their parameters reset to the default value.