### PR TITLE
Ticket 1179: Add the SasView version to Report Files

### DIFF
--- a/src/sas/sascalc/fit/pagestate.py
+++ b/src/sas/sascalc/fit/pagestate.py
@@ -637,11 +637,10 @@ class PageState(object):
                 chi2 = ("Chi2/Npts = " + value)
                 chi2_string = CENTRE % chi2
             elif name == "Title":
-                from sas.sasview.__init__ import __version__ as sasview_version
                 if len(value.strip()) == 0:
                     continue
                 title = (value + " [" + repo_time + "] [SasView v" +
-                         sasview_version + "]")
+                         SASVIEW_VERSION + "]")
                 title_name = HEADER % title
             elif name == "data":
                 try:

--- a/src/sas/sascalc/fit/pagestate.py
+++ b/src/sas/sascalc/fit/pagestate.py
@@ -637,9 +637,11 @@ class PageState(object):
                 chi2 = ("Chi2/Npts = " + value)
                 chi2_string = CENTRE % chi2
             elif name == "Title":
+                from sas.sasview.__init__ import __version__ as sasview_version
                 if len(value.strip()) == 0:
                     continue
-                title = value + " [" + repo_time + "]"
+                title = (value + " [" + repo_time + "] [SasView v" +
+                         sasview_version + "]")
                 title_name = HEADER % title
             elif name == "data":
                 try:

--- a/src/sas/sasgui/perspectives/invariant/invariant_state.py
+++ b/src/sas/sasgui/perspectives/invariant/invariant_state.py
@@ -129,10 +129,12 @@ class InvariantState(object):
         compute_state = self.state_list[str(compute_num)]
         my_time, date = self.timestamp
         file_name = self.file
+        from sas.sasview.__init__ import __version__ as sasview_version
 
         state_num = int(self.saved_state['state_num'])
         state = "\n[Invariant computation for %s: " % file_name
-        state += "performed at %s on %s] \n" % (my_time, date)
+        state += "performed at %s on %s] " % (my_time, date)
+        state += "[SasView v%s]\n" % (sasview_version)
         state += "State No.: %d \n" % state_num
         state += "\n=== Inputs ===\n"
 


### PR DESCRIPTION
The SasView version number is added to the title bar in Fit and Invariant reports. This handles ticket 1179 for v4.2, but I can't speak for v5.0 and beyond.