### PR TITLE
Ticket 1004: remove e-06 from default magnetism values.

### DIFF
--- a/src/sas/sasgui/perspectives/fitting/basepage.py
+++ b/src/sas/sasgui/perspectives/fitting/basepage.py
@@ -2883,11 +2883,11 @@ class BasicPage(ScrolledPanel, PanelBase):
         if button.GetLabel().count('ON') > 0:
             self.magnetic_on = True
             button.SetLabel("Magnetic OFF")
-            m_value = 1.0e-06
+            m_value = 1
             for key in self.model.magnetic_params:
                 if key.count('M0') > 0:
                     self.model.setParam(key, m_value)
-                    m_value += 0.5e-06
+                    m_value += 0.5
         else:
             self.magnetic_on = False
             button.SetLabel("Magnetic ON")


### PR DESCRIPTION
Set magnetic defaults in units of `1e-6/Ang^2`.

This does not address the main part of the ticket, which is that the magnetic values reset to the default when magnetism is toggled off and on.