### PR TITLE
simplify C build

### DIFF
--- a/run.py
+++ b/run.py
@@ -66,7 +66,7 @@ def import_dll(modname, build_path):
     return imp.load_dynamic(modname, path)
 
 
-def prepare():
+def prepare(rebuild=True):
     # Don't create *.pyc files
     sys.dont_write_bytecode = True
 
@@ -94,60 +94,46 @@ def prepare():
     # add periodictable to the path
     try:
         import periodictable
-    except:
+    except ImportError:
         addpath(joinpath(root, '..', 'periodictable'))
 
     try:
         import bumps
-    except:
+    except ImportError:
         addpath(joinpath(root, '..', 'bumps'))
 
     try:
         import tinycc
-    except:
+    except ImportError:
         addpath(joinpath(root, '../tinycc/build/lib'))
 
     # select wx version
     #addpath(os.path.join(root, '..','wxPython-src-3.0.0.0','wxPython'))
 
-    # Build project if the build directory does not already exist.
-    # PAK: with "update" we can always build since it is fast
-    if True or not os.path.exists(build_path):
+    # Put the sas source tree on the path
+    addpath(joinpath(root, 'src'))
+
+    # Put sasmodels on the path
+    addpath(joinpath(root, '../sasmodels/'))
+
+    # Check if the C extensions are already built
+    try:
+        from sas.sascalc.pr import _pr_inversion
+        from sas.sascalc.calculator import _sld2i
+        from sas.sascalc.file_converter import _bsl_loader
+    except ImportError:
+        rebuild = True
+
+    # Build C extensions if necessary.  Do an inplace build to simplify path.
+    if rebuild:
         import subprocess
-        build_cmd = [sys.executable, "setup.py", "build", "update"]
+        build_cmd = [sys.executable, "setup.py", "build_ext", "--inplace", "update"]
         if os.name == 'nt':
             build_cmd.append('--compiler=tinycc')
         # need shell=True on windows to keep console box from popping up
         shell = (os.name == 'nt')
         with cd(root):
             subprocess.call(build_cmd, shell=shell)
-
-    # Put the source trees on the path
-    addpath(joinpath(root, 'src'))
-
-    # sasmodels on the path
-    addpath(joinpath(root, '../sasmodels/'))
-
-    # The sas.models package Compiled Model files should be pulled in from the build directory even though
-    # the source is stored in src/sas/models.
-
-    # Compiled modules need to be pulled from the build directory.
-    # Some packages are not where they are needed, so load them explicitly.
-    import sas.sascalc.pr
-    sas.sascalc.pr.core = import_package('sas.sascalc.pr.core',
-                                         joinpath(build_path, 'sas', 'sascalc', 'pr', 'core'))
-
-    # Compiled modules need to be pulled from the build directory.
-    # Some packages are not where they are needed, so load them explicitly.
-    import sas.sascalc.file_converter
-    sas.sascalc.file_converter.core = import_package('sas.sascalc.file_converter.core',
-                                                     joinpath(build_path, 'sas', 'sascalc', 'file_converter', 'core'))
-
-    import sas.sascalc.calculator
-    sas.sascalc.calculator.core = import_package('sas.sascalc.calculator.core',
-                                                 joinpath(build_path, 'sas', 'sascalc', 'calculator', 'core'))
-
-    sys.path.append(build_path)
 
     set_git_tag()
     # print "\n".join(sys.path)

--- a/setup.py
+++ b/setup.py
@@ -11,16 +11,20 @@ import os
 import subprocess
 import shutil
 import sys
-from distutils.command.build_ext import build_ext
-from distutils.core import Command
 
 import numpy as np
+
 from setuptools import Extension, setup
+from setuptools import Command
+from setuptools.command.build_ext import build_ext
 
 try:
     import tinycc.distutils
 except ImportError:
     pass
+
+# Convert "test" argument to "pytest" so 'python setup.py test' works
+sys.argv = [("pytest" if s == "test" else s) for s in sys.argv]
 
 # Manage version number ######################################
 with open(os.path.join("src", "sas", "sasview", "__init__.py")) as fid:
@@ -245,11 +249,10 @@ packages.extend(["sas.sascalc.dataloader", "sas.sascalc.dataloader.readers",
 
 # sas.sascalc.calculator
 gen_dir = os.path.join("src", "sas", "sascalc", "calculator", "c_extensions")
-package_dir["sas.sascalc.calculator.core"] = gen_dir
 package_dir["sas.sascalc.calculator"] = os.path.join(
     "src", "sas", "sascalc", "calculator")
-packages.extend(["sas.sascalc.calculator", "sas.sascalc.calculator.core"])
-ext_modules.append(Extension("sas.sascalc.calculator.core.sld2i",
+packages.append("sas.sascalc.calculator")
+ext_modules.append(Extension("sas.sascalc.calculator._sld2i",
                              sources=[
                                  os.path.join(gen_dir, "sld2i_module.c"),
                                  os.path.join(gen_dir, "sld2i.c"),
@@ -257,15 +260,13 @@ ext_modules.append(Extension("sas.sascalc.calculator.core.sld2i",
                                  os.path.join(gen_dir, "librefl.c"),
                              ],
                              include_dirs=[gen_dir],
-                             )
-                   )
+                             ))
 
 # sas.sascalc.pr
 srcdir = os.path.join("src", "sas", "sascalc", "pr", "c_extensions")
-package_dir["sas.sascalc.pr.core"] = srcdir
 package_dir["sas.sascalc.pr"] = os.path.join("src", "sas", "sascalc", "pr")
-packages.extend(["sas.sascalc.pr", "sas.sascalc.pr.core"])
-ext_modules.append(Extension("sas.sascalc.pr.core.pr_inversion",
+packages.append("sas.sascalc.pr")
+ext_modules.append(Extension("sas.sascalc.pr._pr_inversion",
                              sources=[os.path.join(srcdir, "Cinvertor.c"),
                                       os.path.join(srcdir, "invertor.c"),
                                       ],
@@ -275,12 +276,10 @@ ext_modules.append(Extension("sas.sascalc.pr.core.pr_inversion",
 
 # sas.sascalc.file_converter
 mydir = os.path.join("src", "sas", "sascalc", "file_converter", "c_ext")
-package_dir["sas.sascalc.file_converter.core"] = mydir
 package_dir["sas.sascalc.file_converter"] = os.path.join(
     "src", "sas", "sascalc", "file_converter")
-packages.extend(["sas.sascalc.file_converter",
-                 "sas.sascalc.file_converter.core"])
-ext_modules.append(Extension("sas.sascalc.file_converter.core.bsl_loader",
+packages.append("sas.sascalc.file_converter")
+ext_modules.append(Extension("sas.sascalc.file_converter._bsl_loader",
                              sources=[os.path.join(mydir, "bsl_loader.c")],
                              include_dirs=[np.get_include()],
                              ))
@@ -442,5 +441,7 @@ setup(
     },
     cmdclass={'build_ext': build_ext_subclass,
               'docs': BuildSphinxCommand,
-              'disable_openmp': DisableOpenMPCommand}
+              'disable_openmp': DisableOpenMPCommand},
+    setup_requires=['pytest-runner'] if 'pytest' in sys.argv else [],
+    tests_require=['pytest'],
 )

--- a/src/sas/sascalc/calculator/c_extensions/__init__.py
+++ b/src/sas/sascalc/calculator/c_extensions/__init__.py
@@ -1,3 +1,0 @@
-"""
-    C extensions to provide the sas_gen computations.
-"""

--- a/src/sas/sascalc/calculator/c_extensions/sld2i_module.c
+++ b/src/sas/sascalc/calculator/c_extensions/sld2i_module.c
@@ -1,8 +1,11 @@
 /**
   SLD2I module to perform point and I calculations
  */
-#include <Python.h>
 #include <stdio.h>
+
+//#define Py_LIMITED_API 0x03020000
+#include <Python.h>
+
 #include "sld2i.h"
 
 #if PY_MAJOR_VERSION < 3
@@ -159,9 +162,9 @@ static PyMethodDef module_methods[] = {
 };
 
 #define MODULE_DOC "Sld2i C Library"
-#define MODULE_NAME "sld2i"
-#define MODULE_INIT2 initsld2i
-#define MODULE_INIT3 PyInit_sld2i
+#define MODULE_NAME "_sld2i"
+#define MODULE_INIT2 init_sld2i
+#define MODULE_INIT3 PyInit__sld2i
 #define MODULE_METHODS module_methods
 
 /* ==== boilerplate python 2/3 interface bootstrap ==== */

--- a/src/sas/sascalc/calculator/sas_gen.py
+++ b/src/sas/sascalc/calculator/sas_gen.py
@@ -13,7 +13,7 @@ from periodictable import formula
 from periodictable import nsf
 import numpy as np
 
-from .core import sld2i as mod
+from . import _sld2i
 from .BaseComponent import BaseComponent
 
 logger = logging.getLogger(__name__)
@@ -144,17 +144,17 @@ class GenSAS(BaseComponent):
             self.params['Up_frac_in'],
             self.params['Up_frac_out'],
             self.params['Up_theta'])
-        model = mod.new_GenI(*args)
+        model = _sld2i.new_GenI(*args)
         if len(qy):
             qx, qy = _vec(qx), _vec(qy)
             I_out = np.empty_like(qx)
             #print("npoints", qx.shape, "npixels", pos_x.shape)
-            mod.genicomXY(model, qx, qy, I_out)
+            _sld2i.genicomXY(model, qx, qy, I_out)
             #print("I_out after", I_out)
         else:
             qx = _vec(qx)
             I_out = np.empty_like(qx)
-            mod.genicom(model, qx, I_out)
+            _sld2i.genicom(model, qx, I_out)
         vol_correction = self.data_total_volume / self.params['total_volume']
         result = (self.params['scale'] * vol_correction * I_out
                   + self.params['background'])
@@ -303,8 +303,8 @@ class OMF2SLD(object):
                 z_dir2 = ((self.pos_z - z_c / 2.0) / z_r)
                 z_dir2 *= z_dir2
                 mask = (x_dir2 + y_dir2 + z_dir2) <= 1.0
-            except Exception:
-                logger.error(sys.exc_value)
+            except Exception as exc:
+                logger.error(exc)
         self.output = MagSLD(self.pos_x[mask], self.pos_y[mask],
                              self.pos_z[mask], self.sld_n[mask],
                              self.mx[mask], self.my[mask], self.mz[mask])
@@ -599,8 +599,8 @@ class PDBReader(object):
                         x_lines.append(x_line)
                         y_lines.append(y_line)
                         z_lines.append(z_line)
-                except Exception:
-                    logger.error(sys.exc_value)
+                except Exception as exc:
+                    logger.error(exc)
 
             output = MagSLD(pos_x, pos_y, pos_z, sld_n, sld_mx, sld_my, sld_mz)
             output.set_conect_lines(x_line, y_line, z_line)
@@ -690,11 +690,11 @@ class SLDReader(object):
                         try:
                             _vol_pix = float(toks[7])
                             vol_pix = np.append(vol_pix, _vol_pix)
-                        except Exception:
+                        except Exception as exc:
                             vol_pix = None
-                    except Exception:
+                    except Exception as exc:
                         # Skip non-data lines
-                        logger.error(sys.exc_value)
+                        logger.error(exc)
             output = MagSLD(pos_x, pos_y, pos_z, sld_n,
                             sld_mx, sld_my, sld_mz)
             output.filename = os.path.basename(path)

--- a/src/sas/sascalc/file_converter/bsl_loader.py
+++ b/src/sas/sascalc/file_converter/bsl_loader.py
@@ -1,4 +1,4 @@
-from sas.sascalc.file_converter.core.bsl_loader import CLoader
+from sas.sascalc.file_converter._bsl_loader import CLoader
 from sas.sascalc.dataloader.data_info import Data2D
 from copy import deepcopy
 import os
@@ -66,7 +66,7 @@ class BSLLoader(CLoader):
                     'frames': int(metadata[2]),
                     'swap_bytes': int(metadata[3])
                 }
-            except:
+            except Exception:
                 is_valid = False
                 err_msg = "Invalid metadata in header file for {}"
                 err_msg = err_msg.format(sasdata_filename)

--- a/src/sas/sascalc/file_converter/c_ext/__init__.py
+++ b/src/sas/sascalc/file_converter/c_ext/__init__.py
@@ -1,3 +1,0 @@
-"""
-    Data loader for the Diamond BSL beamline.
-"""

--- a/src/sas/sascalc/file_converter/c_ext/bsl_loader.c
+++ b/src/sas/sascalc/file_converter/c_ext/bsl_loader.c
@@ -1,9 +1,12 @@
-#include <Python.h>
-#define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
-#include <numpy/arrayobject.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include "structmember.h"
+
+//#define Py_LIMITED_API 0x03020000
+#include <Python.h>
+#include <structmember.h>
+#define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
+#include <numpy/arrayobject.h>
+
 #include "bsl_loader.h"
 
 typedef struct {
@@ -291,9 +294,9 @@ void addCLoader(PyObject *module)
 }
 
 #define MODULE_DOC "C module for loading bsl."
-#define MODULE_NAME "bsl_loader"
-#define MODULE_INIT2 initbsl_loader
-#define MODULE_INIT3 PyInit_bsl_loader
+#define MODULE_NAME "_bsl_loader"
+#define MODULE_INIT2 init_bsl_loader
+#define MODULE_INIT3 PyInit__bsl_loader
 #define MODULE_METHODS module_methods
 
 /* ==== boilerplate python 2/3 interface bootstrap ==== */

--- a/src/sas/sascalc/pr/c_extensions/Cinvertor.c
+++ b/src/sas/sascalc/pr/c_extensions/Cinvertor.c
@@ -4,15 +4,16 @@
  * and provides the underlying computations.
  *
  */
-#include <Python.h>
-#include "structmember.h"
 #include <stdio.h>
 #include <stdlib.h>
 #include <math.h>
 #include <time.h>
 
-#include "invertor.h"
+//#define Py_LIMITED_API 0x03050000
+#include <Python.h>
+#include <structmember.h>
 
+#include "invertor.h"
 
 /// Error object for raised exceptions
 PyObject * CinvertorError;
@@ -1120,9 +1121,9 @@ void addCinvertor(PyObject *module) {
 
 
 #define MODULE_DOC "C extension module for inversion to P(r)."
-#define MODULE_NAME "pr_inversion"
-#define MODULE_INIT2 initpr_inversion
-#define MODULE_INIT3 PyInit_pr_inversion
+#define MODULE_NAME "_pr_inversion"
+#define MODULE_INIT2 init_pr_inversion
+#define MODULE_INIT3 PyInit__pr_inversion
 #define MODULE_METHODS module_methods
 
 /* ==== boilerplate python 2/3 interface bootstrap ==== */

--- a/src/sas/sascalc/pr/c_extensions/Cinvertor.c
+++ b/src/sas/sascalc/pr/c_extensions/Cinvertor.c
@@ -13,25 +13,31 @@
 #include <Python.h>
 #include <structmember.h>
 
+// Vector binding glue
+#if (PY_VERSION_HEX > 0x03000000) && !defined(Py_LIMITED_API)
+  // Assuming that a view into a writable vector points to a
+  // non-changing pointer for the duration of the C call, capture
+  // the view pointer and immediately free the view.
+  #define VECTOR(VEC_obj, VEC_buf, VEC_len) do { \
+    Py_buffer VEC_view; \
+    int VEC_err = PyObject_GetBuffer(VEC_obj, &VEC_view, PyBUF_WRITABLE|PyBUF_FORMAT); \
+    if (VEC_err < 0 || sizeof(*VEC_buf) != VEC_view.itemsize) return NULL; \
+    VEC_buf = (typeof(VEC_buf))VEC_view.buf; \
+    VEC_len = VEC_view.len/sizeof(*VEC_buf); \
+    PyBuffer_Release(&VEC_view); \
+  } while (0)
+#else
+  #define VECTOR(VEC_obj, VEC_buf, VEC_len) do { \
+    int VEC_err = PyObject_AsWriteBuffer(VEC_obj, (void **)(&VEC_buf), &VEC_len); \
+    if (VEC_err < 0) return NULL; \
+    VEC_len /= sizeof(*VEC_buf); \
+  } while (0)
+#endif
+
 #include "invertor.h"
 
 /// Error object for raised exceptions
 PyObject * CinvertorError;
-
-#define INVECTOR(obj,buf,len)										\
-    do { \
-        int err = PyObject_AsReadBuffer(obj, (const void **)(&buf), &len); \
-        if (err < 0) return NULL; \
-        len /= sizeof(*buf); \
-    } while (0)
-
-#define OUTVECTOR(obj,buf,len) \
-    do { \
-        int err = PyObject_AsWriteBuffer(obj, (void **)(&buf), &len); \
-        if (err < 0) return NULL; \
-        len /= sizeof(*buf); \
-    } while (0)
-
 
 // Class definition
 /**
@@ -99,7 +105,7 @@ static PyObject * set_x(Cinvertor *self, PyObject *args) {
 	int i;
 
 	if (!PyArg_ParseTuple(args, "O", &data_obj)) return NULL;
-	OUTVECTOR(data_obj,data,ndata);
+	VECTOR(data_obj,data,ndata);
 
 	free(self->params.x);
 	self->params.x = (double*) malloc(ndata*sizeof(double));
@@ -131,7 +137,7 @@ static PyObject * get_x(Cinvertor *self, PyObject *args) {
     int i;
 
 	if (!PyArg_ParseTuple(args, "O", &data_obj)) return NULL;
-	OUTVECTOR(data_obj, data, ndata);
+	VECTOR(data_obj, data, ndata);
 
 	// Check that the input array is large enough
 	if (ndata < self->params.npoints) {
@@ -164,7 +170,7 @@ static PyObject * set_y(Cinvertor *self, PyObject *args) {
 	int i;
 
 	if (!PyArg_ParseTuple(args, "O", &data_obj)) return NULL;
-	OUTVECTOR(data_obj,data,ndata);
+	VECTOR(data_obj,data,ndata);
 
 	free(self->params.y);
 	self->params.y = (double*) malloc(ndata*sizeof(double));
@@ -196,7 +202,7 @@ static PyObject * get_y(Cinvertor *self, PyObject *args) {
     int i;
 
 	if (!PyArg_ParseTuple(args, "O", &data_obj)) return NULL;
-	OUTVECTOR(data_obj, data, ndata);
+	VECTOR(data_obj, data, ndata);
 
 	// Check that the input array is large enough
 	if (ndata < self->params.ny) {
@@ -229,7 +235,7 @@ static PyObject * set_err(Cinvertor *self, PyObject *args) {
 	int i;
 
 	if (!PyArg_ParseTuple(args, "O", &data_obj)) return NULL;
-	OUTVECTOR(data_obj,data,ndata);
+	VECTOR(data_obj,data,ndata);
 
 	free(self->params.err);
 	self->params.err = (double*) malloc(ndata*sizeof(double));
@@ -261,7 +267,7 @@ static PyObject * get_err(Cinvertor *self, PyObject *args) {
     int i;
 
 	if (!PyArg_ParseTuple(args, "O", &data_obj)) return NULL;
-	OUTVECTOR(data_obj, data, ndata);
+	VECTOR(data_obj, data, ndata);
 
 	// Check that the input array is large enough
 	if (ndata < self->params.nerr) {
@@ -517,7 +523,7 @@ static PyObject * residuals(Cinvertor *self, PyObject *args) {
 
 	if (!PyArg_ParseTuple(args, "O", &data_obj)) return NULL;
 
-	OUTVECTOR(data_obj,pars,npars);
+	VECTOR(data_obj,pars,npars);
 
     // PyList of residuals
 	// Should create this list only once and refill it
@@ -568,7 +574,7 @@ static PyObject * pr_residuals(Cinvertor *self, PyObject *args) {
 
 	if (!PyArg_ParseTuple(args, "O", &data_obj)) return NULL;
 
-	OUTVECTOR(data_obj,pars,npars);
+	VECTOR(data_obj,pars,npars);
 
 	// Should create this list only once and refill it
     residuals = PyList_New(self->params.npoints);
@@ -609,7 +615,7 @@ static PyObject * get_iq(Cinvertor *self, PyObject *args) {
 	Py_ssize_t npars;
 
 	if (!PyArg_ParseTuple(args, "Od", &data_obj, &q)) return NULL;
-	OUTVECTOR(data_obj,pars,npars);
+	VECTOR(data_obj,pars,npars);
 
 	iq_value = iq(pars, self->params.d_max, (int)npars, q);
 	return Py_BuildValue("f", iq_value);
@@ -634,7 +640,7 @@ static PyObject * get_iq_smeared(Cinvertor *self, PyObject *args) {
 	Py_ssize_t npars;
 
 	if (!PyArg_ParseTuple(args, "Od", &data_obj, &q)) return NULL;
-	OUTVECTOR(data_obj,pars,npars);
+	VECTOR(data_obj,pars,npars);
 
 	iq_value = iq_smeared(pars, self->params.d_max, (int)npars,
 							self->params.slit_height, self->params.slit_width,
@@ -659,7 +665,7 @@ static PyObject * get_pr(Cinvertor *self, PyObject *args) {
 	Py_ssize_t npars;
 
 	if (!PyArg_ParseTuple(args, "Od", &data_obj, &r)) return NULL;
-	OUTVECTOR(data_obj,pars,npars);
+	VECTOR(data_obj,pars,npars);
 
 	pr_value = pr(pars, self->params.d_max, (int)npars, r);
 	return Py_BuildValue("f", pr_value);
@@ -686,13 +692,13 @@ static PyObject * get_pr_err(Cinvertor *self, PyObject *args) {
 	Py_ssize_t npars2;
 
 	if (!PyArg_ParseTuple(args, "OOd", &data_obj, &err_obj, &r)) return NULL;
-	OUTVECTOR(data_obj,pars,npars);
+	VECTOR(data_obj,pars,npars);
 
 	if (err_obj == Py_None) {
 		pr_value = pr(pars, self->params.d_max, (int)npars, r);
 		pr_err_value = 0.0;
 	} else {
-		OUTVECTOR(err_obj,pars_err,npars2);
+		VECTOR(err_obj,pars_err,npars2);
 		pr_err(pars, pars_err, self->params.d_max, (int)npars, r, &pr_value, &pr_err_value);
 	}
 	return Py_BuildValue("ff", pr_value, pr_err_value);
@@ -726,7 +732,7 @@ static PyObject * oscillations(Cinvertor *self, PyObject *args) {
 	double oscill, norm;
 
 	if (!PyArg_ParseTuple(args, "O", &data_obj)) return NULL;
-	OUTVECTOR(data_obj,pars,npars);
+	VECTOR(data_obj,pars,npars);
 
 	oscill = reg_term(pars, self->params.d_max, (int)npars, 100);
 	norm   = int_p2(pars, self->params.d_max, (int)npars, 100);
@@ -747,7 +753,7 @@ static PyObject * get_peaks(Cinvertor *self, PyObject *args) {
 	int count;
 
 	if (!PyArg_ParseTuple(args, "O", &data_obj)) return NULL;
-	OUTVECTOR(data_obj,pars,npars);
+	VECTOR(data_obj,pars,npars);
 
 	count = npeaks(pars, self->params.d_max, (int)npars, 100);
 
@@ -768,7 +774,7 @@ static PyObject * get_positive(Cinvertor *self, PyObject *args) {
 	double fraction;
 
 	if (!PyArg_ParseTuple(args, "O", &data_obj)) return NULL;
-	OUTVECTOR(data_obj,pars,npars);
+	VECTOR(data_obj,pars,npars);
 
 	fraction = positive_integral(pars, self->params.d_max, (int)npars, 100);
 
@@ -792,8 +798,8 @@ static PyObject * get_pos_err(Cinvertor *self, PyObject *args) {
 	double fraction;
 
 	if (!PyArg_ParseTuple(args, "OO", &data_obj, &err_obj)) return NULL;
-	OUTVECTOR(data_obj,pars,npars);
-	OUTVECTOR(err_obj,pars_err,npars2);
+	VECTOR(data_obj,pars,npars);
+	VECTOR(err_obj,pars_err,npars2);
 
 	fraction = positive_errors(pars, pars_err, self->params.d_max, (int)npars, 51);
 
@@ -813,7 +819,7 @@ static PyObject * get_rg(Cinvertor *self, PyObject *args) {
 	double value;
 
 	if (!PyArg_ParseTuple(args, "O", &data_obj)) return NULL;
-	OUTVECTOR(data_obj,pars,npars);
+	VECTOR(data_obj,pars,npars);
 
 	value = rg(pars, self->params.d_max, (int)npars, 101);
 
@@ -833,7 +839,7 @@ static PyObject * get_iq0(Cinvertor *self, PyObject *args) {
 	double value;
 
 	if (!PyArg_ParseTuple(args, "O", &data_obj)) return NULL;
-	OUTVECTOR(data_obj,pars,npars);
+	VECTOR(data_obj,pars,npars);
 
 	value = 4.0*acos(-1.0)*int_pr(pars, self->params.d_max, (int)npars, 101);
 
@@ -874,8 +880,8 @@ static PyObject * get_matrix(Cinvertor *self, PyObject *args) {
 	int offset;
 
 	if (!PyArg_ParseTuple(args, "iiOO", &nfunc, &nr, &a_obj, &b_obj)) return NULL;
-	OUTVECTOR(a_obj,a,n_a);
-	OUTVECTOR(b_obj,b,n_b);
+	VECTOR(a_obj,a,n_a);
+	VECTOR(b_obj,b,n_b);
 
 	assert(n_b>=nfunc);
 	assert(n_a>=nfunc*(nr+self->params.npoints));
@@ -947,8 +953,8 @@ static PyObject * get_invcov_matrix(Cinvertor *self, PyObject *args) {
 	int i, j, k;
 
 	if (!PyArg_ParseTuple(args, "iiOO", &nfunc, &nr, &a_obj, &cov_obj)) return NULL;
-	OUTVECTOR(a_obj,a,n_a);
-	OUTVECTOR(cov_obj,inv_cov,n_cov);
+	VECTOR(a_obj,a,n_a);
+	VECTOR(cov_obj,inv_cov,n_cov);
 
 	assert(n_cov>=nfunc*nfunc);
 	assert(n_a>=nfunc*(nr+self->params.npoints));
@@ -981,7 +987,7 @@ static PyObject * get_reg_size(Cinvertor *self, PyObject *args) {
 	double sum_sig, sum_reg;
 
 	if (!PyArg_ParseTuple(args, "iiO", &nfunc, &nr, &a_obj)) return NULL;
-	OUTVECTOR(a_obj,a,n_a);
+	VECTOR(a_obj,a,n_a);
 
 	assert(n_a>=nfunc*(nr+self->params.npoints));
 

--- a/src/sas/sascalc/pr/c_extensions/__init__.py
+++ b/src/sas/sascalc/pr/c_extensions/__init__.py
@@ -1,3 +1,0 @@
-"""
-    C extensions to provide the P(r) inversion computations.
-"""

--- a/src/sas/sascalc/pr/fit/BumpsFitting.py
+++ b/src/sas/sascalc/pr/fit/BumpsFitting.py
@@ -1,6 +1,8 @@
 """
 BumpsFitting module runs the bumps optimizer.
 """
+from __future__ import division
+
 import os
 from datetime import timedelta, datetime
 
@@ -33,7 +35,7 @@ from sas.sascalc.fit.expression import compile_constraints
 
 class Progress(object):
     def __init__(self, history, max_step, pars, dof):
-        remaining_time = int(history.time[0]*(float(max_step)/history.step[0]-1))
+        remaining_time = int(history.time[0]*(max_step/history.step[0]-1))
         # Depending on the time remaining, either display the expected
         # time of completion, or the amount of time remaining.  Use precision
         # appropriate for the duration.

--- a/src/sas/sascalc/pr/fit/Loader.py
+++ b/src/sas/sascalc/pr/fit/Loader.py
@@ -1,8 +1,9 @@
+"""
+class Loader  to load any kind of file
+"""
+
 from __future__ import print_function
 
-# class Loader  to load any king of file
-#import wx
-#import string
 import numpy as np
 
 class Load:

--- a/src/sas/sascalc/pr/invertor.py
+++ b/src/sas/sascalc/pr/invertor.py
@@ -473,7 +473,7 @@ class Invertor(Cinvertor):
             raise RuntimeError("Invertor: could not invert I(Q)\n  %s" % str(exc))
 
         # Perform the inversion (least square fit)
-        c, chi2, _, _ = lstsq(a, b, rcond=None)
+        c, chi2, _, _ = lstsq(a, b, rcond=-1)
         # Sanity check
         try:
             float(chi2)

--- a/src/sas/sascalc/pr/invertor.py
+++ b/src/sas/sascalc/pr/invertor.py
@@ -16,7 +16,7 @@ import re
 import logging
 from numpy.linalg import lstsq
 from scipy import optimize
-from sas.sascalc.pr.core.pr_inversion import Cinvertor
+from sas.sascalc.pr._pr_inversion import Cinvertor
 
 logger = logging.getLogger(__name__)
 
@@ -70,7 +70,7 @@ class Invertor(Cinvertor):
 
         A[j][i] = (Fourier transformed base function for point j)
 
-    We them choose a number of r-points, n_r, to evaluate the second
+    We then choose a number of r-points, n_r, to evaluate the second
     derivative of P(r) at. This is used as our regularization term.
     For a vector r of length n_r, the following n_r rows are set to ::
 
@@ -143,7 +143,7 @@ class Invertor(Cinvertor):
         Access the parent class methods for
         x, y, err, d_max, q_min, q_max and alpha
         """
-        if   name == 'x':
+        if name == 'x':
             if 0.0 in value:
                 msg = "Invertor: one of your q-values is zero. "
                 msg += "Delete that entry before proceeding"
@@ -267,7 +267,7 @@ class Invertor(Cinvertor):
 
             A[i][j] = (Fourier transformed base function for point j)
 
-        We them choose a number of r-points, n_r, to evaluate the second
+        We then choose a number of r-points, n_r, to evaluate the second
         derivative of P(r) at. This is used as our regularization term.
         For a vector r of length n_r, the following n_r rows are set to ::
 
@@ -415,7 +415,7 @@ class Invertor(Cinvertor):
 
             A[i][j] = (Fourier transformed base function for point j)
 
-        We them choose a number of r-points, n_r, to evaluate the second
+        We then choose a number of r-points, n_r, to evaluate the second
         derivative of P(r) at. This is used as our regularization term.
         For a vector r of length n_r, the following n_r rows are set to ::
 
@@ -472,7 +472,7 @@ class Invertor(Cinvertor):
             raise RuntimeError("Invertor: could not invert I(Q)\n  %s" % str(exc))
 
         # Perform the inversion (least square fit)
-        c, chi2, _, _ = lstsq(a, b)
+        c, chi2, _, _ = lstsq(a, b, rcond=None)
         # Sanity check
         try:
             float(chi2)
@@ -496,10 +496,10 @@ class Invertor(Cinvertor):
         try:
             cov = np.linalg.pinv(inv_cov)
             err = math.fabs(chi2 / float(npts - nfunc)) * cov
-        except:
+        except Exception as exc:
             # We were not able to estimate the errors
             # Return an empty error matrix
-            logger.error(sys.exc_value)
+            logger.error(exc)
 
         # Keep a copy of the last output
         if not self.est_bck:
@@ -536,15 +536,15 @@ class Invertor(Cinvertor):
         :return: number of terms, alpha, message
 
         """
-        from num_term import NTermEstimator
+        from .num_term import NTermEstimator
         estimator = NTermEstimator(self.clone())
         try:
             return estimator.num_terms(isquit_func)
-        except:
+        except Exception as exc:
             # If we fail, estimate alpha and return the default
             # number of terms
             best_alpha, _, _ = self.estimate_alpha(self.nfunc)
-            logger.warning("Invertor.estimate_numterms: %s" % sys.exc_value)
+            logger.warning("Invertor.estimate_numterms: %s" % exc)
             return self.nfunc, best_alpha, "Could not estimate number of terms"
 
     def estimate_alpha(self, nfunc):
@@ -630,8 +630,8 @@ class Invertor(Cinvertor):
 
                 return best_alpha, message, elapsed
 
-        except:
-            message = "Invertor.estimate_alpha: %s" % sys.exc_value
+        except Exception as exc:
+            message = "Invertor.estimate_alpha: %s" % exc
             return 0, message, elapsed
 
     def to_file(self, path, npts=100):
@@ -747,8 +747,8 @@ class Invertor(Cinvertor):
 
                         self.cov[i][i] = float(toks2[1])
 
-            except:
-                msg = "Invertor.from_file: corrupted file\n%s" % sys.exc_value
+            except Exception as exc:
+                msg = "Invertor.from_file: corrupted file\n%s" % exc
                 raise RuntimeError(msg)
         else:
             msg = "Invertor.from_file: '%s' is not a file" % str(path)

--- a/src/sas/sascalc/pr/invertor.py
+++ b/src/sas/sascalc/pr/invertor.py
@@ -5,6 +5,7 @@ The module contains the Invertor class.
 
 FIXME: The way the Invertor interacts with its C component should be cleaned up
 """
+from __future__ import division
 
 import numpy as np
 import sys
@@ -495,7 +496,7 @@ class Invertor(Cinvertor):
 
         try:
             cov = np.linalg.pinv(inv_cov)
-            err = math.fabs(chi2 / float(npts - nfunc)) * cov
+            err = math.fabs(chi2 / (npts - nfunc)) * cov
         except Exception as exc:
             # We were not able to estimate the errors
             # Return an empty error matrix

--- a/src/sas/sascalc/pr/num_term.py
+++ b/src/sas/sascalc/pr/num_term.py
@@ -1,4 +1,4 @@
-from __future__ import print_function
+from __future__ import print_function, division
 
 import math
 import numpy as np
@@ -50,7 +50,7 @@ class NTermEstimator(object):
         """
         osc = self.sort_osc()
         dv = len(osc)
-        med = float(dv) / 2.0
+        med = 0.5*dv
         odd = self.is_odd(dv)
         medi = 0
         for i in range(dv):
@@ -139,7 +139,7 @@ class NTermEstimator(object):
             self.isquit_func = isquit_func
             nts = self.compare_err()
             div = len(nts)
-            tem = float(div) / 2.0
+            tem = 0.5*div
             if self.is_odd(div):
                 nt = nts[int(tem)]
             else:


### PR DESCRIPTION
Move c extensions from core/module.so to _module.so.  This allows an inplace build of the C models so that run.py doesn't need to do tricks to load the module from the build path while the rest of the package is loaded from the src path.

Also included is some cleanup for improved python 3 support.