### PR TITLE
support pytest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,7 @@ Thumbs.db
 /docs/sphinx-docs/node-package.json
 
 # test outputs
+/.eggs
 /test/pr_inversion/test/test_output.txt
 /test/sasdataloader/test/plugins.zip
 /test/sasdataloader/test/test_log.txt

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,7 @@
+"""
+Pytest configuration file.
+"""
+
+# Prepare the runtime environment for the tests
+import run
+run.prepare()


### PR DESCRIPTION
Note: based off of simplify-c-build, which already contains mods to allow `python setup.py test`.

The .eggs directory is created during the test to pull in pytest helpers.  Without an internet connection, need to use `pip install pytest_runner`, which should perhaps be added to the requirements files and yaml files for setting up conda environments.