### PR TITLE
Ticket 1205: use data weights from the GUI in the fit

### DIFF
--- a/src/sas/sasgui/perspectives/fitting/fitting.py
+++ b/src/sas/sasgui/perspectives/fitting/fitting.py
@@ -775,10 +775,8 @@ class Plugin(PluginBase):
         :param fid: id corresponding to a fit problem (data, model)
         :param weight: current dy data
         """
-        # If we are not dealing with a specific fit problem, then
-        # there is no point setting the weights.
-        if fid is None:
-            return
+        # Note: this is used to set the data weights for the fit based on
+        # the weight selection in the GUI.
         if uid in self.page_finder.keys():
             self.page_finder[uid].set_weight(flag=flag, is2d=is2d)
 


### PR DESCRIPTION
Fixes the problem with data weights set in the GUI being ignored in the fit.

Note that the bug was introduced while fix something to do with 2D plotting.  With this fix, a quick test doesn't show any problem.  Tried with 1D and 2D calculations, with and without data, and with 1D and 2D fits.  Maybe this change was put in to fix a more subtle bug?