### PR TITLE
Ticket 1206 - fix problems in smearing sizer

### DIFF
--- a/src/sas/sasgui/perspectives/fitting/fitpage.py
+++ b/src/sas/sasgui/perspectives/fitting/fitpage.py
@@ -17,6 +17,7 @@ import logging
 from sasmodels.weights import MODELS as POLYDISPERSITY_MODELS
 
 from sas.sascalc.fit.qsmearing import smear_selection
+from sas.sascalc.dataloader.data_info import Data1D, Data2D
 
 from sas.sasgui.guiframe.events import StatusEvent, NewPlotEvent, \
     PlotQrangeEvent
@@ -186,8 +187,7 @@ class FitPage(BasicPage):
 
         :return: True or False
         """
-        if self.data.__class__.__name__ == "Data2D" or \
-                        self.enable2D:
+        if isinstance(self.data, Data2D) or self.enable2D:
             return True
         return False
 
@@ -201,8 +201,7 @@ class FitPage(BasicPage):
         is_2d_data = False
 
         # Check if data is 2D
-        if self.data.__class__.__name__ == "Data2D" or \
-                        self.enable2D:
+        if isinstance(self.data, Data2D) or self.enable2D:
             is_2d_data = True
 
         title = "Fitting"
@@ -517,7 +516,7 @@ class FitPage(BasicPage):
         is_2d_data = False
 
         # check if it is 2D data
-        if self.data.__class__.__name__ == "Data2D" or self.enable2D:
+        if isinstance(self.data, Data2D) or self.enable2D:
             is_2d_data = True
 
         self.sizer5.Clear(True)
@@ -820,8 +819,7 @@ class FitPage(BasicPage):
                         wx.EVT_CHECKBOX(self, cb.GetId(), self.select_param)
                         self.sizer4_4.Add(cb, (iy, ix), (1, 1),
                                 wx.LEFT | wx.EXPAND | wx.ADJUST_MINSIZE, 5)
-                        if self.data.__class__.__name__ == "Data2D" or \
-                                    self.enable2D:
+                        if isinstance(self.data, Data2D) or self.enable2D:
                             cb.Show(True)
                         elif cb.IsShown():
                             cb.Hide()
@@ -833,8 +831,7 @@ class FitPage(BasicPage):
                         poly_tip = "Absolute Sigma for %s." % item
                         ctl1.SetToolTipString(poly_tip)
                         ctl1.SetValue(str(format_number(value, True)))
-                        if self.data.__class__.__name__ == "Data2D" or \
-                                    self.enable2D:
+                        if isinstance(self.data, Data2D) or self.enable2D:
                             if first_orient:
                                 values.SetLabel('PD[ratio], Sig[deg]')
                                 poly_text = "PD(polydispersity for lengths):\n"
@@ -868,8 +865,7 @@ class FitPage(BasicPage):
                                           wx.EXPAND | wx.ADJUST_MINSIZE, 0)
 
                         ctl2.Hide()
-                        if self.data.__class__.__name__ == "Data2D" or \
-                                self.enable2D:
+                        if isinstance(self.data, Data2D) or self.enable2D:
                             if self.is_mac:
                                 text2.Show(True)
                                 ctl2.Show(True)
@@ -894,8 +890,7 @@ class FitPage(BasicPage):
                                           wx.EXPAND | wx.ADJUST_MINSIZE, 0)
                         ctl4.Hide()
 
-                        if self.data.__class__.__name__ == "Data2D" or \
-                                self.enable2D:
+                        if isinstance(self.data, Data2D) or self.enable2D:
                             ctl3.Show(True)
                             ctl4.Show(True)
 
@@ -907,8 +902,7 @@ class FitPage(BasicPage):
                                              style=wx.TE_PROCESS_ENTER)
 
                         Tctl.SetValue(str(format_number(value)))
-                        if self.data.__class__.__name__ == "Data2D" or \
-                                self.enable2D:
+                        if isinstance(self.data, Data2D) or self.enable2D:
                             Tctl.Show(True)
                         else:
                             Tctl.Hide()
@@ -927,8 +921,7 @@ class FitPage(BasicPage):
                                              style=wx.TE_PROCESS_ENTER)
 
                         Tct2.SetValue(str(format_number(value)))
-                        if self.data.__class__.__name__ == "Data2D" or \
-                                self.enable2D:
+                        if isinstance(self.data, Data2D) or self.enable2D:
                             Tct2.Show(True)
                         else:
                             Tct2.Hide()
@@ -955,8 +948,7 @@ class FitPage(BasicPage):
                 self.orientation_params_disp.append([cb, name1, ctl1,
                                             text2, ctl2, ctl3, ctl4, disp_box])
 
-                if self.data.__class__.__name__ == "Data2D" or \
-                                self.enable2D:
+                if isinstance(self.data, Data2D) or self.enable2D:
                     disp_box.Show(True)
                 else:
                     disp_box.Hide()
@@ -1341,8 +1333,7 @@ class FitPage(BasicPage):
                     elif self.pinhole_smearer.GetValue():
                         flag1 = self.update_pinhole_smear()
                         flag = flag or flag1
-                elif self.data.__class__.__name__ != "Data2D" and \
-                        not self.enable2D:
+                elif not isinstance(self.data, Data2D) and not self.enable2D:
                     enable_smearer = not self.disable_smearer.GetValue()
                     self._manager.set_smearer(smearer=temp_smearer,
                                               fid=self.data.id,
@@ -1415,7 +1406,7 @@ class FitPage(BasicPage):
         """
         if event is not None:
             event.Skip()
-        if self.data.__class__.__name__ == "Data2D":
+        if isinstance(self.data, Data2D):
             return
         is_click = event.LeftDown()
         if is_click:
@@ -1433,7 +1424,7 @@ class FitPage(BasicPage):
         """
         if event is not None:
             event.Skip()
-        if self.data.__class__.__name__ == "Data2D":
+        if isinstance(self.data, Data2D):
             return
         act_ctrl = event.GetEventObject()
         d_id = self.data.id
@@ -1449,7 +1440,7 @@ class FitPage(BasicPage):
         On Key down
         """
         event.Skip()
-        if self.data.__class__.__name__ == "Data2D":
+        if isinstance(self.data, Data2D):
             return
         ctrl = event.GetEventObject()
         try:
@@ -1510,8 +1501,7 @@ class FitPage(BasicPage):
                 return
             # Check if # of points for theory model are valid(>0).
             # check for 2d
-            if self.data.__class__.__name__ == "Data2D" or \
-                    self.enable2D:
+            if isinstance(self.data, Data2D) or self.enable2D:
                 # set mask
                 radius = np.sqrt(self.data.qx_data * self.data.qx_data +
                                     self.data.qy_data * self.data.qy_data)
@@ -1563,8 +1553,7 @@ class FitPage(BasicPage):
             for item in self.parameters:
                 if item[0].IsShown():
                     # Skip the angle parameters if 1D data
-                    if self.data.__class__.__name__ != "Data2D" and \
-                            not self.enable2D:
+                    if not isinstance(self.data, Data2D) and not self.enable2D:
                         if item in self.orientation_params:
                             continue
                     if item in self.param_toFit:
@@ -1582,8 +1571,7 @@ class FitPage(BasicPage):
             for item in self.fittable_param:
                 if item[0].IsShown():
                     # Skip the angle parameters if 1D data
-                    if self.data.__class__.__name__ != "Data2D" and \
-                            not self.enable2D:
+                    if not isinstance(self.data, Data2D) and not self.enable2D:
                         if item in self.orientation_params:
                             continue
                     if item in self.param_toFit:
@@ -1633,7 +1621,7 @@ class FitPage(BasicPage):
         #If so check that data set has smearing info and that none are zero.
         #Otherwise no smearing can be applied using smear from data (a Gaussian
         #width of zero will cause a divide by zero error)
-        if self.data.__class__.__name__ == "Data2D":
+        if isinstance(self.data, Data2D):
             if data.dqx_data is not None and data.dqy_data is not None \
               and data.dqx_data.all()and data.dqy_data.all():
                 self.smear_type = "Pinhole2d"
@@ -1653,7 +1641,7 @@ class FitPage(BasicPage):
         #not both simultaneously) and, as for 2D, are non zero .
         #Otherwise no smearing can be applied using smear from data (a Gaussian
         #width of zero will cause a divide by zero error)
-        elif self.data.__class__.__name__ == "Data1D":
+        elif isinstance(self.data, Data1D):
             #is it valid 1D pinhole resolution data?
             if data.dx is not None and np.all(data.dx):
                 self.smear_type = "Pinhole"
@@ -1974,8 +1962,7 @@ class FitPage(BasicPage):
             # more disables for 2D
             di_flag = False
             dq_flag = False
-            if self.data.__class__.__name__ == "Data2D" or \
-                        self.enable2D:
+            if isinstance(self.data, Data2D) or self.enable2D:
                 self.slit_smearer.Disable()
                 self.pinhole_smearer.Enable(True)
                 self.default_mask = copy.deepcopy(self.data.mask)
@@ -2060,7 +2047,7 @@ class FitPage(BasicPage):
         self.Refresh()
         # update model plot with new data information
         if flag:
-            if self.data.__class__.__name__ == "Data2D":
+            if isinstance(self.data, Data2D):
                 self.enable2D = True
                 self.model_view.SetLabel("2D Mode")
             else:
@@ -2127,8 +2114,7 @@ class FitPage(BasicPage):
             return
         npts2fit = 0
         qmin, qmax = self.get_range()
-        if self.data.__class__.__name__ == "Data2D" or \
-                        self.enable2D:
+        if isinstance(self.data, Data2D) or self.enable2D:
             radius = np.sqrt(self.data.qx_data * self.data.qx_data +
                                 self.data.qy_data * self.data.qy_data)
             index_data = (self.qmin_x <= radius) & (radius <= self.qmax_x)
@@ -2518,7 +2504,7 @@ class FitPage(BasicPage):
         :return: message to inform the user about the validity
             of the values entered for slit smear
         """
-        if self.data.__class__.__name__ == "Data2D" or self.enable2D:
+        if isinstance(self.data, Data2D) or self.enable2D:
             return
         # make sure once more if it is smearer
         data = copy.deepcopy(self.data)
@@ -2714,8 +2700,7 @@ class FitPage(BasicPage):
         self.param_toFit = []
         for item in self.parameters:
             # Skip t ifhe angle parameters if 1D data
-            if self.data.__class__.__name__ != "Data2D" and\
-                        not self.enable2D:
+            if not isinstance(self.data, Data2D) and not self.enable2D:
                 if item in self.orientation_params:
                     continue
             # Select parameters to fit for list of primary parameters
@@ -2731,8 +2716,7 @@ class FitPage(BasicPage):
         #        with dispersion
         for item in self.fittable_param:
             # Skip t ifhe angle parameters if 1D data
-            if self.data.__class__.__name__ != "Data2D" and\
-                        not self.enable2D:
+            if not isinstance(self.data, Data2D) and not self.enable2D:
                 if item in self.orientation_params:
                     continue
             if item[0].GetValue() and item[0].IsShown():
@@ -2744,8 +2728,7 @@ class FitPage(BasicPage):
                     self.param_toFit.remove(item)
 
         # Calculate num. of angle parameters
-        if self.data.__class__.__name__ == "Data2D" or \
-                       self.enable2D:
+        if isinstance(self.data, Data2D) or self.enable2D:
             len_orient_para = 0
         else:
             len_orient_para = len(self.orientation_params)  # assume even len
@@ -3038,7 +3021,7 @@ class FitPage(BasicPage):
                 # all buttons on IF mag has mag and has 2D
                 if not self._has_magnetic:
                     mag_on_button.Show(False)
-                elif not self.data.__class__.__name__ == "Data2D":
+                elif not isinstance(self.data, Data2D):
                     mag_on_button.Show(False)
                 else:
                     mag_on_button.Show(True)
@@ -3054,8 +3037,7 @@ class FitPage(BasicPage):
                         mag_help_button.Show(False)
                         mag_angle_help_button.Show(False)
 
-                if not self.data.__class__.__name__ == "Data2D" and \
-                        not self.enable2D:
+                if not isinstance(self.data, Data2D) and not self.enable2D:
                     orient_angle.Hide()
                 else:
                     orient_angle.Show(True)
@@ -3079,8 +3061,7 @@ class FitPage(BasicPage):
                     cb.SetValue(CHECK_STATE)
                     cb.SetToolTipString("Check mark to fit")
                     wx.EVT_CHECKBOX(self, cb.GetId(), self.select_param)
-                    if self.data.__class__.__name__ == "Data2D" or \
-                            self.enable2D:
+                    if isinstance(self.data, Data2D) or self.enable2D:
                         cb.Show(True)
                     else:
                         cb.Hide()
@@ -3095,8 +3076,7 @@ class FitPage(BasicPage):
                     ctl1.SetToolTipString(
                                 "Hit 'Enter' after typing to update the plot.")
                     ctl1.SetValue(format_number(value, True))
-                    if self.data.__class__.__name__ == "Data2D" or \
-                            self.enable2D:
+                    if isinstance(self.data, Data2D) or self.enable2D:
                         ctl1.Show(True)
                     else:
                         ctl1.Hide()
@@ -3136,8 +3116,7 @@ class FitPage(BasicPage):
 
                     ctl4.Hide()
 
-                    if self.data.__class__.__name__ == "Data2D" or \
-                            self.enable2D:
+                    if isinstance(self.data, Data2D) or self.enable2D:
                         if self.is_mac:
                             text2.Show(True)
                             ctl2.Show(True)
@@ -3153,8 +3132,7 @@ class FitPage(BasicPage):
                     else:
                         units = wx.StaticText(self, -1, "",
                                               style=wx.ALIGN_LEFT)
-                    if self.data.__class__.__name__ == "Data2D" or \
-                            self.enable2D:
+                    if isinstance(self.data, Data2D) or self.enable2D:
                         units.Show(True)
                     else:
                         units.Hide()
@@ -3233,14 +3211,13 @@ class FitPage(BasicPage):
         Set semarer radio buttons
         """
         # more disables for 2D
-        if self.data.__class__.__name__ == "Data2D" or \
-                    self.enable2D:
+        if isinstance(self.data, Data2D) or self.enable2D:
             self.slit_smearer.Disable()
             self.default_mask = copy.deepcopy(self.data.mask)
             if self.model is not None:
                 self.pinhole_smearer.Enable(True)
 
-        elif self.data.__class__.__name__ == "Data1D":
+        elif isinstance(self.data, Data1D):
             if self.model is not None:
                 self.slit_smearer.Enable(True)
                 self.pinhole_smearer.Enable(True)

--- a/src/sas/sasgui/perspectives/fitting/fitpage.py
+++ b/src/sas/sasgui/perspectives/fitting/fitpage.py
@@ -1627,8 +1627,10 @@ class FitPage(BasicPage):
         # check if it is pinhole smear and get min max if it is.
         if data.dx is not None and np.any(data.dx):
             self.smear_type = "Pinhole"
-            self.dq_l = data.dx[0]
-            self.dq_r = data.dx[-1]
+            #report in % for display makes more sense than absolute value
+            #for pinhole smearing
+            self.dq_l = data.dx[0] / data.x[0] * 100
+            self.dq_r = data.dx[-1] / data.x[-1] * 100
 
         # check if it is slit smear and get min max if it is.
         elif data.dxl is not None or data.dxw is not None:

--- a/src/sas/sasgui/perspectives/fitting/fitpage.py
+++ b/src/sas/sasgui/perspectives/fitting/fitpage.py
@@ -1617,7 +1617,7 @@ class FitPage(BasicPage):
                 return
             elif self.current_smearer is not None \
                 and data.dqx_data.any() != 0 \
-                and data.dqx_data.any() != 0:
+                and data.dqy_data.any() != 0:
                 self.smear_type = "Pinhole2d"
                 self.dq_l = format_number(np.average(data.dqx_data))
                 self.dq_r = format_number(np.average(data.dqy_data))

--- a/src/sas/sasgui/perspectives/fitting/fitpage.py
+++ b/src/sas/sasgui/perspectives/fitting/fitpage.py
@@ -3236,11 +3236,17 @@ class FitPage(BasicPage):
         if self.data.__class__.__name__ == "Data2D" or \
                     self.enable2D:
             self.slit_smearer.Disable()
-            self.pinhole_smearer.Enable(True)
             self.default_mask = copy.deepcopy(self.data.mask)
+            if self.model is not None:
+                self.pinhole_smearer.Enable(True)
+
+        elif self.data.__class__.__name__ == "Data1D":
+            if self.model is not None:
+                self.slit_smearer.Enable(True)
+                self.pinhole_smearer.Enable(True)
         else:
-            self.slit_smearer.Enable(True)
-            self.pinhole_smearer.Enable(True)
+            msg="data is not recognized as either 1D or 2D"
+            logger.info(msg)
 
 
 class BGTextCtrl(wx.TextCtrl):

--- a/src/sas/sasgui/perspectives/fitting/fitpage.py
+++ b/src/sas/sasgui/perspectives/fitting/fitpage.py
@@ -214,7 +214,9 @@ class FitPage(BasicPage):
               "Please enter a fixed percentage to be applied to all Q values..."
         smear_message_2d_x_title = "<dQp>[1/A]:"
         smear_message_2d_y_title = "<dQs>[1/A]:"
-        smear_message_pinhole_percent_title = "dQ[%]:"
+        smear_message_pinhole_percent_min_title = "[dQ/Q]min(%):"
+        smear_message_pinhole_percent_max_title = "[dQ/Q]max(%):"
+        smear_message_pinhole_percent_title = "dQ/Q(%):"
         smear_message_slit_height_title = "Slit height[1/A]:"
         smear_message_slit_width_title = "Slit width[1/A]:"
 
@@ -422,6 +424,12 @@ class FitPage(BasicPage):
                             smear_message_2d_y_title, style=wx.ALIGN_LEFT)
         self.smear_description_2d_y.SetToolTipString(
                                     " dQs(perpendicular) in q_phi direction.")
+        self.smear_description_pin_percent_min = wx.StaticText(self, wx.ID_ANY,
+                                            smear_message_pinhole_percent_min_title,
+                                            style=wx.ALIGN_LEFT)
+        self.smear_description_pin_percent_max = wx.StaticText(self, wx.ID_ANY,
+                                            smear_message_pinhole_percent_max_title,
+                                            style=wx.ALIGN_LEFT)
         self.smear_description_pin_percent = wx.StaticText(self, wx.ID_ANY,
                                             smear_message_pinhole_percent_title,
                                             style=wx.ALIGN_LEFT)
@@ -448,20 +456,24 @@ class FitPage(BasicPage):
                                  0, wx.CENTER, 10)
         self.sizer_new_smear.Add((15, -1))
         self.sizer_new_smear.Add(self.smear_description_2d_x, 0, wx.CENTER, 10)
+        self.sizer_new_smear.Add(self.smear_description_pin_percent_min,
+                                 0, wx.CENTER, 10)
+        self.sizer_new_smear.Add(self.smear_description_pin_percent,
+                                 0, wx.CENTER, 10)
         self.sizer_new_smear.Add(self.smear_description_slit_height,
                                  0, wx.CENTER, 10)
 
+        self.sizer_new_smear.Add(self.smear_pinhole_percent, 0, wx.CENTER, 10)
         self.sizer_new_smear.Add(self.smear_slit_height, 0, wx.CENTER, 10)
         self.sizer_new_smear.Add(self.smear_data_left, 0, wx.CENTER, 10)
         self.sizer_new_smear.Add((20, -1))
         self.sizer_new_smear.Add(self.smear_description_2d_y,
                                  0, wx.CENTER, 10)
-        self.sizer_new_smear.Add(self.smear_description_pin_percent,
+        self.sizer_new_smear.Add(self.smear_description_pin_percent_max,
                                  0, wx.CENTER, 10)
         self.sizer_new_smear.Add(self.smear_description_slit_width,
                                  0, wx.CENTER, 10)
 
-        self.sizer_new_smear.Add(self.smear_pinhole_percent, 0, wx.CENTER, 10)
         self.sizer_new_smear.Add(self.smear_slit_width, 0, wx.CENTER, 10)
         self.sizer_new_smear.Add(self.smear_data_right, 0, wx.CENTER, 10)
 
@@ -1628,7 +1640,9 @@ class FitPage(BasicPage):
         if data.dx is not None and np.any(data.dx):
             self.smear_type = "Pinhole"
             #report in % for display makes more sense than absolute value
-            #for pinhole smearing
+            #for pinhole smearing.  Keep old names of dq_l rather than 
+            #dq_percent_l as it is close entough, minimizez changes,
+            #particularly since both slit AND pinhole are using these variables.
             self.dq_l = data.dx[0] / data.x[0] * 100
             self.dq_r = data.dx[-1] / data.x[-1] * 100
 
@@ -1668,17 +1682,18 @@ class FitPage(BasicPage):
                     self.smear_description_slit_height.Show(True)
                     self.smear_description_slit_width.Show(True)
                 elif self.smear_type == 'Pinhole':
-                    self.smear_description_pin_percent.Show(True)
+                    self.smear_description_pin_percent_min.Show(True)
+                    self.smear_description_pin_percent_max.Show(True)
                 self.smear_description_smear_type.Show(True)
                 self.smear_description_type.Show(True)
                 self.smear_data_left.Show(True)
                 self.smear_data_right.Show(True)
         # custom pinhole smear
         elif self.pinhole_smearer.GetValue():
-            if self.smear_type == 'Pinhole':
-                self.smear_message_new_p.Show(True)
-                self.smear_description_pin_percent.Show(True)
-
+#            if self.smear_type == 'Pinhole':
+            self.smear_message_new_p.Show(True)
+            self.smear_description_pin_percent.Show(True)
+            #note - was outside of above commented out if statement
             self.smear_pinhole_percent.Show(True)
         # custom slit smear
         elif self.slit_smearer.GetValue():
@@ -1704,6 +1719,8 @@ class FitPage(BasicPage):
         self.smear_accuracy.Hide()
         self.smear_data_left.Hide()
         self.smear_data_right.Hide()
+        self.smear_description_pin_percent_min.Hide()
+        self.smear_description_pin_percent_max.Hide()
         self.smear_description_pin_percent.Hide()
         self.smear_pinhole_percent.Hide()
         self.smear_description_slit_height.Hide()

--- a/src/sas/sasgui/perspectives/fitting/fitpage.py
+++ b/src/sas/sasgui/perspectives/fitting/fitpage.py
@@ -1650,7 +1650,7 @@ class FitPage(BasicPage):
         #If not check that data is 1D
         #If so check for pinhole vs slit by veryfing whehter dx or dxl or dxw
         #have data (currently sasview only supports either dx or dxl/dxw but
-        #not both simultaneously) and as, for 2D, are non zero .
+        #not both simultaneously) and, as for 2D, are non zero .
         #Otherwise no smearing can be applied using smear from data (a Gaussian
         #width of zero will cause a divide by zero error)
         elif self.data.__class__.__name__ == "Data1D":
@@ -1659,17 +1659,17 @@ class FitPage(BasicPage):
                 self.smear_type = "Pinhole"
                 #report in % for display makes more sense than absolute value
                 #for pinhole smearing .. but keep old names of dq_l
-                self.dq_l = data.dx[0] / data.x[0] * 100
-                self.dq_r = data.dx[-1] / data.x[-1] * 100
+                self.dq_l = format_number(data.dx[0] / data.x[0] * 100,1)
+                self.dq_r = format_number(data.dx[-1] / data.x[-1] * 100,1)
             #If not, is it valid 1D slit resolution data?
             elif (data.dxl is not None or data.dxw is not None) \
                 and (np.all(data.dxl, 0) or np.all(data.dxw, 0)):
                 self.smear_type = "Slit"
                 #for slit units of 1/A make most sense
                 if data.dxl is not None and np.all(data.dxl, 0):
-                    self.dq_l = data.dxl[0]
+                    self.dq_l = format_number(data.dxl[0],1)
                 if data.dxw is not None and np.all(data.dxw, 0):
-                    self.dq_r = data.dxw[0]
+                    self.dq_r = format_number(data.dxw[0],1)
             #otherwise log that the data did not conatain resolution info
             else:
                 self.msg = "1D Data did not contain recognizable " \

--- a/src/sas/sasgui/perspectives/fitting/fitpage.py
+++ b/src/sas/sasgui/perspectives/fitting/fitpage.py
@@ -215,8 +215,8 @@ class FitPage(BasicPage):
               "Please enter only the value of interest to customize smearing..."
         smear_message_new_psmear = \
               "Please enter a fixed percentage to be applied to all Q values..."
-        smear_message_2d_x_title = "<dQ/Q>p[%]:"
-        smear_message_2d_y_title = "<dQ/Q>s[%]:"
+        smear_message_2d_x_title = "<dQ/Q>_r[%]:"
+        smear_message_2d_y_title = "<dQ/Q>_phi[%]:"
         smear_message_pinhole_percent_min_title = "[dQ/Q]min(%):"
         smear_message_pinhole_percent_max_title = "[dQ/Q]max(%):"
         smear_message_pinhole_percent_title = "dQ/Q(%):"
@@ -422,11 +422,11 @@ class FitPage(BasicPage):
         self.smear_description_2d_x = wx.StaticText(self, wx.ID_ANY,
                             smear_message_2d_x_title, style=wx.ALIGN_LEFT)
         self.smear_description_2d_x.SetToolTipString(
-                                        "  dQp(parallel) in q_r direction.")
+                                        "  dQ_r q_r in polar coordinates.")
         self.smear_description_2d_y = wx.StaticText(self, wx.ID_ANY,
                             smear_message_2d_y_title, style=wx.ALIGN_LEFT)
         self.smear_description_2d_y.SetToolTipString(
-                                    " dQs(perpendicular) in q_phi direction.")
+                                    " dQ_phi q_phi in polar coordinates.")
         self.smear_description_pin_percent_min = wx.StaticText(self, wx.ID_ANY,
                                             smear_message_pinhole_percent_min_title,
                                             style=wx.ALIGN_LEFT)


### PR DESCRIPTION
All changes are to fitpage.py.  Changed behavior so that both 1D and 2D smearing from data are shown as dq/q in % and changed several labels to more clearly indicate what is being displayed.  2D smearing had some serious logic problems (for example when using dq from data both boxes come up but showed "NONE" while for custom pinhole the same two boxes show up (non editable) even though only one input is allowed.  Finally issues with switching from 2D to 1D displayed options for smearing even if there was not model to smear. 

Also added a bunch of logging statements

Since some (not insignificant in this convoluted module) logic had to be changed the code should be checked carefully as well as tested. 

Addresses #1206
Addresses #1222