### PR TITLE
Ticket 1223: Expand permitted range of transformed data in Corfunc implementation

### DIFF
--- a/src/sas/sascalc/corfunc/transform_thread.py
+++ b/src/sas/sascalc/corfunc/transform_thread.py
@@ -44,7 +44,7 @@ class FourierThread(CalcThread):
             # ----- 3D Correlation Function -----
             # gamma3(R) = 1/R int_{0}^{R} gamma1(x) dx
             # trapz uses the trapezium rule to calculate the integral
-            mask = xs <= 200.0 # Only calculate gamma3 up to x=200 (as this is all that's plotted)
+            mask = xs <= 1000.0 # Only calculate gamma3 up to x=1000 (as this is all that's plotted)
             # gamma3 = [trapz(gamma1[:n], xs[:n])/xs[n-1] for n in range(2, len(xs[mask]) + 1)]j
             # gamma3.insert(0, 1.0) # Gamma_3(0) is defined as 1
             n = len(xs[mask])
@@ -78,7 +78,7 @@ class FourierThread(CalcThread):
         self.update(msg="Fourier transform completed.")
 
         transform1 = Data1D(xs, gamma1)
-        transform3 = Data1D(xs[xs <= 200], gamma3)
+        transform3 = Data1D(xs[xs <= 1000], gamma3)
         idf = Data1D(xs, idf)
 
         transforms = (transform1, transform3, idf)

--- a/src/sas/sasgui/perspectives/corfunc/corfunc_panel.py
+++ b/src/sas/sasgui/perspectives/corfunc/corfunc_panel.py
@@ -276,14 +276,14 @@ class CorfuncPanel(ScrolledPanel,PanelBase):
 
         self._transformed_data = transforms
         (transform1, transform3, idf) = transforms
-        plot_x = transform1.x[transform1.x <= 200]
-        plot_y = transform1.y[transform1.x <= 200]
+        plot_x = transform1.x[transform1.x <= 1000]
+        plot_y = transform1.y[transform1.x <= 1000]
         self._manager.show_data(Data1D(plot_x, plot_y), TRANSFORM_LABEL1)
-        # No need to shorten gamma3 as it's only calculated up to x=200
+        # No need to shorten gamma3 as it's only calculated up to x=1000
         self._manager.show_data(transform3, TRANSFORM_LABEL3)
 
-        plot_x = idf.x[idf.x <= 200]
-        plot_y = idf.y[idf.x <= 200]
+        plot_x = idf.x[idf.x <= 1000]
+        plot_y = idf.y[idf.x <= 1000]
         self._manager.show_data(Data1D(plot_x, plot_y), IDF_LABEL)
 
         # Only enable extract params button if a fourier trans. has been done


### PR DESCRIPTION
This upgrades the default corfunc range from 200 to 1000.  For version 5, we should make this into a controlable parameter, but this will be enough for 4.2.1