### PR TITLE
FIX: add a proper entry point

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -196,6 +196,7 @@ class BuildSphinxCommand(Command):
         import build_sphinx
         build_sphinx.rebuild()
 
+_ = subprocess.call([sys.executable, "src/sas/qtgui/convertUI.py"])
 
 # sas module
 package_dir["sas"] = os.path.join("src", "sas")
@@ -453,6 +454,18 @@ package_data['sas.sasview'] = ['images/*',
                                'test/upcoming_formats/*',
                                ]
 packages.append("sas.sasview")
+package_data['sas.qtgui'] = ['Calculators/UI/*',
+                             'MainWindow/UI/*',
+                             'Perspectives/Corfunc/UI/*',
+                             'Perspectives/Fitting/UI/*',
+                             'Perspectives/Invariant/UI/*',
+                             'Perspectives/Inversion/UI/*',
+                             'Plotting/UI/*',
+                             'Utilities/UI/*',
+                             'UI/*',
+                             'UI/res/*',
+                             ]
+packages.append("sas.qtgui")
 
 required = [
     'bumps>=0.7.5.9', 'periodictable>=1.5.0', 'pyparsing>=2.0.0',
@@ -489,7 +502,7 @@ setup(
     zip_safe=False,
     entry_points={
         'console_scripts': [
-            "sasview = sas.run",
+            "sasview=sas.qtgui.MainWindow.MainWindow:run_sasview",
         ]
     },
     cmdclass={'build_ext': build_ext_subclass,


### PR DESCRIPTION
Dear developers,

I attempted to install this package at NSLS-II, and had some problems with executing it once it's installed. This PR attempts to resolve the entry point, so that one does not have to run `python run.py`. Instead, simple calling of `sasview` will pop up the GUI window. The PR is based on the [v5.0-beta.2](https://github.com/SasView/sasview/releases/tag/v5.0-beta.2) tag.

I hope it will help to make the package easier to use. Our plan is to create a corresponding conda package in our channel https://anaconda.org/lightsource2-tag based on the updated installer. Please let me know if there is an interest in contribution.

Regards,
Maksim Rakitin
DAMA group, NSLS-II, BNL