### PR TITLE
py3/wx4 compatibility changes for gui

### DIFF
--- a/src/sas/sasgui/guiframe/data_processor.py
+++ b/src/sas/sasgui/guiframe/data_processor.py
@@ -78,7 +78,7 @@ def parse_string(sentence, list):
             separator_pos = label_pos + len(label)
             if label_pos != -1 and len(elt) >= separator_pos  and\
                 elt[separator_pos] == "[":
-                # the label contain , meaning the range selected is not 
+                # the label contain , meaning the range selected is not
                 # continuous
                 if elt.count(',') > 0:
                     new_temp = []
@@ -106,11 +106,11 @@ def parse_string(sentence, list):
 
 class SPanel(ScrolledPanel):
     """
-    ensure proper scrolling of GridPanel 
-    
-    Adds a SetupScrolling call to the normal ScrolledPanel init.    
+    ensure proper scrolling of GridPanel
+
+    Adds a SetupScrolling call to the normal ScrolledPanel init.
     GridPanel then subclasses this class
-    
+
     """
     def __init__(self, parent, *args, **kwds):
         """
@@ -128,7 +128,7 @@ class GridCellEditor(sheet.CCellEditor):
     This subclasses the sheet.CCellEditor (itself a subclass of
     grid.GridCellEditor) in order to override two of its methods:
     PaintBackrgound and EndEdit.
-    
+
     This is necessary as the sheet module is broken in wx 3.0.2 and
     improperly subclasses grid.GridCellEditor
     """
@@ -246,7 +246,7 @@ class GridPage(sheet.CSheet):
 
 
 
-        # The following events must be bound even if CSheet is working 
+        # The following events must be bound even if CSheet is working
         # properly and does not need the above re-implementation of the
         # CSheet init method.  Basically these override any intrinsic binding
         self.Bind(wx.grid.EVT_GRID_LABEL_RIGHT_CLICK, self.on_right_click)
@@ -312,7 +312,7 @@ class GridPage(sheet.CSheet):
 
     def OnCellChange(self, event):
         """
-        Overrides sheet.CSheet.OnCellChange.  
+        Overrides sheet.CSheet.OnCellChange.
 
         Processes when a cell has been edited by a cell editor. Checks for the
         edited row being outside the max row to use attribute and if so updates
@@ -557,7 +557,7 @@ class GridPage(sheet.CSheet):
         Remove the col column from the current grid
         """
 
-        # add data to the grid    
+        # add data to the grid
         row = 0
         col_name = self.GetCellValue(row, col)
         self.data[col_name] = []
@@ -582,7 +582,7 @@ class GridPage(sheet.CSheet):
 
         Sets up to insert column into the current grid before the current
         highlighted column location and sets up what to populate that column
-        with.  Then calls insert_column method to actually do the insertion. 
+        with.  Then calls insert_column method to actually do the insertion.
         """
 
         if self.selected_cols is not None or len(self.selected_cols) > 0:
@@ -603,7 +603,7 @@ class GridPage(sheet.CSheet):
 
         Sets up to insert column into the current grid after the current
         highlighted column location and sets up what to populate that column
-        with.  Then calls insert_column method to actually do the insertion. 
+        with.  Then calls insert_column method to actually do the insertion.
         """
 
         if self.selected_cols is not None or len(self.selected_cols) > 0:
@@ -757,7 +757,7 @@ class GridPage(sheet.CSheet):
 
     def onContextMenu(self, event):
         """
-        Method to handle cell right click context menu. 
+        Method to handle cell right click context menu.
 
         THIS METHOD IS NOT CURRENTLY USED.  It is designed to provide a
         cell pop up context by right clicking on a cell and gives the
@@ -1123,7 +1123,7 @@ class Notebook(nb, PanelBase):
         Append a new column to the grid
         """
 
-        # I Believe this is no longer used now that we have removed the 
+        # I Believe this is no longer used now that we have removed the
         # edit menu from the menubar - PDB July 12, 2015
         pos = self.GetSelection()
         grid = self.GetPage(pos)
@@ -1133,7 +1133,7 @@ class Notebook(nb, PanelBase):
         """
         Remove the selected column from the grid
         """
-        # I Believe this is no longer used now that we have removed the 
+        # I Believe this is no longer used now that we have removed the
         # edit menu from the menubar - PDB July 12, 2015
         pos = self.GetSelection()
         grid = self.GetPage(pos)
@@ -1636,7 +1636,7 @@ class GridFrame(wx.Frame):
 
         # We need to grab a WxMenu handle here, otherwise the next one to grab
         # the handle will be treated as the Edit Menu handle when checking in
-        # on_menu_open event handler and thus raise an exception when it hits an 
+        # on_menu_open event handler and thus raise an exception when it hits an
         # unitialized object.  Alternative is to comment out that whole section
         # in on_menu_open, but that would make it more difficult to undo the
         # hidding of the menu.   PDB  July 12, 2015.
@@ -1689,7 +1689,7 @@ class GridFrame(wx.Frame):
         """
         On Copy from the Edit menu item on the menubar
         """
-        # I Believe this is no longer used now that we have removed the 
+        # I Believe this is no longer used now that we have removed the
         # edit menu from the menubar - PDB July 12, 2015
         if event is not None:
             event.Skip()
@@ -1701,7 +1701,7 @@ class GridFrame(wx.Frame):
         """
         On Paste from the Edit menu item on the menubar
         """
-        # I Believe this is no longer used now that we have removed the 
+        # I Believe this is no longer used now that we have removed the
         # edit menu from the menubar - PDB July 12, 2015
         if event is not None:
             event.Skip()
@@ -1713,7 +1713,7 @@ class GridFrame(wx.Frame):
         """
         On Clear from the Edit menu item on the menubar
         """
-        # I Believe this is no longer used now that we have removed the 
+        # I Believe this is no longer used now that we have removed the
         # edit menu from the menubar - PDB July 12, 2015
         pos = self.panel.notebook.GetSelection()
         grid = self.panel.notebook.GetPage(pos)
@@ -1732,7 +1732,7 @@ class GridFrame(wx.Frame):
         """
         On remove column from the Edit menu Item on the menubar
         """
-        # I Believe this is no longer used now that we have removed the 
+        # I Believe this is no longer used now that we have removed the
         # edit menu from the menubar - PDB July 12, 2015
         pos = self.panel.notebook.GetSelection()
         grid = self.panel.notebook.GetPage(pos)
@@ -1823,7 +1823,7 @@ class GridFrame(wx.Frame):
             if self.parent is not None:
                 location = os.path.dirname(grid.file_name)
                 dlg = wx.FileDialog(self, "Save Project file",
-                                    location, grid.file_name, ext, wx.SAVE)
+                                    location, grid.file_name, ext, wx.FD_SAVE)
                 path = None
                 if dlg.ShowModal() == wx.ID_OK:
                     path = dlg.GetPath()
@@ -2008,7 +2008,7 @@ class BatchOutputFrame(wx.Frame):
             if self.parent is not None:
                 location = os.path.dirname(self.file_name)
                 dlg = wx.FileDialog(self, "Save Project file",
-                                    location, self.file_name, ext, wx.SAVE)
+                                    location, self.file_name, ext, wx.FD_SAVE)
                 path = None
                 if dlg.ShowModal() == wx.ID_OK:
                     path = dlg.GetPath()

--- a/src/sas/sasgui/guiframe/gui_manager.py
+++ b/src/sas/sasgui/guiframe/gui_manager.py
@@ -1916,7 +1916,7 @@ class ViewerFrame(PARENT_FRAME):
         dlg = wx.FileDialog(self, "Save Project file",
                             self._default_save_location, "sasview_proj",
                             extension,
-                            wx.SAVE)
+                            wx.FD_SAVE)
         if dlg.ShowModal() == wx.ID_OK:
             path = dlg.GetPath()
             self._default_save_location = os.path.dirname(path)
@@ -2413,7 +2413,7 @@ class ViewerFrame(PARENT_FRAME):
         options = [".txt", ".xml",".h5"]
         dlg = wx.FileDialog(self, "Choose a file",
                             self._default_save_location,
-                            default_name, wildcard, wx.SAVE)
+                            default_name, wildcard, wx.FD_SAVE)
 
         if dlg.ShowModal() == wx.ID_OK:
             path = dlg.GetPath()
@@ -2550,7 +2550,7 @@ class ViewerFrame(PARENT_FRAME):
                    "NXcanSAS files (*.h5)|*.h5|"
         dlg = wx.FileDialog(self, "Choose a file",
                             self._default_save_location,
-                            default_name, wildcard, wx.SAVE)
+                            default_name, wildcard, wx.FD_SAVE)
 
         if dlg.ShowModal() == wx.ID_OK:
             path = dlg.GetPath()

--- a/src/sas/sasgui/guiframe/gui_manager.py
+++ b/src/sas/sasgui/guiframe/gui_manager.py
@@ -281,7 +281,7 @@ class ViewerFrame(PARENT_FRAME):
         # Adjust toolbar height
         toolbar = self.GetToolBar()
         if toolbar is not None:
-            _, tb_h = toolbar.GetSizeTuple()
+            _, tb_h = toolbar.GetSize()
             height -= tb_h
         return width, height
 
@@ -947,7 +947,7 @@ class ViewerFrame(PARENT_FRAME):
                 w, h = self._get_panels_size(panel_class)
                 if panel_class.CENTER_PANE:
                     self.panels[str(wx_id)] = panel_class
-                    _, pos_y = frame.GetPositionTuple()
+                    _, pos_y = frame.GetPosition()
                     frame.SetPosition((d_panel_width + 1, pos_y))
                     frame.SetSize((w, h))
                     frame.Show(False)
@@ -1115,7 +1115,7 @@ class ViewerFrame(PARENT_FRAME):
         p.frame.name = p.window_name
         if not IS_WIN:
             p.frame.Center()
-            x_pos, _ = p.frame.GetPositionTuple()
+            x_pos, _ = p.frame.GetPosition()
             p.frame.SetPosition((x_pos, 112))
         p.frame.Show(True)
 
@@ -3010,7 +3010,7 @@ class ViewerFrame(PARENT_FRAME):
         size_y = 0
         if self.GetToolBar() is not None and self.GetToolBar().IsShown():
             if not IS_LINUX:
-                _, size_y = self.GetToolBar().GetSizeTuple()
+                _, size_y = self.GetToolBar().GetSize()
         return size_y
 
     def set_schedule_full_draw(self, panel=None, func='del'):
@@ -3129,7 +3129,7 @@ class ViewerFrame(PARENT_FRAME):
         :returns: size
         :rtype: tuple
         """
-        width, height = self.GetSizeTuple()
+        width, height = self.GetSize()
         if not IS_WIN:
             # Subtract toolbar height to get real window side
             if self._toolbar.IsShown():

--- a/src/sas/sasgui/guiframe/gui_statusbar.py
+++ b/src/sas/sasgui/guiframe/gui_statusbar.py
@@ -111,7 +111,7 @@ class Console(wx.Frame):
         """
         Method to send an arbitrary number of messages to the console log
 
-        :param messages: A list of strings to be sent to the console log. 
+        :param messages: A list of strings to be sent to the console log.
         """
         if messages:
             for status in messages:
@@ -233,7 +233,7 @@ class StatusBar(wxStatusB):
         """
         If the window is resized, redraw the window.
         """
-        self.reposition() 
+        self.reposition()
         self.size_changed = True
 
     def get_msg_position(self):
@@ -359,7 +359,7 @@ class StatusBar(wxStatusB):
         """
         if hasattr(event, "status"):
             self.SetStatusText(text=str(event.status), event=event)
-  
+
     def set_gauge(self, event):
         """
         change the state of the gauge according the state of the current job
@@ -422,7 +422,7 @@ class SPageStatusbar(wxStatusB):
         wxStatusB.__init__(self, parent, *args, **kwds)
         self.SetFieldsCount(1)
         self.timeout = timeout
-        width, height = parent.GetSizeTuple()
+        width, height = parent.GetSize()
         self.gauge = wx.Gauge(self, style=wx.GA_HORIZONTAL,
                               size=(width, height/10))
         rect = self.GetFieldRect(0)

--- a/src/sas/sasgui/guiframe/local_perspectives/plotting/AnnulusSlicer.py
+++ b/src/sas/sasgui/guiframe/local_perspectives/plotting/AnnulusSlicer.py
@@ -160,12 +160,12 @@ class AnnulusInteractor(_BaseInteractor):
         new_plot.interactive = True
         new_plot.detector = self.base.data2D.detector
         # If the data file does not tell us what the axes are, just assume...
-        new_plot.xaxis("\\rm{\phi}", 'degrees')
-        new_plot.yaxis("\\rm{Intensity} ", "cm^{-1}")
-        if hasattr(data, "scale") and data.scale == 'linear' and \
-                self.base.data2D.name.count("Residuals") > 0:
+        new_plot.xaxis(r"\rm{\phi}", 'degrees')
+        new_plot.yaxis(r"\rm{Intensity} ", "cm^{-1}")
+        if (hasattr(data, "scale") and data.scale == 'linear'
+                and self.base.data2D.name.count("Residuals") > 0):
             new_plot.ytransform = 'y'
-            new_plot.yaxis("\\rm{Residuals} ", "/")
+            new_plot.yaxis(r"\rm{Residuals} ", "/")
 
         new_plot.group_id = "AnnulusPhi" + self.base.data2D.name
         new_plot.id = "AnnulusPhi" + self.base.data2D.name

--- a/src/sas/sasgui/guiframe/local_perspectives/plotting/Plotter1D.py
+++ b/src/sas/sasgui/guiframe/local_perspectives/plotting/Plotter1D.py
@@ -204,9 +204,9 @@ class ModelPanel1D(PlotPanel, PanelBase):
         self.resizing = True
         self.canvas.set_resizing(self.resizing)
         self.parent.set_schedule(True)
-        pos_x, pos_y = self.GetPositionTuple()
+        pos_x, pos_y = self.GetPosition()
         if pos_x != 0 and pos_y != 0:
-            self.size, _ = self.GetClientSizeTuple()
+            self.size, _ = self.GetClientSize()
         self.SetSizer(self.sizer)
         wx.CallAfter(self.parent.disable_app_menu, self)
 
@@ -713,7 +713,7 @@ class ModelPanel1D(PlotPanel, PanelBase):
             pos_evt = event.GetPosition()
             pos = self.ScreenToClient(pos_evt)
         except:
-            pos_x, pos_y = self.toolbar.GetPositionTuple()
+            pos_x, pos_y = self.toolbar.GetPosition()
             pos = (pos_x, pos_y + 5)
         self.PopupMenu(self._slicerpop, pos)
 

--- a/src/sas/sasgui/guiframe/local_perspectives/plotting/Plotter2D.py
+++ b/src/sas/sasgui/guiframe/local_perspectives/plotting/Plotter2D.py
@@ -178,8 +178,8 @@ class ModelPanel2D(ModelPanel1D):
         self.toolbar.Realize()
         # On Windows platform, default window size is incorrect, so set
         # toolbar width to figure width.
-        _, th = self.toolbar.GetSizeTuple()
-        fw, _ = self.canvas.GetSizeTuple()
+        _, th = self.toolbar.GetSize()
+        fw, _ = self.canvas.GetSize()
         self.toolbar.SetSize(wx.Size(fw, th))
         self.sizer.Add(self.toolbar, 0, wx.LEFT | wx.EXPAND)
         # update the axes menu on the toolbar
@@ -399,7 +399,7 @@ class ModelPanel2D(ModelPanel1D):
             pos_evt = event.GetPosition()
             pos = self.ScreenToClient(pos_evt)
         except:
-            pos_x, pos_y = self.toolbar.GetPositionTuple()
+            pos_x, pos_y = self.toolbar.GetPosition()
             pos = (pos_x, pos_y + 5)
         self.PopupMenu(slicerpop, pos)
 

--- a/src/sas/sasgui/guiframe/local_perspectives/plotting/SimplePlot.py
+++ b/src/sas/sasgui/guiframe/local_perspectives/plotting/SimplePlot.py
@@ -83,7 +83,7 @@ class SimplePlotPanel(PlotPanel):
             pos_evt = event.GetPosition()
             pos = self.ScreenToClient(pos_evt)
         except:
-            pos_x, pos_y = self.toolbar.GetPositionTuple()
+            pos_x, pos_y = self.toolbar.GetPosition()
             pos = (pos_x, pos_y + 5)
         self.PopupMenu(slicerpop, pos)
         if self.scale is not None:
@@ -134,9 +134,9 @@ class SimplePlotPanel(PlotPanel):
         event.Skip()
         # set the resizing flag
         self.canvas.set_resizing(self.resizing)
-        pos_x, pos_y = self.GetPositionTuple()
+        pos_x, pos_y = self.GetPosition()
         if pos_x != 0 and pos_y != 0:
-            self.size, _ = self.GetClientSizeTuple()
+            self.size, _ = self.GetClientSize()
         self.SetSizer(self.sizer)
 
     def on_set_focus(self, event):

--- a/src/sas/sasgui/guiframe/plugin_base.py
+++ b/src/sas/sasgui/guiframe/plugin_base.py
@@ -104,7 +104,7 @@ class PluginBase(object):
 
     def delete_data(self, data_id):
         """
-        Delete all references of data which id are in data_list. 
+        Delete all references of data which id are in data_list.
         """
 
     def load_data(self, event):
@@ -141,7 +141,7 @@ class PluginBase(object):
     def populate_menu(self, parent):
         """
         Create and return the list of application menu
-        items for the plug-in. 
+        items for the plug-in.
 
         :param parent: parent window
 
@@ -237,7 +237,7 @@ class PluginBase(object):
 
         if self.frame is not None:
             if old_frame is not None:
-                pos_x, pos_y = old_frame.GetPositionTuple()
+                pos_x, pos_y = old_frame.GetPosition()
                 self.frame.SetPosition((pos_x, pos_y))
             if not self.frame.IsShown():
                 self.frame.Show(True)
@@ -253,14 +253,14 @@ class PluginBase(object):
         """
         need to be overwritten by the derivated class
         """
-    
+
     def post_init(self):
         """
         Post initialization call back to close the loose ends
         """
         pass
 
-    def set_state(self, state=None, datainfo=None):    
+    def set_state(self, state=None, datainfo=None):
         """
         update state
         """

--- a/src/sas/sasgui/guiframe/startup_configuration.py
+++ b/src/sas/sasgui/guiframe/startup_configuration.py
@@ -126,7 +126,7 @@ class StartupConfiguration(wx.Dialog):
             p_size = None
             for panel in self.parent.plot_panels.values():
                 #p_panel = self.parent._mgr.GetPane(panel.window_name)
-                width, _ = panel.frame.GetSizeTuple()
+                width, _ = panel.frame.GetSize()
                 if panel.frame.IsShown():
                     if p_size is None or width > p_size:
                         p_size = width
@@ -136,14 +136,14 @@ class StartupConfiguration(wx.Dialog):
 
             try:
                 control_frame = self.parent.get_current_perspective().frame
-                control_w, control_h = control_frame.GetSizeTuple()
+                control_w, control_h = control_frame.GetSize()
                 self.current_string['CONTROL_WIDTH'] = control_w
                 self.current_string['CONTROL_HEIGHT'] = control_h
             except:
                 self.current_string['CONTROL_WIDTH'] = -1
                 self.current_string['CONTROL_HEIGHT'] = -1
 
-            data_pw, _ = self.parent.panels["data_panel"].frame.GetSizeTuple()
+            data_pw, _ = self.parent.panels["data_panel"].frame.GetSize()
             if data_pw is None:
                 data_pw = CURRENT_STRINGS['DATAPANEL_WIDTH']
             self.current_string['DATAPANEL_WIDTH'] = data_pw

--- a/src/sas/sasgui/perspectives/calculator/data_editor.py
+++ b/src/sas/sasgui/perspectives/calculator/data_editor.py
@@ -18,7 +18,7 @@ from .console import ConsoleDialog
 _QMIN_DEFAULT = 0.001
 _QMAX_DEFAULT = 0.13
 _NPTS_DEFAULT = 50
-#Control panel width 
+#Control panel width
 if sys.platform.count("darwin") == 0:
     PANEL_WIDTH = 500
     PANEL_HEIGTH = 350
@@ -195,7 +195,7 @@ class DataEditorPanel(wx.ScrolledWindow):
                                         size=(-1, 200))
         summary = 'No data info available...'
         self.data_summary.SetValue(summary)
-        #self.summary_sizer.Add(self.data_summary, 1, wx.EXPAND|wx.ALL, 10)  
+        #self.summary_sizer.Add(self.data_summary, 1, wx.EXPAND|wx.ALL, 10)
 
     def _layout_button(self):
         """
@@ -578,7 +578,8 @@ class DataEditorPanel(wx.ScrolledWindow):
         path = None
         wildcard = "CanSAS 1D files(*.xml)|*.xml"
         dlg = wx.FileDialog(self, "Choose a file",
-                            self._default_save_location, "", wildcard , wx.SAVE)
+                            self._default_save_location, "", wildcard ,
+                            wx.FD_SAVE)
 
         for data in self._data:
             if issubclass(data.__class__, Data2D):

--- a/src/sas/sasgui/perspectives/calculator/data_operator.py
+++ b/src/sas/sasgui/perspectives/calculator/data_operator.py
@@ -865,7 +865,7 @@ class SmallPanel(PlotPanel):
             pos = self.ScreenToClient(pos_evt)
         except:
             # toolbar event
-            pos_x, pos_y = self.toolbar.GetPositionTuple()
+            pos_x, pos_y = self.toolbar.GetPosition()
             pos = (pos_x, pos_y + 5)
         self.PopupMenu(slicerpop, pos)
 

--- a/src/sas/sasgui/perspectives/calculator/gen_scatter_panel.py
+++ b/src/sas/sasgui/perspectives/calculator/gen_scatter_panel.py
@@ -42,7 +42,7 @@ from sas.sasgui.guiframe.documentation_window import DocumentationWindow
 logger = logging.getLogger(__name__)
 
 _BOX_WIDTH = 76
-#Slit length panel size 
+#Slit length panel size
 if sys.platform.count("win32") > 0:
     PANEL_TOP = 0
     PANEL_WIDTH = 570
@@ -132,10 +132,10 @@ class SasGenPanel(ScrolledPanel, PanelBase):
                                *args, **kwds)
         #kwds['style'] = wx.SUNKEN_BORDER
         PanelBase.__init__(self)
-        #Font size 
+        #Font size
         self.SetWindowVariant(variant=FONT_VARIANT)
         self.SetupScrolling()
-        #thread to read data 
+        #thread to read data
         self.reader = None
         self.ext = None
         self.id = 'GenSAS'
@@ -217,36 +217,36 @@ class SasGenPanel(ScrolledPanel, PanelBase):
         ix = 0
         iy = 0
         param_title = wx.StaticText(self, -1, 'Parameter')
-        sizer.Add(param_title, (iy, ix), (1, 1), \
-                            wx.EXPAND | wx.ADJUST_MINSIZE, 0)
+        sizer.Add(param_title, (iy, ix), (1, 1),
+                  wx.EXPAND | wx.ADJUST_MINSIZE, 0)
         ix += 1
         value_title = wx.StaticText(self, -1, 'Value')
-        sizer.Add(value_title, (iy, ix), (1, 1), \
-                            wx.EXPAND | wx.ADJUST_MINSIZE, 0)
+        sizer.Add(value_title, (iy, ix), (1, 1),
+                  wx.EXPAND | wx.ADJUST_MINSIZE, 0)
         ix += 1
         unit_title = wx.StaticText(self, -1, 'Unit')
-        sizer.Add(unit_title, (iy, ix), (1, 1), \
-                            wx.EXPAND | wx.ADJUST_MINSIZE, 0)
+        sizer.Add(unit_title, (iy, ix), (1, 1),
+                  wx.EXPAND | wx.ADJUST_MINSIZE, 0)
         for param in sorted(params.keys()):
             iy += 1
             ix = 0
             p_name = wx.StaticText(self, -1, param)
-            sizer.Add(p_name, (iy, ix), (1, 1), \
-                            wx.EXPAND | wx.ADJUST_MINSIZE, 0)
+            sizer.Add(p_name, (iy, ix), (1, 1),
+                      wx.EXPAND | wx.ADJUST_MINSIZE, 0)
             ## add parameter value
             ix += 1
             value = model.getParam(param)
             ctl = InputTextCtrl(self, -1, size=(_BOX_WIDTH * 2, 20),
                                 style=wx.TE_PROCESS_ENTER)
-            #ctl.SetToolTipString(\
+            #ctl.SetToolTipString(
             #            "Hit 'Enter' after typing to update the plot.")
             ctl.SetValue(format_number(value, True))
             sizer.Add(ctl, (iy, ix), (1, 1), wx.EXPAND)
             ## add unit
             ix += 1
             unit = wx.StaticText(self, -1, details[param][0])
-            sizer.Add(unit, (iy, ix), (1, 1), \
-                            wx.EXPAND | wx.ADJUST_MINSIZE, 0)
+            sizer.Add(unit, (iy, ix), (1, 1),
+                      wx.EXPAND | wx.ADJUST_MINSIZE, 0)
             self.parameters.append([p_name, ctl, unit])
 
         self.param_sizer.Add(sizer, 0, wx.LEFT, 10)
@@ -339,25 +339,25 @@ class SasGenPanel(ScrolledPanel, PanelBase):
         ix = 0
         iy = 0
         name = wx.StaticText(self, -1, 'No. of Qx (Qy) bins: ')
-        sizer.Add(name, (iy, ix), (1, 1), \
-                        wx.EXPAND | wx.ADJUST_MINSIZE, 0)
+        sizer.Add(name, (iy, ix), (1, 1),
+                  wx.EXPAND | wx.ADJUST_MINSIZE, 0)
         ## add parameter value
         ix += 1
         self.npt_ctl = InputTextCtrl(self, -1, size=(_BOX_WIDTH * 1.5, 20),
-                            style=wx.TE_PROCESS_ENTER)
+                                     style=wx.TE_PROCESS_ENTER)
         self.npt_ctl.Bind(wx.EVT_TEXT, self._onparamEnter)
         self.npt_ctl.SetValue(format_number(self.npts_x, True))
         sizer.Add(self.npt_ctl, (iy, ix), (1, 1), wx.EXPAND)
         ## add unit
         ix += 1
         unit = wx.StaticText(self, -1, '')
-        sizer.Add(unit, (iy, ix), (1, 1), \
-                        wx.EXPAND | wx.ADJUST_MINSIZE, 0)
+        sizer.Add(unit, (iy, ix), (1, 1),
+                  wx.EXPAND | wx.ADJUST_MINSIZE, 0)
         iy += 1
         ix = 0
         name = wx.StaticText(self, -1, 'Qx (Qy) Max: ')
-        sizer.Add(name, (iy, ix), (1, 1), \
-                        wx.EXPAND | wx.ADJUST_MINSIZE, 0)
+        sizer.Add(name, (iy, ix), (1, 1),
+                  wx.EXPAND | wx.ADJUST_MINSIZE, 0)
         ## add parameter value
         ix += 1
         self.qmax_ctl = InputTextCtrl(self, -1, size=(_BOX_WIDTH * 1.5, 20),
@@ -368,8 +368,8 @@ class SasGenPanel(ScrolledPanel, PanelBase):
         ## add unit
         ix += 1
         unit = wx.StaticText(self, -1, '[1/A]')
-        sizer.Add(unit, (iy, ix), (1, 1), \
-                        wx.EXPAND | wx.ADJUST_MINSIZE, 0)
+        sizer.Add(unit, (iy, ix), (1, 1),
+                  wx.EXPAND | wx.ADJUST_MINSIZE, 0)
         self.qrange_sizer.Add(sizer, 0, wx.LEFT, 10)
 
     def _layout_button(self):
@@ -683,7 +683,7 @@ class SasGenPanel(ScrolledPanel, PanelBase):
 
         self.sld_data = self.parent.get_sld_from_omf()
         output = self.sld_data
-        #frame_size = wx.Size(470, 470)    
+        #frame_size = wx.Size(470, 470)
         self.plot_frame = PlotFrame(self, -1, 'testView')
         frame = self.plot_frame
         frame.Show(False)
@@ -702,11 +702,13 @@ class SasGenPanel(ScrolledPanel, PanelBase):
                 raise
         panel.dimension = 3
         graph_title = self._sld_plot_helper(ax, output, has_arrow)
-        # Use y, z axes (in mpl 3d) as z, y axes 
+        # Use y, z axes (in mpl 3d) as z, y axes
         # that consistent with our SAS detector coords.
-        ax.set_xlabel('x ($\A%s$)' % output.pos_unit)
-        ax.set_ylabel('z ($\A%s$)' % output.pos_unit)
-        ax.set_zlabel('y ($\A%s$)' % output.pos_unit)
+        # Format Angstrom units (A) as latex $\AA$
+        units = output.pos_unit if output.pos_unit != "A" else r"$\AA$"
+        ax.set_xlabel('x (%s)' % units)
+        ax.set_ylabel('z (%s)' % units)
+        ax.set_zlabel('y (%s)' % units)
         panel.subplot.figure.subplots_adjust(left=0.05, right=0.95,
                                              bottom=0.05, top=0.96)
         if output.pix_type == 'atom':
@@ -740,8 +742,8 @@ class SasGenPanel(ScrolledPanel, PanelBase):
         if output.pix_type == 'atom':
             marker = 'o'
             m_size = 3.5
-        sld_tot = (np.fabs(sld_mx) + np.fabs(sld_my) + \
-                   np.fabs(sld_mz) + np.fabs(output.sld_n))
+        sld_tot = (np.fabs(sld_mx) + np.fabs(sld_my)
+                   + np.fabs(sld_mz) + np.fabs(output.sld_n))
         is_nonzero = sld_tot > 0.0
         is_zero = sld_tot == 0.0
         # I. Plot null points
@@ -765,7 +767,7 @@ class SasGenPanel(ScrolledPanel, PanelBase):
                 ax.plot(pos_x[chosen_color], pos_z[chosen_color],
                         pos_y[chosen_color], marker, c=color, alpha=0.5,
                         markeredgecolor=color, markersize=m_size, label=key)
-        # III. Plot All others        
+        # III. Plot All others
         if np.any(other_color):
             a_name = ''
             if output.pix_type == 'atom':
@@ -1027,8 +1029,8 @@ class SasGenPanel(ScrolledPanel, PanelBase):
         self.npts_x = int(float(self.npt_ctl.GetValue()))
         self.data = Data2D()
         qmax = self.qmax_x #/ np.sqrt(2)
-        self.data.xaxis('\\rm{Q_{x}}', '\AA^{-1}')
-        self.data.yaxis('\\rm{Q_{y}}', '\AA^{-1}')
+        self.data.xaxis(r'\rm{Q_{x}}', r'\AA^{-1}')
+        self.data.yaxis(r'\rm{Q_{y}}', r'\AA^{-1}')
         self.data.is_data = False
         self.data.id = str(self.uid) + " GenData"
         self.data.group_id = str(self.uid) + " Model2D"
@@ -1119,17 +1121,17 @@ class SasGenPanel(ScrolledPanel, PanelBase):
         new_plot = Data1D(x=data.x, y=y_out)
         new_plot.dx = data.dx
         new_plot.dy = data.dy
-        new_plot.xaxis('\\rm{Q_{x}}', '\AA^{-1}')
-        new_plot.yaxis('\\rm{Intensity}', 'cm^{-1}')
+        new_plot.xaxis(r'\rm{Q_{x}}', r'\AA^{-1}')
+        new_plot.yaxis(r'\rm{Intensity}', 'cm^{-1}')
         new_plot.is_data = False
         new_plot.id = str(self.uid) + " GenData1D"
         new_plot.group_id = str(self.uid) + " Model1D"
         new_plot.name = model.name + '1d'
         new_plot.title = "Generic model1D "
-        new_plot.id = str(page_id) + ': ' + self.file_name \
-                        + ' #%s' % str(self.graph_num) + "_1D"
-        new_plot.group_id = str(page_id) + " Model1D" + \
-                             ' #%s' % str(self.graph_num) + "_1D"
+        new_plot.id = (str(page_id) + ': ' + self.file_name
+                       + ' #%s' % str(self.graph_num) + "_1D")
+        new_plot.group_id = (str(page_id) + " Model1D"
+                             + ' #%s' % str(self.graph_num) + "_1D")
         new_plot.is_data = False
 
         title = new_plot.title
@@ -1174,10 +1176,10 @@ class SasGenPanel(ScrolledPanel, PanelBase):
         new_plot = Data2D(image=image, err_image=data.err_data)
         new_plot.name = model.name + '2d'
         new_plot.title = "Generic model 2D "
-        new_plot.id = str(page_id) + ': ' + self.file_name \
-                        + ' #%s' % str(self.graph_num) + "_2D"
-        new_plot.group_id = str(page_id) + " Model2D" \
-                        + ' #%s' % str(self.graph_num) + "_2D"
+        new_plot.id = (str(page_id) + ': ' + self.file_name
+                       + ' #%s' % str(self.graph_num) + "_2D")
+        new_plot.group_id = (str(page_id) + " Model2D"
+                             + ' #%s' % str(self.graph_num) + "_2D")
         new_plot.detector = data.detector
         new_plot.source = data.source
         new_plot.is_data = False
@@ -1242,7 +1244,7 @@ class OmfPanel(ScrolledPanel, PanelBase):
         ScrolledPanel.__init__(self, parent, style=wx.RAISED_BORDER,
                                *args, **kwds)
         PanelBase.__init__(self)
-        #Font size 
+        #Font size
         self.SetWindowVariant(variant=FONT_VARIANT)
         self.SetupScrolling()
         # Object that receive status event
@@ -1445,8 +1447,8 @@ class OmfPanel(ScrolledPanel, PanelBase):
             iy += 1
             ix = 0
             name = wx.StaticText(self, -1, key)
-            sizer.Add(name, (iy, ix), (1, 1), \
-                            wx.EXPAND | wx.ADJUST_MINSIZE, 0)
+            sizer.Add(name, (iy, ix), (1, 1),
+                      wx.EXPAND | wx.ADJUST_MINSIZE, 0)
             ## add parameter value
             ix += 1
             ctl = InputTextCtrl(self, -1, size=(_BOX_WIDTH, 20),
@@ -1458,8 +1460,8 @@ class OmfPanel(ScrolledPanel, PanelBase):
             ix += 1
             s_unit = '[' + omfdata.sld_unit + ']'
             unit = wx.StaticText(self, -1, s_unit)
-            sizer.Add(unit, (iy, ix), (1, 1), \
-                            wx.EXPAND | wx.ADJUST_MINSIZE, 0)
+            sizer.Add(unit, (iy, ix), (1, 1),
+                      wx.EXPAND | wx.ADJUST_MINSIZE, 0)
             self.slds.append([key, ctl, unit])
         self.sld_sizer.Add(sizer, 0, wx.LEFT, 10)
 
@@ -1480,8 +1482,8 @@ class OmfPanel(ScrolledPanel, PanelBase):
             iy += 1
             ix = 0
             name = wx.StaticText(self, -1, key)
-            sizer.Add(name, (iy, ix), (1, 1), \
-                            wx.EXPAND | wx.ADJUST_MINSIZE, 0)
+            sizer.Add(name, (iy, ix), (1, 1),
+                      wx.EXPAND | wx.ADJUST_MINSIZE, 0)
             ## add parameter value
             ix += 1
             ctl = InputTextCtrl(self, -1, size=(_BOX_WIDTH, 20),
@@ -1493,8 +1495,8 @@ class OmfPanel(ScrolledPanel, PanelBase):
             ## add unit
             ix += 1
             unit = wx.StaticText(self, -1, '')
-            sizer.Add(unit, (iy, ix), (1, 1), \
-                            wx.EXPAND | wx.ADJUST_MINSIZE, 0)
+            sizer.Add(unit, (iy, ix), (1, 1),
+                      wx.EXPAND | wx.ADJUST_MINSIZE, 0)
             self.nodes.append([key, ctl, unit])
         self.node_sizer.Add(sizer, 0, wx.LEFT, 10)
 
@@ -1515,8 +1517,8 @@ class OmfPanel(ScrolledPanel, PanelBase):
             iy += 1
             ix = 0
             name = wx.StaticText(self, -1, key)
-            sizer.Add(name, (iy, ix), (1, 1), \
-                            wx.EXPAND | wx.ADJUST_MINSIZE, 0)
+            sizer.Add(name, (iy, ix), (1, 1),
+                      wx.EXPAND | wx.ADJUST_MINSIZE, 0)
             ## add parameter value
             ix += 1
             ctl = InputTextCtrl(self, -1, size=(_BOX_WIDTH, 20),
@@ -1529,8 +1531,8 @@ class OmfPanel(ScrolledPanel, PanelBase):
             ix += 1
             p_unit = '[' + omfdata.pos_unit + ']'
             unit = wx.StaticText(self, -1, p_unit)
-            sizer.Add(unit, (iy, ix), (1, 1), \
-                            wx.EXPAND | wx.ADJUST_MINSIZE, 0)
+            sizer.Add(unit, (iy, ix), (1, 1),
+                      wx.EXPAND | wx.ADJUST_MINSIZE, 0)
             self.stepsize.append([key, ctl, unit])
         self.step_sizer.Add(sizer, 0, wx.LEFT, 10)
 
@@ -1625,7 +1627,7 @@ class OmfPanel(ScrolledPanel, PanelBase):
         if sld_data is None:
             for ctr_list in self.slds:
                 ctr_list[1].Enable(False)
-                #break   
+                #break
             return
 
         self.sld_data = sld_data
@@ -1636,8 +1638,8 @@ class OmfPanel(ScrolledPanel, PanelBase):
                     min_val = np.min(sld_list[key])
                     max_val = np.max(sld_list[key])
                     mean_val = np.mean(sld_list[key])
-                    enable = (min_val == max_val) and \
-                             sld_data.pix_type == 'pixel'
+                    enable = ((min_val == max_val)
+                              and sld_data.pix_type == 'pixel')
                     ctr_list[1].SetValue(format_number(mean_val, True))
                     ctr_list[1].Enable(enable)
                     #ctr_list[2].SetLabel("[" + sld_data.sld_unit + "]")

--- a/src/sas/sasgui/perspectives/calculator/gen_scatter_panel.py
+++ b/src/sas/sasgui/perspectives/calculator/gen_scatter_panel.py
@@ -1670,7 +1670,7 @@ class OmfPanel(ScrolledPanel, PanelBase):
         dlg = wx.FileDialog(self, "Save sld file",
                             location, "sld_file",
                              extension,
-                             wx.SAVE)
+                             wx.FD_SAVE)
         if dlg.ShowModal() == wx.ID_OK:
             path = dlg.GetPath()
             self.parent.set_file_location(os.path.dirname(path))

--- a/src/sas/sasgui/perspectives/calculator/image_viewer.py
+++ b/src/sas/sasgui/perspectives/calculator/image_viewer.py
@@ -61,7 +61,7 @@ class ImageView:
                 # Note that matplotlib only reads png natively.
                 # Any other formats (tiff, jpeg, etc) are passed
                 # to PIL which seems to have a problem in version
-                # 1.1.7 that causes a close error which shows up in 
+                # 1.1.7 that causes a close error which shows up in
                 # the log file.  This does not seem to have any adverse
                 # effects.  PDB   --- September 17, 2017.
                 img = mpimg.imread(file_path)
@@ -382,7 +382,7 @@ class SetDialog(wx.Dialog):
             else:
                 print(err_msg)
 
-        self.OnClose(event)
+        self.EndModal(wx.ID_OK)
 
     def convert_image(self, rgb, xmin, xmax, ymin, ymax, zscale):
         """
@@ -416,8 +416,8 @@ class SetDialog(wx.Dialog):
         output.xmax = xmax
         output.ymin = ymin
         output.ymax = ymax
-        output.xaxis('\\rm{Q_{x}}', '\AA^{-1}')
-        output.yaxis('\\rm{Q_{y}}', '\AA^{-1}')
+        output.xaxis(r'\rm{Q_{x}}', r'\AA^{-1}')
+        output.yaxis(r'\rm{Q_{y}}', r'\AA^{-1}')
         # Store loading process information
         output.meta_data['loader'] = self.title.split('.')[-1] + "Reader"
         output.is_data = True
@@ -450,7 +450,8 @@ class SetDialog(wx.Dialog):
         """
         # clear event
         event.Skip()
-        self.Destroy()
+        self.EndModal(wx.ID_CANCEL)
+        #self.Destroy()
 
 if __name__ == "__main__":
     app = wx.App()

--- a/src/sas/sasgui/perspectives/corfunc/corfunc_panel.py
+++ b/src/sas/sasgui/perspectives/corfunc/corfunc_panel.py
@@ -336,7 +336,7 @@ class CorfuncPanel(ScrolledPanel,PanelBase):
 
         dlg = wx.FileDialog(self, "Choose a file",
                             default_save_location, \
-                            self.window_caption, "*.crf", wx.SAVE)
+                            self.window_caption, "*.crf", wx.FD_SAVE)
         if dlg.ShowModal() == wx.ID_OK:
             path = dlg.GetPath()
             default_save_location = os.path.dirname(path)

--- a/src/sas/sasgui/perspectives/fitting/basepage.py
+++ b/src/sas/sasgui/perspectives/fitting/basepage.py
@@ -675,7 +675,7 @@ class BasicPage(ScrolledPanel, PanelBase):
             self._default_save_location = \
                         self._manager.parent._default_save_location
         dlg = wx.FileDialog(self, "Choose a file", self._default_save_location,
-                            self.window_caption, "*.fitv", wx.SAVE)
+                            self.window_caption, "*.fitv", wx.FD_SAVE)
 
         if dlg.ShowModal() == wx.ID_OK:
             path = dlg.GetPath()

--- a/src/sas/sasgui/perspectives/fitting/report_dialog.py
+++ b/src/sas/sasgui/perspectives/fitting/report_dialog.py
@@ -48,7 +48,7 @@ class ReportDialog(BaseReportDialog):
         #todo: complete saving fig file and as a txt file
         dlg = wx.FileDialog(self, "Choose a file",
                             wildcard=self.wild_card,
-                            style=wx.SAVE | wx.OVERWRITE_PROMPT | wx.CHANGE_DIR)
+                            style=wx.FD_SAVE | wx.OVERWRITE_PROMPT | wx.CHANGE_DIR)
         dlg.SetFilterIndex(0)  # Set .html files to be default
 
         if dlg.ShowModal() != wx.ID_OK:

--- a/src/sas/sasgui/perspectives/invariant/invariant_panel.py
+++ b/src/sas/sasgui/perspectives/invariant/invariant_panel.py
@@ -1254,7 +1254,7 @@ class InvariantPanel(ScrolledPanel, PanelBase):
             self._default_save_location = os.getcwd()
         dlg = wx.FileDialog(self, "Choose a file",
                             self._default_save_location, \
-                            self.window_caption, "*.inv", wx.SAVE)
+                            self.window_caption, "*.inv", wx.FD_SAVE)
         if dlg.ShowModal() == wx.ID_OK:
             path = dlg.GetPath()
             self._default_save_location = os.path.dirname(path)

--- a/src/sas/sasgui/perspectives/invariant/report_dialog.py
+++ b/src/sas/sasgui/perspectives/invariant/report_dialog.py
@@ -51,7 +51,7 @@ class ReportDialog(BaseReportDialog):
         # todo: complete saving fig file and as a txt file
         dlg = wx.FileDialog(self, "Choose a file",
                             wildcard=self.wild_card,
-                            style=wx.SAVE | wx.OVERWRITE_PROMPT | wx.CHANGE_DIR)
+                            style=wx.FD_SAVE | wx.OVERWRITE_PROMPT | wx.CHANGE_DIR)
         dlg.SetFilterIndex(0)  # Set .html files to be default
 
         if dlg.ShowModal() != wx.ID_OK:

--- a/src/sas/sasgui/perspectives/pr/explore_dialog.py
+++ b/src/sas/sasgui/perspectives/pr/explore_dialog.py
@@ -49,7 +49,7 @@ class OutputPlot(PlotPanel):
     ## Title for plottools
     window_caption = "D Explorer"
 
-    def __init__(self, d_min, d_max, parent, id= -1, color=None, \
+    def __init__(self, d_min, d_max, parent, id= -1, color=None,
                  dpi=None, style=wx.NO_FULL_REPAINT_ON_RESIZE, **kwargs):
         """
         Initialization. The parameters added to PlotPanel are:
@@ -76,10 +76,10 @@ class OutputPlot(PlotPanel):
         self.plot.name = DEFAULT_OUTPUT
         self.plot.symbol = GUIFRAME_ID.CURVE_SYMBOL_NUM
 
-        # Graph        
+        # Graph
         self.graph = Graph()
-        self.graph.xaxis("\\rm{D_{max}}", 'A')
-        self.graph.yaxis("\\rm{%s}" % DEFAULT_OUTPUT, "")
+        self.graph.xaxis(r"\rm{D_{max}}", 'A')
+        self.graph.yaxis(r"\rm{%s}" % DEFAULT_OUTPUT, "")
         self.graph.add(self.plot)
         self.graph.render(self)
 
@@ -132,10 +132,10 @@ class Results(object):
 
         # Dictionary of outputs
         self.outputs = {}
-        self.outputs['Chi2/dof'] = ["\chi^2/dof", "a.u.", self.chi2]
+        self.outputs['Chi2/dof'] = [r"\chi^2/dof", "a.u.", self.chi2]
         self.outputs['Oscillation parameter'] = ["Osc", "a.u.", self.osc]
         self.outputs['Positive fraction'] = ["P^+", "a.u.", self.pos]
-        self.outputs['1-sigma positive fraction'] = ["P^+_{1\ \sigma}",
+        self.outputs['1-sigma positive fraction'] = [r"P^+_{1\ \sigma}",
                                                      "a.u.", self.pos_err]
         self.outputs['Rg'] = ["R_g", "A", self.rg]
         self.outputs['I(q=0)'] = ["I(q=0)", "1/A", self.iq0]

--- a/src/sas/sasgui/perspectives/pr/inversion_panel.py
+++ b/src/sas/sasgui/perspectives/pr/inversion_panel.py
@@ -281,7 +281,7 @@ class InversionControl(ScrolledPanel, PanelBase):
             self._default_save_location = self.parent._default_save_location
         dlg = wx.FileDialog(self, "Choose a file",
                             self._default_save_location,
-                            self.window_caption, "*.prv", wx.SAVE)
+                            self.window_caption, "*.prv", wx.FD_SAVE)
         if dlg.ShowModal() == wx.ID_OK:
             path = dlg.GetPath()
             self._default_save_location = os.path.dirname(path)

--- a/src/sas/sasgui/perspectives/simulation/SimCanvas.py
+++ b/src/sas/sasgui/perspectives/simulation/SimCanvas.py
@@ -1,7 +1,7 @@
 """
 This software was developed by the University of Tennessee as part of the
 Distributed Data Analysis of Neutron Scattering Experiments (DANSE)
-project funded by the US National Science Foundation. 
+project funded by the US National Science Foundation.
 
 See the license text in license.txt
 
@@ -31,9 +31,9 @@ try:
     haveOpenGL = True
 except ImportError:
     haveOpenGL = False
-    
+
 # Color set
-DEFAULT_COLOR = [1.0, 1.0, 0.0, .2]    
+DEFAULT_COLOR = [1.0, 1.0, 0.0, .2]
 COLOR_RED     = [1.0, 0.0, 0.0, .2]
 COLOR_GREEN   = [0.0, 1.0, 0.0, .2]
 COLOR_BLUE    = [0.0, 0.0, 1.0, .2]
@@ -47,20 +47,20 @@ import ShapeParameters
 
 class SimPanel(wx.Panel):
     """
-        3D viewer to support real-space simulation. 
+        3D viewer to support real-space simulation.
     """
     window_name = "3dview"
     window_caption = "3D viewer"
-    
+
     def __init__(self, parent, id = -1, plots = None, standalone=False, **kwargs):
         wx.Panel.__init__(self, parent, id = id, **kwargs)
         self.parent = parent
-    
+
         #Add a sizer
         mainSizer = wx.BoxSizer(wx.VERTICAL)
         sliderSizer = wx.BoxSizer(wx.HORIZONTAL)
-    
-        self.canvas    = CanvasBase(self) 
+
+        self.canvas    = CanvasBase(self)
         self.canvas.SetMinSize((200,2100))
 
         #Add the model to it's sizer
@@ -71,8 +71,8 @@ class SimPanel(wx.Panel):
 
         self.SetSizer(mainSizer)
         self.Bind(wx.EVT_CONTEXT_MENU, self._on_context_menu)
-        
- 
+
+
     def _on_context_menu(self, event):
         """
             Default context menu for a plot panel
@@ -82,18 +82,18 @@ class SimPanel(wx.Panel):
         slicerpop = wx.Menu()
         slicerpop.Append(id, '&Reset 3D View')
         wx.EVT_MENU(self, id, self.canvas.resetView)
-       
+
         pos = event.GetPosition()
         pos = self.ScreenToClient(pos)
-        self.PopupMenu(slicerpop, pos)        
-    
+        self.PopupMenu(slicerpop, pos)
+
 class CanvasBase(glcanvas.GLCanvas):
     """
         3D canvas to display OpenGL 3D shapes
     """
     window_name = "Simulation"
     window_caption = "Simulation"
-    
+
     def __init__(self, parent):
         glcanvas.GLCanvas.__init__(self, parent, -1)
         self.init = False
@@ -112,23 +112,23 @@ class CanvasBase(glcanvas.GLCanvas):
         self.Bind(wx.EVT_RIGHT_UP, self.OnRightUp)
         self.Bind(wx.EVT_MOTION, self.OnMouseMotion)
         self.Bind(wx.EVT_MOUSEWHEEL, self._onMouseWheel)
-        
+
         self.initialized = False
         self.shapes = []
         self.parent = parent
-        
+
         # Reference vectors
         self.x_vec = [1,0,0]
         self.y_vec = [0,1,0]
-        
+
         self.mouse_down = False
         self.scale = 1.0
         self.zoom  = 1.0
         self.translation = [0,0,0]
-        
+
         # Bind to Edit events
         self.parent.Bind(ShapeParameters.EVT_EDIT_SHAPE, self._onEditShape)
-        
+
     def resetView(self, evt=None):
         """
             Resets zooming, translation and rotation.
@@ -139,7 +139,7 @@ class CanvasBase(glcanvas.GLCanvas):
         self.y_vec = [0,1,0]
         glLoadIdentity()
         self.Refresh()
-                
+
     def _onEditShape(self, evt):
         evt.Skip()
         evt.shape.highlight(True)
@@ -157,38 +157,38 @@ class CanvasBase(glcanvas.GLCanvas):
             glViewport(0, 0, size.width, size.height)
         event.Skip()
 
-    def OnPaint(self, event):     
+    def OnPaint(self, event):
         size = self.GetClientSize()
         side = size.width
         if size.height<size.width:
             side = size.height
-        
+
         if self.GetContext():
             glViewport(0, 0, side, side)
             self.SetMinSize((side,side))
-            
+
         dc = wx.PaintDC(self)
         self.SetCurrent()
         if not self.init:
             self.InitGL()
             self.init = True
         self.OnDraw()
-        event.Skip()        
-        
+        event.Skip()
+
     def _onMouseWheel(self, evt):
         # Initialize mouse position so we don't have unwanted rotation
         self.x, self.y = self.lastx, self.lasty = evt.GetPosition()
         self.tr_x, self.tr_y = self.tr_lastx, self.tr_lasty = evt.GetPosition()
-        
+
         scale = 1.15
         if evt.GetWheelRotation()<0:
             scale = 1.0/scale
-             
-        self.zoom *= scale             
-             
+
+        self.zoom *= scale
+
         glScale(scale, scale, scale)
         self.Refresh(False)
-        
+
     def OnMouseDown(self, evt):
         self.SetFocus()
         self.CaptureMouse()
@@ -213,61 +213,61 @@ class CanvasBase(glcanvas.GLCanvas):
         slicerpop = wx.Menu()
         slicerpop.Append(id, '&Reset 3D View')
         wx.EVT_MENU(self, id, self.resetView)
-       
+
         pos = event.GetPosition()
         #pos = self.ScreenToClient(pos)
-        self.PopupMenu(slicerpop, pos)        
+        self.PopupMenu(slicerpop, pos)
 
     def OnMouseMotion(self, evt):
         if evt.Dragging() and evt.LeftIsDown():
             self.tr_lastx, self.tr_lasty = self.tr_x, self.tr_y
             x, y = evt.GetPosition()
-            
+
             # Min distance to do anything
             if math.fabs(self.lastx-x)>10 or math.fabs(self.lasty-y)>10:
-                
+
                 self.lastx, self.lasty = self.x, self.y
-        
-                
+
+
                 if math.fabs(self.lastx-x)>math.fabs(self.lasty-y):
                     self.x = x
                 else:
                     self.y = y
-                
+
                 #self.x, self.y = evt.GetPosition()
                 self.Refresh(False)
-                
+
         elif evt.Dragging() and evt.RightIsDown():
             self.lastx, self.lasty = self.x, self.y
             self.tr_lastx, self.tr_lasty = self.tr_x, self.tr_y
             self.tr_x, self.tr_y = evt.GetPosition()
             self.Refresh(False)
-            
-    def InitGL( self ):      
+
+    def InitGL( self ):
         glutInitDisplayMode (GLUT_DOUBLE | GLUT_RGBA)
         #glShadeModel(GL_FLAT);
-        
+
         glMatrixMode(GL_PROJECTION)
-        
+
         glLight(GL_LIGHT0, GL_AMBIENT, [.2, .2, .2, 0])
-        
+
         # Object color
         #glLight(GL_LIGHT0, GL_DIFFUSE, COLOR_BLUE)
-        
+
         glLight(GL_LIGHT0, GL_POSITION, [1.0, 1.0, -1.0, 0.0])
-        
-        
+
+
         glLightModelfv(GL_LIGHT_MODEL_AMBIENT, [1, 1, 1, 0])
         glEnable(GL_LIGHTING)
         glEnable(GL_LIGHT0)
         glEnable(GL_BLEND)
         glBlendFunc (GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
-        
+
         glEnable ( GL_ALPHA_TEST ) ;
         glAlphaFunc ( GL_GREATER, 0 ) ;
         glPixelStorei(GL_PACK_ALIGNMENT, 1)
         glPixelStorei(GL_UNPACK_ALIGNMENT, 1)
-        
+
         glEnable(GL_NORMALIZE)
         glDepthFunc(GL_LESS)
         glEnable(GL_DEPTH_TEST)
@@ -275,8 +275,8 @@ class CanvasBase(glcanvas.GLCanvas):
         glClearColor (1.0, 1.0, 1.0, 0.0);
         #glClear (GL_COLOR_BUFFER_BIT);
         glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT)
-        
-        
+
+
         gluPerspective(0, 1.0, 0.1, 60.0);
 
         glMatrixMode(GL_MODELVIEW)
@@ -295,7 +295,7 @@ class CanvasBase(glcanvas.GLCanvas):
         # clear color and depth buffers
         glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT)
         # use a fresh transformation matrix
-        
+
         # get the max object size to re-scale
         max_size = 1.0
         # Ready to draw shapes
@@ -304,29 +304,29 @@ class CanvasBase(glcanvas.GLCanvas):
             l = item.get_length()
             if l>max_size:
                 max_size = l
-        
+
         max_size *= 1.05
         scale = self.scale/max_size
         glScale(scale, scale, scale)
         self.scale = max_size
-        
+
         self.drawAxes()
-        
+
         if self.mouse_down:
             if math.fabs((self.x - self.lastx))>math.fabs((self.y - self.lasty)):
-                angle = 10.0*(self.x - self.lastx) / math.fabs(self.x - self.lastx) 
+                angle = 10.0*(self.x - self.lastx) / math.fabs(self.x - self.lastx)
                 glRotate(angle, self.y_vec[0], self.y_vec[1], self.y_vec[2]);
                 self._rot_y(angle)
             elif math.fabs(self.y - self.lasty)>0:
-                angle = 10.0*(self.y - self.lasty) / math.fabs(self.y - self.lasty) 
+                angle = 10.0*(self.y - self.lasty) / math.fabs(self.y - self.lasty)
                 glRotate(angle, self.x_vec[0], self.x_vec[1], self.x_vec[2]);
                 self._rot_x(angle)
 
             self.lasty = self.y
             self.lastx = self.x
-        
-            w,h = self.GetVirtualSizeTuple()
-        
+
+            w, h = self.GetVirtualSize()
+
             # Translate in the x-y plane
             vx = self.x_vec[0] * 2.0*float(self.tr_x - self.tr_lastx)/w \
                + self.y_vec[0] * 2.0*float(self.tr_lasty - self.tr_y)/h
@@ -334,15 +334,15 @@ class CanvasBase(glcanvas.GLCanvas):
                + self.y_vec[1] * 2.0*float(self.tr_lasty - self.tr_y)/h
             vz = self.x_vec[2] * 2.0*float(self.tr_x - self.tr_lastx)/w \
                + self.y_vec[2] * 2.0*float(self.tr_lasty - self.tr_y)/h
-            
-            glTranslate(self.scale*vx/self.zoom, self.scale*vy/self.zoom, self.scale*vz/self.zoom)    
-                
+
+            glTranslate(self.scale*vx/self.zoom, self.scale*vy/self.zoom, self.scale*vz/self.zoom)
+
         # push into visible buffer
         self.SwapBuffers()
-        
+
     def _matrix_mult(self, v, axis, angle):
         c = math.cos(angle)
-        s = math.sin(angle) 
+        s = math.sin(angle)
         x = axis[0]
         y = axis[1]
         z = axis[2]
@@ -350,23 +350,23 @@ class CanvasBase(glcanvas.GLCanvas):
         vy = v[0]*(y*x*(1-c)+z*s) + v[1]*(y*y*(1-c)+c)   + v[2]*(y*z*(1-c)-x*s)
         vz = v[0]*(x*z*(1-c)-y*s) + v[1]*(y*z*(1-c)+x*s) + v[2]*(z*z*(1-c)+c)
         return [vx, vy, vz]
-    
+
     def _rot_y(self, theta):
         """
             Rotate the view by theta around the y-axis
         """
-        angle = theta/180.0*math.pi 
+        angle = theta/180.0*math.pi
         axis = self.y_vec
         self.x_vec = self._matrix_mult(self.x_vec, self.y_vec, -angle)
-        
+
     def _rot_x(self, theta):
         """
             Rotate the view by theta around the x-axis
         """
         angle = theta/180.0*math.pi
         self.y_vec = self._matrix_mult(self.y_vec, self.x_vec, -angle)
-        
-        
+
+
     def addShape(self, shape, name=None):
         """
             Add a shape to the list of displayed shapes
@@ -402,31 +402,31 @@ class CanvasBase(glcanvas.GLCanvas):
         return sum
 
     def drawAxes(self):
-        """ 
+        """
             Draw 3D axes
         """
         pos = self.scale * 0.7
-       
+
         # Z-axis is red
-        zaxis= Arrow(x=pos, y=-pos, z=0, r_cyl=self.scale*0.005, r_cone=self.scale*0.01, 
+        zaxis= Arrow(x=pos, y=-pos, z=0, r_cyl=self.scale*0.005, r_cone=self.scale*0.01,
                      l_cyl=self.scale*0.1, l_cone=self.scale*0.05)
         zaxis.color = COLOR_RED
         zaxis.draw()
-        
+
         # Y-axis is yellow
-        yaxis= Arrow(x=pos, y=-pos, z=0, r_cyl=self.scale*0.005, r_cone=self.scale*0.01, 
+        yaxis= Arrow(x=pos, y=-pos, z=0, r_cyl=self.scale*0.005, r_cone=self.scale*0.01,
                      l_cyl=self.scale*0.1, l_cone=self.scale*0.05)
         yaxis.color = COLOR_YELLOW
         yaxis.rotate(-90,0,0)
         yaxis.draw()
-        
+
         # X-axis is green
-        xaxis= Arrow(x=pos, y=-pos, z=0, r_cyl=self.scale*0.005, r_cone=self.scale*0.01, 
+        xaxis= Arrow(x=pos, y=-pos, z=0, r_cyl=self.scale*0.005, r_cone=self.scale*0.01,
                      l_cyl=self.scale*0.1, l_cone=self.scale*0.05)
         xaxis.color = COLOR_GREEN
         xaxis.rotate(0,-90,0)
         xaxis.draw()
-        
+
         glLight(GL_LIGHT0, GL_DIFFUSE, DEFAULT_COLOR)
 
 
@@ -444,7 +444,7 @@ class BaseShape:
         self.theta_x = 0
         self.theta_y = 0
         self.theta_z = 0
-        
+
         # Params
         self.params = {}
         self.params['contrast']  = 1.0
@@ -452,21 +452,21 @@ class BaseShape:
         self.details = {}
         self.details['contrast'] = 'A-2'
         self.details['order']    = ' '
-        
+
         self.highlighted = False
         self.color = DEFAULT_COLOR
-    
+
     def get_volume(self):
         return 0
-    
+
     def get_length(self):
         return 1.0
-    
+
     def highlight(self, value=False):
         self.highlighted = value
-        
+
     def rotate(self, alpha, beta, gamma):
-        """ 
+        """
             Set the rotation angles of the shape
             @param alpha: angle around the x-axis [degrees]
             @param beta: angle around the y-axis [degrees]
@@ -475,19 +475,19 @@ class BaseShape:
         self.theta_x = alpha
         self.theta_y = beta
         self.theta_z = gamma
-        
+
     def _rotate(self):
         """
             Perform the OpenGL rotation
-            
+
             Note that the rotation order is reversed.
             We do Y, X, Z do be compatible with simulation...
         """
-        
+
         glRotated(self.theta_z, 0, 0, 1)
         glRotated(self.theta_x, 1, 0, 0)
         glRotated(self.theta_y, 0, 1, 0)
-        
+
     def _pre_draw(self):
         if self.highlighted:
             glLight(GL_LIGHT0, GL_DIFFUSE, COLOR_HIGHLIGHT)
@@ -505,12 +505,12 @@ class Arrow(BaseShape):
         self.r_cone = r_cone
         self.l_cyl = l_cyl
         self.l_cone = l_cone
-           
+
     def draw(self):
         self._pre_draw()
         glPushMatrix()
         glTranslate(self.x, self.y, self.z)
-        
+
         # Perform rotation
         glRotate(self.theta_x, 1, 0, 0)
         glRotate(self.theta_y, 0, 1, 0)
@@ -519,12 +519,12 @@ class Arrow(BaseShape):
         # Draw axis cylinder
         qobj = gluNewQuadric();
         gluCylinder(qobj, self.r_cyl, self.r_cyl, self.l_cyl, 15, 5);
-                
+
         glTranslate(0, 0, self.z+self.l_cyl)
-        
+
         # Draw cone of the arrow
         glutSolidCone(self.r_cone, self.l_cone, 30, 5)
-        
+
         # Translate back to original position
         glTranslate(-self.x, -self.y, -self.z)
         glPopMatrix()
@@ -537,7 +537,7 @@ class Cone(BaseShape):
         BaseShape.__init__(self, x, y, z)
         self.radius = radius
         self.height = height
-        
+
     def draw(self):
         glPushMatrix()
         glTranslate(self.x, self.y, self.z)
@@ -555,13 +555,13 @@ class Sphere(BaseShape):
         self.name = 'sphere'
         self.params['radius'] = radius
         self.details['radius'] = 'A'
-        
+
     def get_volume(self):
         return 4.0/3.0*math.pi*self.params['radius']*self.params['radius']*self.params['radius']
-        
+
     def get_length(self):
         return 2.0*self.params['radius']
-    
+
     def draw(self):
         self._pre_draw()
         glPushMatrix()
@@ -583,8 +583,8 @@ class Sphere(BaseShape):
 class Cylinder(BaseShape):
     """
         Cylinder shape, by default the cylinder is oriented along
-        the z-axis. 
-        
+        the z-axis.
+
         The reference point of the cylinder is the center of the
         bottom circle.
     """
@@ -595,22 +595,22 @@ class Cylinder(BaseShape):
         self.params['length'] = length
         self.details['radius'] = 'A'
         self.details['length'] = 'A'
-        
+
     def get_volume(self):
         return math.pi*self.params['radius']*self.params['radius']*self.params['length']
-        
+
     def get_length(self):
         if self.params['length']>2.0*self.params['radius']:
             return self.params['length']
         else:
             return 2.0*self.params['radius']
-        
+
     def draw(self):
         self._pre_draw()
         glPushMatrix()
-        
+
         glTranslate(self.x, self.y, self.z)
-        self._rotate() 
+        self._rotate()
         qobj = gluNewQuadric();
         # gluCylinder(qobj, r_base, r_top, L, div around z, div along z)
         gluCylinder(qobj, self.params['radius'], self.params['radius'], self.params['length'], 15, 5);
@@ -618,23 +618,23 @@ class Cylinder(BaseShape):
         glTranslate(-self.x, -self.y, -self.z)
         glPopMatrix()
         glLight(GL_LIGHT0, GL_DIFFUSE, DEFAULT_COLOR)
-        
+
     def accept(self, visitor):
         return visitor.fromCylinder(self)
-        
+
     def accept_update(self, visitor):
         return visitor.update_cylinder(self)
-        
+
 # Fill the shape list
 SHAPE_LIST.append(dict(name='Sphere',   id=wx.NewId(), cl=Sphere))
 SHAPE_LIST.append(dict(name='Cylinder', id=wx.NewId(), cl=Cylinder))
-        
+
 def getShapes():
     """
         Returns a list of all available shapes
     """
     return SHAPE_LIST
-    
+
 def getShapeClass(id):
     """
         Returns a child class of BaseShape corresponding
@@ -646,7 +646,7 @@ def getShapeClass(id):
         shape = filter(f, SHAPE_LIST)
         return shape[0]['cl']
     return None
-    
+
 def getShapeClassByName(name):
     """
         Returns a child class of BaseShape corresponding

--- a/src/sas/sasgui/plottools/PlotPanel.py
+++ b/src/sas/sasgui/plottools/PlotPanel.py
@@ -338,8 +338,8 @@ class PlotPanel(wx.Panel):
         #else:
         # On Windows platform, default window size is incorrect, so set
         # toolbar width to figure width.
-        tw, th = self.toolbar.GetSizeTuple()
-        fw, fh = self.canvas.GetSizeTuple()
+        tw, th = self.toolbar.GetSize()
+        fw, fh = self.canvas.GetSize()
         # By adding toolbar in sizer, we are able to put it at the bottom
         # of the frame - so appearance is closer to GTK version.
         # As noted above, doesn't work for Mac.
@@ -438,8 +438,8 @@ class PlotPanel(wx.Panel):
         if y > hi_y:
             y = hi_y
         # Move the legend from its previous location by that same amount
-        loc_in_canvas = self.legend_x - mouse_diff_x, \
-                        self.legend_y - mouse_diff_y
+        loc_in_canvas = (self.legend_x - mouse_diff_x,
+                         self.legend_y - mouse_diff_y)
         # Transform into legend coordinate system
         trans_axes = self.legend.parent.transAxes.inverted()
         loc_in_norm_axes = trans_axes.transform_point(loc_in_canvas)
@@ -629,8 +629,8 @@ class PlotPanel(wx.Panel):
         """
         Return values and labels used by Fit Dialog
         """
-        return self.xLabel, self.yLabel, self.Avalue, self.Bvalue, \
-                self.ErrAvalue, self.ErrBvalue, self.Chivalue
+        return (self.xLabel, self.yLabel, self.Avalue, self.Bvalue,
+                self.ErrAvalue, self.ErrBvalue, self.Chivalue)
 
     def setTrans(self, xtrans, ytrans):
         """
@@ -666,8 +666,8 @@ class PlotPanel(wx.Panel):
                             transform=self.returnTrans,
                             title='Linear Fit')
 
-            if (self.xmin != 0.0)and (self.xmax != 0.0)\
-                and(self.xminView != 0.0)and (self.xmaxView != 0.0):
+            if ((self.xmin != 0.0) and (self.xmax != 0.0)
+                    and (self.xminView != 0.0) and (self.xmaxView != 0.0)):
                 dlg.setFitRange(self.xminView, self.xmaxView,
                                 self.xmin, self.xmax)
             else:
@@ -924,7 +924,7 @@ class PlotPanel(wx.Panel):
             pos = self.ScreenToClient(pos_evt)
         except:
             # toolbar event
-            pos_x, pos_y = self.toolbar.GetPositionTuple()
+            pos_x, pos_y = self.toolbar.GetPosition()
             pos = (pos_x, pos_y + 5)
 
         self.PopupMenu(slicerpop, pos)
@@ -1058,8 +1058,8 @@ class PlotPanel(wx.Panel):
         """
         Allows you to add text to the plot
         """
-        xaxis_label, xaxis_unit, xaxis_font, xaxis_color, \
-                     is_ok, is_tick = self._on_axis_label(axis='x')
+        xaxis_label, xaxis_unit, xaxis_font, xaxis_color, is_ok, is_tick \
+            = self._on_axis_label(axis='x')
         if not is_ok:
             return
 
@@ -1072,8 +1072,8 @@ class PlotPanel(wx.Panel):
 
         if self.data is not None:
             # 2D
-            self.xaxis(self.xaxis_label, self.xaxis_unit, \
-                        self.xaxis_font, self.xaxis_color, self.xaxis_tick)
+            self.xaxis(self.xaxis_label, self.xaxis_unit,
+                       self.xaxis_font, self.xaxis_color, self.xaxis_tick)
             self.subplot.figure.canvas.draw_idle()
         else:
             # 1D
@@ -1105,8 +1105,8 @@ class PlotPanel(wx.Panel):
         """
         Allows you to add text to the plot
         """
-        yaxis_label, yaxis_unit, yaxis_font, yaxis_color, \
-                        is_ok, is_tick = self._on_axis_label(axis='y')
+        yaxis_label, yaxis_unit, yaxis_font, yaxis_color, is_ok, is_tick \
+            = self._on_axis_label(axis='y')
         if not is_ok:
             return
 
@@ -1119,7 +1119,7 @@ class PlotPanel(wx.Panel):
 
         if self.data is not None:
             # 2D
-            self.yaxis(self.yaxis_label, self.yaxis_unit, \
+            self.yaxis(self.yaxis_label, self.yaxis_unit,
                         self.yaxis_font, self.yaxis_color, self.yaxis_tick)
             self.subplot.figure.canvas.draw_idle()
         else:
@@ -1155,9 +1155,10 @@ class PlotPanel(wx.Panel):
                 colour = textdial.getColor()
                 is_tick = textdial.getTickLabel()
                 label_temp = textdial.getText()
-                if label_temp.count("\%s" % "\\") > 0:
+                if r"\\" in label_temp:
+                    label = label_temp.replace(r"\\", r"??")
                     if self.parent is not None:
-                        msg = "Add Label: Error. Can not use double '\\' "
+                        msg = r"Add Label error: Can not use double '\\' "
                         msg += "characters..."
                         wx.PostEvent(self.parent, StatusEvent(status=msg))
                 else:
@@ -1532,8 +1533,8 @@ class PlotPanel(wx.Panel):
 
         """
         # No qx or qy given in a vector format
-        if self.qx_data is None or self.qy_data is None \
-                or self.qx_data.ndim != 1 or self.qy_data.ndim != 1:
+        if (self.qx_data is None or self.qy_data is None
+                or self.qx_data.ndim != 1 or self.qy_data.ndim != 1):
             # do we need deepcopy here?
             return copy.deepcopy(self.data)
 
@@ -1592,8 +1593,8 @@ class PlotPanel(wx.Panel):
         where each one corresponds to  x, or y axis values
         """
         # No qx or qy given in a vector format
-        if self.qx_data is None or self.qy_data is None \
-                or self.qx_data.ndim != 1 or self.qy_data.ndim != 1:
+        if (self.qx_data is None or self.qy_data is None
+                or self.qx_data.ndim != 1 or self.qy_data.ndim != 1):
             # do we need deepcopy here?
             return copy.deepcopy(self.data)
 
@@ -1643,9 +1644,8 @@ class PlotPanel(wx.Panel):
 
         """
         # No image matrix given
-        if image is None or np.ndim(image) != 2 \
-                or np.isfinite(image).all() \
-                or weights is None:
+        if (image is None or np.ndim(image) != 2
+                or np.isfinite(image).all() or weights is None):
             return image
         # Get bin size in y and x directions
         len_y = len(image)
@@ -1675,20 +1675,20 @@ class PlotPanel(wx.Panel):
                         weit[n_y][n_x] += 1
                     # go 4 next nearest neighbors when no non-zero
                     # neighbor exists
-                    if n_y != 0 and n_x != 0 and \
-                            np.isfinite(image[n_y - 1][n_x - 1]):
+                    if (n_y != 0 and n_x != 0
+                            and np.isfinite(image[n_y - 1][n_x - 1])):
                         temp_image[n_y][n_x] += image[n_y - 1][n_x - 1]
                         weit[n_y][n_x] += 1
-                    if n_y != len_y - 1 and n_x != 0 and \
-                            np.isfinite(image[n_y + 1][n_x - 1]):
+                    if (n_y != len_y - 1 and n_x != 0
+                            and np.isfinite(image[n_y + 1][n_x - 1])):
                         temp_image[n_y][n_x] += image[n_y + 1][n_x - 1]
                         weit[n_y][n_x] += 1
-                    if n_y != len_y and n_x != len_x - 1 and \
-                            np.isfinite(image[n_y - 1][n_x + 1]):
+                    if (n_y != len_y and n_x != len_x - 1
+                            and np.isfinite(image[n_y - 1][n_x + 1])):
                         temp_image[n_y][n_x] += image[n_y - 1][n_x + 1]
                         weit[n_y][n_x] += 1
-                    if n_y != len_y - 1 and n_x != len_x - 1 and \
-                            np.isfinite(image[n_y + 1][n_x + 1]):
+                    if (n_y != len_y - 1 and n_x != len_x - 1
+                            and np.isfinite(image[n_y + 1][n_x + 1])):
                         temp_image[n_y][n_x] += image[n_y + 1][n_x + 1]
                         weit[n_y][n_x] += 1
 
@@ -1783,14 +1783,14 @@ class PlotPanel(wx.Panel):
             if self.xLabel == "x^(2)":
                 item.transformX(transform.toX2, transform.errToX2)
                 xunits = convert_unit(2, xunits)
-                self.graph._xaxis_transformed("%s^{2}" % xname, "%s" % xunits)
+                self.graph._xaxis_transformed("%s^2" % xname, "%s" % xunits)
             if self.xLabel == "x^(4)":
                 item.transformX(transform.toX4, transform.errToX4)
                 xunits = convert_unit(4, xunits)
-                self.graph._xaxis_transformed("%s^{4}" % xname, "%s" % xunits)
+                self.graph._xaxis_transformed("%s^4" % xname, "%s" % xunits)
             if self.xLabel == "ln(x)":
                 item.transformX(transform.toLogX, transform.errToLogX)
-                self.graph._xaxis_transformed("\ln{(%s)}" % xname, "%s" % xunits)
+                self.graph._xaxis_transformed(r"\ln(%s)" % xname, "%s" % xunits)
             if self.xLabel == "log10(x)":
                 item.transformX(transform.toX_pos, transform.errToX_pos)
                 _xscale = 'log'
@@ -1798,11 +1798,11 @@ class PlotPanel(wx.Panel):
             if self.xLabel == "log10(x^(4))":
                 item.transformX(transform.toX4, transform.errToX4)
                 xunits = convert_unit(4, xunits)
-                self.graph._xaxis_transformed("%s^{4}" % xname, "%s" % xunits)
+                self.graph._xaxis_transformed("%s^4" % xname, "%s" % xunits)
                 _xscale = 'log'
             if self.yLabel == "ln(y)":
                 item.transformY(transform.toLogX, transform.errToLogX)
-                self.graph._yaxis_transformed("\ln{(%s)}" % yname, "%s" % yunits)
+                self.graph._yaxis_transformed(r"\ln(%s)" % yname, "%s" % yunits)
             if self.yLabel == "y":
                 item.transformY(transform.toX, transform.errToX)
                 self.graph._yaxis_transformed("%s" % yname, "%s" % yunits)
@@ -1821,38 +1821,38 @@ class PlotPanel(wx.Panel):
             if self.yLabel == "y*x^(2)":
                 item.transformY(transform.toYX2, transform.errToYX2)
                 xunits = convert_unit(2, self.xaxis_unit)
-                self.graph._yaxis_transformed("%s \ \ %s^{2}" % (yname, xname),
+                self.graph._yaxis_transformed(r"%s \ \ %s^2" % (yname, xname),
                                               "%s%s" % (yunits, xunits))
             if self.yLabel == "y*x^(4)":
                 item.transformY(transform.toYX4, transform.errToYX4)
                 xunits = convert_unit(4, self.xaxis_unit)
-                self.graph._yaxis_transformed("%s \ \ %s^{4}" % (yname, xname),
+                self.graph._yaxis_transformed(r"%s \ \ %s^4" % (yname, xname),
                                               "%s%s" % (yunits, xunits))
             if self.yLabel == "1/sqrt(y)":
                 item.transformY(transform.toOneOverSqrtX,
                                 transform.errOneOverSqrtX)
                 yunits = convert_unit(-0.5, yunits)
-                self.graph._yaxis_transformed("1/\sqrt{%s}" % yname,
+                self.graph._yaxis_transformed(r"1/\sqrt{%s}" % yname,
                                               "%s" % yunits)
             if self.yLabel == "ln(y*x)":
                 item.transformY(transform.toLogXY, transform.errToLogXY)
-                self.graph._yaxis_transformed("\ln{(%s \ \ %s)}" % (yname, xname),
+                self.graph._yaxis_transformed(r"\ln(%s \ \ %s)" % (yname, xname),
                                               "%s%s" % (yunits, self.xaxis_unit))
             if self.yLabel == "ln(y*x^(2))":
                 item.transformY(transform.toLogYX2, transform.errToLogYX2)
                 xunits = convert_unit(2, self.xaxis_unit)
-                self.graph._yaxis_transformed("\ln (%s \ \ %s^{2})" % (yname, xname),
+                self.graph._yaxis_transformed(r"\ln(%s \ \ %s^2)" % (yname, xname),
                                               "%s%s" % (yunits, xunits))
             if self.yLabel == "ln(y*x^(4))":
                 item.transformY(transform.toLogYX4, transform.errToLogYX4)
                 xunits = convert_unit(4, self.xaxis_unit)
-                self.graph._yaxis_transformed("\ln (%s \ \ %s^{4})" % (yname, xname),
+                self.graph._yaxis_transformed(r"\ln(%s \ \ %s^4)" % (yname, xname),
                                               "%s%s" % (yunits, xunits))
             if self.yLabel == "log10(y*x^(4))":
                 item.transformY(transform.toYX4, transform.errToYX4)
                 xunits = convert_unit(4, self.xaxis_unit)
                 _yscale = 'log'
-                self.graph._yaxis_transformed("%s \ \ %s^{4}" % (yname, xname),
+                self.graph._yaxis_transformed(r"%s \ \ %s^4" % (yname, xname),
                                               "%s%s" % (yunits, xunits))
             item.transformView()
 
@@ -1896,7 +1896,7 @@ class PlotPanel(wx.Panel):
 
         # Saving value to redisplay in Fit Dialog when it is opened again
         self.Avalue, self.Bvalue, self.ErrAvalue, \
-                      self.ErrBvalue, self.Chivalue = func
+            self.ErrBvalue, self.Chivalue = func
         self.xminView = xminView
         self.xmaxView = xmaxView
         self.xmin = xmin

--- a/src/sas/sasgui/plottools/PlotPanel.py
+++ b/src/sas/sasgui/plottools/PlotPanel.py
@@ -1234,7 +1234,6 @@ class PlotPanel(wx.Panel):
         # TODO: Redraw is brutal.  Render to a backing store and swap in
         # TODO: rather than redrawing on the fly.
         self.subplot.clear()
-        self.subplot.hold(True)
 
     def render(self):
         """Commit the plot after all objects are drawn"""

--- a/src/sas/sasgui/plottools/canvas.py
+++ b/src/sas/sasgui/plottools/canvas.py
@@ -52,9 +52,9 @@ def OnPrintPage(self, page):
     except:
         ppw = 1
         pph = 1
-    (pgw, _) = self.GetPageSizePixels()  # page size in pixels
-    (dcw, _) = dc.GetSize()
-    (grw, _) = self.canvas.GetSizeTuple()
+    pgw, _ = self.GetPageSizePixels()  # page size in pixels
+    dcw, _ = dc.GetSize()
+    grw, _ = self.canvas.GetSize()
 
     # save current figure dpi resolution and bg color,
     # so that we can temporarily set them to the dpi of
@@ -151,9 +151,11 @@ class FigureCanvas(FigureCanvasWxAgg):
         """
         Render after a delay if no other render requests have been made.
         """
-        self.panel.subplot.grid(self.panel.grid_on)
-        if self.panel.legend is not None and self.panel.legend_pos_loc:
-            self.panel.legend._loc = self.panel.legend_pos_loc
+        if self.panel is not None:
+            # TODO: grid/panel manip doesn't belong here
+            self.panel.subplot.grid(self.panel.grid_on)
+            if self.panel.legend is not None and self.panel.legend_pos_loc:
+                self.panel.legend._loc = self.panel.legend_pos_loc
         self.idletimer.Restart(5, *args, **kwargs)  # Delay by 5 ms
 
     def _onDrawIdle(self, *args, **kwargs):

--- a/src/sas/sasgui/plottools/toolbar.py
+++ b/src/sas/sasgui/plottools/toolbar.py
@@ -157,8 +157,8 @@ class PlotPrintout(wx.Printout):
         canvas size keeping the aspect ratio intact, then prints as bitmap
         """
         _dc = self.GetDC()
-        (_dcX, _dcY) = _dc.GetSizeTuple()
-        (_bmpX,_bmpY) = self.canvas.GetSize()
+        _dcX, _dcY = _dc.GetSize()
+        _bmpX, _bmpY = self.canvas.GetSize()
         _scale = min(_dcX/_bmpX, _dcY/_bmpY)
         _dc.SetUserScale(_scale, _scale)
         _dc.DrawBitmap(self.canvas.bitmap, 0, 0, False,)

--- a/src/sas/sasview/sasview.py
+++ b/src/sas/sasview/sasview.py
@@ -226,13 +226,15 @@ def setup_wx():
 
     try:
         logger.info("Wx version: %s", wx.__version__)
+        logger.info("Wx PlatformInfo: %s", wx.PlatformInfo)
     except AttributeError:
         logger.error("Wx version: error reading version")
 
     # TODO: Do we need the call later fix for wx 3? Or is it wx < 3 only?
     if "phoenix" in wx.PlatformInfo:
         #wx.NewId = wx.Window.NewControlId
-        pass
+        from . import wx4cruft
+        wx4cruft.patch_py_editor()
     else:
         from . import wxcruft
         wxcruft.call_later_fix()

--- a/src/sas/sasview/wx4cruft.py
+++ b/src/sas/sasview/wx4cruft.py
@@ -19,12 +19,12 @@ def patch_py_editor():
 def read(self):
     """Return contents of file."""
     if self.filepath and os.path.exists(self.filepath):
-        with io.open(self.filepath, 'r', encoding='utf8') as f:
+        with io.open(self.filepath, mode='r', encoding='utf8') as f:
             return f.read()
     else:
         return ''
 
 def write(self, text):
     """Write text to file."""
-    with io.open(self.filepath, 'w', encoding='utf8') as f:
+    with io.open(self.filepath, mode='w', encoding='utf8') as f:
         f.write(text)

--- a/src/sas/sasview/wx4cruft.py
+++ b/src/sas/sasview/wx4cruft.py
@@ -1,0 +1,30 @@
+import os
+import sys
+import io
+
+import wx.py.document
+
+def patch_py_editor():
+    """
+    Monkeypatch wx.py.document.Document with py2/3 compatible file I/O.
+
+    Tested on py2 and py3 with wx 4.0.1.  It works well enough for loading
+    and saving from wx.py.editor, but it changes the interface to Document
+    to only support unicode text, whereas the old version of Document in
+    python 2.7 only supports bytes.
+    """
+    wx.py.document.Document.read = read
+    wx.py.document.Document.write = write
+
+def read(self):
+    """Return contents of file."""
+    if self.filepath and os.path.exists(self.filepath):
+        with io.open(self.filepath, 'r', encoding='utf8') as f:
+            return f.read()
+    else:
+        return ''
+
+def write(self, text):
+    """Write text to file."""
+    with io.open(self.filepath, 'w', encoding='utf8') as f:
+        f.write(text)


### PR DESCRIPTION
#1260 (from trac [#1233](http://trac.sasview.org/ticket/1233))
#1273 (from trac [#1249](http://trac.sasview.org/ticket/1249))
#1286 (from trac [#1266](http://trac.sasview.org/ticket/1266))

* Python 3 is strict about backslash escape sequences.  In python 2, `\k` would be left alone since `k` is not a special character, but in python 3 backslash must be followed by a special character (see [table](https://docs.python.org/3/reference/lexical_analysis.html#string-and-bytes-literals)).

* wx 4 drops the `...Tuple()` methods; remove the `Tuple` from the name and is still works since the returned `Size` object supports `w, h = Size()` same as a tuple.

* simple lint cleanup, such as removing unnecessary backslash at the end of lines, etc.

* a **bug fix on mac**, which traps the user in an invisible modal dialog on > Image Viewer > Convert to Data, even in the released 4.2 series.  (File `src/sas/sasgui/perspectives/calculator/image_viewer.py`)

* remove a frequent **error in plot draw_idle**, wherein panel was being changed without checking if it was None first. (File `src/sas/sasgui/plottools/canvas.py`)

* FileDialog now uses wx.FD_SAVE rather than wx.SAVE (works in both wx 3 and 4).

* Model load/save works with wx4.

Tested somewhat on py2/wx3 and py3/wx4 for mac.
