### PR TITLE
Sasview 1079

### DIFF
--- a/src/sas/qtgui/Perspectives/Corfunc/CorfuncPerspective.py
+++ b/src/sas/qtgui/Perspectives/Corfunc/CorfuncPerspective.py
@@ -117,6 +117,8 @@ class CorfuncWindow(QtWidgets.QDialog, Ui_CorfuncDialog):
 
         self._canvas = MyMplCanvas(self.model)
         self.mainVerticalLayout.insertWidget(0, self._canvas)
+        self._realplot = MyMplCanvas(self.model)
+        self.mainVerticalLayout.insertWidget(1, self._realplot)
 
         # Connect buttons to slots.
         # Needs to be done early so default values propagate properly.
@@ -239,11 +241,11 @@ class CorfuncWindow(QtWidgets.QDialog, Ui_CorfuncDialog):
         self.model.setItem(W.W_CRYSTAL, QtGui.QStandardItem("{:.3g}".format(params['fill'])))
         self.model.setItem(W.W_POLY, QtGui.QStandardItem("{:.3g}".format(params['A'])))
         self.model.setItem(W.W_PERIOD, QtGui.QStandardItem("{:.3g}".format(params['max'])))
-        #self._realplot.data = transforms
+        self._realplot.data = transforms
 
         self.update_real_space_plot(transforms)
 
-        #self._realplot.draw_real_space()
+        self._realplot.draw_real_space()
 
     def update_real_space_plot(self, datas):
         """take the datas tuple and create a plot in DE"""
@@ -359,8 +361,8 @@ class CorfuncWindow(QtWidgets.QDialog, Ui_CorfuncDialog):
         self._canvas.draw_q_space()
         self.cmdTransform.setEnabled(False)
 
-        #self._realplot.data = None
-        #self._realplot.draw_real_space()
+        self._realplot.data = None
+        self._realplot.draw_real_space()
 
     def setClosable(self, value=True):
         """

--- a/src/sas/qtgui/Perspectives/Corfunc/CorfuncPerspective.py
+++ b/src/sas/qtgui/Perspectives/Corfunc/CorfuncPerspective.py
@@ -49,6 +49,9 @@ class MyMplCanvas(FigureCanvas):
         self.axes = self.fig.add_subplot(111)
         self.axes.set_xscale("log")
         self.axes.set_yscale("log")
+        self.axes.set_xlabel("Q [$\AA^{-1}$]")
+        self.axes.set_ylabel("I(Q) [cm$^{-1}$]")
+        self.fig.tight_layout()
 
         qmin = float(self.model.item(W.W_QMIN).text())
         qmax1 = float(self.model.item(W.W_QMAX).text())
@@ -80,6 +83,9 @@ class MyMplCanvas(FigureCanvas):
         self.axes = self.fig.add_subplot(111)
         self.axes.set_xscale("linear")
         self.axes.set_yscale("linear")
+        self.axes.set_xlabel("Z [$\AA$]")
+        self.axes.set_ylabel("Correlation")
+        self.fig.tight_layout()
 
         if self.data:
             data1, data3, data_idf = self.data

--- a/src/sas/qtgui/Perspectives/Corfunc/CorfuncPerspective.py
+++ b/src/sas/qtgui/Perspectives/Corfunc/CorfuncPerspective.py
@@ -6,6 +6,7 @@ This module provides the intelligence behind the gui interface for Corfunc.
 # global
 from matplotlib.backends.backend_qt5agg import FigureCanvasQTAgg \
     as FigureCanvas
+from matplotlib.backends.backend_qt5agg import NavigationToolbar2QT
 from matplotlib.figure import Figure
 from numpy.linalg.linalg import LinAlgError
 
@@ -124,8 +125,10 @@ class CorfuncWindow(QtWidgets.QDialog, Ui_CorfuncDialog):
 
         self._canvas = MyMplCanvas(self.model)
         self.plotLayout.insertWidget(0, self._canvas)
+        self.plotLayout.insertWidget(1, NavigationToolbar2QT(self._canvas, self))
         self._realplot = MyMplCanvas(self.model)
-        self.plotLayout.insertWidget(1, self._realplot)
+        self.plotLayout.insertWidget(2, self._realplot)
+        self.plotLayout.insertWidget(3, NavigationToolbar2QT(self._realplot, self))
 
         self.gridLayout_8.setColumnStretch(0, 1)
         self.gridLayout_8.setColumnStretch(1, 3)

--- a/src/sas/qtgui/Perspectives/Corfunc/CorfuncPerspective.py
+++ b/src/sas/qtgui/Perspectives/Corfunc/CorfuncPerspective.py
@@ -52,6 +52,7 @@ class MyMplCanvas(FigureCanvas):
         self.axes.set_yscale("log")
         self.axes.set_xlabel("Q [$\AA^{-1}$]")
         self.axes.set_ylabel("I(Q) [cm$^{-1}$]")
+        self.axes.set_title("Scattering data")
         self.fig.tight_layout()
 
         qmin = float(self.model.item(W.W_QMIN).text())
@@ -59,7 +60,8 @@ class MyMplCanvas(FigureCanvas):
         qmax2 = float(self.model.item(W.W_QCUTOFF).text())
 
         if self.data:
-            self.axes.plot(self.data.x, self.data.y)
+            # self.axes.plot(self.data.x, self.data.y, label="Experimental Data")
+            self.axes.errorbar(self.data.x, self.data.y, yerr=self.data.dy, label="Experimental Data")
             self.axes.axvline(qmin)
             self.axes.axvline(qmax1)
             self.axes.axvline(qmax2)
@@ -67,8 +69,12 @@ class MyMplCanvas(FigureCanvas):
                                max(self.data.x) * 1.5 - 0.5 * min(self.data.x))
             self.axes.set_ylim(min(self.data.y) / 2,
                                max(self.data.y) * 1.5 - 0.5 * min(self.data.y))
+
         if self.extrap:
-            self.axes.plot(self.extrap.x, self.extrap.y)
+            self.axes.plot(self.extrap.x, self.extrap.y, label="Extrapolation")
+
+        if self.data or self.extrap:
+            self.axes.legend()
 
         self.draw()
 
@@ -86,6 +92,7 @@ class MyMplCanvas(FigureCanvas):
         self.axes.set_yscale("linear")
         self.axes.set_xlabel("Z [$\AA$]")
         self.axes.set_ylabel("Correlation")
+        self.axes.set_title("Real Space Correlations")
         self.fig.tight_layout()
 
         if self.data:

--- a/src/sas/qtgui/Perspectives/Corfunc/CorfuncPerspective.py
+++ b/src/sas/qtgui/Perspectives/Corfunc/CorfuncPerspective.py
@@ -94,7 +94,7 @@ class MyMplCanvas(FigureCanvas):
             self.axes.plot(data3.x, data3.y, label="3D Correlation")
             self.axes.plot(data_idf.x, data_idf.y,
                            label="Interface Distribution Function")
-            self.axes.set_xlim(min(data1.x), max(data1.x) / 4)
+            self.axes.set_xlim(0, max(data1.x) / 4)
             self.axes.legend()
 
         self.draw()

--- a/src/sas/qtgui/Perspectives/Corfunc/CorfuncPerspective.py
+++ b/src/sas/qtgui/Perspectives/Corfunc/CorfuncPerspective.py
@@ -34,6 +34,7 @@ class MyMplCanvas(FigureCanvas):
 
         self.data = None
         self.extrap = None
+        self.setMinimumSize(300, 300)
 
     def draw_q_space(self):
         """Draw the Q space data in the plot window

--- a/src/sas/qtgui/Perspectives/Corfunc/CorfuncPerspective.py
+++ b/src/sas/qtgui/Perspectives/Corfunc/CorfuncPerspective.py
@@ -116,9 +116,9 @@ class CorfuncWindow(QtWidgets.QDialog, Ui_CorfuncDialog):
         self.txtLowerQMin.setEnabled(False)
 
         self._canvas = MyMplCanvas(self.model)
-        self.mainVerticalLayout.insertWidget(0, self._canvas)
+        self.columnLayout.insertWidget(0, self._canvas)
         self._realplot = MyMplCanvas(self.model)
-        self.mainVerticalLayout.insertWidget(1, self._realplot)
+        self.columnLayout.insertWidget(1, self._realplot)
 
         # Connect buttons to slots.
         # Needs to be done early so default values propagate properly.

--- a/src/sas/qtgui/Perspectives/Corfunc/CorfuncPerspective.py
+++ b/src/sas/qtgui/Perspectives/Corfunc/CorfuncPerspective.py
@@ -117,9 +117,9 @@ class CorfuncWindow(QtWidgets.QDialog, Ui_CorfuncDialog):
         self.txtLowerQMin.setEnabled(False)
 
         self._canvas = MyMplCanvas(self.model)
-        self.columnLayout.insertWidget(0, self._canvas)
+        self.plotLayout.insertWidget(0, self._canvas)
         self._realplot = MyMplCanvas(self.model)
-        self.columnLayout.insertWidget(1, self._realplot)
+        self.plotLayout.insertWidget(1, self._realplot)
 
         # Connect buttons to slots.
         # Needs to be done early so default values propagate properly.

--- a/src/sas/qtgui/Perspectives/Corfunc/CorfuncPerspective.py
+++ b/src/sas/qtgui/Perspectives/Corfunc/CorfuncPerspective.py
@@ -60,6 +60,8 @@ class MyMplCanvas(FigureCanvas):
             self.axes.axvline(qmax2)
             self.axes.set_xlim(min(self.data.x) / 2,
                                max(self.data.x) * 1.5 - 0.5 * min(self.data.x))
+            self.axes.set_ylim(min(self.data.y) / 2,
+                               max(self.data.y) * 1.5 - 0.5 * min(self.data.y))
         if self.extrap:
             self.axes.plot(self.extrap.x, self.extrap.y)
 

--- a/src/sas/qtgui/Perspectives/Corfunc/CorfuncPerspective.py
+++ b/src/sas/qtgui/Perspectives/Corfunc/CorfuncPerspective.py
@@ -121,6 +121,9 @@ class CorfuncWindow(QtWidgets.QDialog, Ui_CorfuncDialog):
         self._realplot = MyMplCanvas(self.model)
         self.plotLayout.insertWidget(1, self._realplot)
 
+        self.gridLayout_8.setColumnStretch(0, 1)
+        self.gridLayout_8.setColumnStretch(1, 3)
+
         # Connect buttons to slots.
         # Needs to be done early so default values propagate properly.
         self.setup_slots()

--- a/src/sas/qtgui/Perspectives/Corfunc/UI/CorfuncPanel.ui
+++ b/src/sas/qtgui/Perspectives/Corfunc/UI/CorfuncPanel.ui
@@ -319,7 +319,14 @@
            </widget>
           </item>
           <item row="0" column="1">
-           <widget class="QLineEdit" name="txtLongPeriod"/>
+           <widget class="QLineEdit" name="txtLongPeriod" width="50">
+	     <property name="minimumSize" stdset="0">
+	       <size>
+		 <width>60</width>
+		 <height>20</height>
+	       </size>
+	     </property>
+	   </widget>
           </item>
           <item row="0" column="2">
            <widget class="QLabel" name="label_15">
@@ -329,7 +336,14 @@
            </widget>
           </item>
           <item row="0" column="3">
-           <widget class="QLineEdit" name="txtAvgIntThick"/>
+           <widget class="QLineEdit" name="txtAvgIntThick">
+	     <property name="minimumSize" stdset="0">
+	       <size>
+		 <width>60</width>
+		 <height>20</height>
+	       </size>
+	     </property>
+	   </widget>
           </item>
           <item row="1" column="0">
            <widget class="QLabel" name="label_16">

--- a/src/sas/qtgui/Perspectives/Corfunc/UI/CorfuncPanel.ui
+++ b/src/sas/qtgui/Perspectives/Corfunc/UI/CorfuncPanel.ui
@@ -17,19 +17,6 @@
    <item row="0" column="0">
     <layout class="QVBoxLayout" name="mainVerticalLayout">
      <item>
-      <spacer name="verticalSpacer">
-       <property name="orientation">
-        <enum>Qt::Vertical</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>20</width>
-         <height>38</height>
-        </size>
-       </property>
-      </spacer>
-     </item>
-     <item>
       <widget class="QGroupBox" name="groupBox">
        <property name="title">
         <string>I(q) data source</string>
@@ -427,6 +414,19 @@
         </widget>
        </item>
       </layout>
+     </item>
+     <item>
+	<spacer name="verticalSpacer">
+	<property name="orientation">
+	    <enum>Qt::Vertical</enum>
+	</property>
+	<property name="sizeHint" stdset="0">
+	    <size>
+	    <width>20</width>
+	    <height>38</height>
+	    </size>
+	</property>
+	</spacer>
      </item>
     </layout>
    </item>

--- a/src/sas/qtgui/Perspectives/Corfunc/UI/CorfuncPanel.ui
+++ b/src/sas/qtgui/Perspectives/Corfunc/UI/CorfuncPanel.ui
@@ -417,7 +417,7 @@
     </layout>
    </item>
    <item row="0" column="1">
-    <layout class="QVBoxLayout" name="columnLayout">
+    <layout class="QVBoxLayout" name="plotLayout">
     </layout>
    </item>
   </layout>

--- a/src/sas/qtgui/Perspectives/Corfunc/UI/CorfuncPanel.ui
+++ b/src/sas/qtgui/Perspectives/Corfunc/UI/CorfuncPanel.ui
@@ -416,6 +416,10 @@
      </item>
     </layout>
    </item>
+   <item row="0" column="1">
+    <layout class="QVBoxLayout" name="columnLayout">
+    </layout>
+   </item>
   </layout>
  </widget>
  <resources/>

--- a/src/sas/sascalc/corfunc/transform_thread.py
+++ b/src/sas/sascalc/corfunc/transform_thread.py
@@ -44,10 +44,9 @@ class FourierThread(CalcThread):
             # ----- 3D Correlation Function -----
             # gamma3(R) = 1/R int_{0}^{R} gamma1(x) dx
             # trapz uses the trapezium rule to calculate the integral
-            mask = xs <= 200.0 # Only calculate gamma3 up to x=200 (as this is all that's plotted)
             # gamma3 = [trapz(gamma1[:n], xs[:n])/xs[n-1] for n in range(2, len(xs[mask]) + 1)]j
             # gamma3.insert(0, 1.0) # Gamma_3(0) is defined as 1
-            n = len(xs[mask])
+            n = len(xs)
             gamma3 = cumtrapz(gamma1[:n], xs[:n])/xs[1:n]
             gamma3 = np.hstack((1.0, gamma3)) # Gamma_3(0) is defined as 1
 
@@ -78,7 +77,7 @@ class FourierThread(CalcThread):
         self.update(msg="Fourier transform completed.")
 
         transform1 = Data1D(xs, gamma1)
-        transform3 = Data1D(xs[xs <= 200], gamma3)
+        transform3 = Data1D(xs, gamma3)
         idf = Data1D(xs, idf)
 
         transforms = (transform1, transform3, idf)


### PR DESCRIPTION
I've fixed the Corfunc perspective so that both the Q-Space extrapolation and the real space transform are both plotted.  Additionally, the plots are now included alongside the dialog on the right, instead of being squeezed in at the top, which make the plots easier to read.  Finally, I've added axes labels to the plots for additional clarity.

Ignore to odd colour scheme in the imags below.  That's a known issue with my computer alone.

Before

![before](https://user-images.githubusercontent.com/1728853/54922091-54551580-4eff-11e9-8056-875c73471d55.png)

After

![after](https://user-images.githubusercontent.com/1728853/54922102-5cad5080-4eff-11e9-8365-6c462d17219a.png)
