### PR TITLE
Ticket 1009: Added type of distribution used for PD parameters in report

### DIFF
--- a/src/sas/sascalc/fit/pagestate.py
+++ b/src/sas/sascalc/fit/pagestate.py
@@ -490,7 +490,12 @@ class PageState(object):
         Helper method to print a state
         """
         for item in list:
-            rep += "parameter name: %s \n" % str(item[1])
+            if str(item[1][-5:]) == 'width':
+                par = str(item[1][:-6])
+                pd_type = str(self.model.dispersion[par]['type'])
+                rep += "parameter name: %s (%s) \n" % (str(item[1]), pd_type)
+            else:
+                rep += "parameter name: %s \n" % str(item[1])
             rep += "value: %s\n" % str(item[2])
             rep += "selected: %s\n" % str(item[0])
             rep += "error displayed : %s \n" % str(item[4][0])


### PR DESCRIPTION
This small change adresses the initial purpose of ticket 1009, i.e. adding the information about the type of polydispersity distribution used in the fit to the report. The following discussion about the report format and contents needs more discussion and work.

