### PR TITLE
SasView Jira 1293

### DIFF
--- a/src/sas/qtgui/Plotting/Plotter.py
+++ b/src/sas/qtgui/Plotting/Plotter.py
@@ -81,11 +81,20 @@ class PlotterWidget(PlotterBase):
         is_fit = (self.data.id=="fit")
 
         if not is_fit:
+            logging.info("Plot")
+            logging.info(self.data.ytransform)
+            logging.info(self.data.isSesans)
             # make sure we have some function to operate on
             if self.data.xtransform is None:
-                self.data.xtransform = 'log10(x)'
+                if self.data.isSesans:
+                    self.data.xtransform='x'
+                else:
+                    self.data.xtransform = 'log10(x)'
             if self.data.ytransform is None:
-                self.data.ytransform = 'log10(y)'
+                if self.data.isSesans:
+                    self.data.ytransform='y'
+                else:
+                    self.data.ytransform = 'log10(y)'
             #Added condition to Dmax explorer from P(r) perspective
             if self.data._xaxis == 'D_{max}':
                 self.xscale = 'linear'

--- a/src/sas/qtgui/Plotting/Plotter.py
+++ b/src/sas/qtgui/Plotting/Plotter.py
@@ -81,9 +81,6 @@ class PlotterWidget(PlotterBase):
         is_fit = (self.data.id=="fit")
 
         if not is_fit:
-            logging.info("Plot")
-            logging.info(self.data.ytransform)
-            logging.info(self.data.isSesans)
             # make sure we have some function to operate on
             if self.data.xtransform is None:
                 if self.data.isSesans:

--- a/src/sas/qtgui/Plotting/UnitTesting/PlotterTest.py
+++ b/src/sas/qtgui/Plotting/UnitTesting/PlotterTest.py
@@ -80,7 +80,7 @@ class PlotterTest(unittest.TestCase):
     def testPlotWithSesans(self):
         """ Ensure that Sesans data is plotted in linear cooredinates"""
         data = Data1D(x=[1.0, 2.0, 3.0],
-                      y=[10.0, 11.0, 12.0],
+                      y=[-10.0, -11.0, -12.0],
                       dx=[0.1, 0.2, 0.3],
                       dy=[0.1, 0.2, 0.3])
         data.title = "Sesans data"
@@ -96,6 +96,10 @@ class PlotterTest(unittest.TestCase):
 
         self.assertEqual(self.plotter.ax.get_xscale(), 'linear')
         self.assertEqual(self.plotter.ax.get_yscale(), 'linear')
+        self.assertEqual(
+            len(self.plotter.data.view.y),
+            len(data.view.y))
+        self.assertEqual(self.plotter.data.ytransform, "y")
         self.assertTrue(FigureCanvas.draw_idle.called)
 
     def testCreateContextMenuQuick(self):

--- a/src/sas/qtgui/Plotting/UnitTesting/PlotterTest.py
+++ b/src/sas/qtgui/Plotting/UnitTesting/PlotterTest.py
@@ -96,9 +96,6 @@ class PlotterTest(unittest.TestCase):
 
         self.assertEqual(self.plotter.ax.get_xscale(), 'linear')
         self.assertEqual(self.plotter.ax.get_yscale(), 'linear')
-        self.assertEqual(
-            len(self.plotter.data.view.y),
-            len(data.view.y))
         self.assertEqual(self.plotter.data.ytransform, "y")
         self.assertTrue(FigureCanvas.draw_idle.called)
 


### PR DESCRIPTION
In the 5.0 GUI, SESANS data is correctly flagged that it should be plotted on a linear scale, instead of a log scale.  However, on a different abstraction level, the data is transformed to remove all of the negative values to prepare for log plotting.  Since SESANS data is always negative, this results with nothing being plotted.  There was an existing workaround of switch to log scale and then back to a linear scale, but this patch plots the data correctly on first load.

I've also modified the unit tests to catch any regressions.