### PR TITLE
Only show volfraction once if it appears in both P and S models.

### DIFF
--- a/src/sas/qtgui/Perspectives/Fitting/FittingLogic.py
+++ b/src/sas/qtgui/Perspectives/Fitting/FittingLogic.py
@@ -215,6 +215,8 @@ class FittingLogic(object):
         """
         plots = []
         for name, result in return_data['intermediate_results'].items():
+            if isinstance(result, tuple) and len(result) > 1:
+                result = result[1]
             if not isinstance(result, np.ndarray):
                 continue
             plots.append(self._create1DPlot(tab_id, return_data['x'], result,


### PR DESCRIPTION
Refs #1280, #1295, sasview/sasmodels#219, sasview/sasmodels#199, sasview/sasmodels#101.

Removes confusion when volfraction appears in both S and P models.  No longer supports volfraction renamed to volfraction_S or any other name collisions.   

This is a short-term fix.  Longer term address #1190, #1194 and sasview/sasmodels#231 to better decouple the GUI and the sasmodels library. 