### PR TITLE
Load in Mask Data column from NCNR 2D data.

### DIFF
--- a/src/sas/sascalc/dataloader/file_reader_base_class.py
+++ b/src/sas/sascalc/dataloader/file_reader_base_class.py
@@ -229,6 +229,11 @@ class FileReader(object):
                     data.dqy_data = data.dqy_data.astype(np.float64)
                 if data.mask is not None:
                     data.mask = data.mask.astype(dtype=bool)
+                    # If all mask elements are False, give a warning to the user
+                    if not data.mask.any():
+                        error = "The entire dataset is masked and may not "
+                        error += "produce usable fits."
+                        data.errors.append(error)
 
                 if len(data.data.shape) == 2:
                     n_rows, n_cols = data.data.shape

--- a/src/sas/sascalc/dataloader/readers/red2d_reader.py
+++ b/src/sas/sascalc/dataloader/readers/red2d_reader.py
@@ -226,6 +226,8 @@ class Reader(FileReader):
         if col_num > (5 + ver):
             dqy_data = data_point[(5 + ver)]
         #if col_num > (6 + ver): mask[data_point[(6 + ver)] < 1] = False
+        if col_num > (7 + ver):
+            mask = np.invert(np.asarray(data_point[(7 + ver)], dtype=bool))
         q_data = np.sqrt(qx_data*qx_data+qy_data*qy_data+qz_data*qz_data)
 
         # Extra protection(it is needed for some data files):

--- a/src/sas/sascalc/dataloader/readers/red2d_reader.py
+++ b/src/sas/sascalc/dataloader/readers/red2d_reader.py
@@ -230,11 +230,6 @@ class Reader(FileReader):
             mask = np.invert(np.asarray(data_point[(7 + ver)], dtype=bool))
         q_data = np.sqrt(qx_data*qx_data+qy_data*qy_data+qz_data*qz_data)
 
-        # Extra protection(it is needed for some data files):
-        # If all mask elements are False, put all True
-        if not mask.any():
-            mask[mask == False] = True
-
         # Store limits of the image in q space
         xmin = np.min(qx_data)
         xmax = np.max(qx_data)


### PR DESCRIPTION
The 2D data format from the VSANS instrument at the NCNR is now outputting a mask flag for each data point. This should read in the mask and format it so SasView can use it.

NB - I have no data sets with the mask column to test. The latest release of the Igor Macros (v7.93 - June 12, 2019) adds the mask data to the reduced data file. This PR may (should?) never get merged into master because we are actively working on writing VSANS data in NXcanSAS, which may supercede the .DAT format.