### PR TITLE
wx4 bug in fileconverter: AddSpacer interface is changed

### DIFF
--- a/src/sas/sasgui/perspectives/file_converter/converter_widgets.py
+++ b/src/sas/sasgui/perspectives/file_converter/converter_widgets.py
@@ -106,7 +106,7 @@ class VectorInput(object):
         self._inputs['x'] = x_input
         x_input.Bind(wx.EVT_TEXT, self._callback)
 
-        self._sizer.AddSpacer((10, -1))
+        self._sizer.AddSpacer(10)
 
         y_label = wx.StaticText(self.parent, -1, self.labels[1],
             style=wx.ALIGN_CENTER_VERTICAL)
@@ -118,7 +118,7 @@ class VectorInput(object):
         y_input.Bind(wx.EVT_TEXT, self._callback)
 
         if self.z_enabled:
-            self._sizer.AddSpacer((10, -1))
+            self._sizer.AddSpacer(10)
 
             z_label = wx.StaticText(self.parent, -1, self.labels[2],
                 style=wx.ALIGN_CENTER_VERTICAL)


### PR DESCRIPTION
Fixes small bug in setting file metadata for the file converter widget.  

AddSpacer interface changed between wxpython 3 and 4.

Tested against wx 3: `conda install -c travis wxpython`
```
11:20:02 - INFO : sas.sasview.sasview: 198: Python: 2.7.16 |Anaconda, Inc.| (default, Aug 22 2019, 10:59:10) 
11:20:03 - INFO : sas.sasview.sasview: 228: Wx version: 3.0.0.0
11:20:03 - INFO : sas.sasview.sasview: 229: Wx PlatformInfo: ('__WXMAC__', 'wxMac', 'unicode', 'wxOSX', 'wxOSX-cocoa', 'wx-assertions-on', 'SWIG-1.3.29')
```

and wx 4: `conda install wxpython`
```
11:20:58 - INFO : sas.sasview.sasview: 198: Python: 3.7.0 (default, Jun 28 2018, 07:39:16) 
11:20:58 - INFO : sas.sasview.sasview: 228: Wx version: 4.0.4
11:20:58 - INFO : sas.sasview.sasview: 229: Wx PlatformInfo: ('__WXMAC__', 'wxMac', 'unicode', 'unicode-wchar', 'wxOSX', 'wxOSX-cocoa', 'wx-assertions-on', 'phoenix', 'wxWidgets 3.0.5', 'autoidman', 'sip-4.19.13', 'build-type: development')
```