### PR TITLE
Skip Qt imports when building docs

### DIFF
--- a/docs/sphinx-docs/source/conf.py
+++ b/docs/sphinx-docs/source/conf.py
@@ -107,6 +107,8 @@ exclude_patterns = ["*sas.sasgui.perspectives.simulation.rst",
                     "*sas.sasgui.guiframe.custom_pstats.rst", # pstats not in standard library on Ubuntu out of the box
                     ]
 
+autodoc_mock_imports = ['sip', 'PyQt5']
+
 # The reST default role (used for this markup: `text`) to use for all documents.
 #default_role = None
 


### PR DESCRIPTION
Mock-out Qt imports from the autodoc calls so that Qt is not imported; importing Qt adds lots of noise to the docs and also requires a display to be available.