### PR TITLE
Don't build Qt GUI when setup.py is asked to clean

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -196,7 +196,8 @@ class BuildSphinxCommand(Command):
         import build_sphinx
         build_sphinx.rebuild()
 
-_ = subprocess.call([sys.executable, "src/sas/qtgui/convertUI.py"])
+if 'clean' not in sys.argv:
+    _ = subprocess.call([sys.executable, "src/sas/qtgui/convertUI.py"])
 
 # sas module
 package_dir["sas"] = os.path.join("src", "sas")


### PR DESCRIPTION
Calling "setup.py clean" should remove generated files and be fast, rather than creating lots of files and be slow. This patch at least stops "setup.py clean" from building the Qt GUI, although it doesn't clean up the generated files.

This is a bit of a crude hack; it's better than the current situation but far from perfect.