### PR TITLE
Test more on travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,8 @@ addons:
     - liblapack-dev
     - gfortran
     - libhdf5-serial-dev
+services:
+  - xvfb
 before_install:
 - echo $TRAVIS_OS_NAME
 - wget $MINICONDA -O miniconda.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,7 +45,7 @@ script:
 - git clone --depth=50 --branch=master https://github.com/SasView/sasmodels.git sasmodels
 - git clone --depth=50 --branch=master https://github.com/bumps/bumps.git
 - ls -ltr
-- if [ ! -d "utils" ]; then mkdir utils; fi
+- mkdir -p utils
 - /bin/sh -xe sasview/build_tools/travis_build.sh
 - export LC_ALL=en_US.UTF-8
 - export LANG=en_US.UTF-8

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,9 +36,9 @@ before_install:
 - hash -r
 #- conda update --yes conda
 - conda info -a
-- conda install --yes python=$PY numpy scipy cython pylint wxpython matplotlib lxml h5py sphinx pyparsing html5lib reportlab pybind11 appdirs six numba mako
+- conda install --yes python=$PY numpy scipy cython pylint wxpython matplotlib lxml h5py sphinx pyparsing html5lib reportlab pybind11 appdirs six numba mako ipython qtconsole
 install:
-- pip install periodictable xhtml2pdf unittest-xml-reporting pylint
+- pip install periodictable xhtml2pdf unittest-xml-reporting pylint qt5reactor
 # Note: use "... || true" below to silently ignore failure
 - pip install pyopencl
 script:

--- a/build_tools/travis_build.sh
+++ b/build_tools/travis_build.sh
@@ -58,3 +58,11 @@ done
 # TEST
 cd $WORKSPACE/sasview/test
 $PYTHON utest_sasview.py
+# If a display is available, also run the GUI tests
+if [ -n "$DISPLAY" ]; then
+  cd $WORKSPACE/sasview/src/sas/qtgui
+  # suppress errors from the GUI tests until a baseline 'pass' is obtained
+  $PYTHON GUITests.py || true
+else
+  echo "NOTE: GUITests.py skipped as no DISPLAY was found"
+fi

--- a/build_tools/travis_build.sh
+++ b/build_tools/travis_build.sh
@@ -51,6 +51,10 @@ $PYTHON build_sphinx.py
 cd $WORKSPACE/sasview/dist
 $EASY_INSTALL -d $WORKSPACE/sasview/sasview-install sasview*.egg
 
+for egg in $WORKSPACE/sasview/utils/*egg $WORKSPACE/sasview/sasview-install/*egg; do
+  PYTHONPATH=$egg:$PYTHONPATH
+done
+
 # TEST
 cd $WORKSPACE/sasview/test
 $PYTHON utest_sasview.py

--- a/build_tools/travis_build.sh
+++ b/build_tools/travis_build.sh
@@ -1,5 +1,4 @@
 # Simplified build for Travis CI
-# No documentation is built
 export PATH=$PATH:/usr/local/bin/
 
 PYTHON=${PYTHON:-`which python`}
@@ -39,6 +38,14 @@ cd $WORKSPACE/sasview
 $PYTHON setup.py clean
 # $PYTHON setup.py build docs bdist_egg
 $PYTHON setup.py bdist_egg
+
+# BUILD DOCS
+NUM=4
+mkdir -p ~/.sasmodels/compiled_models
+make PYTHON=$PYTHON -j $NUM -C $WORKSPACE/bumps/doc html
+make PYTHON=$PYTHON -j $NUM -C $WORKSPACE/sasmodels/doc html
+cd $WORKSPACE/sasview/docs/sphinx-docs/
+$PYTHON build_sphinx.py
 
 # INSTALL SASVIEW
 cd $WORKSPACE/sasview/dist

--- a/docs/sphinx-docs/build_sphinx.py
+++ b/docs/sphinx-docs/build_sphinx.py
@@ -181,7 +181,12 @@ def apidoc():
         "-o", SASVIEW_API_TARGET, # Output dir.
         "-d", "8", # Max depth of TOC.
         "-H", "SasView", # Package header
-        SASVIEW_BUILD
+        SASVIEW_BUILD,
+        # omit the following documents from the API documentation
+        joinpath(SASVIEW_BUILD, "sas", "qtgui", "GUITests.py"),
+        joinpath(SASVIEW_BUILD, "sas", "qtgui", "convertUI.py"),
+        joinpath(SASVIEW_BUILD, "sas", "sasview", "welcome_panel.py"),
+        joinpath(SASVIEW_BUILD, "sas", "sasview", "wxcruft.py"),
     ])
 
     subprocess.check_call([
@@ -190,7 +195,8 @@ def apidoc():
         "-d", "8", # Max depth of TOC.
         "-H", "sasmodels", # Package header
         SASMODELS_BUILD,
-        joinpath(SASMODELS_BUILD, "sasmodels", "models"), # exclude
+        # omit the following documents from the API documentation
+        joinpath(SASMODELS_BUILD, "sasmodels", "models"),
     ])
 
 def build_pdf():

--- a/docs/sphinx-docs/build_sphinx.py
+++ b/docs/sphinx-docs/build_sphinx.py
@@ -235,8 +235,10 @@ def build():
     print("=== Build HTML Docs from ReST Files ===")
     subprocess.check_call([
         "sphinx-build",
+        "-v",
         "-b", "html", # Builder name. TODO: accept as arg to setup.py.
         "-d", joinpath(SPHINX_BUILD, "doctrees"),
+        "-W", "--keep-going",
         SPHINX_SOURCE,
         joinpath(SPHINX_BUILD, "html")
     ])

--- a/docs/sphinx-docs/build_sphinx.py
+++ b/docs/sphinx-docs/build_sphinx.py
@@ -176,30 +176,35 @@ def apidoc():
     # Clean directory before generating a new version.
     #_remove_dir(SASVIEW_API_TARGET)
 
-    subprocess.call(["sphinx-apidoc",
-                     "-o", SASVIEW_API_TARGET, # Output dir.
-                     "-d", "8", # Max depth of TOC.
-                     "-H", "SasView", # Package header
-                     SASVIEW_BUILD])
+    subprocess.check_call([
+        "sphinx-apidoc",
+        "-o", SASVIEW_API_TARGET, # Output dir.
+        "-d", "8", # Max depth of TOC.
+        "-H", "SasView", # Package header
+        SASVIEW_BUILD
+    ])
 
-    subprocess.call(["sphinx-apidoc",
-                     "-o", SASMODELS_API_TARGET, # Output dir.
-                     "-d", "8", # Max depth of TOC.
-                     "-H", "sasmodels", # Package header
-                     SASMODELS_BUILD,
-                     joinpath(SASMODELS_BUILD, "sasmodels", "models"), # exclude
-                     ])
+    subprocess.check_call([
+        "sphinx-apidoc",
+        "-o", SASMODELS_API_TARGET, # Output dir.
+        "-d", "8", # Max depth of TOC.
+        "-H", "sasmodels", # Package header
+        SASMODELS_BUILD,
+        joinpath(SASMODELS_BUILD, "sasmodels", "models"), # exclude
+    ])
 
 def build_pdf():
     """
     Runs sphinx-build for pdf.  Reads in all .rst files and spits out the final html.
     """
     print("=== Build PDF Docs from ReST Files ===")
-    subprocess.call(["sphinx-build",
-                     "-b", "latex", # Builder name. TODO: accept as arg to setup.py.
-                     "-d", joinpath(SPHINX_BUILD, "doctrees"),
-                     SPHINX_SOURCE,
-                     joinpath(SPHINX_BUILD, "latex")])
+    subprocess.check_call([
+        "sphinx-build",
+        "-b", "latex", # Builder name. TODO: accept as arg to setup.py.
+        "-d", joinpath(SPHINX_BUILD, "doctrees"),
+        SPHINX_SOURCE,
+        joinpath(SPHINX_BUILD, "latex")
+    ])
 
     LATEXDIR = joinpath(SPHINX_BUILD, "latex")
     #TODO: Does it need to be done so many time?
@@ -222,11 +227,13 @@ def build():
     Runs sphinx-build.  Reads in all .rst files and spits out the final html.
     """
     print("=== Build HTML Docs from ReST Files ===")
-    subprocess.call(["sphinx-build",
-                     "-b", "html", # Builder name. TODO: accept as arg to setup.py.
-                     "-d", joinpath(SPHINX_BUILD, "doctrees"),
-                     SPHINX_SOURCE,
-                     joinpath(SPHINX_BUILD, "html")])
+    subprocess.check_call([
+        "sphinx-build",
+        "-b", "html", # Builder name. TODO: accept as arg to setup.py.
+        "-d", joinpath(SPHINX_BUILD, "doctrees"),
+        SPHINX_SOURCE,
+        joinpath(SPHINX_BUILD, "html")
+    ])
 
     print("=== Copy HTML Docs to Build Directory ===")
     html = joinpath(SPHINX_BUILD, "html")

--- a/docs/sphinx-docs/source/conf.py
+++ b/docs/sphinx-docs/source/conf.py
@@ -107,7 +107,7 @@ exclude_patterns = ["*sas.sasgui.perspectives.simulation.rst",
                     "*sas.sasgui.guiframe.custom_pstats.rst", # pstats not in standard library on Ubuntu out of the box
                     ]
 
-autodoc_mock_imports = ['sip', 'PyQt5']
+autodoc_mock_import = ['sip']
 
 # The reST default role (used for this markup: `text`) to use for all documents.
 #default_role = None

--- a/docs/sphinx-docs/source/user/tools.rst
+++ b/docs/sphinx-docs/source/user/tools.rst
@@ -26,4 +26,4 @@ Tools & Utilities
 
    Image Viewer <qtgui/Calculators/image_viewer_help>
 
-   File Converter <sasgui/perspectives/file_converter/file_converter_help>
+   File Converter <qtgui/Calculators/file_converter_help>

--- a/setup.py
+++ b/setup.py
@@ -109,8 +109,10 @@ class BuildSphinxCommand(Command):
 
 
 # _standard_ commands which should trigger the Qt build
-build_commands = ['install', 'build', 'build_py', 'bdist', 'bdist_rpm',
-                  'bdist_wheel', 'develop', 'test']
+build_commands = [
+    'install', 'build', 'build_py', 'bdist', 'bdist_egg', 'bdist_rpm',
+    'bdist_wheel', 'develop', 'test'
+]
 # determine if this run requires building of Qt GUI ui->py
 build_qt = any(c in sys.argv for c in build_commands)
 

--- a/src/sas/qtgui/GUITests.py
+++ b/src/sas/qtgui/GUITests.py
@@ -1,3 +1,4 @@
+import os
 import unittest
 import sys
 from PyQt5 import QtGui
@@ -229,3 +230,5 @@ if __name__ == "__main__":
             for r in errors[1]:
                     print("\nSuite: %s had following failures:\n %s : %s"%(suite, r[0], r[1]))
             print("=================================================")
+        print("Exiting with error")
+        os._exit(1)

--- a/src/sas/qtgui/Utilities/FileConverter.py
+++ b/src/sas/qtgui/Utilities/FileConverter.py
@@ -116,7 +116,7 @@ class FileConverterWidget(QtWidgets.QDialog, Ui_FileConverterUI):
 
     def onConvert(self):
         """
-        Call the conversion method (*and update DataExplorer with converted data)?
+        Call the conversion method (and update DataExplorer with converted data)?
         """
         self.readMetadata()
 
@@ -375,7 +375,7 @@ class FileConverterWidget(QtWidgets.QDialog, Ui_FileConverterUI):
         :return x_data: A 1D array containing all the x coordinates of the data
         :return y_data: A 1D array containing all the y coordinates of the data
         :return frame_data: A dictionary of the form *{frame_number: data}*,
-        where data is a 2D numpy array containing the intensity data
+            where data is a 2D numpy array containing the intensity data
         """
         loader = Utilities.BSLLoader(filename)
         frames = [0]

--- a/src/sas/sascalc/dataloader/loader.py
+++ b/src/sas/sascalc/dataloader/loader.py
@@ -55,12 +55,15 @@ class Registry(ExtensionRegistry):
     def load(self, path, format=None, debug=False, use_defaults=True):
         """
         Call the loader for the file type of path.
+
         :param path: file path
-        :param format: explicit extension, to force the use
-            of a particular reader
+        :param format: explicit extension, to force the use of a particular
+                       reader
         :param debug: when True, print the traceback for each loader that fails
-        :param use_defaults: Flag to use the default readers as a backup if the
+        :param use_defaults:
+            Flag to use the default readers as a backup if the
             main reader fails or no reader exists
+
         Defaults to the ascii (multi-column), cansas XML, and cansas NeXuS
         readers if no reader was registered for the file's extension.
         """

--- a/src/sas/sascalc/invariant/invariant.py
+++ b/src/sas/sascalc/invariant/invariant.py
@@ -148,8 +148,11 @@ class Guinier(Transform):
         return [self.radius, self.scale], [self.dradius, self.dscale]
 
     def evaluate_model(self, x):
-        """
-        return F(x)= scale* e-((radius*x)**2/3)
+        r"""
+        return calculated I(q) for the model
+
+        Calculates the Guinier expression
+        $F(x)= s * \exp\left(-(r x)^{2/3}\right)$
         """
         return self._guinier(x)
 
@@ -167,14 +170,16 @@ class Guinier(Transform):
         return np.array([math.sqrt(err) for err in diq2])
 
     def _guinier(self, x):
-        """
+        r"""
         Retrieve the guinier function after apply an inverse guinier function
         to x
-        Compute a F(x) = scale* e-((radius*x)**2/3).
+        Compute $F(x) = s * \exp\left(-(r x)^{2/3}\right)$.
 
         :param x: a vector of q values
-        :param scale: the scale value
-        :param radius: the guinier radius value
+
+        Also uses:
+         - self.scale: $s$, the scale value
+         - self.radius: $r$, the guinier radius value
 
         :return: F(x)
         """
@@ -204,7 +209,7 @@ class PowerLaw(Transform):
 
         :param value: q-value
 
-        :return: log(q)
+        :return: $\log(q)$
         """
         return math.log(value)
 
@@ -291,7 +296,7 @@ class Extrapolator(object):
 
     def fit(self, power=None, qmin=None, qmax=None):
         """
-        Fit data for y = ax + b  return a and b
+        Fit data for $y = ax + b$  return $a$ and $b$
 
         :param power: a fixed, otherwise None
         :param qmin: Minimum Q-value
@@ -608,7 +613,8 @@ class InvariantCalculator(object):
         """
         Compute the invariant for extrapolated data at low q range.
 
-        Implementation:
+        Implementation: ::
+
             data = self._get_extra_data_low()
             return self._get_qstar()
 
@@ -647,7 +653,8 @@ class InvariantCalculator(object):
         """
         Compute the invariant for extrapolated data at high q range.
 
-        Implementation:
+        Implementation: ::
+
             data = self._get_extra_data_high()
             return self._get_qstar()
 
@@ -816,11 +823,15 @@ class InvariantCalculator(object):
 
         Historically, Sv was computed with the invariant and the Porod
         constant so as not to have to know the contrast in order to get the
-        Sv as:
+        Sv as: ::
+
             surface = (pi * V * (1- V) * porod_const) / q_star
+
         However, that turns out to be a pointless exercise since it
         also requires a knowledge of the volume fractions and from the
-        volumer fraction and the invariant the contrast can be calculated as:
+        volume fraction and the invariant the contrast can be calculated
+        as: ::
+
             contrast**2 = q_star / (2 * pi**2 * V * (1- V))
 
         Thus either way, mathematically it is always identical to computing
@@ -829,10 +840,11 @@ class InvariantCalculator(object):
         circular approach.
 
         Implementation: ::
-           Given the above, as of SasView 4.3 and 5.0.2 we compute Sv simply
-           from the Porod Constant and the contrast between the two phases as:
-             surface = porod_const / (2 * pi contrast**2) 
 
+            Given the above, as of SasView 4.3 and 5.0.2 we compute Sv simply
+            from the Porod Constant and the contrast between the two phases as:
+
+            surface = porod_const / (2 * pi contrast**2)
 
         :param contrast: contrast between the two phases
         :param porod_const: Porod constant
@@ -849,7 +861,7 @@ class InvariantCalculator(object):
 
     def get_volume_fraction(self, contrast, extrapolation=None):
         """
-        Compute volume fraction is deduced as follow: ::
+        Compute volume fraction is deduced as follows: ::
 
             q_star = 2*(pi*contrast)**2* volume( 1- volume)
             for k = 10^(-8)*q_star/(2*(pi*|contrast|)**2)
@@ -924,16 +936,19 @@ class InvariantCalculator(object):
 
             sigV = dV/dq_star * sigq_star
             
-            so that
+        so that: ::
+
             sigV = (k * sigq_star) /(q_star * math.sqrt(1 - 4 * k))
 
             for k = 10^(-8)*q_star/(2*(pi*|contrast|)**2)
 
-            10^(-8) converts from cm^-1 to A^-1
-            q_star: the invariant, in cm^-1A^-3, including extrapolated values
-                if they have been requested
-            dq_star: the invariant uncertainty
-            dV: the volume uncertainty
+        Notes:
+
+        - 10^(-8) converts from cm^-1 to A^-1
+        - q_star: the invariant, in cm^-1A^-3, including extrapolated values
+          if they have been requested
+        - dq_star: the invariant uncertainty
+        - dV: the volume uncertainty
 
         The uncertainty will be set to -1 if it can't be computed.
 
@@ -964,13 +979,17 @@ class InvariantCalculator(object):
         from the contrast and porod_constant wich are currently user inputs
         with no option for any uncertainty so no uncertainty can be calculated.
         However we include the uncertainty computation for future use if and
-        when these values get an uncertainty. This is given as:
+        when these values get an uncertainty. This is given as: ::
 
-            ds = sqrt[(s'_cp)**2 * dcp**2 + (s'_contrast)**2 * dcontrast**2]
-            where s'_x is the partial derivative of S with respect to x 
-        which gives (this should be checked before using in anger)
+            ds = sqrt[(s\'_cp)**2 * dcp**2 + (s\'_contrast)**2 * dcontrast**2]
+
+        where s'_x is the partial derivative of S with respect to x
+
+        which gives (this should be checked before using in anger): ::
+
             ds = sqrt((dporod_const**2 * contrast**2 + 4 * (porod_const *
                           dcontrast)**2) / (4 * pi**2 * contrast**6))
+
         We also assume some users will never enter a value for uncertainty so
         allow for None even when it is an option.
 

--- a/src/sas/sascalc/pr/calc.py
+++ b/src/sas/sascalc/pr/calc.py
@@ -297,7 +297,7 @@ def positive_integral(pars, d_max, nslice):
     :param nslice: nslice.
 
     :return: The fraction of the integral of P(r) over the whole
-    range of r that is above 0.
+        range of r that is above 0.
     """
     dx = d_max/nslice
     r = np.linspace(0., d_max - dx, nslice)
@@ -320,7 +320,7 @@ def positive_errors(pars, err, d_max, nslice):
     :param nslice: nslice.
 
     :return: The fraction of the integral of P(r) over the whole range
-    of r that is at least one sigma above 0.
+        of r that is at least one sigma above 0.
     """
     dx = d_max/nslice
     r = np.linspace(0., d_max - dx, nslice)


### PR DESCRIPTION
Recent work updating the Debian packages for sasview indicated that the 5.0.0 release went out with tests that failed and documentation that couldn't be built. Some of these things were fixed immediately following the release while others have been in subsequent PRs.

Building the documentation and running `GUITests.py` on travis so that failures are visible earlier will make it easier to spot regressions and help improve the quality of the SasView releases.

This PR enables:
 * building of the documentation on travis-ci; the documentation build throws a lot of warnings some of which are undoubtedly bugs to be fixed.
 * running of `GUITests.py` (test runner for the Qt GUI); these tests currently fail on CI. Some of these will be easy to fix while some will not.

While this PR will cause the test checks on GitHub to go from "passing" to "failing", it is only because it is running more tests. I think it's important to enable these additional tests, to fix either tests or code in subsequent PRs and to then gate future merging on the tests successfully passing.

Thoughts?