### PR TITLE
Use same interpretor to build sasmodels

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -186,7 +186,12 @@ class BuildSphinxCommand(Command):
             if os.path.isdir(SASMODELS_DOCPATH):
                 # if available, build sasmodels docs
                 print("============= Building sasmodels model documentation ===============")
-                smdocbuild = subprocess.call(["make", "-C", SASMODELS_DOCPATH, "html"])
+                smdocbuild = subprocess.call([
+                    "make",
+                    "PYTHON=%s" % sys.executable,
+                    "-C", SASMODELS_DOCPATH,
+                    "html"
+                ])
         else:
             # if not available warning message
             print("== !!WARNING!! sasmodels directory not found. Cannot build model docs. ==")


### PR DESCRIPTION
`setup.py` will build the sasmodels documentation if it is not present. The documentation build should be performed with the same interpreter as `setup.py` is using. If the interpreter is not specified when calling `make`, then the path will be searched for an executable called `python`; this can mean accidentally switching from Python 3 to Python 2, with required tools like sphinx perhaps not being available for that interpreter.
