### PR TITLE
Drop qrc file from .ui to permit doc building

### DIFF
--- a/src/sas/qtgui/MainWindow/UI/TabbedFileLoadUI.ui
+++ b/src/sas/qtgui/MainWindow/UI/TabbedFileLoadUI.ui
@@ -346,8 +346,6 @@
    </layout>
   </widget>
  </widget>
- <resources>
-  <include location="../../UI/main_resources.qrc"/>
- </resources>
+ <resources/>
  <connections/>
 </ui>


### PR DESCRIPTION
`TabbedFileLoadUI.ui` refers to the resources file which then causes an `import main resources_rc` statement to be added to the bottom of the corresponding `TabbedFileLoadUI.py`. 

sphinx then dislikes this import:

> WARNING: autodoc: failed to import module 'TabbedFileLoadUI' from module 'sas.qtgui.MainWindow.UI'; the following exception was raised:
> No module named 'main_resources_rc'

(While this is currently only a warning, it does prevent apidocs being generated for that file; the documentation build needs to become free of warnings so that CI can be made to gate on the build passing. See #1399)

I've not been able to figure out whether it's the use of relative paths in the include or some other issue. Simply stopping `TabbedFileLoadUI.ui` from referring to the qrc file seems to be enough and the UI seemed unchanged. 

I don't know enough about PyQt to say whether this is the right solution. Someone with good PyQt should look at this carefully.