### PR TITLE
setuptools downgraded to 0.45

### DIFF
--- a/build_tools/conda_qt5_min_ubuntu.yml
+++ b/build_tools/conda_qt5_min_ubuntu.yml
@@ -19,7 +19,7 @@ dependencies:
  - pyqt>=5.9 # required for GTK themes to work correctly
  - testpath=0.3.1
  - numpy=1.14.3  # NEED TO DOWNGRADE NUMPY!!!
- - setuptools=45.0.0
+ - setuptools=41.6.0
 # - pyopencl
 # - pocl
  - pip:

--- a/build_tools/conda_qt5_min_ubuntu.yml
+++ b/build_tools/conda_qt5_min_ubuntu.yml
@@ -19,6 +19,7 @@ dependencies:
  - pyqt>=5.9 # required for GTK themes to work correctly
  - testpath=0.3.1
  - numpy=1.14.3  # NEED TO DOWNGRADE NUMPY!!!
+ - setuptools=45.0.0
 # - pyopencl
 # - pocl
  - pip:


### PR DESCRIPTION
Due to issue with pyinstaller we need to downgrade setuptools. 
https://github.com/pypa/setuptools/issues/1963
Testing if this works on build system. Don't review!