### PR TITLE
ESS GUI: Warn user when data set fully masked

### DIFF
--- a/src/sas/qtgui/MainWindow/DataExplorer.py
+++ b/src/sas/qtgui/MainWindow/DataExplorer.py
@@ -1265,7 +1265,7 @@ class DataExplorerWindow(DroppableDataLoadWidget):
                     if hasattr(item, 'errors'):
                         for error_data in item.errors:
                             data_error = True
-                            message += "\tError: {0}\n".format(error_data)
+                            error_message += "\tError: {0}\n".format(error_data)
                     else:
 
                         logging.error("Loader returned an invalid object:\n %s" % str(item))
@@ -1275,7 +1275,7 @@ class DataExplorerWindow(DroppableDataLoadWidget):
                 logging.error(sys.exc_info()[1])
 
                 any_error = True
-            if any_error or error_message != "":
+            if any_error or data_error or error_message != "":
                 if error_message == "":
                     error = "Error: " + str(sys.exc_info()[1]) + "\n"
                     error += "while loading Data: \n%s\n" % str(basename)

--- a/src/sas/sascalc/dataloader/file_reader_base_class.py
+++ b/src/sas/sascalc/dataloader/file_reader_base_class.py
@@ -229,6 +229,11 @@ class FileReader(object):
                     data.dqy_data = data.dqy_data.astype(np.float64)
                 if data.mask is not None:
                     data.mask = data.mask.astype(dtype=bool)
+                    # If all mask elements are False, give a warning to the user
+                    if not data.mask.any():
+                        error = "The entire dataset is masked and may not "
+                        error += "produce usable fits."
+                        data.errors.append(error)
 
                 if len(data.data.shape) == 2:
                     n_rows, n_cols = data.data.shape

--- a/src/sas/sascalc/dataloader/readers/red2d_reader.py
+++ b/src/sas/sascalc/dataloader/readers/red2d_reader.py
@@ -226,6 +226,8 @@ class Reader(FileReader):
         if col_num > (5 + ver):
             dqy_data = data_point[(5 + ver)]
         #if col_num > (6 + ver): mask[data_point[(6 + ver)] < 1] = False
+        if col_num > (7 + ver):
+            mask = np.invert(np.asarray(data_point[(7 + ver)], dtype=bool))
         q_data = np.sqrt(qx_data*qx_data+qy_data*qy_data+qz_data*qz_data)
 
         # Store limits of the image in q space

--- a/src/sas/sascalc/dataloader/readers/red2d_reader.py
+++ b/src/sas/sascalc/dataloader/readers/red2d_reader.py
@@ -228,11 +228,6 @@ class Reader(FileReader):
         #if col_num > (6 + ver): mask[data_point[(6 + ver)] < 1] = False
         q_data = np.sqrt(qx_data*qx_data+qy_data*qy_data+qz_data*qz_data)
 
-        # Extra protection(it is needed for some data files):
-        # If all mask elements are False, put all True
-        if not mask.any():
-            mask[mask == False] = True
-
         # Store limits of the image in q space
         xmin = np.min(qx_data)
         xmax = np.max(qx_data)


### PR DESCRIPTION
This PR matches 5.x up to the 4.x branch by attaching a warning to any data set that is fully masked when it is loaded. The first of the two commits has already been merged into the ESS_GUI branch, but the 2nd commit (cherry-picked here) has not.

The PR for the 4.x branch: #1356 
The 1st PR for the 5.x branch: #1368 