### PR TITLE
Ticket 1462: Default to linear axes for P(r) plot

### DIFF
--- a/src/sas/qtgui/Perspectives/Inversion/InversionLogic.py
+++ b/src/sas/qtgui/Perspectives/Inversion/InversionLogic.py
@@ -150,7 +150,8 @@ class InversionLogic(object):
         new_plot.yaxis("\\rm{P(r)} ", "cm^{-3}")
         new_plot.title = "P(r) fit"
         new_plot.id = PR_FIT_LABEL
-        new_plot.scale = "linear"
+        new_plot.xtransform = "x"
+        new_plot.ytransform = "y"
         new_plot.group_id = GROUP_ID_PR_FIT
 
         return new_plot


### PR DESCRIPTION
This is a fix for #1462. The P(r) plot now defaults to linear x and y axes.