### PR TITLE
4.x: Check packages comparison to YAML files

### DIFF
--- a/check_packages.py
+++ b/check_packages.py
@@ -4,10 +4,16 @@ Check the existing environment against expected values
 from __future__ import print_function
 
 import sys
-import yaml
 import subprocess
-
-from colorama import Fore, Style
+try:
+    import yaml
+    from colorama import Fore, Style
+except ImportError:
+    print("The PyYaml and colorama packages are required for this module. To " +
+          "install them, please try one of the following:")
+    print("\tAnaconda: conda install pyyaml colorama")
+    print("\tBase python: pip install pyyaml colorama")
+    quit()
 
 
 # Output strings

--- a/check_packages.py
+++ b/check_packages.py
@@ -10,41 +10,48 @@ from colorama import Fore, Back, Style
 
 
 if sys.platform == 'win32':
-    file_location = 'build_tools/conda/ymls/sasview-env-build_win.yml'
+    file_location = './build_tools/conda/ymls/sasview-env-build_win.yml'
 elif sys.platform == 'darwin':
-    file_location = 'build_tools/conda/ymls/sasview-env-build_osx.yml'
+    file_location = './build_tools/conda/ymls/sasview-env-build_osx.yml'
 else:
-    file_location = 'build_tools/conda/ymls/sasview-env-build_linux.yml'
+    file_location = './build_tools/conda/ymls/sasview-env-build_linux.yml'
 
 with open(file_location, 'r') as stream:
     try:
         yaml_dict = yaml.load(stream, Loader=yaml.SafeLoader)
-        print(yaml_dict)
         common_required_package_list = yaml_dict['dependencies']
     except Exception as e:
         print(e)
 
-print(Style.RESET_ALL)
-print("CHECKING REQUIRED PACKAGES....")
+print("")
+print(Style.RESET_ALL +
+      "....COMPARING PACKAGES LISTED IN {0} to INSTALLED PACKAGES....".format(
+          file_location))
+print("")
 
 for yaml_name in common_required_package_list:
-    text_split = yaml_name.split('=')
+    try:
+        text_split = yaml_name.split('=')
+    except AttributeError as e:
+        # Continue for tiered files including pip installs
+        continue
     package_name = text_split[0]
     package_version = text_split[1]
 
-    print(Style.RESET_ALL)
     try:
-        i = __import__(package_name, fromlist=[''])
-        if package_version is None:
-            print("%s Installed (Unknown version)" % package_name)
-        elif package_name == 'lxml':
-            verstring = str(getattr(i, 'LXML_VERSION'))
-            print("%s Version Installed: %s" % (package_name, verstring.replace(', ', '.').lstrip('(').rstrip(')')))
+        if package_name == 'python':
+            full_version = sys.version.split()
+            installed_version = full_version[0]
         else:
-            print("%s Version Installed: %s" % (package_name, getattr(i, '__version__')))
+            i = __import__(package_name, fromlist=[''])
+            installed_version = getattr(i, '__version__')
+        if package_version == installed_version:
+            print(Style.RESET_ALL + "{0} - Expected Version Installed: {1}".format(package_name, installed_version))
+        else:
+            print(Fore.LIGHTYELLOW_EX + "{0} - Version Mismatch - Installed: {1}, Expected: {2}".format(package_name, installed_version, package_version))
     except AttributeError:
-        print("%s Installed (Unknown version)" % package_name)
+        print(Fore.YELLOW + "{0} - Version Cannot Be Determined - Expected: {1}".format(package_name, package_version))
     except ImportError:
-        print(Fore.BLACK + Back.WHITE + '%s NOT INSTALLED' % package_name)
+        print(Fore.LIGHTRED_EX + '{0} NOT INSTALLED'.format(package_name))
 
 print(Style.RESET_ALL)

--- a/check_packages.py
+++ b/check_packages.py
@@ -3,6 +3,7 @@ Check the existing environment against expected values
 """
 from __future__ import print_function
 
+import re
 import sys
 import subprocess
 try:
@@ -37,19 +38,10 @@ with open(file_location, 'r') as stream:
     try:
         yaml_dict = yaml.load(stream, Loader=yaml.SafeLoader)
         yaml_packages = yaml_dict['dependencies']
-        common_required_package_list = []
-        pip_packages = yaml_packages.pop()
-        inter_package_list = yaml_packages
-        if isinstance(pip_packages, dict):
-            pip_packages = pip_packages['pip']
-            for pip_package in pip_packages:
-                inter_package_list.append(pip_package)
-        else:
-            inter_package_list = yaml_packages.append(pip_packages)
-        for package in inter_package_list:
-            package = package.replace(">=",
-                                      "=").replace("<=", "=").replace("==", "=")
-            common_required_package_list.append(package)
+        inter_package_list = [p for entry in yaml_packages for p in (
+            entry['pip'] if isinstance(entry, dict) else [entry])]
+        common_required_package_list = [re.sub("[<>=]=", "=", package) for
+                                        package in inter_package_list]
     except Exception as e:
         print(e)
 

--- a/check_packages.py
+++ b/check_packages.py
@@ -1,14 +1,24 @@
 """
-Checking and reinstalling the external packages
+Check the existing environment against expected values
 """
 from __future__ import print_function
 
 import sys
 import yaml
+import subprocess
 
-from colorama import Fore, Back, Style
+from colorama import Fore, Style
 
 
+# Output strings
+CORRECT = Style.RESET_ALL + "{0} - Expected Version Installed: {1}"
+VERSION_MISMATCH = Fore.LIGHTYELLOW_EX +\
+          "{0} - Version Mismatch - Installed: {1}, Expected: {2}"
+VERSION_UNKNOWN = Fore.YELLOW +\
+                  "{0} - Version Cannot Be Determined - Expected: {1}"
+NOT_INSTALLED = Fore.LIGHTRED_EX + '{0} NOT INSTALLED'
+
+# Location of yaml files
 if sys.platform == 'win32':
     file_location = './build_tools/conda/ymls/sasview-env-build_win.yml'
 elif sys.platform == 'darwin':
@@ -16,6 +26,7 @@ elif sys.platform == 'darwin':
 else:
     file_location = './build_tools/conda/ymls/sasview-env-build_linux.yml'
 
+# Open yaml and get packages
 with open(file_location, 'r') as stream:
     try:
         yaml_dict = yaml.load(stream, Loader=yaml.SafeLoader)
@@ -23,19 +34,44 @@ with open(file_location, 'r') as stream:
     except Exception as e:
         print(e)
 
+# Get list of system packages (conda or pip)
+isConda = True
+try:
+    reqs = subprocess.check_output(['conda', 'list'])
+except Exception:
+    reqs = subprocess.check_output([sys.executable, '-m', 'pip', 'freeze'])
+    isConda = False
+
+packages_installed = []
+versions_installed = []
+
+if isConda:
+    for r in reqs.splitlines():
+        if r.decode().split()[0] == "#" or len(r.decode().split()) < 2:
+            continue
+        package = r.decode().split()[0].lower()
+        version = r.decode().split()[1]
+        packages_installed.append(package)
+        versions_installed.append(version)
+else:
+    packages_installed = [r.decode().split('==')[0].lower() for r in
+                          reqs.split()]
+    versions_installed = [r.decode().split('==')[1] for r in reqs.split()]
+
 print("")
 print(Style.RESET_ALL +
       "....COMPARING PACKAGES LISTED IN {0} to INSTALLED PACKAGES....".format(
           file_location))
 print("")
 
+# Step through each yaml package and check its version against system
 for yaml_name in common_required_package_list:
     try:
         text_split = yaml_name.split('=')
     except AttributeError as e:
         # Continue for tiered files including pip installs
         continue
-    package_name = text_split[0]
+    package_name = text_split[0].lower()
     package_version = text_split[1]
 
     try:
@@ -43,15 +79,16 @@ for yaml_name in common_required_package_list:
             full_version = sys.version.split()
             installed_version = full_version[0]
         else:
-            i = __import__(package_name, fromlist=[''])
-            installed_version = getattr(i, '__version__')
+            i = packages_installed.index(package_name)
+            installed_version = versions_installed[i]
         if package_version == installed_version:
-            print(Style.RESET_ALL + "{0} - Expected Version Installed: {1}".format(package_name, installed_version))
+            print(CORRECT.format(package_name, installed_version))
         else:
-            print(Fore.LIGHTYELLOW_EX + "{0} - Version Mismatch - Installed: {1}, Expected: {2}".format(package_name, installed_version, package_version))
+            print(VERSION_MISMATCH.format(package_name, installed_version,
+                                          package_version))
     except AttributeError:
-        print(Fore.YELLOW + "{0} - Version Cannot Be Determined - Expected: {1}".format(package_name, package_version))
-    except ImportError:
-        print(Fore.LIGHTRED_EX + '{0} NOT INSTALLED'.format(package_name))
+        print(VERSION_UNKNOWN.format(package_name, package_version))
+    except ValueError:
+        print(NOT_INSTALLED.format(package_name))
 
 print(Style.RESET_ALL)

--- a/check_packages.py
+++ b/check_packages.py
@@ -4,99 +4,47 @@ Checking and reinstalling the external packages
 from __future__ import print_function
 
 import sys
+import yaml
 
-# Fix for error: hash-collision-3-both-1-and-1/
-# See http://jaredforsyth.com/blog/2010/apr/28/accessinit-hash-collision-3-both-1-and-1/
-try:
-    import PIL.Image
-except ImportError:
-    pass
+from colorama import Fore, Back, Style
+
+
+if sys.platform == 'win32':
+    file_location = 'build_tools/conda/ymls/sasview-env-build_win.yml'
+elif sys.platform == 'darwin':
+    file_location = 'build_tools/conda/ymls/sasview-env-build_osx.yml'
 else:
-    sys.modules['Image'] = PIL.Image
+    file_location = 'build_tools/conda/ymls/sasview-env-build_linux.yml'
 
-if sys.version_info[0] > 2:
-    print("To use the sasview GUI you must use Python 2\n")
-
-common_required_package_list = {
-    'setuptools': {'version': '0.6c11', 'import_name': 'setuptools', 'test': '__version__'},
-    'pyparsing': {'version': '1.5.5', 'import_name': 'pyparsing', 'test': '__version__'},
-    'html5lib': {'version': '0.95', 'import_name': 'html5lib', 'test': '__version__'},
-    'reportlab': {'version': '2.5', 'import_name': 'reportlab', 'test': 'Version'},
-    'h5py': {'version': '2.5', 'import_name': 'h5py', 'test': '__version__'},
-    'lxml': {'version': '2.3', 'import_name': 'lxml.etree', 'test': 'LXML_VERSION'},
-    'PIL': {'version': '1.1.7', 'import_name': 'Image', 'test': 'VERSION'},
-    'pylint': {'version': None, 'import_name': 'pylint', 'test': None},
-    'periodictable': {'version': '1.5.0', 'import_name': 'periodictable', 'test': '__version__'},
-    'bumps': {'version': '0.7.5.9', 'import_name': 'bumps', 'test': '__version__'},
-    'numpy': {'version': '1.7.1', 'import_name': 'numpy', 'test': '__version__'},
-    'scipy': {'version': '0.18.0', 'import_name': 'scipy', 'test': '__version__'},
-    'wx': {'version': '2.8.12.1', 'import_name': 'wx', 'test': '__version__'},
-    'matplotlib': {'version': '1.1.0', 'import_name': 'matplotlib', 'test': '__version__'},
-    'xhtml2pdf': {'version': '3.0.33', 'import_name': 'xhtml2pdf', 'test': '__version__'},
-    'sphinx': {'version': '1.2.1', 'import_name': 'sphinx', 'test': '__version__'},
-    'unittest-xml-reporting': {'version': '1.10.0', 'import_name': 'xmlrunner', 'test': '__version__'},
-    'pyopencl': {'version': '2015.1', 'import_name': 'pyopencl', 'test': 'VERSION_TEXT'},
-}
-win_required_package_list = {
-    'comtypes': {'version': '0.6.2', 'import_name': 'comtypes', 'test': '__version__'},
-    'pywin': {'version': '217', 'import_name': 'pywin', 'test': '__version__'},
-    'py2exe': {'version': '0.6.9', 'import_name': 'py2exe', 'test': '__version__'},
-}
-mac_required_package_list = {
-    'py2app': {'version': None, 'import_name': 'py2app', 'test': '__version__'},
-}
-
-deprecated_package_list = {
-    'pyPdf': {'version': '1.13', 'import_name': 'pyPdf', 'test': '__version__'},
-}
-
-print("Checking Required Package Versions....\n")
-print("Common Packages")
-
-for package_name, test_vals in common_required_package_list.items():
+with open(file_location, 'r') as stream:
     try:
-        i = __import__(test_vals['import_name'], fromlist=[''])
-        if test_vals['test'] is None:
+        yaml_dict = yaml.load(stream, Loader=yaml.SafeLoader)
+        print(yaml_dict)
+        common_required_package_list = yaml_dict['dependencies']
+    except Exception as e:
+        print(e)
+
+print(Style.RESET_ALL)
+print("CHECKING REQUIRED PACKAGES....")
+
+for yaml_name in common_required_package_list:
+    text_split = yaml_name.split('=')
+    package_name = text_split[0]
+    package_version = text_split[1]
+
+    print(Style.RESET_ALL)
+    try:
+        i = __import__(package_name, fromlist=[''])
+        if package_version is None:
             print("%s Installed (Unknown version)" % package_name)
         elif package_name == 'lxml':
             verstring = str(getattr(i, 'LXML_VERSION'))
-            print("%s Version Installed: %s"% (package_name, verstring.replace(', ', '.').lstrip('(').rstrip(')')))
+            print("%s Version Installed: %s" % (package_name, verstring.replace(', ', '.').lstrip('(').rstrip(')')))
         else:
-            print("%s Version Installed: %s"% (package_name, getattr(i, test_vals['test'])))
+            print("%s Version Installed: %s" % (package_name, getattr(i, '__version__')))
+    except AttributeError:
+        print("%s Installed (Unknown version)" % package_name)
     except ImportError:
-        print('%s NOT INSTALLED'% package_name)
+        print(Fore.BLACK + Back.WHITE + '%s NOT INSTALLED' % package_name)
 
-if sys.platform == 'win32':
-    print("")
-    print("Windows Specific Packages:")
-    for package_name, test_vals in win_required_package_list.items():
-        try:
-            i = __import__(test_vals['import_name'], fromlist=[''])
-            print("%s Version Installed: %s"% (package_name, getattr(i, test_vals['test'], "unknown")))
-        except ImportError:
-            print('%s NOT INSTALLED'% package_name)
-
-if sys.platform == 'darwin':
-    print("")
-    print("MacOS Specific Packages:")
-    for package_name, test_vals in mac_required_package_list.items():
-        try:
-            i = __import__(test_vals['import_name'], fromlist=[''])
-            print("%s Version Installed: %s"% (package_name, getattr(i, test_vals['test'])))
-        except ImportError:
-            print('%s NOT INSTALLED'% package_name)
-
-
-print("")
-print("Deprecated Packages")
-print("You can remove these unless you need them for other reasons!")
-for package_name, test_vals in deprecated_package_list.items():
-    try:
-        i = __import__(test_vals['import_name'], fromlist=[''])
-        if package_name == 'pyPdf':
-            # pyPdf doesn't have the version number internally
-            print('pyPDF Installed (Version unknown)')
-        else:
-            print("%s Version Installed: %s"% (package_name, getattr(i, test_vals['test'])))
-    except ImportError:
-        print('%s NOT INSTALLED'% package_name)
+print(Style.RESET_ALL)


### PR DESCRIPTION
As suggested yesterday, check_packages.py in master now compares the appropriate yaml file against what is currently installed on the users system. I've added two new dependencies that might need to be incorporated into the existing yaml files, but I only have a Windows system right now. The 5.x fix is a little more complex due to the number of yaml files in the branch so I haven't finished it yet.

Features:
- Checks the installed packages against the yaml file, including version numbers
- Flags packages that aren't installed as a major issue
- Flags packages with unexpected or unknown versions as a minor issue

Possible TODOs:
- Add PyYaml and colorama to the dependency files