### PR TITLE
Added utf-8 specs to open plugin file. Addressing #1431

### DIFF
--- a/src/sas/qtgui/Utilities/TabbedModelEditor.py
+++ b/src/sas/qtgui/Utilities/TabbedModelEditor.py
@@ -145,7 +145,7 @@ class TabbedModelEditor(QtWidgets.QDialog, Ui_TabbedModelEditor):
         Performs the load operation and updates the view
         """
         self.editor_widget.blockSignals(True)
-        with open(filename, 'r') as plugin:
+        with open(filename, 'r', encoding="utf-8") as plugin:
             self.editor_widget.txtEditor.setPlainText(plugin.read())
         self.editor_widget.setEnabled(True)
         self.editor_widget.blockSignals(False)
@@ -164,7 +164,7 @@ class TabbedModelEditor(QtWidgets.QDialog, Ui_TabbedModelEditor):
         self.c_editor_widget = ModelEditor(self, is_python=False)
         self.tabWidget.addTab(self.c_editor_widget, display_name)
         # Read in the file and set in on the widget
-        with open(c_path, 'r') as plugin:
+        with open(c_path, 'r', encoding="utf-8") as plugin:
             self.c_editor_widget.txtEditor.setPlainText(plugin.read())
         self.c_editor_widget.modelModified.connect(self.editorModelModified)
 
@@ -412,7 +412,7 @@ class TabbedModelEditor(QtWidgets.QDialog, Ui_TabbedModelEditor):
         """
         Write model content to file "fname"
         """
-        with open(fname, 'w') as out_f:
+        with open(fname, 'w', encoding="utf-8") as out_f:
             out_f.write(model_str)
 
     def generateModel(self, model, fname):


### PR DESCRIPTION
When loading plugin model with a spurious unicode character plugin editor crashes #1431