### PR TITLE
Ess gui 1522 poly check

### DIFF
--- a/src/sas/qtgui/Perspectives/Fitting/ComplexConstraint.py
+++ b/src/sas/qtgui/Perspectives/Fitting/ComplexConstraint.py
@@ -137,7 +137,7 @@ class ComplexConstraint(QtWidgets.QDialog, Ui_ComplexConstraintUI):
         Tooltip for txtConstraint
         """
         p1 = self.tab_names[0] + ":" + self.cbParam1.currentText()
-        p2 = self.tab_names[1] if len(self.tab_names) != 1 else self.tab_names[0] +"."+self.cbParam2.currentText()
+        p2 = self.tab_names[1] +"."+self.cbParam2.currentText() if len(self.tab_names) != 1 else self.tab_names[0] +"."+self.cbParam2.currentText()
         tooltip = "E.g.\n%s = 2.0 * (%s)\n" %(p1, p2)
         tooltip += "%s = sqrt(%s) + 5"%(p1, p2)
         self.txtConstraint.setToolTip(tooltip)

--- a/src/sas/qtgui/Perspectives/Fitting/FittingWidget.py
+++ b/src/sas/qtgui/Perspectives/Fitting/FittingWidget.py
@@ -1405,10 +1405,8 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
                 if parameter_name_w in self.poly_params_to_fit:
                     self.poly_params_to_fit.remove(parameter_name_w)
             self.cmdFit.setEnabled(self.haveParamsToFit())
-            # force data update
-            key = parameter_name + '.' + delegate.columnDict()[delegate.poly_pd]
-            self.poly_params[key] = value
-            self.updateData()
+            # Update state stack
+            self.updateUndo()
 
         elif model_column in [delegate.poly_min, delegate.poly_max]:
             try:

--- a/src/sas/qtgui/Perspectives/Fitting/UnitTesting/FittingWidgetTest.py
+++ b/src/sas/qtgui/Perspectives/Fitting/UnitTesting/FittingWidgetTest.py
@@ -442,6 +442,8 @@ class FittingWidgetTest(unittest.TestCase):
         self.widget._poly_model.item(0,0).setCheckState(2)
         # Assure the parameter is added
         self.assertEqual(self.widget.poly_params_to_fit, ['radius_bell.width'])
+        # Check that it's value has not changed (reproduce the polydispersity checkbox bug)
+        self.assertEqual(self.widget.poly_params['radius_bell.width'], 0.0)
 
         # Add another parameter
         self.widget._poly_model.item(2,0).setCheckState(2)


### PR DESCRIPTION
fixes #1522 
Wrong behaviour was caused by a the PD value attributed to the checkbox state. Also added a test that will fail if the bug happens.