### PR TITLE
Ess gui 1538 poly constraints

### DIFF
--- a/src/sas/qtgui/Perspectives/Fitting/FittingWidget.py
+++ b/src/sas/qtgui/Perspectives/Fitting/FittingWidget.py
@@ -1439,6 +1439,7 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
                 return
             key = parameter_name + '.' + delegate.columnDict()[model_column]
             self.poly_params[key] = value
+            self.kernel_module.setParam(key, value)
 
             # Update plot
             self.updateData()

--- a/src/sas/qtgui/Perspectives/Fitting/FittingWidget.py
+++ b/src/sas/qtgui/Perspectives/Fitting/FittingWidget.py
@@ -1423,7 +1423,7 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
                 # Can't be converted properly, bring back the old value and exit
                 return
 
-            current_details = self.kernel_module.details[parameter_name]
+            current_details = self.kernel_module.details[parameter_name + '.width']
             if self.has_poly_error_column:
                 # err column changes the indexing
                 current_details[model_column-2] = value

--- a/src/sas/qtgui/Perspectives/Fitting/FittingWidget.py
+++ b/src/sas/qtgui/Perspectives/Fitting/FittingWidget.py
@@ -508,11 +508,9 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         # Set sasmodel polydispersity to 0 if polydispersity is unchecked, if not use Qmodel values
         if self._poly_model.rowCount() > 0:
             for key, value in self.poly_params.items():
-                if key[-5:] == 'width':
-                    if isChecked:
-                        self.kernel_module.setParam(key, value)
-                    else:
-                        self.kernel_module.setParam(key, 0)
+                if key[-6:] == '.width':
+                    self.kernel_module.setParam(key, (value if isChecked else 0))
+
 
     def toggleMagnetism(self, isChecked):
         """ Enable/disable the magnetism tab """

--- a/src/sas/qtgui/Perspectives/Fitting/FittingWidget.py
+++ b/src/sas/qtgui/Perspectives/Fitting/FittingWidget.py
@@ -505,6 +505,14 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         self.tabFitting.setTabEnabled(TAB_POLY, isChecked)
         # Check if any parameters are ready for fitting
         self.cmdFit.setEnabled(self.haveParamsToFit())
+        # Set sasmodel polydispersity to 0 if polydispersity is unchecked, if not use Qmodel values
+        if self._poly_model.rowCount() > 0:
+            for key, value in self.poly_params.items():
+                if key[-5:] == 'width':
+                    if isChecked:
+                        self.kernel_module.setParam(key, value)
+                    else:
+                        self.kernel_module.setParam(key, 0)
 
     def toggleMagnetism(self, isChecked):
         """ Enable/disable the magnetism tab """

--- a/src/sas/qtgui/Perspectives/Fitting/FittingWidget.py
+++ b/src/sas/qtgui/Perspectives/Fitting/FittingWidget.py
@@ -1399,12 +1399,12 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
             parameter_name = parameter_name.rsplit()[-1]
 
         delegate = self.lstPoly.itemDelegate()
+        parameter_name_w = parameter_name + '.width'
 
         # Extract changed value.
         if model_column == delegate.poly_parameter:
             # Is the parameter checked for fitting?
             value = item.checkState()
-            parameter_name_w = parameter_name + '.width'
             if value == QtCore.Qt.Checked:
                 self.poly_params_to_fit.append(parameter_name_w)
             else:
@@ -1421,7 +1421,7 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
                 # Can't be converted properly, bring back the old value and exit
                 return
 
-            current_details = self.kernel_module.details[parameter_name + '.width']
+            current_details = self.kernel_module.details[parameter_name_w]
             if self.has_poly_error_column:
                 # err column changes the indexing
                 current_details[model_column-2] = value

--- a/src/sas/qtgui/Perspectives/Fitting/UnitTesting/FittingWidgetTest.py
+++ b/src/sas/qtgui/Perspectives/Fitting/UnitTesting/FittingWidgetTest.py
@@ -469,8 +469,15 @@ class FittingWidgetTest(unittest.TestCase):
         self.assertEqual(self.widget.poly_params['radius_bell.width'], 0.0)
         self.widget._poly_model.item(0,1).setText("0.8")
         self.assertAlmostEqual(self.widget.poly_params['radius_bell.width'], 0.8)
-        # test that sasmodel is updated with the new value
+        # Test that sasmodel is updated with the new value
         self.assertAlmostEqual(self.widget.kernel_module.getParam('radius_bell.width'), 0.8)
+
+        # Uncheck pd
+        self.widget.chkPolydispersity.setCheckState(False)
+        # Should not change the value of the qt model
+        self.assertAlmostEqual(self.widget.poly_params['radius_bell.width'], 0.8)
+        # sasmodel should be set to 0
+        self.assertAlmostEqual(self.widget.kernel_module.getParam('radius_bell.width'), 0.0)
 
         # try something stupid
         self.widget._poly_model.item(0,4).setText("butt")

--- a/src/sas/qtgui/Perspectives/Fitting/UnitTesting/FittingWidgetTest.py
+++ b/src/sas/qtgui/Perspectives/Fitting/UnitTesting/FittingWidgetTest.py
@@ -472,8 +472,9 @@ class FittingWidgetTest(unittest.TestCase):
         # Test that sasmodel is updated with the new value
         self.assertAlmostEqual(self.widget.kernel_module.getParam('radius_bell.width'), 0.8)
 
-        # Uncheck pd
-        self.widget.chkPolydispersity.setCheckState(False)
+        # Uncheck pd in the fitting widget
+        self.widget.chkPolydispersity.setCheckState(2)
+        self.widget.chkPolydispersity.click()
         # Should not change the value of the qt model
         self.assertAlmostEqual(self.widget.poly_params['radius_bell.width'], 0.8)
         # sasmodel should be set to 0

--- a/src/sas/qtgui/Perspectives/Fitting/UnitTesting/FittingWidgetTest.py
+++ b/src/sas/qtgui/Perspectives/Fitting/UnitTesting/FittingWidgetTest.py
@@ -462,6 +462,16 @@ class FittingWidgetTest(unittest.TestCase):
         self.assertEqual(self.widget.poly_params['radius_bell.npts'], 35)
         self.widget._poly_model.item(0,4).setText("22")
         self.assertEqual(self.widget.poly_params['radius_bell.npts'], 22)
+        # test that sasmodel is updated with the new value
+        self.assertEqual(self.widget.kernel_module.getParam('radius_bell.npts'), 22)
+
+        # Change the pd value
+        self.assertEqual(self.widget.poly_params['radius_bell.width'], 0.0)
+        self.widget._poly_model.item(0,1).setText("0.8")
+        self.assertAlmostEqual(self.widget.poly_params['radius_bell.width'], 0.8)
+        # test that sasmodel is updated with the new value
+        self.assertAlmostEqual(self.widget.kernel_module.getParam('radius_bell.width'), 0.8)
+
         # try something stupid
         self.widget._poly_model.item(0,4).setText("butt")
         # see that this didn't annoy the control at all

--- a/src/sas/qtgui/Perspectives/Fitting/UnitTesting/FittingWidgetTest.py
+++ b/src/sas/qtgui/Perspectives/Fitting/UnitTesting/FittingWidgetTest.py
@@ -451,9 +451,11 @@ class FittingWidgetTest(unittest.TestCase):
         self.assertEqual(self.widget.poly_params_to_fit, ['radius_bell.width', 'length.width'])
 
         # Change the min/max values
-        self.assertEqual(self.widget.kernel_module.details['radius_bell'][1], 0.0)
+        self.assertEqual(self.widget.kernel_module.details['radius_bell.width'][1], 0.0)
         self.widget._poly_model.item(0,2).setText("1.0")
-        self.assertEqual(self.widget.kernel_module.details['radius_bell'][1], 1.0)
+        self.assertEqual(self.widget.kernel_module.details['radius_bell.width'][1], 1.0)
+        # Check that changing the polydispersity min/max value doesn't affect the paramer min/max
+        self.assertEqual(self.widget.kernel_module.details['radius_bell'][1], 0.0)
 
         #self.widget.show()
         #QtWidgets.QApplication.exec_()


### PR DESCRIPTION
Fixes #1538

Corrects some bugs on the polydispersity and adds some unit tests, updates `sasmodel` polydispersity with the GUI values, and also adds a mechanism that sets the `sasmodel` polydispersity to 0 whenever the polydispersity is unchecked in the GUI.