### PR TITLE
Save inversion state in project and analysis files (ESS_GUI)

### DIFF
--- a/src/sas/qtgui/MainWindow/DataExplorer.py
+++ b/src/sas/qtgui/MainWindow/DataExplorer.py
@@ -502,6 +502,7 @@ class DataExplorerWindow(DroppableDataLoadWidget):
                     logging.error("Project load failed with " + str(ex))
                     return
         cs_keys = []
+        visible_perspective = DEFAULT_PERSPECTIVE
         for key, value in all_data.items():
             if key == 'is_batch':
                 self.chkBatch.setChecked(value == 'True')
@@ -514,15 +515,24 @@ class DataExplorerWindow(DroppableDataLoadWidget):
             if 'cs_tab' in key:
                 cs_keys.append(key)
                 continue
+            if 'visible_perspective' in key:
+                visible_perspective = value
             # send newly created items to the perspective
             self.updatePerspectiveWithProperties(key, value)
 
+        # Set to fitting perspective and load in Batch and C&S Pages
+        self.cbFitting.setCurrentIndex(
+            self.cbFitting.findText(DEFAULT_PERSPECTIVE))
         # See if there are any batch pages defined and create them, if so
         self.updateWithBatchPages(all_data)
 
         # Only now can we create/assign C&S pages.
         for key in cs_keys:
             self.updatePerspectiveWithProperties(key, all_data[key])
+
+        # Set to perspective shown when project was saved
+        self.cbFitting.setCurrentIndex(
+                self.cbFitting.findText(visible_perspective))
 
     def updateWithBatchPages(self, all_data):
         """
@@ -558,12 +568,12 @@ class DataExplorerWindow(DroppableDataLoadWidget):
     def updatePerspectiveWithProperties(self, key, value):
         """
         """
-        if value.get('fit_data'):
+        if 'fit_data' in value:
             data_dict = {key:value['fit_data']}
             # Create new model items in the data explorer
             items = self.updateModelFromData(data_dict)
 
-        if value.get('fit_params'):
+        if 'fit_params' in value:
             self.cbFitting.setCurrentIndex(self.cbFitting.findText(DEFAULT_PERSPECTIVE))
             params = value['fit_params']
             # Make the perspective read the rest of the read data
@@ -582,7 +592,7 @@ class DataExplorerWindow(DroppableDataLoadWidget):
                 self.sendItemToPerspective(items[0], tab_index=tab_index)
                 # Assign parameters to the most recent (current) page.
                 self._perspective().updateFromParameters(page)
-        if value.get('pr_params'):
+        if 'pr_params' in value:
             self.cbFitting.setCurrentIndex(self.cbFitting.findText('Inversion'))
             params = value['pr_params']
             self.sendItemToPerspective(items[0])

--- a/src/sas/qtgui/MainWindow/DataExplorer.py
+++ b/src/sas/qtgui/MainWindow/DataExplorer.py
@@ -272,10 +272,9 @@ class DataExplorerWindow(DroppableDataLoadWidget):
             self.default_project_location = os.path.dirname(filename)
             self.deleteAllItems()
             # Currently project load is available only for fitting
-            if self.cbFitting.currentText != DEFAULT_PERSPECTIVE:
-                self.cbFitting.setCurrentIndex(self.cbFitting.findText(DEFAULT_PERSPECTIVE))
-            # delete all (including the default) tabs
-            self._perspective().deleteAllTabs()
+            if self.cbFitting.currentText == DEFAULT_PERSPECTIVE:
+                # delete all (including the default) tabs
+                self._perspective().deleteAllTabs()
             self.readProject(filename)
 
     def loadAnalysis(self):

--- a/src/sas/qtgui/MainWindow/DataExplorer.py
+++ b/src/sas/qtgui/MainWindow/DataExplorer.py
@@ -270,9 +270,12 @@ class DataExplorerWindow(DroppableDataLoadWidget):
         filename = QtWidgets.QFileDialog.getOpenFileName(**kwargs)[0]
         if filename:
             self.default_project_location = os.path.dirname(filename)
+            # Inversion perspective will remove all data with delete
             self.deleteAllItems()
             # Currently project load is available only for fitting
-            if self.cbFitting.currentText == DEFAULT_PERSPECTIVE:
+            if self.cbFitting.currentText != DEFAULT_PERSPECTIVE:
+                self.cbFitting.setCurrentIndex(
+                    self.cbFitting.findText(DEFAULT_PERSPECTIVE))
                 # delete all (including the default) tabs
                 self._perspective().deleteAllTabs()
             self.readProject(filename)

--- a/src/sas/qtgui/MainWindow/DataExplorer.py
+++ b/src/sas/qtgui/MainWindow/DataExplorer.py
@@ -313,13 +313,13 @@ class DataExplorerWindow(DroppableDataLoadWidget):
 
         return filename
 
-    def saveAsAnalysisFile(self, tab_id=1):
+    def saveAsAnalysisFile(self, tab_id=1, extension='fitv'):
         """
         Show the save as... dialog and return the chosen filepath
         """
-        default_name = "FitPage"+str(tab_id)+".fitv"
+        default_name = "Analysis"+str(tab_id)+"."+str(extension)
 
-        wildcard = "fitv files (*.fitv)"
+        wildcard = "{0} files (*.{0})".format(extension)
         kwargs = {
             'caption'   : 'Save As',
             'directory' : default_name,
@@ -331,16 +331,16 @@ class DataExplorerWindow(DroppableDataLoadWidget):
         filename = filename_tuple[0]
         return filename
 
-    def saveAnalysis(self, data, tab_id=1):
+    def saveAnalysis(self, data, tab_id=1, ext='fitv'):
         """
         Called when the "Save Analysis" menu item chosen.
         """
-        filename = self.saveAsAnalysisFile(tab_id)
+        filename = self.saveAsAnalysisFile(tab_id, ext)
         if not filename:
             return
         _, extension = os.path.splitext(filename)
         if not extension:
-            filename = '.'.join((filename, 'fitv'))
+            filename = '.'.join((filename, ext))
         self.communicator.statusBarUpdateSignal.emit("Saving analysis... %s\n" % os.path.basename(filename))
 
         with open(filename, 'w') as outfile:
@@ -466,7 +466,7 @@ class DataExplorerWindow(DroppableDataLoadWidget):
 
     def readProject(self, filename):
         """
-        Read out datasets and fitpages from file
+        Read out datasets and perspective information from file
         """
         # Find out the filetype based on extension
         ext = os.path.splitext(filename)[1]
@@ -558,6 +558,7 @@ class DataExplorerWindow(DroppableDataLoadWidget):
             # Create new model items in the data explorer
             items = self.updateModelFromData(data_dict)
 
+        # TODO: Move 'fit_params' to FittingPerspective
         if 'fit_params' in value:
             params = value['fit_params']
             # Make the perspective read the rest of the read data

--- a/src/sas/qtgui/MainWindow/DataExplorer.py
+++ b/src/sas/qtgui/MainWindow/DataExplorer.py
@@ -579,7 +579,7 @@ class DataExplorerWindow(DroppableDataLoadWidget):
                 self.sendItemToPerspective(items[0], tab_index=tab_index)
                 # Assign parameters to the most recent (current) page.
                 self._perspective().updateFromParameters(page)
-        elif value.get('pr_params'):
+        if value.get('pr_params'):
             self.cbFitting.setCurrentIndex(self.cbFitting.findText('Inversion'))
             params = value['pr_params']
             self.sendItemToPerspective(items[0])

--- a/src/sas/qtgui/MainWindow/GuiManager.py
+++ b/src/sas/qtgui/MainWindow/GuiManager.py
@@ -646,7 +646,7 @@ class GuiManager(object):
         all_data = self.filesWidget.getSerializedData()
         analysis = {}
         for id, data in all_data.items():
-            analysis[id] = {'fit-data': data}
+            analysis[id] = {'fit_data': data}
 
         # fit tabs
         per = self.perspective()
@@ -670,7 +670,7 @@ class GuiManager(object):
         all_data = self.filesWidget.getSerializedData()
         analysis = {}
         for id, data in all_data.items():
-            analysis[id] = {'fit-data': data}
+            analysis[id] = {'fit_data': data}
         analysis = per.serializeCurrentPage(analysis)
         # Find dataset ids for the current tab
         # (can be multiple, if batch)

--- a/src/sas/qtgui/MainWindow/GuiManager.py
+++ b/src/sas/qtgui/MainWindow/GuiManager.py
@@ -658,10 +658,10 @@ class GuiManager(object):
         for id, data in all_data.items():
             analysis[id] = {'fit_data': data}
 
-        # fit tabs
-        per = self.perspective()
-        if hasattr(per, 'isSerializable') and per.isSerializable:
-            analysis = per.serializeAll(analysis)
+        # Save from all serializable perspectives
+        for name, per in self.loadedPerspectives.items():
+            if hasattr(per, 'isSerializable') and per.isSerializable:
+                analysis = per.serializeAll(analysis)
 
         analysis['is_batch'] = analysis.get('is_batch', False)
         analysis['batch_grid'] = self.grid_window.data_dict

--- a/src/sas/qtgui/MainWindow/GuiManager.py
+++ b/src/sas/qtgui/MainWindow/GuiManager.py
@@ -644,35 +644,17 @@ class GuiManager(object):
 
         # datasets
         all_data = self.filesWidget.getSerializedData()
+        analysis = {}
+        for id, data in all_data.items():
+            analysis[id] = {'fit-data': data}
 
         # fit tabs
-        params={}
-        perspective = self.perspective()
-        if hasattr(perspective, 'isSerializable') and perspective.isSerializable():
-            params = perspective.serializeAllFitpage()
+        per = self.perspective()
+        if hasattr(per, 'isSerializable') and per.isSerializable:
+            analysis = per.serializeAll(analysis)
 
-        # project dictionary structure:
-        # analysis[data.id] = [{"fit_data":[data, checkbox, child data],
-        #                       "fit_params":[fitpage_state]}
-        # "fit_params" not present if dataset not sent to fitting
-        analysis = {}
-
-        for id, data in all_data.items():
-            if id=='is_batch':
-                analysis['is_batch'] = data
-                analysis['batch_grid'] = self.grid_window.data_dict
-                continue
-            data_content = {"fit_data":data}
-            if id in params.keys():
-                # this dataset is represented also by the fit tab. Add to it.
-                data_content["fit_params"] = params[id]
-            analysis[id] = data_content
-
-        # standalone constraint pages
-        for keys, values in params.items():
-            if not 'is_constraint' in values[0]:
-                continue
-            analysis[keys] = values[0]
+        analysis['is_batch'] = analysis.get('is_batch', False)
+        analysis['batch_grid'] = self.grid_window.data_dict
 
         with open(filename, 'w') as outfile:
             GuiUtils.saveData(outfile, analysis)

--- a/src/sas/qtgui/MainWindow/UnitTesting/MainWindowTest.py
+++ b/src/sas/qtgui/MainWindow/UnitTesting/MainWindowTest.py
@@ -3,7 +3,8 @@ import unittest
 import logging
 
 from PyQt5 import QtGui, QtWidgets
-from PyQt5 import QtTest
+from PyQt5.QtGui import *
+from PyQt5.QtTest import QTest
 from PyQt5 import QtCore
 from unittest.mock import MagicMock
 
@@ -57,6 +58,36 @@ class MainWindowTest(unittest.TestCase):
         self.assertEqual(len(tmp_main.workspace.subWindowList()), 3)
 
         tmp_main.close()
+
+    def testPerspectiveChanges(self):
+        """
+        Test all information is retained on perspective change
+        """
+        FIT = 'Fitting'
+        INVAR = 'Invariant'
+        # Verify defaults
+        self.assertEqual(4, len(self.widget.loadedPerspectives))
+        self.assertEqual(FIT, self.widget.perspective.name)
+        # Load data
+        file = ["cyl_400_20.txt"]
+        self.widget.filesWidget.readData(file)
+        # Send data to fitting perspective
+        sendDataButton = self.widget.filesWidget.cmdSendTo
+        QTest.mouseClick(sendDataButton, Qt.LeftButton)
+        # Verify one data set is loaded in the current Fitting Tab
+        self.assertEqual(1, len(self.widget.perspective.currentTabDataId))
+        # Change to Invariant Perspective and verify
+        self.widget.filesWidget.cbFitting.setCurrentIndex(
+            self.cbFitting.findText(INVAR))
+        self.assertEqual(INVAR, self.widget.perspective.name)
+        # Send data to perspective
+        QTest.mouseClick(sendDataButton, Qt.LeftButton)
+        # Change back to Fitting Perspective and verify
+        self.widget.filesWidget.cbFitting.setCurrentIndex(
+            self.cbFitting.findText(FIT))
+        self.assertEqual(FIT, self.widget.perspective.name)
+        # Verify one data set remains loaded in the current Fitting Tab
+        self.assertEqual(1, len(self.widget.perspective.currentTabDataId))
 
     def testExit(self):
         """

--- a/src/sas/qtgui/MainWindow/UnitTesting/MainWindowTest.py
+++ b/src/sas/qtgui/MainWindow/UnitTesting/MainWindowTest.py
@@ -63,31 +63,41 @@ class MainWindowTest(unittest.TestCase):
         """
         Test all information is retained on perspective change
         """
+        def check_after_load(name):
+            self.assertEqual(name, gui.perspective().name)
+            self.assertEqual(1, len(gui.perspective().currentTabDataId()))
+            self.assertTrue(
+                (gui.perspective().currentTabDataId()[0]) in dataIDList)
+
+        # Base definitions
         FIT = 'Fitting'
-        INVAR = 'Invariant'
+        PR = 'Inversion'
+        gui = self.widget.guiManager
+        filesWidget = gui.filesWidget
+        currentPers = filesWidget.cbFitting
+        sendDataButton = filesWidget.cmdSendTo
         # Verify defaults
-        self.assertEqual(4, len(self.widget.loadedPerspectives))
-        self.assertEqual(FIT, self.widget.perspective.name)
+        self.assertTrue(hasattr(gui, 'loadedPerspectives'))
+        self.assertEqual(4, len(gui.loadedPerspectives))
         # Load data
         file = ["cyl_400_20.txt"]
-        self.widget.filesWidget.readData(file)
+        filesWidget.readData(file)
+        data, _ = filesWidget.getAllData()
+        dataIDList = list(data.keys())
         # Send data to fitting perspective
-        sendDataButton = self.widget.filesWidget.cmdSendTo
-        QTest.mouseClick(sendDataButton, Qt.LeftButton)
+        QTest.mouseClick(sendDataButton, QtCore.Qt.LeftButton)
         # Verify one data set is loaded in the current Fitting Tab
-        self.assertEqual(1, len(self.widget.perspective.currentTabDataId))
-        # Change to Invariant Perspective and verify
-        self.widget.filesWidget.cbFitting.setCurrentIndex(
-            self.cbFitting.findText(INVAR))
-        self.assertEqual(INVAR, self.widget.perspective.name)
-        # Send data to perspective
-        QTest.mouseClick(sendDataButton, Qt.LeftButton)
+        check_after_load(FIT)
+        # Change to Inversion Perspective, Send data, and verify
+        currentPers.setCurrentIndex(currentPers.findText(PR))
+        QTest.mouseClick(sendDataButton, QtCore.Qt.LeftButton)
+        check_after_load(PR)
         # Change back to Fitting Perspective and verify
-        self.widget.filesWidget.cbFitting.setCurrentIndex(
-            self.cbFitting.findText(FIT))
-        self.assertEqual(FIT, self.widget.perspective.name)
-        # Verify one data set remains loaded in the current Fitting Tab
-        self.assertEqual(1, len(self.widget.perspective.currentTabDataId))
+        currentPers.setCurrentIndex(currentPers.findText(FIT))
+        check_after_load(FIT)
+        # Go back to Inversion perspective and verify data still exists
+        currentPers.setCurrentIndex(currentPers.findText(PR))
+        check_after_load(PR)
 
     def testExit(self):
         """

--- a/src/sas/qtgui/Perspectives/Fitting/FittingPerspective.py
+++ b/src/sas/qtgui/Perspectives/Fitting/FittingPerspective.py
@@ -25,6 +25,7 @@ class FittingWindow(QtWidgets.QTabWidget):
     fittingStoppedSignal = QtCore.pyqtSignal(list)
 
     name = "Fitting" # For displaying in the combo box in DataExplorer
+    ext = "fitv"  # Extension used for saving analyses
     def __init__(self, parent=None, data=None):
 
         super(FittingWindow, self).__init__()
@@ -125,25 +126,14 @@ class FittingWindow(QtWidgets.QTabWidget):
         # serialize all active fitpages and return
         # a dictionary: {data_id: fitpage_state}
         for i, tab in enumerate(self.tabs):
-            tab_data = self.getSerializedFitpage(tab)
-            if 'data_id' not in tab_data: continue
-            id = tab_data['data_id'][0]
-            if not isinstance(id, list):
-                id = [id]
-            for i in id:
-                if 'is_constraint' in tab_data.keys():
-                    all_data[i] = tab_data
-                elif 'fit-params' in all_data[i]:
-                    all_data[i]['fit_params'].extend(tab_data)
-                else:
-                    all_data[i]['fit_params'] = [tab_data]
+            all_data = self.getSerializedFitpage(tab, all_data)
         return all_data
 
-    def serializeCurrentFitpage(self):
+    def serializeCurrentPage(self, all_data):
         # serialize current(active) fitpage
-        return self.getSerializedFitpage(self.currentTab)
+        return self.getSerializedFitpage(self.currentTab, all_data)
 
-    def getSerializedFitpage(self, tab):
+    def getSerializedFitpage(self, tab, all_data):
         """
         get serialize requested fit tab
         """
@@ -155,7 +145,19 @@ class FittingWindow(QtWidgets.QTabWidget):
             #content = line.split(',')
             if len(line) > 1:
                 line_dict[line[0]] = line[1:]
-        return line_dict
+
+        if 'data_id' not in line_dict: return all_data
+        id = line_dict['data_id'][0]
+        if not isinstance(id, list):
+            id = [id]
+        for i in id:
+            if 'is_constraint' in line_dict.keys():
+                all_data[i] = line_dict
+            elif 'fit-params' in all_data[i]:
+                all_data[i]['fit_params'].extend(line_dict)
+            else:
+                all_data[i]['fit_params'] = [line_dict]
+        return all_data
 
     def currentTabDataId(self):
         """

--- a/src/sas/qtgui/Perspectives/Fitting/FittingPerspective.py
+++ b/src/sas/qtgui/Perspectives/Fitting/FittingPerspective.py
@@ -118,26 +118,26 @@ class FittingWindow(QtWidgets.QTabWidget):
     def onLatexCopy(self):
         self.currentTab.onCopyToClipboard("Latex")
 
-    def serializeAllFitpage(self):
+    def serializeAll(self, all_data):
+        return self.serializeAllFitpage(all_data)
+
+    def serializeAllFitpage(self, all_data):
         # serialize all active fitpages and return
         # a dictionary: {data_id: fitpage_state}
-        params = {}
         for i, tab in enumerate(self.tabs):
             tab_data = self.getSerializedFitpage(tab)
             if 'data_id' not in tab_data: continue
             id = tab_data['data_id'][0]
-            if isinstance(id, list):
-                for i in id:
-                    if i in params:
-                        params[i].append(tab_data)
-                    else:
-                        params[i] = [tab_data]
-            else:
-                if id in params:
-                    params[id].append(tab_data)
+            if not isinstance(id, list):
+                id = [id]
+            for i in id:
+                if 'is_constraint' in tab_data.keys():
+                    all_data[i] = tab_data
+                elif 'fit-params' in all_data[i]:
+                    all_data[i]['fit_params'].extend(tab_data)
                 else:
-                    params[id] = [tab_data]
-        return params
+                    all_data[i]['fit_params'] = [tab_data]
+        return all_data
 
     def serializeCurrentFitpage(self):
         # serialize current(active) fitpage

--- a/src/sas/qtgui/Perspectives/Fitting/UnitTesting/FittingPerspectiveTest.py
+++ b/src/sas/qtgui/Perspectives/Fitting/UnitTesting/FittingPerspectiveTest.py
@@ -168,5 +168,36 @@ class FittingPerspectiveTest(unittest.TestCase):
         self.assertEqual(self.widget.tabText(1), "BatchPage2")
         self.assertEqual(self.widget.tabText(2), "BatchPage3")
 
+    def testSerialization(self):
+        ''' Serialize fit pages and check data '''
+        data = Data1D(x=[1,2], y=[1,2])
+        GuiUtils.dataFromItem = MagicMock(return_value=data)
+        item = QtGui.QStandardItem("test")
+        self.widget.setData([item])
+        tab = self.widget.tabs[0]
+        cbCat = tab.cbCategory
+        cbModel = tab.cbModel
+        cbCat.setCurrentIndex(cbCat.findText("Cylinder"))
+        cbModel.setCurrentIndex(cbModel.findText("barbell"))
+        data_id = str(self.widget.currentTabDataId()[0])
+        # check values - disabled control, present weights
+        rowcount = tab._model_model.rowCount()
+        self.assertEqual(rowcount, 8)
+        state_default = self.widget.serializeAll()
+        state_all = self.widget.serializeAllFitpage()
+        state_cp = self.widget.serializeCurrentPage()
+        page = self.widget.getSerializedFitpage(self.widget.currentTab)
+        # Pull out params from state
+        params = state_all[data_id]['fit_params'][0]
+        # Tests
+        self.assertEqual(len(state_all), len(state_default))
+        self.assertEqual(len(state_cp), len(page))
+        self.assertEqual(len(state_all), 1)
+        # getPage should include an extra param 'data_id' removed by serialize
+        self.assertNotEqual(len(params), len(page))
+        self.assertEqual(len(params), 28)
+        self.assertEqual(page.get('data_id', None), None)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/src/sas/qtgui/Perspectives/Inversion/InversionPerspective.py
+++ b/src/sas/qtgui/Perspectives/Inversion/InversionPerspective.py
@@ -506,7 +506,7 @@ class InversionWindow(QtWidgets.QDialog, Ui_PrInversion):
         Collects all active params into a dictionary of {name: value}
         :return: {name: value}
         """
-        params = {
+        return {
             'alpha': self._calculator.alpha,
             'background': self._calculator.background,
             'chi2': self._calculator.chi2,
@@ -527,14 +527,13 @@ class InversionWindow(QtWidgets.QDialog, Ui_PrInversion):
                                                     self._calculator.cov),
             'q_max': self._calculator.q_max,
             'q_min': self._calculator.q_min,
-            'rg': self._calculator.rg,
+            'rg': self._calculator.rg(self._calculator.out),
             'slit_height': self._calculator.slit_height,
             'slit_width': self._calculator.slit_width,
             'suggested_alpha': self._calculator.suggested_alpha,
             'x': self._calculator.x,
             'y': self._calculator.y,
         }
-        return params
 
     def getNFunc(self):
         """Get the n_func value from the GUI object"""
@@ -632,8 +631,7 @@ class InversionWindow(QtWidgets.QDialog, Ui_PrInversion):
             data_list = [self._data]
         self.closeDMax()
         for data in data_list:
-            if data in self._dataList.keys():
-                self._dataList.pop(data)
+            self._dataList.pop(data, None)
         self._data = None
         length = len(self.dataList)
         for index in reversed(range(length)):
@@ -658,23 +656,23 @@ class InversionWindow(QtWidgets.QDialog, Ui_PrInversion):
             self.dataList.setCurrentIndex(0)
             self.updateGuiValues()
 
-    def serializeAll(self, all_data):
+    def serializeAll(self):
         """
         Serialize the inversion state so data can be saved
         Inversion is not batch-ready so this will only effect a single page
         :return: {data-id: {self.name: {inversion-state}}}
         """
-        return self.serializeCurrentPage(all_data=all_data)
+        return self.serializeCurrentPage()
 
-    def serializeCurrentPage(self, all_data):
+    def serializeCurrentPage(self):
         # Serialize and return a dictionary of {data_id: inversion-state}
         # Return original dictionary if no data
+        state = {}
         if self.logic.data_is_loaded:
             tab_data = self.getPage()
             data_id = tab_data.pop('data_id', '')
-            if data_id in all_data:
-                all_data[data_id]['pr_params'] = tab_data
-        return all_data
+            state[data_id] = {'pr_params': tab_data}
+        return state
 
     def getPage(self):
         """

--- a/src/sas/qtgui/Perspectives/Inversion/InversionPerspective.py
+++ b/src/sas/qtgui/Perspectives/Inversion/InversionPerspective.py
@@ -41,6 +41,7 @@ class InversionWindow(QtWidgets.QDialog, Ui_PrInversion):
     """
 
     name = "Inversion"
+    ext = "pr"  # Extension used for saving analyses
     estimateSignal = QtCore.pyqtSignal(tuple)
     estimateNTSignal = QtCore.pyqtSignal(tuple)
     estimateDynamicNTSignal = QtCore.pyqtSignal(tuple)
@@ -654,8 +655,12 @@ class InversionWindow(QtWidgets.QDialog, Ui_PrInversion):
     def serializeAll(self, all_data):
         """
         Serialize the inversion state so data can be saved
+        Inversion is not batch-ready so this will only effect a single page
         :return: {data-id: {self.name: {inversion-state}}}
         """
+        return self.serializeCurrentPage(all_data=all_data)
+
+    def serializeCurrentPage(self, all_data):
         # Serialize and return a dictionary of {data_id: inversion-state}
         # Return original dictionary if no data
         if self.logic.data_is_loaded:
@@ -674,6 +679,15 @@ class InversionWindow(QtWidgets.QDialog, Ui_PrInversion):
         param_dict['data_name'] = str(self.logic.data.filename)
         param_dict['data_id'] = str(self.logic.data.id)
         return param_dict
+
+    def currentTabDataId(self):
+        """
+        Returns the data ID of the current tab
+        """
+        tab_id = []
+        if self.logic.data_is_loaded:
+            tab_id.append(str(self.logic.data.id))
+        return tab_id
 
     ######################################################################
     # Thread Creators

--- a/src/sas/qtgui/Perspectives/Inversion/InversionPerspective.py
+++ b/src/sas/qtgui/Perspectives/Inversion/InversionPerspective.py
@@ -500,35 +500,34 @@ class InversionWindow(QtWidgets.QDialog, Ui_PrInversion):
         if self.batchResultsWindow is not None:
             self.showBatchOutput()
 
-    def getParameters(self):
+    def getState(self):
         """
         Collects all active params into a dictionary of {name: value}
         :return: {name: value}
         """
-        params = [
-            ['alpha', self._calculator.alpha],
-            ['suggested_alpha', self._calculator.suggested_alpha],
-            ['background', self._calculator.background],
-            ['chi2', self._calculator.chi2],
-            ['chisqr', self._calculator.chisqr],
-            ['cov', self._calculator.cov],
-            ['d_max', self._calculator.d_max],
-            ['elapsed', self._calculator.elapsed],
-            ['err', self._calculator.err],
-            ['est_bck', self._calculator.est_bck],
-            ['nerr', self._calculator.nerr],
-            ['nfunc', self.getNFunc()],
-            ['npoints', self._calculator.npoints],
-            ['ny', self._calculator.ny],
-            ['out', self._calculator.out],
-            ['q_max', self._calculator.q_max],
-            ['q_min', self._calculator.q_min],
-            ['slit_height', self._calculator.slit_height],
-            ['slit_width', self._calculator.slit_width],
-            ['suggested_alpha', self._calculator.suggested_alpha],
-            ['x', self._calculator.x],
-            ['y', self._calculator.y],
-        ]
+        params = {
+            'alpha': self._calculator.alpha,
+            'background': self._calculator.background,
+            'chi2': self._calculator.chi2,
+            'chisqr': self._calculator.chisqr,
+            'cov': self._calculator.cov,
+            'd_max': self._calculator.d_max,
+            'elapsed': self._calculator.elapsed,
+            'err': self._calculator.err,
+            'est_bck': self._calculator.est_bck,
+            'nerr': self._calculator.nerr,
+            'nfunc': self.getNFunc(),
+            'npoints': self._calculator.npoints,
+            'ny': self._calculator.ny,
+            'out': self._calculator.out,
+            'q_max': self._calculator.q_max,
+            'q_min': self._calculator.q_min,
+            'slit_height': self._calculator.slit_height,
+            'slit_width': self._calculator.slit_width,
+            'suggested_alpha': self._calculator.suggested_alpha,
+            'x': self._calculator.x,
+            'y': self._calculator.y,
+        }
         return params
 
     def getNFunc(self):
@@ -652,58 +651,29 @@ class InversionWindow(QtWidgets.QDialog, Ui_PrInversion):
             self.dataList.setCurrentIndex(0)
             self.updateGuiValues()
 
-    def serializeAllFitpage(self):
-        # serialize all active pages and return
-        # a dictionary: {data_id: inversion-state}
-        params = {}
-        tab_data = self.serializeCurrentFitpage()
-        id = tab_data['data_id'][0]
-        if isinstance(id, list):
-            for i in id:
-                if i in params:
-                    params[i].append(tab_data)
-                else:
-                    params[i] = [tab_data]
-        else:
-            if id in params:
-                params[id].append(tab_data)
-            else:
-                params[id] = [tab_data]
-        return params
-
-    def serializeCurrentFitpage(self):
+    def serializeAll(self, all_data):
         """
-        get serialize requested fit tab
+        Serialize the inversion state so data can be saved
+        :return: {data-id: {self.name: {inversion-state}}}
         """
-        pr_state = self.getPage()
-        # put the text into dictionary
-        line_dict = {}
-        for line in pr_state:
-            #content = line.split(',')
-            if len(line) > 1:
-                line_dict[line[0]] = line[1:]
-        return line_dict
+        # Serialize and return a dictionary of {data_id: inversion-state}
+        # Return original dictionary if no data
+        if self.logic.data_is_loaded:
+            tab_data = self.getPage()
+            data_id = tab_data.pop('data_id', '')
+            if data_id in all_data:
+                all_data[data_id]['pr_params'] = tab_data
+        return all_data
 
     def getPage(self):
         """
         serializes full state of this fit page
         """
-        # run a loop over all parameters and pull out
-        # first - regular params
-        param_list = self.getParameters()
-
-        param_list.append(['is_data', str(self.logic.data_is_loaded)])
-        data_ids = []
-        filenames = []
-        if self.logic.data_is_loaded:
-            data_ids = [str(self.logic.data.id)]
-            filenames = [str(self.logic.data.filename)]
-        param_list.append(['data_name', filenames])
-        param_list.append(['data_id', data_ids])
-
-        # checkboxes, if required
-
-        return param_list
+        # Get all parameters from page
+        param_dict = self.getState()
+        param_dict['data_name'] = str(self.logic.data.filename)
+        param_dict['data_id'] = str(self.logic.data.id)
+        return param_dict
 
     ######################################################################
     # Thread Creators

--- a/src/sas/qtgui/Perspectives/Inversion/InversionPerspective.py
+++ b/src/sas/qtgui/Perspectives/Inversion/InversionPerspective.py
@@ -506,6 +506,9 @@ class InversionWindow(QtWidgets.QDialog, Ui_PrInversion):
         Collects all active params into a dictionary of {name: value}
         :return: {name: value}
         """
+        # If no measurement performed, calculate using base params
+        if self.chiDofValue.text() == '':
+            self._calculator.out, self._calculator.cov = self._calculator.invert()
         return {
             'alpha': self._calculator.alpha,
             'background': self._calculator.background,

--- a/src/sas/qtgui/Perspectives/Inversion/InversionPerspective.py
+++ b/src/sas/qtgui/Perspectives/Inversion/InversionPerspective.py
@@ -632,7 +632,8 @@ class InversionWindow(QtWidgets.QDialog, Ui_PrInversion):
             data_list = [self._data]
         self.closeDMax()
         for data in data_list:
-            self._dataList.pop(data)
+            if data in self._dataList.keys():
+                self._dataList.pop(data)
         self._data = None
         length = len(self.dataList)
         for index in reversed(range(length)):

--- a/src/sas/qtgui/Perspectives/Inversion/InversionPerspective.py
+++ b/src/sas/qtgui/Perspectives/Inversion/InversionPerspective.py
@@ -510,19 +510,24 @@ class InversionWindow(QtWidgets.QDialog, Ui_PrInversion):
             'alpha': self._calculator.alpha,
             'background': self._calculator.background,
             'chi2': self._calculator.chi2,
-            'chisqr': self._calculator.chisqr,
             'cov': self._calculator.cov,
             'd_max': self._calculator.d_max,
             'elapsed': self._calculator.elapsed,
             'err': self._calculator.err,
             'est_bck': self._calculator.est_bck,
+            'iq0': self._calculator.iq0(self._calculator.out),
             'nerr': self._calculator.nerr,
             'nfunc': self.getNFunc(),
             'npoints': self._calculator.npoints,
             'ny': self._calculator.ny,
             'out': self._calculator.out,
+            'oscillations': self._calculator.oscillations(self._calculator.out),
+            'pos_frac': self._calculator.get_positive(self._calculator.out),
+            'pos_err': self._calculator.get_pos_err(self._calculator.out,
+                                                    self._calculator.cov),
             'q_max': self._calculator.q_max,
             'q_min': self._calculator.q_min,
+            'rg': self._calculator.rg,
             'slit_height': self._calculator.slit_height,
             'slit_width': self._calculator.slit_width,
             'suggested_alpha': self._calculator.suggested_alpha,
@@ -688,6 +693,32 @@ class InversionWindow(QtWidgets.QDialog, Ui_PrInversion):
         if self.logic.data_is_loaded:
             tab_id.append(str(self.logic.data.id))
         return tab_id
+
+    def updateFromParameters(self, params):
+        self._calculator.suggested_alpha = params['alpha']
+        self.updateDynamicGuiValues()
+        self.acceptAlpha()
+        self.backgroundInput.setText(str(params['background']))
+        self._calculator.chi2 = params['chi2']
+        self._calculator.cov = params['cov']
+        self._calculator.d_max = params['d_max']
+        self._calculator.elapsed = params['elapsed']
+        self._calculator.err = params['err']
+        self._calculator.set_est_bck = bool(params['est_bck'])
+        self._calculator.nerr = params['nerr']
+        self.noOfTermsInput.setText(str(params['nfunc']))
+        self._calculator.npoints = params['npoints']
+        self._calculator.ny = params['ny']
+        self._calculator.out = params['out']
+        self._calculator.q_max = params['q_max']
+        self._calculator.q_min = params['q_min']
+        self._calculator.slit_height = params['slit_height']
+        self._calculator.slit_width = params['slit_width']
+        self._calculator.suggested_alpha = params['suggested_alpha']
+        self._calculator.x = params['x']
+        self._calculator.y = params['y']
+        self.updateGuiValues()
+        self.updateDynamicGuiValues()
 
     ######################################################################
     # Thread Creators

--- a/src/sas/qtgui/Perspectives/Inversion/UnitTesting/InversionPerspectiveTest.py
+++ b/src/sas/qtgui/Perspectives/Inversion/UnitTesting/InversionPerspectiveTest.py
@@ -305,6 +305,29 @@ class InversionTest(unittest.TestCase):
         self.assertTrue(self.widget.dmaxWindow.isVisible())
         self.assertTrue(self.widget.dmaxWindow.windowTitle() == "Dmax Explorer")
 
+    def testSerialization(self):
+        """ Serialization routines """
+        self.widget.setData([self.fakeData1])
+        self.oneDataSetState()
+        data_id = self.widget.currentTabDataId()[0]
+        # Test three separate serialization routines
+        state_all = self.widget.serializeAll()
+        state_one = self.widget.serializeCurrentPage()
+        page = self.widget.getPage()
+        # Pull out params from state
+        params = state_all[data_id]['pr_params']
+        # Tests
+        self.assertEqual(len(state_all), len(state_one))
+        self.assertEqual(len(state_all), 1)
+        # getPage should include an extra param 'data_id' removed by serialize
+        self.assertNotEqual(len(params), len(page))
+        self.assertEqual(len(params), 26)
+        self.assertEqual(params.get('data_id', None), None)
+        self.assertNotEqual(page.get('data_id', None), None)
+        self.assertNotEqual(params.get('alpha', None), None)
+        self.assertEqual(params.get('alpha', None), page.get('alpha', None))
+        self.assertTrue(np.isnan(params.get('rg')))
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
The Inversion perspective can now be saved and loaded in project and analysis files. Also, all perspectives retain their information when changing between perspectives allowing project files to save state of all serializable perspectives at one time.

Closes #1578 
Works toward #1526 - Remaining: save/load Corfunc and Invariant perspectives