### PR TITLE
Ess gui 1545 copy paste

### DIFF
--- a/src/sas/qtgui/Perspectives/Fitting/ComplexConstraint.py
+++ b/src/sas/qtgui/Perspectives/Fitting/ComplexConstraint.py
@@ -136,10 +136,8 @@ class ComplexConstraint(QtWidgets.QDialog, Ui_ComplexConstraintUI):
         """
         Tooltip for txtConstraint
         """
-        p1 = self.tab_names[0] + ":" + self.cbParam1.currentText()
-        p2 = self.tab_names[1] +"."+self.cbParam2.currentText() if len(self.tab_names) != 1 else self.tab_names[0] +"."+self.cbParam2.currentText()
-        tooltip = "E.g.\n%s = 2.0 * (%s)\n" %(p1, p2)
-        tooltip += "%s = sqrt(%s) + 5"%(p1, p2)
+        tooltip = "E.g. M1:scale = 2.0 * M2.scale\n"
+        tooltip += "M1:scale = sqrt(M2.scale) + 5"
         self.txtConstraint.setToolTip(tooltip)
 
     def onParamIndexChange(self, index):

--- a/src/sas/qtgui/Perspectives/Fitting/ComplexConstraint.py
+++ b/src/sas/qtgui/Perspectives/Fitting/ComplexConstraint.py
@@ -137,7 +137,7 @@ class ComplexConstraint(QtWidgets.QDialog, Ui_ComplexConstraintUI):
         Tooltip for txtConstraint
         """
         p1 = self.tab_names[0] + ":" + self.cbParam1.currentText()
-        p2 = self.tab_names[1] if len(self.tab_names) != 1 else self.tab_names[0] +"."+self.cbParam2.currentText()
+        p2 = self.tab_names[1] +"."+self.cbParam2.currentText() if len(self.tab_names) != 1 else self.tab_names[0] +"."+self.cbParam2.currentText()
         tooltip = "E.g.\n%s = 2.0 * (%s)\n" %(p1, p2)
         tooltip += "%s = sqrt(%s) + 5"%(p1, p2)
         self.txtConstraint.setToolTip(tooltip)

--- a/src/sas/qtgui/Perspectives/Fitting/FittingWidget.py
+++ b/src/sas/qtgui/Perspectives/Fitting/FittingWidget.py
@@ -3993,7 +3993,7 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         line_dict = {}
         for line in lines[1:]:
             content = line.split(',')
-            if len(content) > 1:
+            if len(content) > 1 and content[0] != "tab_name":
                 line_dict[content[0]] = content[1:]
 
         self.updatePageWithParameters(line_dict)

--- a/src/sas/qtgui/Perspectives/Fitting/UnitTesting/ComplexConstraintTest.py
+++ b/src/sas/qtgui/Perspectives/Fitting/UnitTesting/ComplexConstraintTest.py
@@ -96,11 +96,8 @@ class ComplexConstraintTest(unittest.TestCase):
 
     def testTooltip(self):
         ''' test the tooltip'''
-        p1 = self.widget.tab_names[0] + ":" + self.widget.cbParam1.currentText()
-        p2 = self.widget.tab_names[1] + "." + self.widget.cbParam2.currentText()
-
-        tooltip = "E.g.\n%s = 2.0 * (%s)\n" %(p1, p2)
-        tooltip += "%s = sqrt(%s) + 5"%(p1, p2)
+        tooltip = "E.g. M1:scale = 2.0 * M2.scale\n"
+        tooltip += "M1:scale = sqrt(M2.scale) + 5"
         self.assertEqual(self.widget.txtConstraint.toolTip(), tooltip)
 
     def notestValidateFormula(self):

--- a/src/sas/qtgui/Perspectives/Fitting/UnitTesting/FittingWidgetTest.py
+++ b/src/sas/qtgui/Perspectives/Fitting/UnitTesting/FittingWidgetTest.py
@@ -1523,6 +1523,30 @@ class FittingWidgetTest(unittest.TestCase):
 
         self.assertEqual(self.widget.getConstraintsForModel(),[('scale', 'poopy.5*sld')])
 
+    def testParameterPaste(self):
+        """
+        Test parameter pasting
+        """
+        # Mock the clipboard and make it return unconsistent string
+        cb = QtWidgets.QApplication.clipboard()
+        cb.text = MagicMock(return_value='foo')
+        # Mock the updatePageWithParameters call
+        widget = self.widget
+        widget.updatePageWithParameters = MagicMock()
+        self.widget.onParameterPaste()
+        # Check if the function is called
+        self.assertFalse(widget.updatePageWithParameters.called)
+        # Now return a consistent string in the
+        cb.text = MagicMock(return_value='sasview_parameter_values:tab_name,M1:scale,0.1:background,0.1')
+        self.widget.onParameterPaste()
+        self.assertTrue(widget.updatePageWithParameters.called)
+        # Get the pasted dict
+        paste_dict = widget.updatePageWithParameters.call_args[0]
+        # tab_name should not be in the dict
+        self.assertFalse('tab_name' in paste_dict[0])
+        # scale and background should
+        self.assertTrue('scale' in paste_dict[0])
+        self.assertTrue('background' in paste_dict[0])
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Fixes #1545 

Removes tab names in the dict used for updating the fit page when pasting. Also adds unit tests for PR #1533 