### PR TITLE
ESS_GUI: allow data replacement on a fit page

### DIFF
--- a/src/sas/qtgui/MainWindow/DataExplorer.py
+++ b/src/sas/qtgui/MainWindow/DataExplorer.py
@@ -732,7 +732,7 @@ class DataExplorerWindow(DroppableDataLoadWidget):
                 title = self._perspective().title()
             else:
                 title = self._perspective().windowTitle()
-            msg = title + " does not allow replacing multiple data. Please select only one data."
+            msg = title + " does not allow replacing multiple data."
             msgbox = QtWidgets.QMessageBox()
             msgbox.setIcon(QtWidgets.QMessageBox.Critical)
             msgbox.setText(msg)

--- a/src/sas/qtgui/MainWindow/DataExplorer.py
+++ b/src/sas/qtgui/MainWindow/DataExplorer.py
@@ -728,8 +728,8 @@ class DataExplorerWindow(DroppableDataLoadWidget):
             return
         #Check that you have only one box item checked when swaping data
         if len(selected_items) > 1 and (self.chkSwap.isChecked() or not self._perspective().allowBatch()):
-            if hasattr(self._perspective(), 'title'):
-                title = self._perspective().title()
+            if hasattr(self._perspective(), 'name'):
+                title = self._perspective().name
             else:
                 title = self._perspective().windowTitle()
             msg = title + " does not allow replacing multiple data."

--- a/src/sas/qtgui/MainWindow/DataExplorer.py
+++ b/src/sas/qtgui/MainWindow/DataExplorer.py
@@ -727,26 +727,12 @@ class DataExplorerWindow(DroppableDataLoadWidget):
         if len(selected_items) < 1:
             return
         #Check that you have only one box item checked when swaping data
-        if len(selected_items) > 1 and self.chkSwap.isChecked():
+        if len(selected_items) > 1 and (self.chkSwap.isChecked() or not self._perspective().allowBatch()):
             if hasattr(self._perspective(), 'title'):
                 title = self._perspective().title()
             else:
                 title = self._perspective().windowTitle()
             msg = title + " does not allow replacing multiple data. Please select only one data."
-            msgbox = QtWidgets.QMessageBox()
-            msgbox.setIcon(QtWidgets.QMessageBox.Critical)
-            msgbox.setText(msg)
-            msgbox.setStandardButtons(QtWidgets.QMessageBox.Ok)
-            retval = msgbox.exec_()
-            return
-
-        # Which perspective has been selected?
-        if len(selected_items) > 1 and not self._perspective().allowBatch():
-            if hasattr(self._perspective(), 'title'):
-                title = self._perspective().title()
-            else:
-                title = self._perspective().windowTitle()
-            msg = title + " does not allow multiple data."
             msgbox = QtWidgets.QMessageBox()
             msgbox.setIcon(QtWidgets.QMessageBox.Critical)
             msgbox.setText(msg)

--- a/src/sas/qtgui/MainWindow/UI/DataExplorerUI.ui
+++ b/src/sas/qtgui/MainWindow/UI/DataExplorerUI.ui
@@ -268,6 +268,13 @@
            </property>
           </widget>
          </item>
+         <item row="2" column="1">
+          <widget class="QCheckBox" name="chkSwap">
+           <property name="text">
+            <string>Swap data</string>
+           </property>
+          </widget>
+         </item>
         </layout>
        </item>
        <item row="2" column="2">

--- a/src/sas/qtgui/MainWindow/UnitTesting/DataExplorerTest.py
+++ b/src/sas/qtgui/MainWindow/UnitTesting/DataExplorerTest.py
@@ -38,7 +38,11 @@ class DataExplorerTest(unittest.TestCase):
                 return Communicate()
             def allowBatch(self):
                 return True
+            def allowSwap(self):
+                return True
             def setData(self, data_item=None, is_batch=False):
+                return None
+            def swapData(self, data_item=None, is_batch=False):
                 return None
             def title(self):
                 return "Dummy Perspective"
@@ -77,6 +81,8 @@ class DataExplorerTest(unittest.TestCase):
         self.assertIsInstance(self.form.cmdSendTo.icon(), QIcon)
         self.assertEqual(self.form.chkBatch.text(), "Batch mode")
         self.assertFalse(self.form.chkBatch.isChecked())
+        self.assertEqual(self.form.chkSwap.text(), "Swap data")
+        self.assertFalse(self.form.chkSwap.isChecked())
 
         # Buttons - theory tab
 
@@ -274,7 +280,7 @@ class DataExplorerTest(unittest.TestCase):
         QTest.mouseClick(deleteButton, Qt.LeftButton)
 
 
-    def notestSendToButton(self):
+    def testSendToButton(self):
         """
         Test that clicking the Send To button sends checked data to a perspective
         """
@@ -295,8 +301,9 @@ class DataExplorerTest(unittest.TestCase):
         QApplication.processEvents()
 
         # setData is the method we want to see called
-        mocked_perspective = self.form.parent.perspective()
-        mocked_perspective.setData = MagicMock(filename)
+        mocked_perspective.setData = MagicMock()
+        mocked_perspective.swapData = MagicMock()
+        self.form.parent.perspective().setData = MagicMock()
 
         # Assure the checkbox is on
         self.form.cbSelect.setCurrentIndex(0)
@@ -307,7 +314,8 @@ class DataExplorerTest(unittest.TestCase):
         QApplication.processEvents()
 
         # Test the set_data method called once
-        self.assertTrue(mocked_perspective.setData.called)
+        self.assertTrue(self.form.parent.perspective().setData.called)
+        self.assertFalse(mocked_perspective.swapData.called)
 
         # open another file
         filename = ["cyl_400_20.txt"]
@@ -321,6 +329,39 @@ class DataExplorerTest(unittest.TestCase):
 
         # Assure the message box popped up
         QMessageBox.assert_called_once()
+
+    def testSwapData(self):
+        """
+        Test that clicking the Send To button when the swap option is checked swaps the data
+        """
+
+        # Check the swap option
+        self.form.chkSwap.setChecked(True)
+
+        # Populate the model
+        filename = ["cyl_400_20.txt"]
+        self.form.readData(filename)
+
+        QApplication.processEvents()
+
+        # Swap data
+        mocked_perspective = self.form.parent.perspective()
+        mocked_perspective.swapData = MagicMock(filename)
+        mocked_perspective.setData = MagicMock(filename)
+
+        # Assure the checkbox is on
+        self.form.cbSelect.setCurrentIndex(0)
+
+        # Click on the Send To  button
+        QTest.mouseClick(self.form.cmdSendTo, Qt.LeftButton)
+
+        QApplication.processEvents()
+
+        # Test the swapData method called
+        #self.assertFalse(mocked_perspective.setData.called)
+        #self.assertTrue(mocked_perspective.swapData.called)
+
+        # Uncheck the swap data
 
     def testDataSelection(self):
         """

--- a/src/sas/qtgui/MainWindow/UnitTesting/DataExplorerTest.py
+++ b/src/sas/qtgui/MainWindow/UnitTesting/DataExplorerTest.py
@@ -324,22 +324,34 @@ class DataExplorerTest(unittest.TestCase):
 
         QApplication.processEvents()
 
-        # Test the set_data method called once
+        # Test the set_data method called
         self.assertTrue(mocked_perspective.setData.called)
         self.assertFalse(mocked_perspective.swapData.called)
+
+        # Now select the swap data checkbox
+        self.form.chkSwap.setChecked(True)
+
+        # Click on the Send To  button
+        QTest.mouseClick(self.form.cmdSendTo, Qt.LeftButton)
+
+        QApplication.processEvents()
+
+        # Now the swap data method should be called
+        self.assertTrue(mocked_perspective.setData.called_once)
+        self.assertTrue(mocked_perspective.swapData.called)
 
         # open another file
         filename = ["cyl_400_20.txt"]
         self.form.readData(filename)
 
         # Mock the warning message
-        QMessageBox = MagicMock()
+        QMessageBox.exec_ = MagicMock()
 
-        # Click on the button
+        # Click on the button to swap both datasets to the perspective
         QTest.mouseClick(self.form.cmdSendTo, Qt.LeftButton)
 
         # Assure the message box popped up
-        #QMessageBox.assert_called_once()
+        QMessageBox.exec_.assert_called_once()
 
     def testDataSelection(self):
         """

--- a/src/sas/qtgui/MainWindow/UnitTesting/DataExplorerTest.py
+++ b/src/sas/qtgui/MainWindow/UnitTesting/DataExplorerTest.py
@@ -345,13 +345,16 @@ class DataExplorerTest(unittest.TestCase):
 
         # Test the exception block
         QMessageBox.exec_ = MagicMock()
-        mocked_perspective.swapData = MagicMock(side_effect = Exception())
+        QMessageBox.setText = MagicMock()
+        mocked_perspective.swapData = MagicMock(side_effect = Exception("foo"))
 
         # Click on the button to so the mocked swapData method raises an exception
         QTest.mouseClick(self.form.cmdSendTo, Qt.LeftButton)
 
         # Assure the message box popped up
         QMessageBox.exec_.assert_called_once()
+        # With the right message
+        QMessageBox.setText.assert_called_with("foo")
 
         # open another file
         filename = ["cyl_400_20.txt"]
@@ -359,6 +362,7 @@ class DataExplorerTest(unittest.TestCase):
 
         # Mock the warning message and the swapData method
         QMessageBox.exec_ = MagicMock()
+        QMessageBox.setText = MagicMock()
         mocked_perspective.swapData = MagicMock()
 
         # Click on the button to swap both datasets to the perspective
@@ -366,6 +370,9 @@ class DataExplorerTest(unittest.TestCase):
 
         # Assure the message box popped up
         QMessageBox.exec_.assert_called_once()
+        # With the right message
+        QMessageBox.setText.assert_called_with(
+            "Dummy Perspective does not allow replacing multiple data.")
 
     def testDataSelection(self):
         """

--- a/src/sas/qtgui/MainWindow/UnitTesting/DataExplorerTest.py
+++ b/src/sas/qtgui/MainWindow/UnitTesting/DataExplorerTest.py
@@ -31,6 +31,9 @@ if not QApplication.instance():
 
 
 class MyPerspective(object):
+    def __init__(self):
+        self.name = "Dummy Perspective"
+
     def communicator(self):
         return Communicate()
 
@@ -47,7 +50,7 @@ class MyPerspective(object):
         return None
 
     def title(self):
-        return "Dummy Perspective"
+        return self.name
 
 
 class dummy_manager(object):
@@ -340,12 +343,23 @@ class DataExplorerTest(unittest.TestCase):
         self.assertTrue(mocked_perspective.setData.called_once)
         self.assertTrue(mocked_perspective.swapData.called)
 
+        # Test the exception block
+        QMessageBox.exec_ = MagicMock()
+        mocked_perspective.swapData = MagicMock(side_effect = Exception())
+
+        # Click on the button to so the mocked swapData method raises an exception
+        QTest.mouseClick(self.form.cmdSendTo, Qt.LeftButton)
+
+        # Assure the message box popped up
+        QMessageBox.exec_.assert_called_once()
+
         # open another file
         filename = ["cyl_400_20.txt"]
         self.form.readData(filename)
 
-        # Mock the warning message
+        # Mock the warning message and the swapData method
         QMessageBox.exec_ = MagicMock()
+        mocked_perspective.swapData = MagicMock()
 
         # Click on the button to swap both datasets to the perspective
         QTest.mouseClick(self.form.cmdSendTo, Qt.LeftButton)

--- a/src/sas/qtgui/MainWindow/UnitTesting/GuiManagerTest.py
+++ b/src/sas/qtgui/MainWindow/UnitTesting/GuiManagerTest.py
@@ -147,9 +147,9 @@ class GuiManagerTest(unittest.TestCase):
         Tests the SasView website version polling
         """
         self.manager.processVersion = MagicMock()
-        version = {'version'     : '4.2.2',
+        version = {'version'     : '5.0.2',
                    'update_url'  : 'http://www.sasview.org/sasview.latestversion', 
-                   'download_url': 'https://github.com/SasView/sasview/releases/tag/v4.2.2'}
+                   'download_url': 'https://github.com/SasView/sasview/releases/tag/v5.0.2'}
         self.manager.checkUpdate()
 
         self.manager.processVersion.assert_called_with(version)

--- a/src/sas/qtgui/Perspectives/Corfunc/CorfuncPerspective.py
+++ b/src/sas/qtgui/Perspectives/Corfunc/CorfuncPerspective.py
@@ -455,6 +455,13 @@ class CorfuncWindow(QtWidgets.QDialog, Ui_CorfuncDialog):
         """
         return False
 
+    @staticmethod
+    def allowSwap():
+        """
+        We cannot swap data with corfunc analysis at this time.
+        """
+        return False
+
     def setData(self, data_item, is_batch=False):
         """
         Obtain a QStandardItem object and dissect it to get Data1D/2D

--- a/src/sas/qtgui/Perspectives/Fitting/ComplexConstraint.py
+++ b/src/sas/qtgui/Perspectives/Fitting/ComplexConstraint.py
@@ -137,7 +137,7 @@ class ComplexConstraint(QtWidgets.QDialog, Ui_ComplexConstraintUI):
         Tooltip for txtConstraint
         """
         p1 = self.tab_names[0] + ":" + self.cbParam1.currentText()
-        p2 = self.tab_names[1] +"."+self.cbParam2.currentText() if len(self.tab_names) != 1 else self.tab_names[0] +"."+self.cbParam2.currentText()
+        p2 = self.tab_names[1] if len(self.tab_names) != 1 else self.tab_names[0] +"."+self.cbParam2.currentText()
         tooltip = "E.g.\n%s = 2.0 * (%s)\n" %(p1, p2)
         tooltip += "%s = sqrt(%s) + 5"%(p1, p2)
         self.txtConstraint.setToolTip(tooltip)

--- a/src/sas/qtgui/Perspectives/Fitting/ComplexConstraint.py
+++ b/src/sas/qtgui/Perspectives/Fitting/ComplexConstraint.py
@@ -137,7 +137,7 @@ class ComplexConstraint(QtWidgets.QDialog, Ui_ComplexConstraintUI):
         Tooltip for txtConstraint
         """
         p1 = self.tab_names[0] + ":" + self.cbParam1.currentText()
-        p2 = self.tab_names[1] if len(self.tab_names) != 1 else self.tab_names[0] +"."+self.cbParam2.currentText()
+        p2 = self.tab_names[1] +"."+self.cbParam2.currentText() if len(self.tab_names) != 1 else self.tab_names[0] +"."+self.cbParam2.currentText()
         tooltip = "E.g.\n%s = 2.0 * (%s)\n" %(p1, p2)
         tooltip += "%s = sqrt(%s) + 5"%(p1, p2)
         self.txtConstraint.setToolTip(tooltip)

--- a/src/sas/qtgui/Perspectives/Fitting/FittingPerspective.py
+++ b/src/sas/qtgui/Perspectives/Fitting/FittingPerspective.py
@@ -389,6 +389,15 @@ class FittingWindow(QtWidgets.QTabWidget):
             else:
                 self.addFit(data, is_batch=is_batch)
 
+    def swapData(self, data):
+        """
+        Replace the data from the current fitting tab
+        """
+        assert isinstance(self.currentWidget(), FittingWidget)
+        self.currentWidget().data = data
+        tab_name = str(self.tabText(self.currentIndex()))
+        self.updateFitDict(data, tab_name)
+
     def onFittingOptionsChange(self, fit_engine):
         """
         React to the fitting algorithm change by modifying window title

--- a/src/sas/qtgui/Perspectives/Fitting/FittingPerspective.py
+++ b/src/sas/qtgui/Perspectives/Fitting/FittingPerspective.py
@@ -345,6 +345,12 @@ class FittingWindow(QtWidgets.QTabWidget):
         """
         return True
 
+    def allowSwap(self):
+        """
+        Tell the caller that you can swap data
+        """
+        return True
+
     def isSerializable(self):
         """
         Tell the caller that this perspective writes its state

--- a/src/sas/qtgui/Perspectives/Fitting/FittingPerspective.py
+++ b/src/sas/qtgui/Perspectives/Fitting/FittingPerspective.py
@@ -399,11 +399,19 @@ class FittingWindow(QtWidgets.QTabWidget):
         """
         Replace the data from the current fitting tab
         """
-        assert isinstance(self.currentWidget(), FittingWidget)
+        if not isinstance(self.currentWidget(), FittingWidget):
+            msg = "Current tab is not  a fitting widget"
+            raise TypeError(msg)
+
         if not isinstance(data, QtGui.QStandardItem):
             msg = "Incorrect type passed to the Fitting Perspective"
             raise AttributeError(msg)
-        self.currentWidget().data = data
+
+        if self.currentTab.is_batch_fitting:
+            msg = "Current tab is in batch mode"
+            raise Exception(msg)
+
+        self.currentTab.data = data
         tab_name = str(self.tabText(self.currentIndex()))
         self.updateFitDict(data, tab_name)
 

--- a/src/sas/qtgui/Perspectives/Fitting/FittingPerspective.py
+++ b/src/sas/qtgui/Perspectives/Fitting/FittingPerspective.py
@@ -408,8 +408,8 @@ class FittingWindow(QtWidgets.QTabWidget):
             raise AttributeError(msg)
 
         if self.currentTab.is_batch_fitting:
-            msg = "Current tab is in batch mode"
-            raise Exception(msg)
+            msg = "Data in Batch Fitting cannot be swapped"
+            raise RuntimeError(msg)
 
         self.currentTab.data = data
         tab_name = str(self.tabText(self.currentIndex()))

--- a/src/sas/qtgui/Perspectives/Fitting/FittingPerspective.py
+++ b/src/sas/qtgui/Perspectives/Fitting/FittingPerspective.py
@@ -400,6 +400,9 @@ class FittingWindow(QtWidgets.QTabWidget):
         Replace the data from the current fitting tab
         """
         assert isinstance(self.currentWidget(), FittingWidget)
+        if not isinstance(data, QtGui.QStandardItem):
+            msg = "Incorrect type passed to the Fitting Perspective"
+            raise AttributeError(msg)
         self.currentWidget().data = data
         tab_name = str(self.tabText(self.currentIndex()))
         self.updateFitDict(data, tab_name)

--- a/src/sas/qtgui/Perspectives/Fitting/FittingWidget.py
+++ b/src/sas/qtgui/Perspectives/Fitting/FittingWidget.py
@@ -219,7 +219,8 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
 
         # Let others know we're full of data now
         self.data_is_loaded = True
-
+        # Reset the smearer
+        #self.smearing_widget.resetSmearer()
         # Enable/disable UI components
         self.setEnablementOnDataLoad()
 

--- a/src/sas/qtgui/Perspectives/Fitting/FittingWidget.py
+++ b/src/sas/qtgui/Perspectives/Fitting/FittingWidget.py
@@ -220,7 +220,7 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         # Let others know we're full of data now
         self.data_is_loaded = True
         # Reset the smearer
-        #self.smearing_widget.resetSmearer()
+        self.smearing_widget.resetSmearer()
         # Enable/disable UI components
         self.setEnablementOnDataLoad()
 

--- a/src/sas/qtgui/Perspectives/Fitting/SmearingWidget.py
+++ b/src/sas/qtgui/Perspectives/Fitting/SmearingWidget.py
@@ -444,3 +444,9 @@ class SmearingWidget(QtWidgets.QWidget, Ui_SmearingWidgetUI):
                 dq_r = GuiUtils.formatNumber(data.dxw[0])
 
         return smear_type, dq_l, dq_r
+
+    def resetSmearer(self):
+        self.current_smearer = None
+        self.cbSmearing.blockSignals(True)
+        self.cbSmearing.clear()
+        self.cbSmearing.blockSignals(False)

--- a/src/sas/qtgui/Perspectives/Fitting/SmearingWidget.py
+++ b/src/sas/qtgui/Perspectives/Fitting/SmearingWidget.py
@@ -317,9 +317,9 @@ class SmearingWidget(QtWidgets.QWidget, Ui_SmearingWidgetUI):
         if accuracy is not None:
             self.model.item(MODEL.index('ACCURACY')).setText(accuracy)
         if d_down is not None:
-            self.model.item(MODEL.index('PINHOLE_MIN')).setText(d_down)
+            self.model.item(MODEL.index('PINHOLE_MIN')).setText(str(d_down))
         if d_up is not None:
-            self.model.item(MODEL.index('PINHOLE_MAX')).setText(d_up)
+            self.model.item(MODEL.index('PINHOLE_MAX')).setText(str(d_up))
 
     def onPinholeSmear(self):
         """

--- a/src/sas/qtgui/Perspectives/Fitting/UnitTesting/FittingPerspectiveTest.py
+++ b/src/sas/qtgui/Perspectives/Fitting/UnitTesting/FittingPerspectiveTest.py
@@ -143,6 +143,27 @@ class FittingPerspectiveTest(unittest.TestCase):
         # Check for 4 tabs
         self.assertEqual(len(self.widget.tabs), 4)
 
+    def testSwapData(self):
+        '''Assure that data swapping is correct'''
+
+        # Mock the datafromitem() call from FittingWidget
+        data1 = Data1D(x=[3,4], y=[3,4])
+        GuiUtils.dataFromItem = MagicMock(return_value=data1)
+
+        # Add a new tab
+        item = QtGui.QStandardItem("test")
+        self.widget.setData([item])
+
+        # Create a new dataset and mock the datafromitemcall()
+        data2 = Data1D(x=[1,2], y=[1,2])
+        GuiUtils.dataFromItem = MagicMock(return_value=data2)
+
+        # Swap the data
+        self.widget.swapData(item)
+
+        # Check that data has been swapped
+        self.assertEqual(self.widget.tabs[0].data, data2)
+
     def testSetBatchData(self):
         ''' Assure that setting batch data is correct'''
 

--- a/src/sas/qtgui/Perspectives/Fitting/UnitTesting/FittingPerspectiveTest.py
+++ b/src/sas/qtgui/Perspectives/Fitting/UnitTesting/FittingPerspectiveTest.py
@@ -7,7 +7,6 @@ from PyQt5 import QtWidgets
 from PyQt5 import QtTest
 from PyQt5 import QtCore
 from unittest.mock import MagicMock
-from unittest.mock import PropertyMock
 
 # set up import paths
 import sas.qtgui.path_prepare
@@ -174,12 +173,18 @@ class FittingPerspectiveTest(unittest.TestCase):
         # It should raise an AttributeError
         self.assertRaises(AttributeError, self.widget.swapData, item)
 
-        # Mock a batch tab
+        # Create a batch tab
         item = QtGui.QStandardItem("test")
-        self.widget.tabs[0].is_batch_fitting = PropertyMock(return_value = True)
+        self.widget.addFit(None, is_batch=True)
 
         # It should raise an exception
         self.assertRaises(Exception, self.widget.swapData, item)
+
+        # Create a non valid tab
+        self.widget.addConstraintTab()
+
+        # It should raise a TypeError
+        self.assertRaises(TypeError, self.widget.swapData, item)
 
     def testSetBatchData(self):
         ''' Assure that setting batch data is correct'''

--- a/src/sas/qtgui/Perspectives/Fitting/UnitTesting/FittingPerspectiveTest.py
+++ b/src/sas/qtgui/Perspectives/Fitting/UnitTesting/FittingPerspectiveTest.py
@@ -178,7 +178,7 @@ class FittingPerspectiveTest(unittest.TestCase):
         self.widget.addFit(None, is_batch=True)
 
         # It should raise an exception
-        self.assertRaises(Exception, self.widget.swapData, item)
+        self.assertRaises(RuntimeError, self.widget.swapData, item)
 
         # Create a non valid tab
         self.widget.addConstraintTab()

--- a/src/sas/qtgui/Perspectives/Fitting/UnitTesting/FittingPerspectiveTest.py
+++ b/src/sas/qtgui/Perspectives/Fitting/UnitTesting/FittingPerspectiveTest.py
@@ -7,6 +7,7 @@ from PyQt5 import QtWidgets
 from PyQt5 import QtTest
 from PyQt5 import QtCore
 from unittest.mock import MagicMock
+from unittest.mock import PropertyMock
 
 # set up import paths
 import sas.qtgui.path_prepare
@@ -166,6 +167,19 @@ class FittingPerspectiveTest(unittest.TestCase):
 
         # We should only have one tab
         self.assertEqual(len(self.widget.tabs), 1)
+
+        # send something stupid as data
+        item = "foo"
+
+        # It should raise an AttributeError
+        self.assertRaises(AttributeError, self.widget.swapData, item)
+
+        # Mock a batch tab
+        item = QtGui.QStandardItem("test")
+        self.widget.tabs[0].is_batch_fitting = PropertyMock(return_value = True)
+
+        # It should raise an exception
+        self.assertRaises(Exception, self.widget.swapData, item)
 
     def testSetBatchData(self):
         ''' Assure that setting batch data is correct'''

--- a/src/sas/qtgui/Perspectives/Fitting/UnitTesting/FittingPerspectiveTest.py
+++ b/src/sas/qtgui/Perspectives/Fitting/UnitTesting/FittingPerspectiveTest.py
@@ -164,6 +164,9 @@ class FittingPerspectiveTest(unittest.TestCase):
         # Check that data has been swapped
         self.assertEqual(self.widget.tabs[0].data, data2)
 
+        # We should only have one tab
+        self.assertEqual(len(self.widget.tabs), 1)
+
     def testSetBatchData(self):
         ''' Assure that setting batch data is correct'''
 

--- a/src/sas/qtgui/Perspectives/Invariant/InvariantPerspective.py
+++ b/src/sas/qtgui/Perspectives/Invariant/InvariantPerspective.py
@@ -824,3 +824,9 @@ class InvariantWindow(QtWidgets.QDialog, Ui_tabbedInvariantUI):
         Tell the caller that we don't accept multiple data instances
         """
         return False
+
+    def allowSwap(self):
+        """
+        Tell the caller that we can't swap data
+        """
+        return False

--- a/src/sas/qtgui/Perspectives/Invariant/InvariantPerspective.py
+++ b/src/sas/qtgui/Perspectives/Invariant/InvariantPerspective.py
@@ -38,6 +38,7 @@ DEFAULT_POWER_LOW = 4
 BG_WHITE = "background-color: rgb(255, 255, 255);"
 BG_RED = "background-color: rgb(244, 170, 164);"
 
+
 class InvariantWindow(QtWidgets.QDialog, Ui_tabbedInvariantUI):
     # The controller which is responsible for managing signal slots connections
     # for the gui and providing an interface to the data model.
@@ -350,7 +351,6 @@ class InvariantWindow(QtWidgets.QDialog, Ui_tabbedInvariantUI):
                 msg += str(ex)
                 logging.warning('High-q calculation failed: {}'.format(msg))
 
-
         if self._low_extrapolate and low_calculation_pass:
             extrapolated_data = inv.get_extra_data_low(self._low_points)
             power_low = inv.get_extrapolation_power(range='low')
@@ -375,9 +375,9 @@ class InvariantWindow(QtWidgets.QDialog, Ui_tabbedInvariantUI):
             # Add the plot to the model item
             # This needs to run in the main thread
             reactor.callFromThread(GuiUtils.updateModelItemWithPlot,
-                                       self._model_item,
-                                       extrapolated_data,
-                                       title)
+                                   self._model_item,
+                                   extrapolated_data,
+                                   title)
 
         if self._high_extrapolate and high_calculation_pass:
             # for presentation in InvariantDetails
@@ -407,14 +407,14 @@ class InvariantWindow(QtWidgets.QDialog, Ui_tabbedInvariantUI):
             # Add the plot to the model item
             # This needs to run in the main thread
             reactor.callFromThread(GuiUtils.updateModelItemWithPlot,
-                                       self._model_item, high_out_data, title)
+                                   self._model_item, high_out_data, title)
 
         reactor.callFromThread(self.updateModelFromThread, WIDGETS.W_VOLUME_FRACTION, volume_fraction)
         reactor.callFromThread(self.updateModelFromThread, WIDGETS.W_VOLUME_FRACTION_ERR, volume_fraction_error)
         if surface:
             reactor.callFromThread(self.updateModelFromThread, WIDGETS.W_SPECIFIC_SURFACE, surface)
             reactor.callFromThread(self.updateModelFromThread, WIDGETS.W_SPECIFIC_SURFACE_ERR,
-                                                    surface_error)
+                                   surface_error)
 
         reactor.callFromThread(self.updateModelFromThread, WIDGETS.W_INVARIANT, qstar_total)
         reactor.callFromThread(self.updateModelFromThread, WIDGETS.W_INVARIANT_ERR, qstar_total_error)
@@ -423,7 +423,6 @@ class InvariantWindow(QtWidgets.QDialog, Ui_tabbedInvariantUI):
         reactor.callFromThread(self.updateModelFromThread, WIDGETS.D_HIGH_QSTAR, qstar_high)
         reactor.callFromThread(self.updateModelFromThread, WIDGETS.D_HIGH_QSTAR_ERR, qstar_high_err)
         return self.model
-
 
     def updateModelFromThread(self, widget, value):
         """
@@ -654,8 +653,8 @@ class InvariantWindow(QtWidgets.QDialog, Ui_tabbedInvariantUI):
         self.rbFixLowQ.setEnabled(clicked)  # and not self._low_guinier)
 
         self.txtPowerLowQ.setEnabled(clicked
-                                    and not self._low_guinier
-                                    and not self._low_fit)
+                                     and not self._low_guinier
+                                     and not self._low_fit)
 
     def setupModel(self):
         """ """
@@ -746,7 +745,7 @@ class InvariantWindow(QtWidgets.QDialog, Ui_tabbedInvariantUI):
         self.mapper.addMapping(self.txtNptsHighQ, WIDGETS.W_NPTS_HIGHQ)
         self.mapper.addMapping(self.rbFitHighQ, WIDGETS.W_HIGHQ_FIT)
         self.mapper.addMapping(self.txtPowerHighQ, WIDGETS.W_HIGHQ_POWER_VALUE)
-    
+
         # Output
         self.mapper.addMapping(self.txtVolFract, WIDGETS.W_VOLUME_FRACTION)
         self.mapper.addMapping(self.txtVolFractErr, WIDGETS.W_VOLUME_FRACTION_ERR)

--- a/src/sas/qtgui/Perspectives/Inversion/InversionPerspective.py
+++ b/src/sas/qtgui/Perspectives/Inversion/InversionPerspective.py
@@ -128,7 +128,7 @@ class InversionWindow(QtWidgets.QDialog, Ui_PrInversion):
     def allowBatch(self):
         return False
 
-    def allowBatch(self):
+    def allowSwap(self):
         """
         Tell the caller we don't accept swapping data
         """

--- a/src/sas/qtgui/Perspectives/Inversion/InversionPerspective.py
+++ b/src/sas/qtgui/Perspectives/Inversion/InversionPerspective.py
@@ -128,6 +128,12 @@ class InversionWindow(QtWidgets.QDialog, Ui_PrInversion):
     def allowBatch(self):
         return False
 
+    def allowBatch(self):
+        """
+        Tell the caller we don't accept swapping data
+        """
+        return False
+
     def setClosable(self, value=True):
         """
         Allow outsiders close this widget


### PR DESCRIPTION
Allows sending a data set to the active fit page via a checkbox in the `DataExplorer`, which will replace the current dataset. Performing the replacement will not delete any children of the replaced data set, as described in the linked issue.
Fixes #1537 
