### PR TITLE
Display sample title instead of filename in DataExplorer window (ESS_GUI)

### DIFF
--- a/src/sas/qtgui/MainWindow/DataExplorer.py
+++ b/src/sas/qtgui/MainWindow/DataExplorer.py
@@ -364,9 +364,9 @@ class DataExplorerWindow(DroppableDataLoadWidget):
             data = GuiUtils.dataFromItem(item)
             if data is None: continue
             # Now, all plots under this item
-            filename = data.name
-            all_data[filename] = data
-            other_datas = GuiUtils.plotsFromFilename(filename, model)
+            name = data.name
+            all_data[name] = data
+            other_datas = GuiUtils.plotsFromDisplayName(name, model)
             # skip the main plot
             other_datas = list(other_datas.values())[1:]
             for data in other_datas:
@@ -391,12 +391,12 @@ class DataExplorerWindow(DroppableDataLoadWidget):
             data = GuiUtils.dataFromItem(item)
             if data is None: continue
             # Now, all plots under this item
-            filename = data.name
+            name = data.name
             is_checked = item.checkState()
             properties['checked'] = is_checked
             other_datas = []
             # save underlying theories
-            other_datas = GuiUtils.plotsFromFilename(filename, model)
+            other_datas = GuiUtils.plotsFromDisplayName(name, model)
             # skip the main plot
             other_datas = list(other_datas.values())[1:]
             all_data[data.id] = [data, properties, other_datas]
@@ -413,10 +413,10 @@ class DataExplorerWindow(DroppableDataLoadWidget):
                 if data is None: continue
                 if data.id != id: continue
                 # We found the dataset - save it.
-                filename = data.name
+                name = data.name
                 is_checked = item.checkState()
                 properties['checked'] = is_checked
-                other_datas = GuiUtils.plotsFromFilename(filename, model)
+                other_datas = GuiUtils.plotsFromDisplayName(name, model)
                 # skip the main plot
                 other_datas = list(other_datas.values())[1:]
                 all_data = [data, properties, other_datas]
@@ -975,20 +975,20 @@ class DataExplorerWindow(DroppableDataLoadWidget):
         if not self.parent.perspective().allowSwap():
             self.chkSwap.setCheckState(False)
 
-    def itemFromFilename(self, filename):
+    def itemFromDisplayName(self, name):
         """
-        Retrieves model item corresponding to the given filename
+        Retrieves model item corresponding to the given display name
         """
-        item = GuiUtils.itemFromFilename(filename, self.model)
+        item = GuiUtils.itemFromDisplayName(name, self.model)
         return item
 
-    def displayFile(self, filename=None, is_data=True, id=None):
+    def displayData(self, name=None, is_data=True, id=None):
         """
-        Forces display of charts for the given filename
+        Forces display of charts for the given name
         """
         model = self.model if is_data else self.theory_model
         # Now query the model item for available plots
-        plots = GuiUtils.plotsFromFilename(filename, model)
+        plots = GuiUtils.plotsFromDisplayName(name, model)
         # Each fitpage contains the name based on fit widget number
         fitpage_name = "" if id is None else "M"+str(id)
         new_plots = []
@@ -1005,8 +1005,8 @@ class DataExplorerWindow(DroppableDataLoadWidget):
             # Don't include plots from different fitpages,
             # but always include the original data
             if (fitpage_name in plot.name
-                    or filename in plot.name
-                    or filename == plot.filename):
+                    or name in plot.name
+                    or name == plot.filename):
                 # Residuals get their own plot
                 if plot.plot_role == Data1D.ROLE_RESIDUAL:
                     plot.yscale='linear'

--- a/src/sas/qtgui/MainWindow/DataExplorer.py
+++ b/src/sas/qtgui/MainWindow/DataExplorer.py
@@ -364,7 +364,7 @@ class DataExplorerWindow(DroppableDataLoadWidget):
             data = GuiUtils.dataFromItem(item)
             if data is None: continue
             # Now, all plots under this item
-            filename = data.filename
+            filename = data.name
             all_data[filename] = data
             other_datas = GuiUtils.plotsFromFilename(filename, model)
             # skip the main plot
@@ -391,7 +391,7 @@ class DataExplorerWindow(DroppableDataLoadWidget):
             data = GuiUtils.dataFromItem(item)
             if data is None: continue
             # Now, all plots under this item
-            filename = data.filename
+            filename = data.name
             is_checked = item.checkState()
             properties['checked'] = is_checked
             other_datas = []
@@ -413,7 +413,7 @@ class DataExplorerWindow(DroppableDataLoadWidget):
                 if data is None: continue
                 if data.id != id: continue
                 # We found the dataset - save it.
-                filename = data.filename
+                filename = data.name
                 is_checked = item.checkState()
                 properties['checked'] = is_checked
                 other_datas = GuiUtils.plotsFromFilename(filename, model)
@@ -621,7 +621,7 @@ class DataExplorerWindow(DroppableDataLoadWidget):
             from sas.sascalc.dataloader.data_info import Data1D as old_data1d
             from sas.sascalc.dataloader.data_info import Data2D as old_data2d
             if isinstance(new_data, (old_data1d, old_data2d)):
-                new_data = self.manager.create_gui_data(value[0], new_data.filename)
+                new_data = self.manager.create_gui_data(value[0], new_data.name)
             if hasattr(value[0], 'id'):
                 new_data.id = value[0].id
                 new_data.group_id = value[0].group_id
@@ -629,7 +629,7 @@ class DataExplorerWindow(DroppableDataLoadWidget):
             # make sure the ID is retained
             properties = value[1]
             is_checked = properties['checked']
-            new_item = GuiUtils.createModelItemWithPlot(new_data, new_data.filename)
+            new_item = GuiUtils.createModelItemWithPlot(new_data, new_data.name)
             new_item.setCheckState(is_checked)
             items.append(new_item)
             model = self.theory_model
@@ -1280,11 +1280,6 @@ class DataExplorerWindow(DroppableDataLoadWidget):
 
                 output_objects = self.loader.load(p_file)
 
-                # Some loaders return a list and some just a single Data1D object.
-                # Standardize.
-                if not isinstance(output_objects, list):
-                    output_objects = [output_objects]
-
                 for item in output_objects:
                     # cast sascalc.dataloader.data_info.Data1D into
                     # sasgui.guiframe.dataFitting.Data1D
@@ -1294,7 +1289,7 @@ class DataExplorerWindow(DroppableDataLoadWidget):
 
                     # Model update should be protected
                     self.mutex.lock()
-                    self.updateModel(new_data, p_file)
+                    self.updateModel(new_data, new_data.name)
                     #self.model.reset()
                     QtWidgets.QApplication.processEvents()
                     self.mutex.unlock()
@@ -1506,7 +1501,7 @@ class DataExplorerWindow(DroppableDataLoadWidget):
         self.txt_widget.setReadOnly(True)
         self.txt_widget.setWindowFlags(QtCore.Qt.Window)
         self.txt_widget.setWindowIcon(QtGui.QIcon(":/res/ball.ico"))
-        self.txt_widget.setWindowTitle("Data Info: %s" % data.filename)
+        self.txt_widget.setWindowTitle("Data Info: %s" % data.name)
         self.txt_widget.clear()
         self.txt_widget.insertPlainText(text_to_show)
 

--- a/src/sas/qtgui/MainWindow/DataManager.py
+++ b/src/sas/qtgui/MainWindow/DataManager.py
@@ -93,7 +93,9 @@ class DataManager(object):
         #creating a name for data
         title = ""
         file_name = os.path.basename(path) if path is not None else os.path.basename(data.filename)
-        if file_name:
+        if data.title:
+            name = data.title
+        elif file_name:
             name = file_name
         elif data.run:
             name = data.run[0]

--- a/src/sas/qtgui/MainWindow/GuiManager.py
+++ b/src/sas/qtgui/MainWindow/GuiManager.py
@@ -524,7 +524,7 @@ class GuiManager(object):
         self.communicate.updateTheoryFromPerspectiveSignal.connect(self.updateTheoryFromPerspective)
         self.communicate.deleteIntermediateTheoryPlotsSignal.connect(self.deleteIntermediateTheoryPlotsByModelID)
         self.communicate.plotRequestedSignal.connect(self.showPlot)
-        self.communicate.plotFromFilenameSignal.connect(self.showPlotFromFilename)
+        self.communicate.plotFromNameSignal.connect(self.showPlotFromName)
         self.communicate.updateModelFromDataOperationPanelSignal.connect(self.updateModelFromDataOperationPanel)
         self.communicate.activeGraphsSignal.connect(self.updatePlotItems)
 
@@ -1169,12 +1169,12 @@ class GuiManager(object):
         self.filesWidget.model.appendRow(new_item)
         self._data_manager.add_data(new_datalist_item)
 
-    def showPlotFromFilename(self, filename):
+    def showPlotFromName(self, name):
         """
         Pass the show plot request to the data explorer
         """
         if hasattr(self, "filesWidget"):
-            self.filesWidget.displayFile(filename=filename, is_data=True)
+            self.filesWidget.displayData(name=name, is_data=True)
 
     def showPlot(self, plot, id):
         """

--- a/src/sas/qtgui/Perspectives/Corfunc/CorfuncPerspective.py
+++ b/src/sas/qtgui/Perspectives/Corfunc/CorfuncPerspective.py
@@ -477,6 +477,7 @@ class CorfuncWindow(QtWidgets.QDialog, Ui_CorfuncDialog):
 
         model_item = data_item[0]
         data = GuiUtils.dataFromItem(model_item)
+        self._path = data.name
         self._model_item = model_item
         self._calculator.set_data(data)
         self.cmdCalculateBg.setEnabled(True)
@@ -500,7 +501,6 @@ class CorfuncWindow(QtWidgets.QDialog, Ui_CorfuncDialog):
         self._canvas.extrap = None
         self.model_changed(None)
         self.cmdTransform.setEnabled(False)
-        self._path = data.name
         self._realplot.data = None
         self._realplot.draw_real_space()
 

--- a/src/sas/qtgui/Perspectives/Fitting/FitPage.py
+++ b/src/sas/qtgui/Perspectives/Fitting/FitPage.py
@@ -26,7 +26,7 @@ class FitPage(object):
 
         self.page_id = 0
         self.data_is_loaded = False
-        self.filename = ""
+        self.name = ""
         self.data = None
         self.parameters_to_fit = []
         self.kernel_module = None

--- a/src/sas/qtgui/Perspectives/Fitting/FittingLogic.py
+++ b/src/sas/qtgui/Perspectives/Fitting/FittingLogic.py
@@ -147,7 +147,7 @@ class FittingLogic(object):
         new_plot.id = str(tab_id) + " " + ("[" + component + "] " if component else "") + model.id
 
         # use data.filename for data, use model.id for theory
-        id_str = data.filename if data.filename else model.id
+        id_str = data.name if data.name else model.id
         new_plot.name = model.name + ((" " + component) if component else "") + " [" + id_str + "]"
 
         new_plot.title = new_plot.name

--- a/src/sas/qtgui/Perspectives/Fitting/FittingUtilities.py
+++ b/src/sas/qtgui/Perspectives/Fitting/FittingUtilities.py
@@ -599,7 +599,7 @@ def plotResiduals(reference_data, current_data, weights):
         return None
 
     theory_name = str(current_data.name.split()[0])
-    res_name = reference_data.filename if reference_data.filename else reference_data.name
+    res_name = reference_data.name if reference_data.name else reference_data.filename
     residuals.name = "Residuals for " + str(theory_name) + "[" + res_name + "]"
     residuals.title = residuals.name
     residuals.ytransform = 'y'

--- a/src/sas/qtgui/Perspectives/Fitting/FittingWidget.py
+++ b/src/sas/qtgui/Perspectives/Fitting/FittingWidget.py
@@ -449,10 +449,10 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         """
         # Tag along functionality
         self.label.setText("Data loaded from: ")
-        if self.logic.data.filename:
-            self.lblFilename.setText(self.logic.data.filename)
-        else:
+        if self.logic.data.name:
             self.lblFilename.setText(self.logic.data.name)
+        else:
+            self.lblFilename.setText(self.logic.data.filename)
         self.updateQRange()
         # Switch off Data2D control
         self.chk2DView.setEnabled(False)
@@ -463,8 +463,8 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         if self.is_batch_fitting:
             self.lblFilename.setVisible(False)
             for dataitem in self.all_data:
-                filename = GuiUtils.dataFromItem(dataitem).filename
-                self.cbFileNames.addItem(filename)
+                name = GuiUtils.dataFromItem(dataitem).name
+                self.cbFileNames.addItem(name)
             self.cbFileNames.setVisible(True)
             self.chkChainFit.setEnabled(True)
             self.chkChainFit.setVisible(True)
@@ -2137,7 +2137,7 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         data_to_show = self.data
         # Any models for this page
         current_index = self.all_data[self.data_index]
-        item = self._requestPlots(self.data.filename, current_index.model())
+        item = self._requestPlots(self.data.name, current_index.model())
         if item:
             # fit+data has not been shown - show just data
             self.communicate.plotRequestedSignal.emit([item, data_to_show], self.tab_id)
@@ -2692,7 +2692,7 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         """
         if self.data_is_loaded:
             if not fitted_data.name:
-                name = self.nameForFittedData(self.data.filename)
+                name = self.nameForFittedData(self.data.name)
                 fitted_data.title = name
                 fitted_data.name = name
                 fitted_data.filename = name
@@ -2741,7 +2741,7 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         Return name for the dataset. Terribly impure function.
         """
         if fitted_data.name is None:
-            name = self.nameForFittedData(self.logic.data.filename)
+            name = self.nameForFittedData(self.logic.data.name)
             fitted_data.title = name
             fitted_data.name = name
             fitted_data.filename = name
@@ -3575,7 +3575,7 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         """
         assert isinstance(fp, FitPage)
         # Main tab info
-        self.logic.data.filename = fp.filename
+        self.logic.data.filename = fp.name
         self.data_is_loaded = fp.data_is_loaded
         self.chkPolydispersity.setCheckState(fp.is_polydisperse)
         self.chkMagnetism.setCheckState(fp.is_magnetic)
@@ -3617,7 +3617,7 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         assert isinstance(fp, FitPage)
 
         # Main tab info
-        fp.filename = self.logic.data.filename
+        fp.filename = self.logic.data.name
         fp.data_is_loaded = self.data_is_loaded
         fp.is_polydisperse = self.chkPolydispersity.isChecked()
         fp.is_magnetic = self.chkMagnetism.isChecked()
@@ -3859,11 +3859,11 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
                 # need item->data->data_id
                 data = GuiUtils.dataFromItem(item)
                 data_ids.append(data.id)
-                filenames.append(data.filename)
+                filenames.append(data.name)
         else:
             if self.data_is_loaded:
                 data_ids = [str(self.logic.data.id)]
-                filenames = [str(self.logic.data.filename)]
+                filenames = [str(self.logic.data.name)]
         param_list.append(['tab_index', str(self.tab_id)])
         param_list.append(['is_batch_fitting', str(self.is_batch_fitting)])
         param_list.append(['data_name', filenames])

--- a/src/sas/qtgui/Perspectives/Fitting/FittingWidget.py
+++ b/src/sas/qtgui/Perspectives/Fitting/FittingWidget.py
@@ -2127,7 +2127,7 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         if self.theory_item is None:
             self.recalculatePlotData()
         elif self.model_data:
-            self._requestPlots(self.model_data.filename, self.theory_item.model())
+            self._requestPlots(self.model_data.name, self.theory_item.model())
 
     def showPlot(self):
         """
@@ -2147,7 +2147,7 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         Emits plotRequestedSignal for all plots found in the given model under the provided item name.
         """
         fitpage_name = self.kernel_module.name
-        plots = GuiUtils.plotsFromFilename(item_name, item_model)
+        plots = GuiUtils.plotsFromDisplayName(item_name, item_model)
         # Has the fitted data been shown?
         data_shown = False
         item = None
@@ -3575,7 +3575,7 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         """
         assert isinstance(fp, FitPage)
         # Main tab info
-        self.logic.data.filename = fp.name
+        self.logic.data.name = fp.name
         self.data_is_loaded = fp.data_is_loaded
         self.chkPolydispersity.setCheckState(fp.is_polydisperse)
         self.chkMagnetism.setCheckState(fp.is_magnetic)
@@ -3617,7 +3617,7 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         assert isinstance(fp, FitPage)
 
         # Main tab info
-        fp.filename = self.logic.data.name
+        fp.name = self.logic.data.name
         fp.data_is_loaded = self.data_is_loaded
         fp.is_polydisperse = self.chkPolydispersity.isChecked()
         fp.is_magnetic = self.chkMagnetism.isChecked()
@@ -3853,20 +3853,20 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
 
         param_list.append(['is_data', str(self.data_is_loaded)])
         data_ids = []
-        filenames = []
+        names = []
         if self.is_batch_fitting:
             for item in self.all_data:
                 # need item->data->data_id
                 data = GuiUtils.dataFromItem(item)
                 data_ids.append(data.id)
-                filenames.append(data.name)
+                names.append(data.name)
         else:
             if self.data_is_loaded:
                 data_ids = [str(self.logic.data.id)]
-                filenames = [str(self.logic.data.name)]
+                names = [str(self.logic.data.name)]
         param_list.append(['tab_index', str(self.tab_id)])
         param_list.append(['is_batch_fitting', str(self.is_batch_fitting)])
-        param_list.append(['data_name', filenames])
+        param_list.append(['data_name', names])
         param_list.append(['data_id', data_ids])
         param_list.append(['tab_name', self.modelName()])
         # option tab

--- a/src/sas/qtgui/Perspectives/Fitting/ReportPageLogic.py
+++ b/src/sas/qtgui/Perspectives/Fitting/ReportPageLogic.py
@@ -100,7 +100,7 @@ class ReportPageLogic(object):
 
     def buildPlotsForReport(self, images):
         """ Convert Matplotlib figure 'fig' into a <img> tag for HTML use using base64 encoding. """
-        html = FEET_1 % self.data.filename
+        html = FEET_1 % self.data.name
 
         for fig in images:
             canvas = FigureCanvas(fig)

--- a/src/sas/qtgui/Perspectives/Invariant/InvariantPerspective.py
+++ b/src/sas/qtgui/Perspectives/Invariant/InvariantPerspective.py
@@ -222,12 +222,12 @@ class InvariantWindow(QtWidgets.QDialog, Ui_tabbedInvariantUI):
         self.model = model
         self.mapper.toFirst()
         self._data = GuiUtils.dataFromItem(self._model_item)
-        filename = self._data.filename
+        name = self._data.name
         # Send the modified model item to DE for keeping in the model
         # Currently -unused
         # self.communicate.updateModelFromPerspectiveSignal.emit(self._model_item)
 
-        plot_data = GuiUtils.plotsFromFilename(filename, self._manager.filesWidget.model)
+        plot_data = GuiUtils.plotsFromDisplayName(name, self._manager.filesWidget.model)
 
         # only the Low-Q/High-Q data for plotting
         data_to_plot = [(self._model_item, p) for p in plot_data.values() if p.plot_role == p.ROLE_DATA]
@@ -665,7 +665,7 @@ class InvariantWindow(QtWidgets.QDialog, Ui_tabbedInvariantUI):
         """ """
         # filename
         item = QtGui.QStandardItem(self._path)
-        self.model.setItem(WIDGETS.W_FILENAME, item)
+        self.model.setItem(WIDGETS.W_NAME, item)
 
         # add Q parameters to the model
         qmin = 0.0
@@ -720,7 +720,7 @@ class InvariantWindow(QtWidgets.QDialog, Ui_tabbedInvariantUI):
         self.mapper.setModel(self.model)
 
         # Filename
-        self.mapper.addMapping(self.txtName, WIDGETS.W_FILENAME)
+        self.mapper.addMapping(self.txtName, WIDGETS.W_NAME)
 
         # Qmin/Qmax
         self.mapper.addMapping(self.txtTotalQMin, WIDGETS.W_QMIN)
@@ -785,7 +785,7 @@ class InvariantWindow(QtWidgets.QDialog, Ui_tabbedInvariantUI):
 
         # Extract data on 1st child - this is the Data1D/2D component
         data = GuiUtils.dataFromItem(self._model_item)
-        self.model.item(WIDGETS.W_FILENAME).setData(self._model_item.text())
+        self.model.item(WIDGETS.W_NAME).setData(self._model_item.text())
         # update GUI and model with info from loaded data
         self.updateGuiFromFile(data=data)
 
@@ -801,23 +801,23 @@ class InvariantWindow(QtWidgets.QDialog, Ui_tabbedInvariantUI):
             raise ValueError(msg)
 
         try:
-            filename = data.filename
+            name = data.name
         except:
-            msg = 'No filename chosen.'
+            msg = 'No data name chosen.'
             raise ValueError(msg)
         try:
             qmin = min(self._data.x)
             qmax = max(self._data.x)
         except:
             msg = "Unable to find q min/max of \n data named %s" % \
-                  data.filename
+                  data.name
             raise ValueError(msg)
 
-        # update model with input form files: filename, qmin, qmax
-        self.model.item(WIDGETS.W_FILENAME).setText(filename)
+        # update model with input form files: name, qmin, qmax
+        self.model.item(WIDGETS.W_NAME).setText(name)
         self.model.item(WIDGETS.W_QMIN).setText(str(qmin))
         self.model.item(WIDGETS.W_QMAX).setText(str(qmax))
-        self._path = filename
+        self._path = data.filename
 
         # Calculate and add to GUI: volume fraction, invariant total,
         # and specific surface if porod checked

--- a/src/sas/qtgui/Perspectives/Invariant/InvariantUtils.py
+++ b/src/sas/qtgui/Perspectives/Invariant/InvariantUtils.py
@@ -1,6 +1,6 @@
 from sas.qtgui.Utilities.GuiUtils import enum
 
-WIDGETS = enum( 'W_FILENAME',
+WIDGETS = enum( 'W_NAME',
                 'W_QMIN',
                 'W_QMAX',
                 'W_BACKGROUND',

--- a/src/sas/qtgui/Perspectives/Invariant/UnitTesting/InvariantPerspectiveTest.py
+++ b/src/sas/qtgui/Perspectives/Invariant/UnitTesting/InvariantPerspectiveTest.py
@@ -384,7 +384,7 @@ class InvariantPerspectiveTest(unittest.TestCase):
 
     def testSetupModel(self):
         """ Test default settings of model"""
-        self.assertEqual(self.widget.model.item(WIDGETS.W_FILENAME).text(),
+        self.assertEqual(self.widget.model.item(WIDGETS.W_NAME).text(),
                          self.widget._path)
 
         self.assertEqual(self.widget.model.item(WIDGETS.W_QMIN).text(), '0.0')

--- a/src/sas/qtgui/Perspectives/Inversion/InversionPerspective.py
+++ b/src/sas/qtgui/Perspectives/Inversion/InversionPerspective.py
@@ -342,13 +342,13 @@ class InversionWindow(QtWidgets.QDialog, Ui_PrInversion):
             self.logic.data_is_loaded and
             self._calculator.nfunc != self.nTermsSuggested)
 
-    def populateDataComboBox(self, filename, data_ref):
+    def populateDataComboBox(self, name, data_ref):
         """
-        Append a new file name to the data combobox
-        :param filename: data filename
+        Append a new name to the data combobox
+        :param name: data name
         :param data_ref: QStandardItem reference for data set to be added
         """
-        self.dataList.addItem(filename, data_ref)
+        self.dataList.addItem(name, data_ref)
 
     def acceptNoTerms(self):
         """Send estimated no of terms to input"""
@@ -434,7 +434,7 @@ class InversionWindow(QtWidgets.QDialog, Ui_PrInversion):
     def showBatchOutput(self):
         """
         Display the batch output in tabular form
-        :param output_data: Dictionary mapping filename -> P(r) instance
+        :param output_data: Dictionary mapping name -> P(r) instance
         """
         if self.batchResultsWindow is None:
             self.batchResultsWindow = BatchInversionOutputPanel(
@@ -487,7 +487,7 @@ class InversionWindow(QtWidgets.QDialog, Ui_PrInversion):
             if np.size(self.logic.data.dy) == 0 or np.all(self.logic.data.dy) == 0:
                 self.logic.add_errors()
             self.updateDataList(data)
-            self.populateDataComboBox(self.logic.data.filename, data)
+            self.populateDataComboBox(self.logic.data.name, data)
         self.dataList.setCurrentIndex(len(self.dataList) - 1)
         #Checking for 1D again to mitigate the case when 2D data is last on the data list
         if isinstance(self.logic.data, Data1D):
@@ -503,7 +503,7 @@ class InversionWindow(QtWidgets.QDialog, Ui_PrInversion):
             DICT_KEYS[2]: self.dataPlot
         }
         # Update batch results window when finished
-        self.batchResults[self.logic.data.filename] = self._calculator
+        self.batchResults[self.logic.data.name] = self._calculator
         if self.batchResultsWindow is not None:
             self.showBatchOutput()
 
@@ -689,7 +689,7 @@ class InversionWindow(QtWidgets.QDialog, Ui_PrInversion):
         """
         # Get all parameters from page
         param_dict = self.getState()
-        param_dict['data_name'] = str(self.logic.data.filename)
+        param_dict['data_name'] = str(self.logic.data.name)
         param_dict['data_id'] = str(self.logic.data.id)
         return param_dict
 
@@ -1004,9 +1004,9 @@ class InversionWindow(QtWidgets.QDialog, Ui_PrInversion):
 
         # Update P(r) and fit plots
         self.prPlot = self.logic.newPRPlot(out, self._calculator, cov)
-        self.prPlot.filename = self.logic.data.filename
+        self.prPlot.name = self.logic.data.name
         self.dataPlot = self.logic.new1DPlot(out, self._calculator)
-        self.dataPlot.filename = self.logic.data.filename
+        self.dataPlot.name = self.logic.data.name
 
         # Udpate internals and GUI
         self.updateDataList(self._data)

--- a/src/sas/qtgui/Utilities/GridPanel.py
+++ b/src/sas/qtgui/Utilities/GridPanel.py
@@ -203,9 +203,9 @@ class BatchOutputPanel(QtWidgets.QMainWindow, Ui_GridPanelUI):
         # look for the 'Data' column and extract the filename
         for row in rows:
             try:
-                filename = data['Data'][row]
+                name = data['Data'][row]
                 # emit a signal so the plots are being shown
-                self.communicate.plotFromFilenameSignal.emit(filename)
+                self.communicate.plotFromNameSignal.emit(name)
             except (IndexError, AttributeError):
                 # data messed up.
                 return

--- a/src/sas/qtgui/Utilities/GuiUtils.py
+++ b/src/sas/qtgui/Utilities/GuiUtils.py
@@ -245,7 +245,7 @@ class Communicate(QtCore.QObject):
     plotRequestedSignal = QtCore.pyqtSignal(list, int)
 
     # Plot from file names
-    plotFromFilenameSignal = QtCore.pyqtSignal(str)
+    plotFromNameSignal = QtCore.pyqtSignal(str)
 
     # Plot update requested from a perspective
     plotUpdateSignal = QtCore.pyqtSignal(list)
@@ -469,17 +469,17 @@ def updateModelItemStatus(model_item, filename="", name="", status=2):
 
     return
 
-def itemFromFilename(filename, model_item):
+def itemFromDisplayName(name, model_item):
     """
-    Returns the model item text=filename in the model
+    Returns the model item text=name in the model
     """
     assert isinstance(model_item, QtGui.QStandardItemModel)
-    assert isinstance(filename, str)
+    assert isinstance(name, str)
 
     # Iterate over model looking for named items
     item = list([i for i in [model_item.item(index)
                              for index in range(model_item.rowCount())]
-                 if str(i.text()) == filename])
+                 if str(i.text()) == name])
     return item[0] if len(item)>0 else None
 
 def plotsFromModel(model_name, model_item):
@@ -505,18 +505,18 @@ def plotsFromModel(model_name, model_item):
 
     return plot_data
 
-def plotsFromFilename(filename, model_item):
+def plotsFromDisplayName(name, model_item):
     """
-    Returns the list of plots for the item with text=filename in the model
+    Returns the list of plots for the item with text=name in the model
     """
     assert isinstance(model_item, QtGui.QStandardItemModel)
-    assert isinstance(filename, str)
+    assert isinstance(name, str)
 
     plot_data = {}
     # Iterate over model looking for named items
     for index in range(model_item.rowCount()):
         item = model_item.item(index)
-        if filename in str(item.text()):
+        if name in str(item.text()):
             # TODO: assure item type is correct (either data1/2D or Plotter)
             plot_data[item] = item.child(0).data()
             # Going 1 level deeper only

--- a/src/sas/qtgui/Utilities/UnitTesting/GridPanelTest.py
+++ b/src/sas/qtgui/Utilities/UnitTesting/GridPanelTest.py
@@ -110,7 +110,7 @@ Chi2,Data,scale,background,radius_equat_core,x_core,thick_shell,x_polar_shell,sl
         '''Test plot generation from selected table rows'''
         # mock tested calls
         #GuiUtils.Communicate.plot
-        spy_plot_signal = QtSignalSpy(self.widget.communicate, self.widget.communicate().plotFromFilenameSignal)
+        spy_plot_signal = QtSignalSpy(self.widget.communicate, self.widget.communicate().plotFromNameSignal)
         # Select row #1
         self.widget.tblParams.selectRow(0)
         QtWidgets.QApplication.processEvents()


### PR DESCRIPTION
The sample title is displayed in the data explorer instead of the file name. This is useful for distinguishing multiple data sets that are loaded from a single file.

This is the 5th PR separating #1559. I do not plan to create a parallel PR for v4.x/wxPython/master.

Closes #1243. 