### PR TITLE
Load constraints after fit pages when loading project

### DIFF
--- a/src/sas/qtgui/MainWindow/DataExplorer.py
+++ b/src/sas/qtgui/MainWindow/DataExplorer.py
@@ -519,14 +519,14 @@ class DataExplorerWindow(DroppableDataLoadWidget):
                 visible_perspective = value
             # send newly created items to the perspective
             self.updatePerspectiveWithProperties(key, value)
-        constraint_dict = self.readConstraintsFromProject(all_data)
-        self._perspective().updateFromConstraints(constraint_dict)
         # Set to fitting perspective and load in Batch and C&S Pages
         self.cbFitting.setCurrentIndex(
             self.cbFitting.findText(DEFAULT_PERSPECTIVE))
         # See if there are any batch pages defined and create them, if so
         self.updateWithBatchPages(all_data)
-
+        # Get the constraint dict and apply it
+        constraint_dict = GuiUtils.getConstraints(all_data)
+        self._perspective().updateFromConstraints(constraint_dict)
         # Only now can we create/assign C&S pages.
         for key in cs_keys:
             self.updatePerspectiveWithProperties(key, all_data[key])

--- a/src/sas/qtgui/MainWindow/DataExplorer.py
+++ b/src/sas/qtgui/MainWindow/DataExplorer.py
@@ -535,47 +535,6 @@ class DataExplorerWindow(DroppableDataLoadWidget):
         self.cbFitting.setCurrentIndex(
                 self.cbFitting.findText(visible_perspective))
 
-    def readConstraintsFromProject(self, all_data):
-        """
-        Extracts constraints from *all_data* dict and returns a dict where keys
-        are the tab name and values are a list of constraints on that tab. The
-        dict can then be passed to the updateFromConstraints method from the
-        fitting perspective to apply the constraints with error checking
-        mechanism
-        """
-        constraint_dict = {}
-        for key, value in all_data.items():
-            # make sure we dealing with params
-            if 'fit_params' not in value:
-                continue
-            params = value['fit_params']
-            for page in params:
-                if not isinstance(page, dict):
-                    continue
-
-                tab_name = None
-                constraint_list = []
-                for param_name, param_value in page.items():
-                    # make sure we are dealing with lists
-                    if not isinstance(param_value, list):
-                        continue
-                    # get the tab name
-                    elif param_name == "tab_name":
-                        tab_name = param_value[0]
-                    # get parameters
-                    elif len(param_value) >= 5:
-                        ioffset = 1 if len(param_value) > 5 else 0
-                        cons = param_value[4+ioffset]
-                        # get the constraint
-                        if cons is not None and len(cons) == 5:
-                            constraint_list.append(cons)
-                    else:
-                        continue
-
-                if tab_name and constraint_list:
-                    constraint_dict.update({tab_name: constraint_list})
-        return constraint_dict
-
     def updateWithBatchPages(self, all_data):
         """
         Checks all properties and see if there are any batch pages defined.

--- a/src/sas/qtgui/MainWindow/DataExplorer.py
+++ b/src/sas/qtgui/MainWindow/DataExplorer.py
@@ -519,7 +519,8 @@ class DataExplorerWindow(DroppableDataLoadWidget):
                 visible_perspective = value
             # send newly created items to the perspective
             self.updatePerspectiveWithProperties(key, value)
-
+        constraint_dict = self.readConstraintsFromProject(all_data)
+        self._perspective().updateFromConstraints(constraint_dict)
         # Set to fitting perspective and load in Batch and C&S Pages
         self.cbFitting.setCurrentIndex(
             self.cbFitting.findText(DEFAULT_PERSPECTIVE))
@@ -533,6 +534,47 @@ class DataExplorerWindow(DroppableDataLoadWidget):
         # Set to perspective shown when project was saved
         self.cbFitting.setCurrentIndex(
                 self.cbFitting.findText(visible_perspective))
+
+    def readConstraintsFromProject(self, all_data):
+        """
+        Extracts constraints from *all_data* dict and returns a dict where keys
+        are the tab name and values are a list of constraints on that tab. The
+        dict can then be passed to the updateFromConstraints method from the
+        fitting perspective to apply the constraints with error checking
+        mechanism
+        """
+        constraint_dict = {}
+        for key, value in all_data.items():
+            # make sure we dealing with params
+            if 'fit_params' not in value:
+                continue
+            params = value['fit_params']
+            for page in params:
+                if not isinstance(page, dict):
+                    continue
+
+                tab_name = None
+                constraint_list = []
+                for param_name, param_value in page.items():
+                    # make sure we are dealing with lists
+                    if not isinstance(param_value, list):
+                        continue
+                    # get the tab name
+                    elif param_name == "tab_name":
+                        tab_name = param_value[0]
+                    # get parameters
+                    elif len(param_value) >= 5:
+                        ioffset = 1 if len(param_value) > 5 else 0
+                        cons = param_value[4+ioffset]
+                        # get the constraint
+                        if cons is not None and len(cons) == 5:
+                            constraint_list.append(cons)
+                    else:
+                        continue
+
+                if tab_name and constraint_list:
+                    constraint_dict.update({tab_name: constraint_list})
+        return constraint_dict
 
     def updateWithBatchPages(self, all_data):
         """

--- a/src/sas/qtgui/MainWindow/UnitTesting/DataExplorerTest.py
+++ b/src/sas/qtgui/MainWindow/UnitTesting/DataExplorerTest.py
@@ -1067,31 +1067,5 @@ class DataExplorerTest(unittest.TestCase):
         # same data but must show, since different model
         self.assertFalse(self.form.isPlotShown(data4))
 
-    def testReadConstraintsFromProject(self):
-        '''test the method that reads constraints from a project and returns
-        a dict with the constraints'''
-        # create a project dict with constraints
-        constraint1 = ['scale', 'scale', 'M2.scale', True, 'M2.scale']
-        constraint2 = ['scale', 'scale', 'M1.scale', True, 'M1.scale']
-        fit_params1 = {'tab_name': ['M1'], 'scale': [True, '1.0', None,
-                                                     '0.0', 'inf',
-                                                     constraint1], 'foo': 'bar'}
-        fit_params2 = {'tab_name': ['M2'], 'scale': [True, '1.0', None,
-                                                     '0.0', 'inf',
-                                                     constraint2], 'foo': 'bar'}
-        fit_page1 = {'fit_data': None, 'fit_params': [fit_params1]}
-        fit_page2 = {'fit_data': None, 'fit_params': [fit_params2]}
-        all_data = {'dataset1': fit_page1, 'dataset2': fit_page2}
-        # get the constraint_dict
-        constraint_dict = self.form.readConstraintsFromProject(all_data)
-        # we have two constraints on different fit pages
-        self.assertEqual(len(constraint_dict), 2)
-        # we have one constraint per fit page
-        self.assertEqual(len(constraint_dict['M1']), 1)
-        self.assertEqual(len(constraint_dict['M2']), 1)
-        # check the constraints in the constraint_dict
-        self.assertEqual(constraint_dict['M1'][0], constraint1)
-        self.assertEqual(constraint_dict['M2'][0], constraint2)
-
 if __name__ == "__main__":
     unittest.main()

--- a/src/sas/qtgui/MainWindow/UnitTesting/DataExplorerTest.py
+++ b/src/sas/qtgui/MainWindow/UnitTesting/DataExplorerTest.py
@@ -1067,6 +1067,31 @@ class DataExplorerTest(unittest.TestCase):
         # same data but must show, since different model
         self.assertFalse(self.form.isPlotShown(data4))
 
+    def testReadConstraintsFromProject(self):
+        '''test the method that reads constraints from a project and returns
+        a dict with the constraints'''
+        # create a project dict with constraints
+        constraint1 = ['scale', 'scale', 'M2.scale', True, 'M2.scale']
+        constraint2 = ['scale', 'scale', 'M1.scale', True, 'M1.scale']
+        fit_params1 = {'tab_name': ['M1'], 'scale': [True, '1.0', None,
+                                                     '0.0', 'inf',
+                                                     constraint1], 'foo': 'bar'}
+        fit_params2 = {'tab_name': ['M2'], 'scale': [True, '1.0', None,
+                                                     '0.0', 'inf',
+                                                     constraint2], 'foo': 'bar'}
+        fit_page1 = {'fit_data': None, 'fit_params': [fit_params1]}
+        fit_page2 = {'fit_data': None, 'fit_params': [fit_params2]}
+        all_data = {'dataset1': fit_page1, 'dataset2': fit_page2}
+        # get the constraint_dict
+        constraint_dict = self.form.readConstraintsFromProject(all_data)
+        # we have two constraints on different fit pages
+        self.assertEqual(len(constraint_dict), 2)
+        # we have one constraint per fit page
+        self.assertEqual(len(constraint_dict['M1']), 1)
+        self.assertEqual(len(constraint_dict['M2']), 1)
+        # check the constraints in the constraint_dict
+        self.assertEqual(constraint_dict['M1'][0], constraint1)
+        self.assertEqual(constraint_dict['M2'][0], constraint2)
 
 if __name__ == "__main__":
     unittest.main()

--- a/src/sas/qtgui/Perspectives/Fitting/FittingPerspective.py
+++ b/src/sas/qtgui/Perspectives/Fitting/FittingPerspective.py
@@ -525,3 +525,16 @@ class FittingWindow(QtWidgets.QTabWidget):
         else:
             constraint_tab = None
         return constraint_tab
+
+    def getTabIndexFromName(self, name):
+        """
+        Returns the index of the tab name equal to *name*, or None if no tab
+        is named *name*
+        """
+        assert(name, str)
+        for tab in self.tabs:
+            if tab.modelName() == name:
+                return tab
+            else:
+                continue
+        return None

--- a/src/sas/qtgui/Perspectives/Fitting/FittingPerspective.py
+++ b/src/sas/qtgui/Perspectives/Fitting/FittingPerspective.py
@@ -557,6 +557,4 @@ class FittingWindow(QtWidgets.QTabWidget):
         for tab in self.tabs:
             if tab.modelName() == name:
                 return tab
-            else:
-                continue
         return None

--- a/src/sas/qtgui/Perspectives/Fitting/FittingPerspective.py
+++ b/src/sas/qtgui/Perspectives/Fitting/FittingPerspective.py
@@ -194,23 +194,24 @@ class FittingWindow(QtWidgets.QTabWidget):
         *constraint_dict*  keys are the fit page name, and the value is a
         list of constraints.
         """
-        for fit_page_name, constraint_list in constraint_dict:
-            tab = ObjectLibrary.getObject(fit_page_name)
-            for constraint_params in constraint_list:
-                if constraint_params is not None and len(constraint_params) == 5:
-                    value = constraint_params[0]
-                    param = constraint_params[1]
-                    value_ex = constraint_params[2]
-                    validate = constraint_params[3]
-                    function = constraint_params[4]
+        for fit_page_name, constraint_list in constraint_dict.items():
+            tab = self.getTabByName(fit_page_name)
+            for constraint_param in constraint_list:
+                if constraint_param is not None and len(constraint_param) == 5:
+                    value = constraint_param[0]
+                    param = constraint_param[1]
+                    value_ex = constraint_param[2]
+                    validate = constraint_param[3]
+                    function = constraint_param[4]
                     constraint = Constraint()
                     constraint.value = value
                     constraint.func = function
                     constraint.param = param
                     constraint.value_ex = value_ex
                     constraint.validate = validate
-                    tab.addConstraintToRow(tab.getRowFromName(constraint[1]),
-                                           constraint)
+                    tab.addConstraintToRow(constraint=constraint,
+                                           row=tab.getRowFromName(
+                                               constraint_param[1]))
 
     def onParamSave(self):
         self.currentTab.onCopyToClipboard("Save")
@@ -550,3 +551,15 @@ class FittingWindow(QtWidgets.QTabWidget):
         else:
             constraint_tab = None
         return constraint_tab
+
+    def getTabByName(self, name):
+        """
+        Returns the tab with with attribute name *name*
+        """
+        assert(name, str)
+        for tab in self.tabs:
+            if tab.modelName() == name:
+                return tab
+            else:
+                continue
+        return None

--- a/src/sas/qtgui/Perspectives/Fitting/FittingPerspective.py
+++ b/src/sas/qtgui/Perspectives/Fitting/FittingPerspective.py
@@ -200,17 +200,12 @@ class FittingWindow(QtWidgets.QTabWidget):
             tab = self.getTabByName(fit_page_name)
             for constraint_param in constraint_list:
                 if constraint_param is not None and len(constraint_param) == 5:
-                    value = constraint_param[0]
-                    param = constraint_param[1]
-                    value_ex = constraint_param[2]
-                    validate = constraint_param[3]
-                    function = constraint_param[4]
                     constraint = Constraint()
-                    constraint.value = value
-                    constraint.func = function
-                    constraint.param = param
-                    constraint.value_ex = value_ex
-                    constraint.validate = validate
+                    constraint.value = constraint_param[0]
+                    constraint.func = constraint_param[4]
+                    constraint.param = constraint_param[1]
+                    constraint.value_ex = constraint_param[2]
+                    constraint.validate = constraint_param[3]
                     tab.addConstraintToRow(constraint=constraint,
                                            row=tab.getRowFromName(
                                                constraint_param[1]))

--- a/src/sas/qtgui/Perspectives/Fitting/FittingPerspective.py
+++ b/src/sas/qtgui/Perspectives/Fitting/FittingPerspective.py
@@ -192,7 +192,9 @@ class FittingWindow(QtWidgets.QTabWidget):
         """
         Updates all tabs with constraints present in *constraint_dict*, where
         *constraint_dict*  keys are the fit page name, and the value is a
-        list of constraints.
+        list of constraints. A constraint is represented by a list [value,
+        param, value_ex, validate, function] of attributes of a Constraint
+        object
         """
         for fit_page_name, constraint_list in constraint_dict.items():
             tab = self.getTabByName(fit_page_name)

--- a/src/sas/qtgui/Perspectives/Fitting/FittingPerspective.py
+++ b/src/sas/qtgui/Perspectives/Fitting/FittingPerspective.py
@@ -13,6 +13,7 @@ from bumps import fitters
 import sas.qtgui.Utilities.LocalConfig as LocalConfig
 import sas.qtgui.Utilities.ObjectLibrary as ObjectLibrary
 import sas.qtgui.Utilities.GuiUtils as GuiUtils
+from sas.qtgui.Perspectives.Fitting.Constraint import Constraint
 
 from sas.qtgui.Perspectives.Fitting.FittingWidget import FittingWidget
 from sas.qtgui.Perspectives.Fitting.ConstraintWidget import ConstraintWidget
@@ -186,6 +187,30 @@ class FittingWindow(QtWidgets.QTabWidget):
         Pass the update parameters to the current fit page
         """
         self.currentTab.createPageForParameters(parameters)
+
+    def updateFromConstraints(self, constraint_dict):
+        """
+        Updates all tabs with constraints present in *constraint_dict*, where
+        *constraint_dict*  keys are the fit page name, and the value is a
+        list of constraints.
+        """
+        for fit_page_name, constraint_list in constraint_dict:
+            tab = ObjectLibrary.getObject(fit_page_name)
+            for constraint_params in constraint_list:
+                if constraint_params is not None and len(constraint_params) == 5:
+                    value = constraint_params[0]
+                    param = constraint_params[1]
+                    value_ex = constraint_params[2]
+                    validate = constraint_params[3]
+                    function = constraint_params[4]
+                    constraint = Constraint()
+                    constraint.value = value
+                    constraint.func = function
+                    constraint.param = param
+                    constraint.value_ex = value_ex
+                    constraint.validate = validate
+                    tab.addConstraintToRow(tab.getRowFromName(constraint[1]),
+                                           constraint)
 
     def onParamSave(self):
         self.currentTab.onCopyToClipboard("Save")
@@ -525,16 +550,3 @@ class FittingWindow(QtWidgets.QTabWidget):
         else:
             constraint_tab = None
         return constraint_tab
-
-    def getTabIndexFromName(self, name):
-        """
-        Returns the index of the tab name equal to *name*, or None if no tab
-        is named *name*
-        """
-        assert(name, str)
-        for tab in self.tabs:
-            if tab.modelName() == name:
-                return tab
-            else:
-                continue
-        return None

--- a/src/sas/qtgui/Perspectives/Fitting/FittingWidget.py
+++ b/src/sas/qtgui/Perspectives/Fitting/FittingWidget.py
@@ -4233,22 +4233,6 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
             except:
                 pass
 
-            # constraints
-            cons = param_dict[param_name][4+ioffset]
-            if cons is not None and len(cons)==5:
-                value = cons[0]
-                param = cons[1]
-                value_ex = cons[2]
-                validate = cons[3]
-                function = cons[4]
-                constraint = Constraint()
-                constraint.value = value
-                constraint.func = function
-                constraint.param = param
-                constraint.value_ex = value_ex
-                constraint.validate = validate
-                self.addConstraintToRow(constraint=constraint, row=row)
-
             self.setFocus()
 
         self.iterateOverModel(updateFittedValues)

--- a/src/sas/qtgui/Utilities/GuiUtils.py
+++ b/src/sas/qtgui/Utilities/GuiUtils.py
@@ -1361,6 +1361,47 @@ def readDataFromFile(fp):
 
     return new_stored_data
 
+def getConstraints(fit_project):
+    """
+    Extracts constraints from *fir_project* dict and returns a dict where keys
+    are the tab name and values are a list of constraints on that tab. The
+    dict can then be passed to the updateFromConstraints method from the
+    fitting perspective to apply the constraints with error checking
+    mechanism
+    """
+    constraint_dict = {}
+    for key, value in fit_project.items():
+        # make sure we dealing with params
+        if 'fit_params' not in value:
+            continue
+        params = value['fit_params']
+        for page in params:
+            if not isinstance(page, dict):
+                continue
+
+            tab_name = None
+            constraint_list = []
+            for param_name, param_value in page.items():
+                # make sure we are dealing with lists
+                if not isinstance(param_value, list):
+                    continue
+                # get the tab name
+                elif param_name == "tab_name":
+                    tab_name = param_value[0]
+                # get parameters
+                elif len(param_value) >= 5:
+                    ioffset = 1 if len(param_value) > 5 else 0
+                    cons = param_value[4+ioffset]
+                    # get the constraint
+                    if cons is not None and len(cons) == 5:
+                        constraint_list.append(cons)
+                else:
+                    continue
+
+            if tab_name and constraint_list:
+                constraint_dict.update({tab_name: constraint_list})
+    return constraint_dict
+
 def readProjectFromSVS(filepath):
     """
     Read old SVS file and convert to the project dictionary

--- a/src/sas/qtgui/Utilities/UnitTesting/GuiUtilsTest.py
+++ b/src/sas/qtgui/Utilities/UnitTesting/GuiUtilsTest.py
@@ -674,6 +674,32 @@ class HashableStandardItemTest(unittest.TestCase):
         item_clone = self.item.clone()
         self.assertEqual(item_clone.__hash__(), 0)
 
+    def testGetConstraints(self):
+        '''test the method that reads constraints from a project and returns
+        a dict with the constraints'''
+        # create a project dict with constraints
+        constraint1 = ['scale', 'scale', 'M2.scale', True, 'M2.scale']
+        constraint2 = ['scale', 'scale', 'M1.scale', True, 'M1.scale']
+        fit_params1 = {'tab_name': ['M1'], 'scale': [True, '1.0', None,
+                                                     '0.0', 'inf',
+                                                     constraint1], 'foo': 'bar'}
+        fit_params2 = {'tab_name': ['M2'], 'scale': [True, '1.0', None,
+                                                     '0.0', 'inf',
+                                                     constraint2], 'foo': 'bar'}
+        fit_page1 = {'fit_data': None, 'fit_params': [fit_params1]}
+        fit_page2 = {'fit_data': None, 'fit_params': [fit_params2]}
+        fit_project = {'dataset1': fit_page1, 'dataset2': fit_page2}
+        # get the constraint_dict
+        constraint_dict = getConstraints(fit_project)
+        # we have two constraints on different fit pages
+        self.assertEqual(len(constraint_dict), 2)
+        # we have one constraint per fit page
+        self.assertEqual(len(constraint_dict['M1']), 1)
+        self.assertEqual(len(constraint_dict['M2']), 1)
+        # check the constraints in the constraint_dict
+        self.assertEqual(constraint_dict['M1'][0], constraint1)
+        self.assertEqual(constraint_dict['M2'][0], constraint2)
+
 if __name__ == "__main__":
     unittest.main()
 


### PR DESCRIPTION
Fixes #1653 
This PR aims at having constraints applied when all fit pages are loaded when loading a project, instead of having them applied immediately after each fit page loading. This was causing problems as the GUI would complain that there where unknown symbols in the constraint if they were referring to parameters of a yet to be loaded fit page.