### PR TITLE
Disable rather than remove constraint when fitting a single fit page

### DIFF
--- a/src/sas/qtgui/Perspectives/Fitting/ConstraintWidget.py
+++ b/src/sas/qtgui/Perspectives/Fitting/ConstraintWidget.py
@@ -1055,7 +1055,7 @@ class ConstraintWidget(QtWidgets.QWidget, Ui_ConstraintWidgetUI):
     def uncheckConstraint(self, name):
         """
         Unchecks the constraint in tblConstraint with *name* slave
-        parameter.
+        parameter and deactivates the constraint.
         """
         for row in range(self.tblConstraints.rowCount()):
             constraint = self.tblConstraints.item(row, 0).data(0)
@@ -1064,3 +1064,7 @@ class ConstraintWidget(QtWidgets.QWidget, Ui_ConstraintWidgetUI):
             # string.
             if name in constraint:
                 self.tblConstraints.item(row, 0).setCheckState(0)
+                # deactivate the constraint
+                tab = self.parent.getTabByName(name[:name.index(":")])
+                row = tab.getRowFromName(name[name.index(":") + 1:])
+                tab.getConstraintForRow(row).active = False

--- a/src/sas/qtgui/Perspectives/Fitting/ConstraintWidget.py
+++ b/src/sas/qtgui/Perspectives/Fitting/ConstraintWidget.py
@@ -1060,7 +1060,7 @@ class ConstraintWidget(QtWidgets.QWidget, Ui_ConstraintWidgetUI):
         for row in range(self.tblConstraints.rowCount()):
             constraint = self.tblConstraints.item(row, 0).data(0)
             # slave parameter has model name and parameter separated
-            # by semicolon e.g `M1:scale` so no need to parse the constraint
+            # by colon e.g `M1:scale` so no need to parse the constraint
             # string.
             if name in constraint:
                 self.tblConstraints.item(row, 0).setCheckState(0)

--- a/src/sas/qtgui/Perspectives/Fitting/ConstraintWidget.py
+++ b/src/sas/qtgui/Perspectives/Fitting/ConstraintWidget.py
@@ -1054,11 +1054,13 @@ class ConstraintWidget(QtWidgets.QWidget, Ui_ConstraintWidgetUI):
 
     def uncheckConstraint(self, name):
         """
-        Unchecks the constraint in tblConstraint list with *name* slave
-        parameter. Only works with equality, this should change when
-        inequality constraints are implemented.
+        Unchecks the constraint in tblConstraint with *name* slave
+        parameter.
         """
         for row in range(self.tblConstraints.rowCount()):
             constraint = self.tblConstraints.item(row, 0).data(0)
-            if constraint[:constraint.index("=")].strip(" ") == name:
+            # slave parameter has model name and parameter separated
+            # by semicolon e.g `M1:scale` so no need to parse the constraint
+            # string.
+            if name in constraint:
                 self.tblConstraints.item(row, 0).setCheckState(0)

--- a/src/sas/qtgui/Perspectives/Fitting/ConstraintWidget.py
+++ b/src/sas/qtgui/Perspectives/Fitting/ConstraintWidget.py
@@ -1051,3 +1051,14 @@ class ConstraintWidget(QtWidgets.QWidget, Ui_ConstraintWidgetUI):
         msgbox.setWindowTitle("Fit Report")
         _ = msgbox.exec_()
         return
+
+    def uncheckConstraint(self, name):
+        """
+        Unchecks the constraint in tblConstraint list with *name* slave
+        parameter. Only works with equality, this should change when
+        inequality constraints are implemented.
+        """
+        for row in range(self.tblConstraints.rowCount()):
+            constraint = self.tblConstraints.item(row, 0).data(0)
+            if constraint[:constraint.index("=")].strip(" ") == name:
+                self.tblConstraints.item(row, 0).setCheckState(0)

--- a/src/sas/qtgui/Perspectives/Fitting/FittingWidget.py
+++ b/src/sas/qtgui/Perspectives/Fitting/FittingWidget.py
@@ -1146,9 +1146,17 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
                 # cancel fit
                 raise ValueError("Fitting cancelled")
             else:
-                # remove constraint
+                constraint_tab = self.parent.perspective().getConstraintTab()
                 for cons in multi_constraints:
-                    self.deleteConstraintOnParameter(param=cons[0])
+                    # deactivate the constraint
+                    row = self.getRowFromName(cons[0])
+                    self.getConstraintForRow(row).active = False
+                    # uncheck in the constraint tab
+                    if constraint_tab:
+                        constraint_tab.uncheckConstraint(
+                            self.kernel_module.name + ':' + cons[0])
+
+
                 # re-read the constraints
                 constraints = self.getComplexConstraintsForModel()
 

--- a/src/sas/qtgui/Perspectives/Fitting/FittingWidget.py
+++ b/src/sas/qtgui/Perspectives/Fitting/FittingWidget.py
@@ -1129,10 +1129,10 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         if multi_constraints:
             # Let users choose what to do
             msg = "The current fit contains constraints relying on other fit pages.\n"
-            msg += "Parameters with those constraints are:\n" +\
-                '\n'.join([cons[0] for cons in multi_constraints])
-            msg += "\n\nWould you like to deactivate these constraints or " \
-                   "cancel fitting?"
+            msg += ("Parameters with those constraints are:\n" +
+                    '\n'.join([cons[0] for cons in multi_constraints]))
+            msg += ("\n\nWould you like to deactivate these constraints or "
+                    "cancel fitting?")
             msgbox = QtWidgets.QMessageBox(self)
             msgbox.setIcon(QtWidgets.QMessageBox.Warning)
             msgbox.setText(msg)

--- a/src/sas/qtgui/Perspectives/Fitting/FittingWidget.py
+++ b/src/sas/qtgui/Perspectives/Fitting/FittingWidget.py
@@ -1131,13 +1131,14 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
             msg = "The current fit contains constraints relying on other fit pages.\n"
             msg += "Parameters with those constraints are:\n" +\
                 '\n'.join([cons[0] for cons in multi_constraints])
-            msg += "\n\nWould you like to remove these constraints or cancel fitting?"
+            msg += "\n\nWould you like to deactivate these constraints or " \
+                   "cancel fitting?"
             msgbox = QtWidgets.QMessageBox(self)
             msgbox.setIcon(QtWidgets.QMessageBox.Warning)
             msgbox.setText(msg)
             msgbox.setWindowTitle("Existing Constraints")
             # custom buttons
-            button_remove = QtWidgets.QPushButton("Remove")
+            button_remove = QtWidgets.QPushButton("Deactivate")
             msgbox.addButton(button_remove, QtWidgets.QMessageBox.YesRole)
             button_cancel = QtWidgets.QPushButton("Cancel")
             msgbox.addButton(button_cancel, QtWidgets.QMessageBox.RejectRole)
@@ -1155,8 +1156,6 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
                     if constraint_tab:
                         constraint_tab.uncheckConstraint(
                             self.kernel_module.name + ':' + cons[0])
-
-
                 # re-read the constraints
                 constraints = self.getComplexConstraintsForModel()
 

--- a/src/sas/qtgui/Perspectives/Fitting/UnitTesting/ConstraintWidgetTest.py
+++ b/src/sas/qtgui/Perspectives/Fitting/UnitTesting/ConstraintWidgetTest.py
@@ -308,7 +308,9 @@ class ConstraintWidgetTest(unittest.TestCase):
             return_value=[('scale', self.constraint1.func)])
         test_tab.getConstraintObjectsForModel = MagicMock(
             return_value=[self.constraint1])
+        test_tab.getConstraintForRow = MagicMock(return_value=self.constraint1)
         self.widget.updateFitLine("test_tab")
+        self.widget.parent.getTabByName = MagicMock(return_value=test_tab)
 
         # Constraint should be checked
         self.assertEqual(self.widget.tblConstraints.item(0, 0).checkState(), 2)
@@ -316,3 +318,5 @@ class ConstraintWidgetTest(unittest.TestCase):
         self.widget.uncheckConstraint('M1:scale')
         # Should be unchecked in tblConstraint
         self.assertEqual(self.widget.tblConstraints.item(0, 0).checkState(), 0)
+        # Constraint should be deactivated
+        self.assertEqual(self.constraint1.active, False)

--- a/src/sas/qtgui/Perspectives/Fitting/UnitTesting/ConstraintWidgetTest.py
+++ b/src/sas/qtgui/Perspectives/Fitting/UnitTesting/ConstraintWidgetTest.py
@@ -291,3 +291,28 @@ class ConstraintWidgetTest(unittest.TestCase):
         self.assertEqual(spy[2][0], 'Fitting completed successfully in: 1.5 '
                                     's.\n')
         self.assertEqual(spy_data[0][0], [[result], 'ConstSimulPage'])
+
+    def testUncheckConstraints(self):
+        '''Tests the unchecking of constraints'''
+        # mock a tab
+        test_tab = MagicMock(spec=FittingWidget)
+        test_tab.data_is_loaded = False
+        test_tab.kernel_module = MagicMock()
+        test_tab.kernel_module.name = "M1"
+        ObjectLibrary.getObject = MagicMock(return_value=test_tab)
+
+        # Add a tab with an active constraint
+        test_tab.getComplexConstraintsForModel = MagicMock(
+            return_value=[('scale', self.constraint1.func)])
+        test_tab.getFullConstraintNameListForModel = MagicMock(
+            return_value=[('scale', self.constraint1.func)])
+        test_tab.getConstraintObjectsForModel = MagicMock(
+            return_value=[self.constraint1])
+        self.widget.updateFitLine("test_tab")
+
+        # Constraint should be checked
+        self.assertEqual(self.widget.tblConstraints.item(0, 0).checkState(), 2)
+
+        self.widget.uncheckConstraint('M1:scale')
+        # Should be unchecked in tblConstraint
+        self.assertEqual(self.widget.tblConstraints.item(0, 0).checkState(), 0)


### PR DESCRIPTION
Fixes #1654 : when fitting a single fit page with a constraint relying on another fit page, the constraint will just be disabled instead of being removed. The corresponding line in the constraint widget will be unchecked, so one can recheck if needed.