### PR TITLE
Handling of constraints in v5.x

### DIFF
--- a/src/sas/qtgui/Perspectives/Fitting/ComplexConstraint.py
+++ b/src/sas/qtgui/Perspectives/Fitting/ComplexConstraint.py
@@ -298,7 +298,7 @@ class ComplexConstraint(QtWidgets.QDialog, Ui_ComplexConstraintUI):
         # loop over parameters in constrained model
         index1 = self.cbModel1.currentIndex()
         index2 = self.cbModel2.currentIndex()
-        items1 = [param for param in self.tabs[index1].main_params_to_fit]
+        items1 = [param for param in self.tabs[index1].kernel_module.params]
         items2 = self.params[index2]
         # create an empty list to store redefined constraints
         redefined_constraints = []

--- a/src/sas/qtgui/Perspectives/Fitting/ComplexConstraint.py
+++ b/src/sas/qtgui/Perspectives/Fitting/ComplexConstraint.py
@@ -339,12 +339,14 @@ class ComplexConstraint(QtWidgets.QDialog, Ui_ComplexConstraintUI):
         *expr* string.
         """
         for tab in tabs:
-            if param in tab.kernel_module.params:
-                constraint = Constraint(param=param, value=param, func=expr,
-                                        value_ex=tab.kernel_module.name + "."
-                                        + param, operator="=")
-                self.constraintReadySignal.emit((tab.kernel_module.name,
-                                                 constraint))
+            if hasattr(tab, "kernel_module"):
+                if param in tab.kernel_module.params:
+                    constraint = Constraint(param=param, value=param,
+                                            func=expr,
+                                            value_ex=tab.kernel_module.name +
+                                            "." + param, operator="=")
+                    self.constraintReadySignal.emit((tab.kernel_module.name,
+                                                     constraint))
 
     def onSetAll(self):
         """

--- a/src/sas/qtgui/Perspectives/Fitting/ComplexConstraint.py
+++ b/src/sas/qtgui/Perspectives/Fitting/ComplexConstraint.py
@@ -244,7 +244,8 @@ class ComplexConstraint(QtWidgets.QDialog, Ui_ComplexConstraintUI):
         param = self.cbParam1.currentText()
         value = self.cbParam2.currentText()
         func = self.txtConstraint.text()
-        value_ex = self.cbModel2.currentText() + "." + self.cbParam2.currentText()
+        value_ex = (self.cbModel1.currentText() + "." +
+                    self.cbParam1.currentText())
         model1 = self.cbModel1.currentText()
         operator = self.cbOperator.currentText()
 

--- a/src/sas/qtgui/Perspectives/Fitting/ComplexConstraint.py
+++ b/src/sas/qtgui/Perspectives/Fitting/ComplexConstraint.py
@@ -100,16 +100,29 @@ class ComplexConstraint(QtWidgets.QDialog, Ui_ComplexConstraintUI):
         """
         Fill out comboboxes and set labels with non-constrained parameters
         """
+        # Store previously select parameter
+        previous_param1 = self.cbParam1.currentText()
+        # Clear the combobox
         self.cbParam1.clear()
         tab_index1 = self.cbModel1.currentIndex()
         items1 = [param for param in self.tabs[tab_index1].main_params_to_fit]
         self.cbParam1.addItems(items1)
+        # Show the previously selected parameter if available
+        if previous_param1 in items1:
+            index1 = self.cbParam1.findText(previous_param1)
+            self.cbParam1.setCurrentIndex(index1)
 
+        # Store previously select parameter
+        previous_param2 = self.cbParam2.currentText()
         # M2 has to be non-constrained
         self.cbParam2.clear()
         tab_index2 = self.cbModel2.currentIndex()
         items2 = [param for param in self.params[tab_index2] if not self.tabs[tab_index2].paramHasConstraint(param)]
         self.cbParam2.addItems(items2)
+        # Show the previously selected parameter if available
+        if previous_param2 in items2:
+            index2 = self.cbParam2.findText(previous_param2)
+            self.cbParam2.setCurrentIndex(index2)
 
         self.txtParam.setText(self.tab_names[tab_index1] + ":" + self.cbParam1.currentText())
 

--- a/src/sas/qtgui/Perspectives/Fitting/ComplexConstraint.py
+++ b/src/sas/qtgui/Perspectives/Fitting/ComplexConstraint.py
@@ -111,10 +111,10 @@ class ComplexConstraint(QtWidgets.QDialog, Ui_ComplexConstraintUI):
         # Populate the left combobox parameter arbitrarily with the parameters
         # from the first tab if `All` option is selected
         if self.cbModel1.currentText() == "All":
-            items1 = [param for param in self.tabs[1].main_params_to_fit]
+            items1 = self.tabs[1].main_params_to_fit
         else:
             tab_index1 = self.cbModel1.currentIndex()
-            items1 = [param for param in self.tabs[tab_index1].main_params_to_fit]
+            items1 = self.tabs[tab_index1].main_params_to_fit
         self.cbParam1.addItems(items1)
         # Show the previously selected parameter if available
         if previous_param1 in items1:
@@ -355,7 +355,7 @@ class ComplexConstraint(QtWidgets.QDialog, Ui_ComplexConstraintUI):
         # loop over parameters in constrained model
         index1 = self.cbModel1.currentIndex()
         index2 = self.cbModel2.currentIndex()
-        items1 = [param for param in self.tabs[index1].kernel_module.params]
+        items1 = self.tabs[index1].kernel_module.params
         items2 = self.params[index2]
         # create an empty list to store redefined constraints
         redefined_constraints = []

--- a/src/sas/qtgui/Perspectives/Fitting/ComplexConstraint.py
+++ b/src/sas/qtgui/Perspectives/Fitting/ComplexConstraint.py
@@ -15,7 +15,6 @@ import webbrowser
 from sas.qtgui.Perspectives.Fitting import FittingUtilities
 import sas.qtgui.Utilities.GuiUtils as GuiUtils
 from sas.qtgui.Perspectives.Fitting.Constraint import Constraint
-from sas.qtgui.Perspectives.Fitting.FittingWidget import FittingWidget
 
 #ALLOWED_OPERATORS = ['=','<','>','>=','<=']
 ALLOWED_OPERATORS = ['=']
@@ -307,13 +306,13 @@ class ComplexConstraint(QtWidgets.QDialog, Ui_ComplexConstraintUI):
         Respond to Add constraint action.
         Send a signal that the constraint is ready to be applied
         """
-        # if the combobox is set to `All` just call `onApplyAcrossTabs` and
+        # if the combobox is set to `All` just call `applyAcrossTabs` and
         # return
         if self.cbModel1.currentText() == "All":
             # exclude the tab on the lhs
             tabs = [tab for tab in self.tabs if
                     tab.kernel_module.name != self.cbModel2.currentText()]
-            self.onApplyAcrossTabs(tabs, self.cbParam1.currentText(),
+            self.applyAcrossTabs(tabs, self.cbParam1.currentText(),
                                    self.txtConstraint.text())
             self.setupParamWidgets()
             return
@@ -332,7 +331,7 @@ class ComplexConstraint(QtWidgets.QDialog, Ui_ComplexConstraintUI):
         if self.parent.constraint_accepted:
             self.setupParamWidgets()
 
-    def onApplyAcrossTabs(self, tabs, param, expr):
+    def applyAcrossTabs(self, tabs, param, expr):
         """
         Apply constraints across tabs, e.g. all `scale` parameters
         constrained to an expression. *tabs* is a list of active fit tabs
@@ -340,7 +339,6 @@ class ComplexConstraint(QtWidgets.QDialog, Ui_ComplexConstraintUI):
         *expr* string.
         """
         for tab in tabs:
-            assert isinstance(tab, FittingWidget)
             if param in tab.kernel_module.params:
                 constraint = Constraint(param=param, value=param, func=expr,
                                         value_ex=tab.kernel_module.name + "."

--- a/src/sas/qtgui/Perspectives/Fitting/ComplexConstraint.py
+++ b/src/sas/qtgui/Perspectives/Fitting/ComplexConstraint.py
@@ -15,6 +15,7 @@ import webbrowser
 from sas.qtgui.Perspectives.Fitting import FittingUtilities
 import sas.qtgui.Utilities.GuiUtils as GuiUtils
 from sas.qtgui.Perspectives.Fitting.Constraint import Constraint
+from sas.qtgui.Perspectives.Fitting.FittingWidget import FittingWidget
 
 #ALLOWED_OPERATORS = ['=','<','>','>=','<=']
 ALLOWED_OPERATORS = ['=']
@@ -304,6 +305,22 @@ class ComplexConstraint(QtWidgets.QDialog, Ui_ComplexConstraintUI):
         # reload the comboboxes
         if self.parent.constraint_accepted:
             self.setupParamWidgets()
+
+    def onApplyAcrossModels(self, tabs, param, expr):
+        """
+        Apply constraints across tabs, e.g. all `scale` parameters
+        constrained to an expression. *tabs* is a list of active fit tabs
+        for which the parameter string *param* will be constrained to the
+        *expr* string.
+        """
+        for tab in tabs:
+            assert(isinstance(tab, FittingWidget))
+            if param in tab.kernel_module.params:
+                constraint = Constraint(param=param, value=param, func=expr,
+                                        value_ex=tab.kernel_module.name + "."
+                                        + param, operator="=")
+                self.constraintReadySignal.emit((tab.kernel_module.name,
+                                                 constraint))
 
     def onSetAll(self):
         """

--- a/src/sas/qtgui/Perspectives/Fitting/ComplexConstraint.py
+++ b/src/sas/qtgui/Perspectives/Fitting/ComplexConstraint.py
@@ -133,8 +133,8 @@ class ComplexConstraint(QtWidgets.QDialog, Ui_ComplexConstraintUI):
             index2 = self.cbParam2.findText(previous_param2)
             self.cbParam2.setCurrentIndex(index2)
 
-        self.txtParam.setText(self.cbModel1.currentText() + ":" +
-                              self.cbParam1.currentText())
+        self.txtParam.setText(self.cbModel1.currentText() + ":"
+                              + self.cbParam1.currentText())
 
         self.cbOperator.clear()
         self.cbOperator.addItems(ALLOWED_OPERATORS)
@@ -273,8 +273,8 @@ class ComplexConstraint(QtWidgets.QDialog, Ui_ComplexConstraintUI):
         param = self.cbParam1.currentText()
         value = self.cbParam2.currentText()
         func = self.txtConstraint.text()
-        value_ex = (self.cbModel1.currentText() + "." +
-                    self.cbParam1.currentText())
+        value_ex = (self.cbModel1.currentText() + "."
+                    + self.cbParam1.currentText())
         model1 = self.cbModel1.currentText()
         operator = self.cbOperator.currentText()
 
@@ -311,8 +311,8 @@ class ComplexConstraint(QtWidgets.QDialog, Ui_ComplexConstraintUI):
         # return
         if self.cbModel1.currentText() == "All":
             # exclude the tab on the lhs
-            tabs = [tab for tab in self.tabs if tab.kernel_module.name !=
-                    self.cbModel2.currentText()]
+            tabs = [tab for tab in self.tabs if
+                    tab.kernel_module.name != self.cbModel2.currentText()]
             self.onApplyAcrossTabs(tabs, self.cbParam1.currentText(),
                                    self.txtConstraint.text())
             self.setupParamWidgets()
@@ -340,7 +340,7 @@ class ComplexConstraint(QtWidgets.QDialog, Ui_ComplexConstraintUI):
         *expr* string.
         """
         for tab in tabs:
-            assert(isinstance(tab, FittingWidget))
+            assert isinstance(tab, FittingWidget)
             if param in tab.kernel_module.params:
                 constraint = Constraint(param=param, value=param, func=expr,
                                         value_ex=tab.kernel_module.name + "."

--- a/src/sas/qtgui/Perspectives/Fitting/ComplexConstraint.py
+++ b/src/sas/qtgui/Perspectives/Fitting/ComplexConstraint.py
@@ -313,7 +313,7 @@ class ComplexConstraint(QtWidgets.QDialog, Ui_ComplexConstraintUI):
             tabs = [tab for tab in self.tabs if
                     tab.kernel_module.name != self.cbModel2.currentText()]
             self.applyAcrossTabs(tabs, self.cbParam1.currentText(),
-                                   self.txtConstraint.text())
+                                 self.txtConstraint.text())
             self.setupParamWidgets()
             return
 
@@ -341,10 +341,12 @@ class ComplexConstraint(QtWidgets.QDialog, Ui_ComplexConstraintUI):
         for tab in tabs:
             if hasattr(tab, "kernel_module"):
                 if param in tab.kernel_module.params:
-                    constraint = Constraint(param=param, value=param,
+                    value_ex = tab.kernel_module.name + "." +param
+                    constraint = Constraint(param=param,
+                                            value=param,
                                             func=expr,
-                                            value_ex=tab.kernel_module.name +
-                                            "." + param, operator="=")
+                                            value_ex=value_ex,
+                                            operator="=")
                     self.constraintReadySignal.emit((tab.kernel_module.name,
                                                      constraint))
 

--- a/src/sas/qtgui/Perspectives/Fitting/ConstraintWidget.py
+++ b/src/sas/qtgui/Perspectives/Fitting/ConstraintWidget.py
@@ -885,6 +885,9 @@ class ConstraintWidget(QtWidgets.QWidget, Ui_ConstraintWidgetUI):
         self.tblConstraints.setEnabled(True)
         self.tblConstraints.blockSignals(True)
         for constraint, constraint_name in zip(constraints, constraint_names):
+            # Ignore constraints that have no *func* attribute defined
+            if constraint.func is None:
+                continue
             # Create the text for widget item
             label = moniker + ":"+ constraint_name[0] + " = " + constraint_name[1]
             pos = self.tblConstraints.rowCount()

--- a/src/sas/qtgui/Perspectives/Fitting/ConstraintWidget.py
+++ b/src/sas/qtgui/Perspectives/Fitting/ConstraintWidget.py
@@ -821,11 +821,12 @@ class ConstraintWidget(QtWidgets.QWidget, Ui_ConstraintWidgetUI):
             self.available_constraints[pos] = constraint
 
             # Show the text in the constraint table
-            item = self.uneditableItem(label)
-            item.setFlags(item.flags() ^ QtCore.Qt.ItemIsUserCheckable)
-            #item = QtWidgets.QTableWidgetItem(label)
+            item = QtWidgets.QTableWidgetItem(label)
+            item.setFlags(QtCore.Qt.ItemIsSelectable |
+                          QtCore.Qt.ItemIsEnabled |
+                          QtCore.Qt.ItemIsUserCheckable |
+                          QtCore.Qt.ItemIsEditable)
             # Why was this set to non-interactive??
-            #item.setFlags(item.flags() ^ QtCore.Qt.ItemIsUserCheckable)
             if constraint_name in active_constraint_names:
                 item.setCheckState(QtCore.Qt.Checked)
             else:

--- a/src/sas/qtgui/Perspectives/Fitting/ConstraintWidget.py
+++ b/src/sas/qtgui/Perspectives/Fitting/ConstraintWidget.py
@@ -453,13 +453,14 @@ class ConstraintWidget(QtWidgets.QWidget, Ui_ConstraintWidgetUI):
         constraint_text = item.data(0)
         # Basic sanity check of the string
         # First check if we have an acceptable sign
-        msgbox = QtWidgets.QMessageBox(self)
-        msgbox.setIcon(QtWidgets.QMessageBox.Critical)
         if "=" not in constraint_text:
-            msg = ("Incorrect operator in constraint definition.Please use = "
+            msg = ("Incorrect operator in constraint definition. Please use = "
                    "sign to define constraints.")
-            msgbox.setText(msg)
-            msgbox.exec()
+            QtWidgets.QMessageBox.critical(
+                self,
+                "Inconsistent constraint",
+                msg,
+                QtWidgets.QMessageBox.Ok)
             self.initializeFitList()
             return
         # Then check if the parameter is correctly defined with colons
@@ -470,8 +471,11 @@ class ConstraintWidget(QtWidgets.QWidget, Ui_ConstraintWidgetUI):
             msg = ("Incorrect constrained parameter definition. Please use "
                    "colons to separate model and parameter on the rhs of the "
                    "definition, e.g. M1:scale")
-            msgbox.setText(msg)
-            msgbox.exec()
+            QtWidgets.QMessageBox.critical(
+                self,
+                "Inconsistent constraint",
+                msg,
+                QtWidgets.QMessageBox.Ok)
             self.initializeFitList()
             return
         # We can parse the string
@@ -486,8 +490,11 @@ class ConstraintWidget(QtWidgets.QWidget, Ui_ConstraintWidgetUI):
             msg = ("Incorrect constrained parameter definition. Please use "
                    "a single known parameter in the rhs of the constraint "
                    "definition, e.g. M1:scale = M1.radius + 2")
-            msgbox.setText(msg)
-            msgbox.exec()
+            QtWidgets.QMessageBox.critical(
+                self,
+                "Inconsistent constraint",
+                msg,
+                QtWidgets.QMessageBox.Ok)
             self.initializeFitList()
             return
         new_function = item.data(0)[item.data(0).index('=') + 1:].strip()

--- a/src/sas/qtgui/Perspectives/Fitting/ConstraintWidget.py
+++ b/src/sas/qtgui/Perspectives/Fitting/ConstraintWidget.py
@@ -482,8 +482,10 @@ class ConstraintWidget(QtWidgets.QWidget, Ui_ConstraintWidgetUI):
         new_param = item.data(0)[
                 item.data(0).index(':') + 1:item.data(0).index('=')].strip()
         new_model = item.data(0)[:item.data(0).index(':')].strip()
-        # Check that the symbol is known
-        # All the conditional statements could be grouped in one
+        # Check that the symbol is known so we dont get an unknown tab
+        # All the conditional statements could be grouped in one or
+        # alternatively we could check with expression.py, but we would still
+        # need to do some checks to parse the string
         symbol_dict = self.parent.parent.perspective(
             ).getSymbolDictForConstraints()
         if (new_model + "." + new_param) not in symbol_dict:
@@ -512,7 +514,7 @@ class ConstraintWidget(QtWidgets.QWidget, Ui_ConstraintWidgetUI):
             # If the constraint is valid and we are changing model or
             # parameter, delete the old constraint
             if self.constraint_accepted and (new_model != model or
-                                                 new_param != param):
+                                             new_param != param):
                 tab.deleteConstraintOnParameter(param)
             # Reload the view
             self.initializeFitList()

--- a/src/sas/qtgui/Perspectives/Fitting/FittingWidget.py
+++ b/src/sas/qtgui/Perspectives/Fitting/FittingWidget.py
@@ -792,10 +792,11 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
             self._model_model.item(row, column).setFont(font)
             # Allow the user to interact or not with the fields depending on
             # whether the parameter is constrained or not
-            self._model_model.item(row, column).setEnabled(fields_enabled)
+            self._model_model.item(row, column).setEditable(fields_enabled)
         # Force checkbox selection when parameter is constrained
         if not fields_enabled and self._model_model.item(row, 0).isCheckable():
                 self._model_model.item(row, 0).setCheckState(2)
+                self._model_model.item(row, 0).setEnabled(False)
         self._model_model.blockSignals(False)
 
     def addConstraintToRow(self, constraint=None, row=0):

--- a/src/sas/qtgui/Perspectives/Fitting/FittingWidget.py
+++ b/src/sas/qtgui/Perspectives/Fitting/FittingWidget.py
@@ -793,10 +793,14 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
             # Allow the user to interact or not with the fields depending on
             # whether the parameter is constrained or not
             self._model_model.item(row, column).setEditable(fields_enabled)
-        # Force checkbox selection when parameter is constrained
+        # Force checkbox selection when parameter is constrained and disable
+        # checkbox interaction
         if not fields_enabled and self._model_model.item(row, 0).isCheckable():
-                self._model_model.item(row, 0).setCheckState(2)
-                self._model_model.item(row, 0).setEnabled(False)
+            self._model_model.item(row, 0).setCheckState(2)
+            self._model_model.item(row, 0).setEnabled(False)
+        else:
+            # Enable checkbox interaction
+            self._model_model.item(row, 0).setEnabled(True)
         self._model_model.blockSignals(False)
 
     def addConstraintToRow(self, constraint=None, row=0):

--- a/src/sas/qtgui/Perspectives/Fitting/FittingWidget.py
+++ b/src/sas/qtgui/Perspectives/Fitting/FittingWidget.py
@@ -790,7 +790,12 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         for column in range(0, self._model_model.columnCount()):
             self._model_model.item(row, column).setForeground(brush)
             self._model_model.item(row, column).setFont(font)
-            self._model_model.item(row, column).setEditable(fields_enabled)
+            # Allow the user to interact or not with the fields depending on
+            # whether the parameter is constrained or not
+            self._model_model.item(row, column).setEnabled(fields_enabled)
+        # Force checkbox selection when parameter is constrained
+        if not fields_enabled and self._model_model.item(row, 0).isCheckable():
+                self._model_model.item(row, 0).setCheckState(2)
         self._model_model.blockSignals(False)
 
     def addConstraintToRow(self, constraint=None, row=0):

--- a/src/sas/qtgui/Perspectives/Fitting/FittingWidget.py
+++ b/src/sas/qtgui/Perspectives/Fitting/FittingWidget.py
@@ -4383,7 +4383,7 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         """
         sym_dict = {}
         # return an empty dict if no model has been selected
-        if self.kernel.module == None:
+        if self.kernel_module == None:
             return sym_dict
         model_name = self.kernel_module.name
         for param in self.getParamNames():

--- a/src/sas/qtgui/Perspectives/Fitting/FittingWidget.py
+++ b/src/sas/qtgui/Perspectives/Fitting/FittingWidget.py
@@ -4382,6 +4382,9 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         and their values, e.g. {'M1.scale':1, 'M1.background': 0.001}
         """
         sym_dict = {}
+        # return an empty dict if no model has been selected
+        if self.kernel.module == None:
+            return sym_dict
         model_name = self.kernel_module.name
         for param in self.getParamNames():
             sym_dict[f"{model_name}.{param}"] = GuiUtils.toDouble(

--- a/src/sas/qtgui/Perspectives/Fitting/FittingWidget.py
+++ b/src/sas/qtgui/Perspectives/Fitting/FittingWidget.py
@@ -847,6 +847,9 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         font.setItalic(True)
         brush = QtGui.QBrush(QtGui.QColor('blue'))
         self.modifyViewOnRow(row, font=font, brush=brush)
+        # update the main parameter list so the constrained parameter gets
+        # updated when fitting
+        self.checkboxSelected(self._model_model.item(row, 0))
         self.communicate.statusBarUpdateSignal.emit('Constraint added')
         if constraint_tab:
             # Set the constraint_accepted flag to True to inform the

--- a/src/sas/qtgui/Perspectives/Fitting/UnitTesting/ComplexConstraintTest.py
+++ b/src/sas/qtgui/Perspectives/Fitting/UnitTesting/ComplexConstraintTest.py
@@ -3,7 +3,7 @@ import unittest
 import numpy as np
 import webbrowser
 
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 from PyQt5 import QtGui, QtWidgets, QtCore, QtTest
 
@@ -12,6 +12,7 @@ import path_prepare
 
 from sas.qtgui.Perspectives.Fitting import FittingUtilities
 from sas.qtgui.Perspectives.Fitting.Constraint import Constraint
+from sas.qtgui.Perspectives.Fitting.ConstraintWidget import ConstraintWidget
 from sas.qtgui.UnitTesting.TestUtils import QtSignalSpy
 from sas.qtgui.Utilities.GuiUtils import Communicate
 
@@ -33,10 +34,12 @@ class ComplexConstraintTest(unittest.TestCase):
         # mockup tabs
         self.tab1 = FittingWidget(dummy_manager())
         self.tab2 = FittingWidget(dummy_manager())
+        self.tab3 = FittingWidget(dummy_manager())
         # mock the constraint error mechanism
         FittingUtilities.checkConstraints = MagicMock(return_value=None)
         self.tab1.parent.perspective = MagicMock()
         self.tab2.parent.perspective = MagicMock()
+        self.tab3.parent.perspective = MagicMock()
 
         # set some models on tabs
         category_index = self.tab1.cbCategory.findText("Shape Independent")
@@ -54,7 +57,14 @@ class ComplexConstraintTest(unittest.TestCase):
         # set tab2 model name to M2
         self.tab2.kernel_module.name = "M2"
 
-        tabs = [self.tab1, self.tab2]
+        category_index = self.tab3.cbCategory.findText("Cylinder")
+        self.tab3.cbCategory.setCurrentIndex(category_index)
+        model_index = self.tab3.cbModel.findText("barbell")
+        self.tab3.cbModel.setCurrentIndex(model_index)
+        # set tab2 model name to M2
+        self.tab3.kernel_module.name = "M3"
+
+        tabs = [self.tab1, self.tab2, self.tab3]
         self.widget = ComplexConstraint(parent=None, tabs=tabs)
 
     def tearDown(self):
@@ -72,7 +82,7 @@ class ComplexConstraintTest(unittest.TestCase):
         self.assertTrue(self.widget.isModal())
 
         # initial tab names
-        self.assertEqual(self.widget.tab_names, ['M1','M2'])
+        self.assertEqual(self.widget.tab_names, ['M1', 'M2', 'M3'])
         self.assertIn('scale', self.widget.params[0])
         self.assertIn('background', self.widget.params[1])
 
@@ -196,4 +206,47 @@ class ComplexConstraintTest(unittest.TestCase):
                           self.widget.constraintReadySignal)
         QtTest.QTest.mouseClick(self.widget.cmdAddAll, QtCore.Qt.LeftButton)
         # Only two constraints should've been added: scale and background
+        self.assertEqual(spy.count(), 2)
+
+
+    def testOnApply(self):
+        """
+        Test the application of constraints
+        """
+        index = self.widget.cbModel2.findText("M2")
+        self.widget.cbModel2.setCurrentIndex(index)
+        cstab = MagicMock(spec=ConstraintWidget, constraint_accepted=True)
+        self.widget.parent = cstab
+        spy = QtSignalSpy(self.widget,
+                          self.widget.constraintReadySignal)
+        QtTest.QTest.mouseClick(self.widget.cmdOK, QtCore.Qt.LeftButton)
+        self.assertEqual(spy.count(), 1)
+        self.assertEqual(spy.signal(0)[0][0], "M1")
+        self.assertTrue(isinstance(spy.signal(0)[0][1], Constraint))
+
+        # Test the `All` option in the combobox
+        self.widget.onApplyAcrossTabs = MagicMock()
+        index = self.widget.cbModel1.findText("All")
+        self.widget.cbModel1.setCurrentIndex(index)
+        self.widget.onApply()
+        self.widget.onApplyAcrossTabs.assert_called_once_with([self.tab1,
+                                                               self.tab3],
+                                                              self.widget.
+                                                              cbParam1.
+                                                              currentText(),
+                                                              self.widget.
+                                                              txtConstraint.
+                                                              text())
+
+    def testOnApplyAcrossTabs(self):
+        """
+        Test the application of constraints across tabs
+        """
+        spy = QtSignalSpy(self.widget,
+                          self.widget.constraintReadySignal)
+        tabs = [self.tab1, self.tab2]
+        param = "scale"
+        expr = "M3.scale"
+        self.widget.onApplyAcrossTabs(tabs, param, expr)
+        # We should have two calls
         self.assertEqual(spy.count(), 2)

--- a/src/sas/qtgui/Perspectives/Fitting/UnitTesting/ComplexConstraintTest.py
+++ b/src/sas/qtgui/Perspectives/Fitting/UnitTesting/ComplexConstraintTest.py
@@ -47,7 +47,7 @@ class ComplexConstraintTest(unittest.TestCase):
         model_index = self.tab1.cbModel.findText("be_polyelectrolyte")
         self.tab1.cbModel.setCurrentIndex(model_index)
         # select some parameters so we can populate the combo box
-        for i in range(0, 5):
+        for i in range(5):
             self.tab1._model_model.item(i, 0).setCheckState(2)
 
         category_index = self.tab2.cbCategory.findText("Cylinder")
@@ -229,14 +229,11 @@ class ComplexConstraintTest(unittest.TestCase):
         index = self.widget.cbModel1.findText("All")
         self.widget.cbModel1.setCurrentIndex(index)
         self.widget.onApply()
-        self.widget.onApplyAcrossTabs.assert_called_once_with([self.tab1,
-                                                               self.tab3],
-                                                              self.widget.
-                                                              cbParam1.
-                                                              currentText(),
-                                                              self.widget.
-                                                              txtConstraint.
-                                                              text())
+        self.widget.onApplyAcrossTabs.assert_called_once_with(
+            [self.tab1, self.tab3],
+            self.widget.cbParam1.currentText(),
+            self.widget.txtConstraint.text(),
+        )
 
     def testOnApplyAcrossTabs(self):
         """

--- a/src/sas/qtgui/Perspectives/Fitting/UnitTesting/ComplexConstraintTest.py
+++ b/src/sas/qtgui/Perspectives/Fitting/UnitTesting/ComplexConstraintTest.py
@@ -225,17 +225,17 @@ class ComplexConstraintTest(unittest.TestCase):
         self.assertTrue(isinstance(spy.signal(0)[0][1], Constraint))
 
         # Test the `All` option in the combobox
-        self.widget.onApplyAcrossTabs = MagicMock()
+        self.widget.applyAcrossTabs = MagicMock()
         index = self.widget.cbModel1.findText("All")
         self.widget.cbModel1.setCurrentIndex(index)
         self.widget.onApply()
-        self.widget.onApplyAcrossTabs.assert_called_once_with(
+        self.widget.applyAcrossTabs.assert_called_once_with(
             [self.tab1, self.tab3],
             self.widget.cbParam1.currentText(),
             self.widget.txtConstraint.text(),
         )
 
-    def testOnApplyAcrossTabs(self):
+    def testApplyAcrossTabs(self):
         """
         Test the application of constraints across tabs
         """
@@ -244,6 +244,6 @@ class ComplexConstraintTest(unittest.TestCase):
         tabs = [self.tab1, self.tab2]
         param = "scale"
         expr = "M3.scale"
-        self.widget.onApplyAcrossTabs(tabs, param, expr)
+        self.widget.applyAcrossTabs(tabs, param, expr)
         # We should have two calls
         self.assertEqual(spy.count(), 2)

--- a/src/sas/qtgui/Perspectives/Fitting/UnitTesting/ConstraintWidgetTest.py
+++ b/src/sas/qtgui/Perspectives/Fitting/UnitTesting/ConstraintWidgetTest.py
@@ -376,12 +376,9 @@ class ConstraintWidgetTest(unittest.TestCase):
 
         msg = ("Incorrect operator in constraint definition. Please use = "
                "sign to define constraints.")
-        QtWidgets.QMessageBox.critical.assert_called_with(self.widget,
-                                                          "Inconsistent "
-                                                          "constraint",
-                                                          msg,
-                                                          QtWidgets.QMessageBox.
-                                                          Ok)
+        (QtWidgets.QMessageBox.critical.
+         assert_called_with(self.widget, "Inconsistent constraint", msg,
+                            QtWidgets.QMessageBox.Ok))
         # Check the reloading of the view
         self.widget.initializeFitList.assert_called_once()
 
@@ -391,12 +388,9 @@ class ConstraintWidgetTest(unittest.TestCase):
         msg = ("Incorrect constrained parameter definition. Please use colons"
                " to separate model and parameter on the rhs of the definition, "
                "e.g. M1:scale")
-        QtWidgets.QMessageBox.critical.assert_called_with(self.widget,
-                                                          "Inconsistent "
-                                                          "constraint",
-                                                          msg,
-                                                          QtWidgets.QMessageBox.
-                                                          Ok)
+        (QtWidgets.QMessageBox.critical.
+         assert_called_with(self.widget, "Inconsistent constraint", msg,
+                            QtWidgets.QMessageBox.Ok))
         # Check the reloading of the view
         self.widget.initializeFitList.assert_called_once()
 
@@ -405,15 +399,12 @@ class ConstraintWidgetTest(unittest.TestCase):
         # Change the constraint to one with an unknown symbol or with several
         # parameters on the rhs of the constraint definition
         self.widget.tblConstraints.item(0, 0).setText("M1:foo = bar")
-        msg = ("Incorrect constrained parameter definition. Please use "
+        msg = ("Unknown parameter M1.foo used in constraint. Please use "
                "a single known parameter in the rhs of the constraint "
                "definition, e.g. M1:scale = M1.radius + 2")
-        QtWidgets.QMessageBox.critical.assert_called_with(self.widget,
-                                                          "Inconsistent "
-                                                          "constraint",
-                                                          msg,
-                                                          QtWidgets.QMessageBox.
-                                                          Ok)
+        (QtWidgets.QMessageBox.critical.
+         assert_called_with(self.widget, "Inconsistent constraint", msg,
+                            QtWidgets.QMessageBox.Ok))
         # Check the reloading of the view
         self.widget.initializeFitList.assert_called_once()
 
@@ -424,15 +415,13 @@ class ConstraintWidgetTest(unittest.TestCase):
         self.widget.tblConstraints.item(0, 0).setText("M1:radius = bar")
         constraint = Constraint(param="radius", func="bar",
                                 value_ex="M1.radius")
-        self.assertEqual(test_tab.addConstraintToRow.call_args[1][
-                             "constraint"].value_ex, constraint.value_ex)
-        self.assertEqual(test_tab.addConstraintToRow.call_args[1][
-                             "constraint"].func, constraint.func)
-        self.assertEqual(test_tab.addConstraintToRow.call_args[1][
-                             "constraint"].param, constraint.param)
-        self.assertEqual(test_tab.addConstraintToRow.call_args[1]["row"], 0)
-        self.assertEqual(test_tab.deleteConstraintOnParameter.call_args[0][
-                             0], "scale")
+        target = test_tab.addConstraintToRow.call_args[1]
+        self.assertEqual(target["constraint"].value_ex, constraint.value_ex)
+        self.assertEqual(target["constraint"].func, constraint.func)
+        self.assertEqual(target["constraint"].param, constraint.param)
+        self.assertEqual(target["row"], 0)
+        target = test_tab.deleteConstraintOnParameter.call_args[0]
+        self.assertEqual(target[0], "scale")
         # Check the reloading of the view
         self.widget.initializeFitList.assert_called_once()
 

--- a/src/sas/qtgui/Perspectives/Fitting/UnitTesting/ConstraintWidgetTest.py
+++ b/src/sas/qtgui/Perspectives/Fitting/UnitTesting/ConstraintWidgetTest.py
@@ -33,6 +33,28 @@ class ConstraintWidgetTest(unittest.TestCase):
                 return GuiUtils.Communicate()
             communicate = GuiUtils.Communicate()
 
+            def __init__(self):
+                self._perspective = dummy_perspective()
+
+            def perspective(self):
+                return self._perspective
+
+        class dummy_perspective(object):
+
+            def __init__(self):
+                self.symbol_dict = {}
+                self.constraint_list = []
+                self.constraint_tab = None
+
+            def getActiveConstraintList(self):
+                return self.constraint_list
+
+            def getSymbolDictForConstraints(self):
+                return self.symbol_dict
+
+            def getConstraintTab(self):
+                return self.constraint_tab
+
         '''Create the perspective'''
         self.perspective = FittingWindow(dummy_manager())
         ConstraintWidget.updateSignalsFromTab = MagicMock()
@@ -40,7 +62,9 @@ class ConstraintWidgetTest(unittest.TestCase):
         self.widget = ConstraintWidget(parent=self.perspective)
 
         # Example constraint object
-        self.constraint1 = Constraint(parent=None, param="test", value="7.0", min="0.0", max="inf", func="M1.sld")
+        self.constraint1 = Constraint(parent=None, param="scale", value="7.0",
+                                      min="0.0", max="inf", func="M1.sld",
+                                      value_ex="M1.scale")
         self.constraint2 = Constraint(parent=None, param="poop", value="7.0", min="0.0", max="inf", func="7.0")
 
     def tearDown(self):
@@ -291,3 +315,114 @@ class ConstraintWidgetTest(unittest.TestCase):
         self.assertEqual(spy[2][0], 'Fitting completed successfully in: 1.5 '
                                     's.\n')
         self.assertEqual(spy_data[0][0], [[result], 'ConstSimulPage'])
+
+    def testOnConstraintChange(self):
+        ''' test edition of the constraint list '''
+        # mock a tab
+        test_tab = MagicMock(spec=FittingWidget)
+        test_tab.data_is_loaded = False
+        test_tab.kernel_module = MagicMock()
+        test_tab.kernel_module.name = "M1"
+        test_tab.getRowFromName = MagicMock(return_value=0)
+        ObjectLibrary.getObject = MagicMock(return_value=test_tab)
+
+        # Add a constraint to the tab
+        test_tab.getComplexConstraintsForModel = MagicMock(
+            return_value=[('scale', self.constraint1.func)])
+        test_tab.getFullConstraintNameListForModel = MagicMock(
+            return_value=[('scale', self.constraint1.func)])
+        test_tab.getConstraintObjectsForModel = MagicMock(
+            return_value=[self.constraint1])
+
+        self.widget.updateFitLine("test_tab")
+
+        self.widget.initializeFitList = MagicMock()
+        QtWidgets.QMessageBox.critical = MagicMock()
+
+        # Change the constraint to one with no equal sign
+        self.widget.tblConstraints.item(0, 0).setText("foo")
+
+        msg = ("Incorrect operator in constraint definition. Please use = "
+               "sign to define constraints.")
+        QtWidgets.QMessageBox.critical.assert_called_with(self.widget,
+                                                          "Inconsistent "
+                                                          "constraint",
+                                                          msg,
+                                                          QtWidgets.QMessageBox.
+                                                          Ok)
+        # Check the reloading of the view
+        self.widget.initializeFitList.assert_called_once()
+
+        self.widget.initializeFitList.reset_mock()
+        # Change the constraint to one with no colons in constrained parameter
+        self.widget.tblConstraints.item(0, 0).setText("foo = bar")
+        msg = ("Incorrect constrained parameter definition. Please use colons"
+               " to separate model and parameter on the rhs of the definition, "
+               "e.g. M1:scale")
+        QtWidgets.QMessageBox.critical.assert_called_with(self.widget,
+                                                          "Inconsistent "
+                                                          "constraint",
+                                                          msg,
+                                                          QtWidgets.QMessageBox.
+                                                          Ok)
+        # Check the reloading of the view
+        self.widget.initializeFitList.assert_called_once()
+
+        self.widget.initializeFitList.reset_mock()
+        perspective = self.widget.parent.parent.perspective()
+        # Change the constraint to one with an unknown symbol or with several
+        # parameters on the rhs of the constraint definition
+        self.widget.tblConstraints.item(0, 0).setText("M1:foo = bar")
+        msg = ("Incorrect constrained parameter definition. Please use "
+               "a single known parameter in the rhs of the constraint "
+               "definition, e.g. M1:scale = M1.radius + 2")
+        QtWidgets.QMessageBox.critical.assert_called_with(self.widget,
+                                                          "Inconsistent "
+                                                          "constraint",
+                                                          msg,
+                                                          QtWidgets.QMessageBox.
+                                                          Ok)
+        # Check the reloading of the view
+        self.widget.initializeFitList.assert_called_once()
+
+        self.widget.initializeFitList.reset_mock()
+        # Check replacement of a constraint
+        perspective.symbol_dict = {"M1.scale": 1, "M1.radius": 1}
+
+        self.widget.tblConstraints.item(0, 0).setText("M1:radius = bar")
+        constraint = Constraint(param="radius", func="bar",
+                                value_ex="M1.radius")
+        self.assertEqual(test_tab.addConstraintToRow.call_args[1][
+                             "constraint"].value_ex, constraint.value_ex)
+        self.assertEqual(test_tab.addConstraintToRow.call_args[1][
+                             "constraint"].func, constraint.func)
+        self.assertEqual(test_tab.addConstraintToRow.call_args[1][
+                             "constraint"].param, constraint.param)
+        self.assertEqual(test_tab.addConstraintToRow.call_args[1]["row"], 0)
+        self.assertEqual(test_tab.deleteConstraintOnParameter.call_args[0][
+                             0], "scale")
+        # Check the reloading of the view
+        self.widget.initializeFitList.assert_called_once()
+
+        self.widget.initializeFitList.reset_mock()
+        # Check the checkbox
+        self.widget.tblConstraints.item(0, 0).setText("M1:scale = M1.sld")
+        self.assertEqual(test_tab.modifyViewOnRow.call_args[0][0], 0)
+        font = QtGui.QFont()
+        font.setItalic(True)
+        self.assertEqual(test_tab.modifyViewOnRow.call_args[1]["font"],
+                         font)
+        brush = QtGui.QBrush(QtGui.QColor('blue'))
+        self.assertEqual(test_tab.modifyViewOnRow.call_args[1]["brush"],
+                         brush)
+        # Check the reloading of the view
+        self.widget.initializeFitList.assert_called_once()
+
+        self.widget.initializeFitList.reset_mock()
+        # Uncheck the checkbox
+        self.widget.tblConstraints.item(0, 0).setCheckState(0)
+        self.assertEqual(test_tab.modifyViewOnRow.call_args[0][0], 0)
+        self.assertTrue(not test_tab.modifyViewOnRow.call_args[1])
+        self.assertEqual(self.constraint1.active, False)
+        # Check the reloading of the view
+        self.widget.initializeFitList.assert_called_once()

--- a/src/sas/qtgui/Perspectives/Fitting/UnitTesting/ConstraintWidgetTest.py
+++ b/src/sas/qtgui/Perspectives/Fitting/UnitTesting/ConstraintWidgetTest.py
@@ -335,6 +335,9 @@ class ConstraintWidgetTest(unittest.TestCase):
         test_tab.getConstraintForRow = MagicMock(return_value=self.constraint1)
         self.widget.updateFitLine("test_tab")
         self.widget.parent.getTabByName = MagicMock(return_value=test_tab)
+        perspective = self.widget.parent.parent.perspective()
+        perspective.symbol_dict = {"M1.scale": 1, "M1.radius": 1}
+        self.widget.initializeFitList = MagicMock()
 
         # Constraint should be checked
         self.assertEqual(self.widget.tblConstraints.item(0, 0).checkState(), 2)


### PR DESCRIPTION
This PR aims at improving the way constraints are handled:
* Enables constraint edition in the constraint tab. The edited constraint replaces the old one if the user does not make a mistake while entering it. If the constraint definition is faulty, changes are reverted and a dialog is shown giving information on the mistake.
* Forces a constraint parameter to be checked when the constraint is active. Fixes #1600 
* `Add all` button in the `ComplexConstraint` dialog constrains **all** parameters with the same name on both fit tabs. Fixes #1589 
* Adds an `All` option in the right combobox of the `ComplexConstraint` dialog as a quick way to set up constraints on the same parameter across all fit tabs e.g. `M1:radius = M4.radius`, `M2:radius = M4.radius`, `M3:radius = M4.radius` by selecting `All:radius` on the lhs and `M4.radius` on the rhs with four tabs named `M1`, `M2`, `M3`, `M4`.