### PR TITLE
Various Invariant Plotting Fixes

### DIFF
--- a/src/sas/qtgui/MainWindow/DataExplorer.py
+++ b/src/sas/qtgui/MainWindow/DataExplorer.py
@@ -995,7 +995,7 @@ class DataExplorerWindow(DroppableDataLoadWidget):
         item = GuiUtils.itemFromDisplayName(name, self.model)
         return item
 
-    def displayData(self, name=None, is_data=True, id=None):
+    def displayDataByName(self, name=None, is_data=True, id=None):
         """
         Forces display of charts for the given name
         """

--- a/src/sas/qtgui/MainWindow/DataExplorer.py
+++ b/src/sas/qtgui/MainWindow/DataExplorer.py
@@ -1035,7 +1035,7 @@ class DataExplorerWindow(DroppableDataLoadWidget):
         Forces display of charts for the given data set
         """
         # data_list = [QStandardItem, Data1D/Data2D]
-        plot_to_show = data_list[1]
+        plots_to_show = data_list[1:]
         plot_item = data_list[0]
 
         # plots to show
@@ -1047,7 +1047,7 @@ class DataExplorerWindow(DroppableDataLoadWidget):
             # Try the current item
             main_data = GuiUtils.dataFromItem(plot_item)
         # 1D dependent plots of 2D sets - special treatment
-        if isinstance(main_data, Data2D) and isinstance(plot_to_show, Data1D):
+        if isinstance(main_data, Data2D) and isinstance(plots_to_show[0], Data1D):
             main_data = None
 
         # Make sure main data for 2D is always displayed
@@ -1058,23 +1058,24 @@ class DataExplorerWindow(DroppableDataLoadWidget):
                 else:
                     self.plotData([(plot_item, main_data)])
 
-        # Check if this is merely a plot update
-        if self.updatePlot(plot_to_show):
-            return
+        for plot_to_show in plots_to_show:
+            # Check if this is merely a plot update
+            if self.updatePlot(plot_to_show):
+                continue
 
-        # Residuals get their own plot
-        if plot_to_show.plot_role == Data1D.ROLE_RESIDUAL:
-            plot_to_show.yscale='linear'
-            self.plotData([(plot_item, plot_to_show)])
-        elif plot_to_show.plot_role == Data1D.ROLE_DELETABLE:
-            # No plot
-            return
-        else:
-            # Plots with main data points on the same chart
-            # Get the main data plot
-            if main_data is not None and not self.isPlotShown(main_data):
-                new_plots.append((plot_item, main_data))
-            new_plots.append((plot_item, plot_to_show))
+            # Residuals get their own plot
+            if plot_to_show.plot_role == Data1D.ROLE_RESIDUAL:
+                plot_to_show.yscale='linear'
+                self.plotData([(plot_item, plot_to_show)])
+            elif plot_to_show.plot_role == Data1D.ROLE_DELETABLE:
+                # No plot
+                continue
+            else:
+                # Plots with main data points on the same chart
+                # Get the main data plot
+                if main_data is not None and not self.isPlotShown(main_data):
+                    new_plots.append((plot_item, main_data))
+                new_plots.append((plot_item, plot_to_show))
         if new_plots:
             self.plotData(new_plots)
 

--- a/src/sas/qtgui/MainWindow/GuiManager.py
+++ b/src/sas/qtgui/MainWindow/GuiManager.py
@@ -1197,7 +1197,7 @@ class GuiManager(object):
         Pass the show plot request to the data explorer
         """
         if hasattr(self, "filesWidget"):
-            self.filesWidget.displayData(name=name, is_data=True)
+            self.filesWidget.displayDataByName(name=name, is_data=True)
 
     def showPlot(self, plot, id):
         """

--- a/src/sas/qtgui/Perspectives/Corfunc/CorfuncPerspective.py
+++ b/src/sas/qtgui/Perspectives/Corfunc/CorfuncPerspective.py
@@ -412,7 +412,8 @@ class CorfuncWindow(QtWidgets.QDialog, Ui_CorfuncDialog):
 
         assert isinstance(datas, tuple)
         plot_id = id(self)
-        titles = ['1D Correlation', '3D Correlation', 'Interface Distribution Function']
+        titles = [f"1D Correlation [{self._path}]", f"3D Correlation [{self._path}]",
+                  'Interface Distribution Function']
         for i, plot in enumerate(datas):
             plot_to_add = self.parent.createGuiData(plot)
             # set plot properties

--- a/src/sas/qtgui/Perspectives/Invariant/InvariantPerspective.py
+++ b/src/sas/qtgui/Perspectives/Invariant/InvariantPerspective.py
@@ -373,7 +373,7 @@ class InvariantWindow(QtWidgets.QDialog, Ui_tabbedInvariantUI):
             power_low = inv.get_extrapolation_power(range='low')
 
             # Plot the chart
-            title = "Low-Q extrapolation"
+            title = f"Low-Q extrapolation: {self._data.name}"
 
             # Convert the data into plottable
             self.low_extrapolation_plot = self._manager.createGuiData(extrapolated_data)
@@ -399,7 +399,7 @@ class InvariantWindow(QtWidgets.QDialog, Ui_tabbedInvariantUI):
             high_out_data = inv.get_extra_data_high(q_end=qmax_plot, npts=500)
 
             # Plot the chart
-            title = "High-Q extrapolation"
+            title = f"High-Q extrapolation: {self._data.name}"
 
             # Convert the data into plottable
             self.high_extrapolation_plot = self._manager.createGuiData(high_out_data)

--- a/src/sas/qtgui/Perspectives/Invariant/InvariantPerspective.py
+++ b/src/sas/qtgui/Perspectives/Invariant/InvariantPerspective.py
@@ -250,7 +250,7 @@ class InvariantWindow(QtWidgets.QDialog, Ui_tabbedInvariantUI):
                                              self.low_extrapolation_plot.title)
             plots.append(self.low_extrapolation_plot)
         if len(plots) > 1:
-            reactor.callFromThread(self.communicate.plotRequestedSignal.emit, plots, None)
+            self.communicate.plotRequestedSignal.emit(plots, None)
 
         # Update the details dialog in case it is open
         self.updateDetailsWidget(model)

--- a/src/sas/qtgui/Perspectives/Invariant/InvariantPerspective.py
+++ b/src/sas/qtgui/Perspectives/Invariant/InvariantPerspective.py
@@ -373,7 +373,7 @@ class InvariantWindow(QtWidgets.QDialog, Ui_tabbedInvariantUI):
             power_low = inv.get_extrapolation_power(range='low')
 
             # Plot the chart
-            title = f"Low-Q extrapolation: {self._data.name}"
+            title = f"Low-Q extrapolation [{self._data.name}]"
 
             # Convert the data into plottable
             self.low_extrapolation_plot = self._manager.createGuiData(extrapolated_data)
@@ -399,7 +399,7 @@ class InvariantWindow(QtWidgets.QDialog, Ui_tabbedInvariantUI):
             high_out_data = inv.get_extra_data_high(q_end=qmax_plot, npts=500)
 
             # Plot the chart
-            title = f"High-Q extrapolation: {self._data.name}"
+            title = f"High-Q extrapolation [{self._data.name}]"
 
             # Convert the data into plottable
             self.high_extrapolation_plot = self._manager.createGuiData(high_out_data)

--- a/src/sas/qtgui/Perspectives/Inversion/InversionLogic.py
+++ b/src/sas/qtgui/Perspectives/Inversion/InversionLogic.py
@@ -72,7 +72,7 @@ class InversionLogic(object):
             logger.log("Could not compute I(q) for q =", list((x[index])))
 
         new_plot = Data1D(x, y)
-        new_plot.name = IQ_FIT_LABEL
+        new_plot.name = IQ_FIT_LABEL + f"[{self._data.name}]"
         new_plot.xaxis("\\rm{Q}", 'A^{-1}')
         new_plot.yaxis("\\rm{Intensity} ", "cm^{-1}")
         title = "I(q)"
@@ -124,7 +124,7 @@ class InversionLogic(object):
             (y, dy) = pr.pr_err(out, cov, x)
             new_plot = Data1D(x, y, dy=dy)
 
-        new_plot.name = PR_FIT_LABEL
+        new_plot.name = PR_FIT_LABEL + f"[{self._data.name}]"
         new_plot.xaxis("\\rm{r}", 'A')
         new_plot.yaxis("\\rm{P(r)} ", "cm^{-3}")
         new_plot.title = "P(r) fit"

--- a/src/sas/qtgui/Perspectives/Inversion/InversionPerspective.py
+++ b/src/sas/qtgui/Perspectives/Inversion/InversionPerspective.py
@@ -1005,9 +1005,9 @@ class InversionWindow(QtWidgets.QDialog, Ui_PrInversion):
 
         # Update P(r) and fit plots
         self.prPlot = self.logic.newPRPlot(out, self._calculator, cov)
-        self.prPlot.name = self.logic.data.name
+        self.prPlot.filename = self.logic.data.filename
         self.dataPlot = self.logic.new1DPlot(out, self._calculator)
-        self.dataPlot.name = self.logic.data.name
+        self.dataPlot.filename = self.logic.data.filename
 
         # Udpate internals and GUI
         self.updateDataList(self._data)


### PR DESCRIPTION
This PR fixes a few issues related to plotting, most of which have to do with the Invariant Perspective.
- Fixes #1541: The invariant perspective now updates existing plots so a new window is not generated every time the calculator is run.
- Fixes #1542 and Fixes #1605: The invariant perspective no longer pulls the plot state from the DataExplorer so plots with similar names as Invariant plots are no longer plotted alongside the Invariant plots (same data name or same theory name like Corfunc).