### PR TITLE
Ticket 1710: Remove deprecated method call from NXcanSAS reader

### DIFF
--- a/src/sas/sascalc/dataloader/readers/cansas_reader_HDF5.py
+++ b/src/sas/sascalc/dataloader/readers/cansas_reader_HDF5.py
@@ -182,7 +182,7 @@ class Reader(FileReader):
 
             elif isinstance(value, h5py.Dataset):
                 # If this is a dataset, store the data appropriately
-                data_set = value.value
+                data_set = value[()]
                 unit = self._get_unit(value)
                 # Put scalars into lists to be sure they are iterable
                 if np.isscalar(data_set):


### PR DESCRIPTION
This fixes #1710. The h5py package v3.0 removed a previously deprecated method that was still present in the NXcanSAS reader. I tested this locally with h5py v2.8, v2.9, and v3.1. I did not update the version for h5py in the build and conda files but I'm not opposed to doing this.