### PR TITLE
Allow display name changes in data explorer (1702)

### DIFF
--- a/src/sas/qtgui/MainWindow/DataExplorer.py
+++ b/src/sas/qtgui/MainWindow/DataExplorer.py
@@ -1495,9 +1495,10 @@ class DataExplorerWindow(DroppableDataLoadWidget):
         self.actionSelect.setEnabled(True)
 
         # Name Changing
-        # Disallow name changes after the data has been sent to any perspective to prevent orphaned plots
-        plots = GuiUtils.plotsFromModel(str(model_item.text()), model_item)
-        self.actionChangeName.setEnabled(len(plots) == 1)
+        # Disallow name changes after the data has been assigned any plots to prevent orphans
+        children = list(GuiUtils.getChildrenFromItem(model_item))
+        hashables = [child for child in children if isinstance(child, GuiUtils.HashableStandardItem)]
+        self.actionChangeName.setEnabled(len(hashables) <= 1)
         # Do not allow name change for lower level plots
         self.actionChangeName.setVisible(model_item.parent() is None)
 
@@ -1521,10 +1522,11 @@ class DataExplorerWindow(DroppableDataLoadWidget):
 
         # Get the model item and update the name change box
         model_item = model.itemFromIndex(proxy.mapToSource(index))
-        plots = GuiUtils.plotsFromModel(str(model_item.text()), model_item)
 
-        # Do not allow name changes then the data is in a perspective
-        if len(plots) == 1:
+        # Do not allow name changes after the data has plots assigned
+        children = list(GuiUtils.getChildrenFromItem(model_item))
+        hashables = [child for child in children if isinstance(child, GuiUtils.HashableStandardItem)]
+        if len(hashables) <= 1:
             self.nameChangeBox.model_item = model_item
             # Open the window
             self.nameChangeBox.show()

--- a/src/sas/qtgui/MainWindow/DataExplorer.py
+++ b/src/sas/qtgui/MainWindow/DataExplorer.py
@@ -130,7 +130,7 @@ class DataExplorerWindow(DroppableDataLoadWidget):
         self.data_proxy.setFilterRegExp(r"[^()]")
 
         # Create a window to allow the display name to change
-        self.nameChangeBox = ChangeName()
+        self.nameChangeBox = ChangeName(self)
 
         # The Data viewer is QTreeView showing the proxy model
         self.treeView.setModel(self.data_proxy)

--- a/src/sas/qtgui/MainWindow/DataExplorer.py
+++ b/src/sas/qtgui/MainWindow/DataExplorer.py
@@ -1449,7 +1449,6 @@ class DataExplorerWindow(DroppableDataLoadWidget):
         self.context_menu.addAction(self.actionDeselect)
         self.context_menu.addSeparator()
         self.context_menu.addAction(self.actionChangeName)
-        self.context_menu.addSeparator()
         self.context_menu.addAction(self.actionDataInfo)
         self.context_menu.addAction(self.actionSaveAs)
         self.context_menu.addAction(self.actionQuickPlot)
@@ -1495,6 +1494,13 @@ class DataExplorerWindow(DroppableDataLoadWidget):
         self.actionEditMask.setEnabled(is_2D)
         self.actionSelect.setEnabled(True)
 
+        # Name Changing
+        # Disallow name changes after the data has been sent to any perspective to prevent orphaned plots
+        plots = GuiUtils.plotsFromModel(str(model_item.text()), model_item)
+        self.actionChangeName.setEnabled(len(plots) == 1)
+        # Do not allow name change for lower level plots
+        self.actionChangeName.setVisible(model_item.parent() is None)
+
         # Freezing
         # check that the selection has inner items
         freeze_enabled = False
@@ -1515,10 +1521,13 @@ class DataExplorerWindow(DroppableDataLoadWidget):
 
         # Get the model item and update the name change box
         model_item = model.itemFromIndex(proxy.mapToSource(index))
-        self.nameChangeBox.model_item = model_item
+        plots = GuiUtils.plotsFromModel(str(model_item.text()), model_item)
 
-        # Open the window
-        self.nameChangeBox.show()
+        # Do not allow name changes then the data is in a perspective
+        if len(plots) == 1:
+            self.nameChangeBox.model_item = model_item
+            # Open the window
+            self.nameChangeBox.show()
 
     def showDataInfo(self):
         """

--- a/src/sas/qtgui/MainWindow/DataExplorer.py
+++ b/src/sas/qtgui/MainWindow/DataExplorer.py
@@ -1444,6 +1444,8 @@ class DataExplorerWindow(DroppableDataLoadWidget):
         self.context_menu.addAction(self.actionSelect)
         self.context_menu.addAction(self.actionDeselect)
         self.context_menu.addSeparator()
+        self.context_menu.addAction(self.actionChangeName)
+        self.context_menu.addSeparator()
         self.context_menu.addAction(self.actionDataInfo)
         self.context_menu.addAction(self.actionSaveAs)
         self.context_menu.addAction(self.actionQuickPlot)
@@ -1459,6 +1461,7 @@ class DataExplorerWindow(DroppableDataLoadWidget):
         # Define the callbacks
         self.actionSelect.triggered.connect(self.onFileListSelected)
         self.actionDeselect.triggered.connect(self.onFileListDeselected)
+        self.actionChangeName.triggered.connect(self.changeName)
         self.actionDataInfo.triggered.connect(self.showDataInfo)
         self.actionSaveAs.triggered.connect(self.saveDataAs)
         self.actionQuickPlot.triggered.connect(self.quickDataPlot)
@@ -1497,6 +1500,13 @@ class DataExplorerWindow(DroppableDataLoadWidget):
 
         # Fire up the menu
         self.context_menu.exec_(self.current_view.mapToGlobal(position))
+
+    def changeName(self):
+        # Placeholder for upcoming feature - #1702
+        index = self.current_view.selectedIndexes()[0]
+        proxy = self.current_view.model()
+        # TODO: Create a modal window that shows base file info and an input box, if desired
+        pass
 
     def showDataInfo(self):
         """
@@ -1876,7 +1886,8 @@ class DataExplorerWindow(DroppableDataLoadWidget):
         checkbox_item.setCheckable(True)
         checkbox_item.setCheckState(QtCore.Qt.Checked)
         if p_file is not None:
-            checkbox_item.setText(os.path.basename(p_file))
+            p_file = os.path.basename(p_file) if os.path.exists(p_file) else p_file
+            checkbox_item.setText(p_file)
 
         # Add the actual Data1D/Data2D object
         object_item = GuiUtils.HashableStandardItem()

--- a/src/sas/qtgui/MainWindow/DataExplorer.py
+++ b/src/sas/qtgui/MainWindow/DataExplorer.py
@@ -26,6 +26,7 @@ from sas.qtgui.Plotting.MaskEditor import MaskEditor
 
 from sas.qtgui.MainWindow.DataManager import DataManager
 from sas.qtgui.MainWindow.DroppableDataLoadWidget import DroppableDataLoadWidget
+from sas.qtgui.MainWindow.NameChanger import ChangeName
 
 import sas.qtgui.Perspectives as Perspectives
 
@@ -127,6 +128,9 @@ class DataExplorerWindow(DroppableDataLoadWidget):
 
         # Don't show "empty" rows with data objects
         self.data_proxy.setFilterRegExp(r"[^()]")
+
+        # Create a window to allow the display name to change
+        self.nameChangeBox = ChangeName()
 
         # The Data viewer is QTreeView showing the proxy model
         self.treeView.setModel(self.data_proxy)
@@ -1502,11 +1506,19 @@ class DataExplorerWindow(DroppableDataLoadWidget):
         self.context_menu.exec_(self.current_view.mapToGlobal(position))
 
     def changeName(self):
-        # Placeholder for upcoming feature - #1702
+        """
+        Open a modal window that can change the display name of the selected data
+        """
         index = self.current_view.selectedIndexes()[0]
         proxy = self.current_view.model()
-        # TODO: Create a modal window that shows base file info and an input box, if desired
-        pass
+        model = proxy.sourceModel()
+
+        # Get the model item and update the name change box
+        model_item = model.itemFromIndex(proxy.mapToSource(index))
+        self.nameChangeBox.model_item = model_item
+
+        # Open the window
+        self.nameChangeBox.show()
 
     def showDataInfo(self):
         """

--- a/src/sas/qtgui/MainWindow/NameChanger.py
+++ b/src/sas/qtgui/MainWindow/NameChanger.py
@@ -6,6 +6,7 @@ from sas.qtgui.Utilities import GuiUtils
 
 from .UI.ChangeNameUI import Ui_ChangeCategoryUI
 
+
 class ChangeName(QtWidgets.QDialog, Ui_ChangeCategoryUI):
     def __init__(self, parent=None):
         super(ChangeName, self).__init__(parent)
@@ -14,11 +15,10 @@ class ChangeName(QtWidgets.QDialog, Ui_ChangeCategoryUI):
         self.setWindowFlags(self.windowFlags() & ~QtCore.Qt.WindowContextHelpButtonHint)
 
         self.setWindowTitle("Display Name Change")
-        self.currentValue = self.txtCurrentName.text()
         self._data = None
         self._model_item = None
 
-        # Disable the fixed inputs
+        # Disable the inputs
         self.txtCurrentName.setEnabled(False)
         self.txtDataName.setEnabled(False)
         self.txtFileName.setEnabled(False)
@@ -52,7 +52,7 @@ class ChangeName(QtWidgets.QDialog, Ui_ChangeCategoryUI):
 
     def addActions(self):
         """
-        Add actions to the logo push buttons
+        Add actions for buttons
         """
         # Close actions - return selected value on ok, otherwise just close
         self.cmdCancel.clicked.connect(lambda: self.close(False))

--- a/src/sas/qtgui/MainWindow/NameChanger.py
+++ b/src/sas/qtgui/MainWindow/NameChanger.py
@@ -1,0 +1,73 @@
+import os
+
+from PyQt5 import QtWidgets, QtCore
+
+from sas.qtgui.Utilities import GuiUtils
+
+from .UI.ChangeNameUI import Ui_ChangeCategoryUI
+
+class ChangeName(QtWidgets.QDialog, Ui_ChangeCategoryUI):
+    def __init__(self, parent=None):
+        super(ChangeName, self).__init__(parent)
+        self.setupUi(self)
+
+        self.setWindowFlags(self.windowFlags() & ~QtCore.Qt.WindowContextHelpButtonHint)
+
+        self.setWindowTitle("Display Name Change")
+        self.currentValue = self.txtCurrentName.text()
+        self._data = None
+        self._model_item = None
+
+        self.addActions()
+
+    @property
+    def model_item(self):
+        return self._model_item
+
+    @model_item.setter
+    def model_item(self, val):
+        assert isinstance(val, GuiUtils.HashableStandardItem)
+        self._model_item = val
+        self.data = GuiUtils.dataFromItem(self._model_item)
+
+    @property
+    def data(self):
+        return self._data
+
+    @data.setter
+    def data(self, var=None):
+        if var:
+            self._data = var
+            self.rbExisting.setChecked(True)
+            self.txtCurrentName.setText(self._data.name)
+            self.txtDataName.setText(self._data.title)
+            self.txtFileName.setText(os.path.basename(self._data.filename))
+            self.txtNewCategory.setText("")
+
+    def addActions(self):
+        """
+        Add actions to the logo push buttons
+        """
+        # Close actions - return selected value on ok, otherwise just close
+        self.cmdCancel.clicked.connect(lambda: self.close(False))
+        self.cmdOK.clicked.connect(lambda: self.close(True))
+
+    def getNewText(self):
+        """
+        Find the radio button that is selected and find its associated textbox
+        """
+        buttonStates = [self.rbExisting.isChecked(), self.rbDataName.isChecked(),
+                   self.rbFileName.isChecked(), self.rbNew.isChecked()]
+        textValues = [self.txtCurrentName.text(), self.txtDataName.text(),
+                      self.txtFileName.text(), self.txtNewCategory.text()]
+        newValues = [textValues[i] for i, value in enumerate(textValues) if buttonStates[i]]
+        self.data.name = newValues[0] if len(newValues) == 1 else self.txtCurrentName.text()
+        GuiUtils.updateModelItem(self.model_item, self.data, self.data.name)
+
+    def close(self, retVal=False):
+        """
+        Return a value - hide the window for now
+        """
+        self.hide()
+        if retVal:
+            self.getNewText()

--- a/src/sas/qtgui/MainWindow/NameChanger.py
+++ b/src/sas/qtgui/MainWindow/NameChanger.py
@@ -18,6 +18,12 @@ class ChangeName(QtWidgets.QDialog, Ui_ChangeCategoryUI):
         self._data = None
         self._model_item = None
 
+        # Disable the fixed inputs
+        self.txtCurrentName.setEnabled(False)
+        self.txtDataName.setEnabled(False)
+        self.txtFileName.setEnabled(False)
+        self.txtNewCategory.setEnabled(False)
+
         self.addActions()
 
     @property
@@ -39,7 +45,7 @@ class ChangeName(QtWidgets.QDialog, Ui_ChangeCategoryUI):
         if var:
             self._data = var
             self.rbExisting.setChecked(True)
-            self.txtCurrentName.setText(self._data.name)
+            self.txtCurrentName.setText(self._model_item.text())
             self.txtDataName.setText(self._data.title)
             self.txtFileName.setText(os.path.basename(self._data.filename))
             self.txtNewCategory.setText("")
@@ -51,6 +57,7 @@ class ChangeName(QtWidgets.QDialog, Ui_ChangeCategoryUI):
         # Close actions - return selected value on ok, otherwise just close
         self.cmdCancel.clicked.connect(lambda: self.close(False))
         self.cmdOK.clicked.connect(lambda: self.close(True))
+        self.rbNew.toggled.connect(lambda: self.txtNewCategory.setEnabled(self.rbNew.isChecked()))
 
     def getNewText(self):
         """
@@ -61,8 +68,8 @@ class ChangeName(QtWidgets.QDialog, Ui_ChangeCategoryUI):
         textValues = [self.txtCurrentName.text(), self.txtDataName.text(),
                       self.txtFileName.text(), self.txtNewCategory.text()]
         newValues = [textValues[i] for i, value in enumerate(textValues) if buttonStates[i]]
-        self.data.name = newValues[0] if len(newValues) == 1 else self.txtCurrentName.text()
-        GuiUtils.updateModelItem(self.model_item, self.data, self.data.name)
+        name = newValues[0] if len(newValues) == 1 and newValues[0] else self.txtCurrentName.text()
+        self._model_item.setText(name)
 
     def close(self, retVal=False):
         """

--- a/src/sas/qtgui/MainWindow/NameChanger.py
+++ b/src/sas/qtgui/MainWindow/NameChanger.py
@@ -84,21 +84,6 @@ class ChangeName(QtWidgets.QDialog, Ui_ChangeCategoryUI):
         new_name = self.manager.rename(newValues[0]) if len(newValues) == 1 else ""
         # Only rename if there is something to add.
         if new_name:
-            # TODO: This needs to update all theories and theory plots
-            old_name = self._model_item.text()
-            # Rename all theory elements
-            # for index in range(self._model_item.rowCount()):
-            #     item = self._model_item.child(index)
-            #     data = GuiUtils.dataFromItem(item)
-            #     if old_name in item.text():
-            #         text = str(item.text())
-            #         item.setText(text.replace(old_name, new_name))
-            #     if data:
-            #         data.name = new_name
-            #         data.title.replace(old_name, new_name)
-            #     if hasattr(item, 'title'):
-            #         item.title.replace(old_name, new_name)
-            #     item.setData(data)
             self._data.name = new_name
             self._model_item.setData(self._data)
             self._model_item.setText(new_name)

--- a/src/sas/qtgui/MainWindow/UI/ChangeNameUI.ui
+++ b/src/sas/qtgui/MainWindow/UI/ChangeNameUI.ui
@@ -1,0 +1,108 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>ChangeCategoryUI</class>
+ <widget class="QDialog" name="ChangeCategoryUI">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>341</width>
+    <height>295</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Change Category:</string>
+  </property>
+  <widget class="QGroupBox" name="groupBox">
+   <property name="geometry">
+    <rect>
+     <x>11</x>
+     <y>11</y>
+     <width>321</width>
+     <height>211</height>
+    </rect>
+   </property>
+   <property name="title">
+    <string>Change Display Name</string>
+   </property>
+   <layout class="QGridLayout" name="gridLayout">
+    <item row="0" column="2">
+     <widget class="QLineEdit" name="txtCurrentName"/>
+    </item>
+    <item row="0" column="0">
+     <widget class="QRadioButton" name="rbExisting">
+      <property name="text">
+       <string>Current name</string>
+      </property>
+     </widget>
+    </item>
+    <item row="2" column="0">
+     <widget class="QRadioButton" name="rbFileName">
+      <property name="text">
+       <string>File name</string>
+      </property>
+     </widget>
+    </item>
+    <item row="1" column="0">
+     <widget class="QRadioButton" name="rbDataName">
+      <property name="text">
+       <string>Data name</string>
+      </property>
+     </widget>
+    </item>
+    <item row="1" column="2">
+     <widget class="QLineEdit" name="txtDataName"/>
+    </item>
+    <item row="3" column="0">
+     <widget class="QRadioButton" name="rbNew">
+      <property name="text">
+       <string>Create new</string>
+      </property>
+     </widget>
+    </item>
+    <item row="3" column="2">
+     <widget class="QLineEdit" name="txtNewCategory"/>
+    </item>
+    <item row="2" column="2">
+     <widget class="QLineEdit" name="txtFileName"/>
+    </item>
+   </layout>
+   <zorder>txtNewCategory</zorder>
+   <zorder>rbNew</zorder>
+   <zorder>rbExisting</zorder>
+   <zorder>txtCurrentName</zorder>
+   <zorder>rbDataName</zorder>
+   <zorder>rbFileName</zorder>
+   <zorder>txtDataName</zorder>
+   <zorder>txtFileName</zorder>
+  </widget>
+  <widget class="QPushButton" name="cmdOK">
+   <property name="geometry">
+    <rect>
+     <x>112</x>
+     <y>247</y>
+     <width>93</width>
+     <height>28</height>
+    </rect>
+   </property>
+   <property name="text">
+    <string>OK</string>
+   </property>
+  </widget>
+  <widget class="QPushButton" name="cmdCancel">
+   <property name="geometry">
+    <rect>
+     <x>12</x>
+     <y>247</y>
+     <width>93</width>
+     <height>28</height>
+    </rect>
+   </property>
+   <property name="text">
+    <string>Cancel</string>
+   </property>
+  </widget>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/src/sas/qtgui/MainWindow/UI/ChangeNameUI.ui
+++ b/src/sas/qtgui/MainWindow/UI/ChangeNameUI.ui
@@ -10,6 +10,12 @@
     <height>295</height>
    </rect>
   </property>
+  <property name="minimumSize">
+   <size>
+    <width>341</width>
+    <height>295</height>
+   </size>
+  </property>
   <property name="windowTitle">
    <string>Change Category:</string>
   </property>
@@ -26,8 +32,21 @@
     <string>Change Display Name</string>
    </property>
    <layout class="QGridLayout" name="gridLayout">
+    <item row="1" column="0">
+     <widget class="QRadioButton" name="rbDataName">
+      <property name="text">
+       <string>Data name</string>
+      </property>
+     </widget>
+    </item>
+    <item row="2" column="2">
+     <widget class="QLineEdit" name="txtFileName"/>
+    </item>
     <item row="0" column="2">
      <widget class="QLineEdit" name="txtCurrentName"/>
+    </item>
+    <item row="1" column="2">
+     <widget class="QLineEdit" name="txtDataName"/>
     </item>
     <item row="0" column="0">
      <widget class="QRadioButton" name="rbExisting">
@@ -36,6 +55,9 @@
       </property>
      </widget>
     </item>
+    <item row="3" column="2">
+     <widget class="QLineEdit" name="txtNewCategory"/>
+    </item>
     <item row="2" column="0">
      <widget class="QRadioButton" name="rbFileName">
       <property name="text">
@@ -43,28 +65,12 @@
       </property>
      </widget>
     </item>
-    <item row="1" column="0">
-     <widget class="QRadioButton" name="rbDataName">
-      <property name="text">
-       <string>Data name</string>
-      </property>
-     </widget>
-    </item>
-    <item row="1" column="2">
-     <widget class="QLineEdit" name="txtDataName"/>
-    </item>
     <item row="3" column="0">
      <widget class="QRadioButton" name="rbNew">
       <property name="text">
        <string>Create new</string>
       </property>
      </widget>
-    </item>
-    <item row="3" column="2">
-     <widget class="QLineEdit" name="txtNewCategory"/>
-    </item>
-    <item row="2" column="2">
-     <widget class="QLineEdit" name="txtFileName"/>
     </item>
    </layout>
    <zorder>txtNewCategory</zorder>
@@ -76,31 +82,44 @@
    <zorder>txtDataName</zorder>
    <zorder>txtFileName</zorder>
   </widget>
-  <widget class="QPushButton" name="cmdOK">
+  <widget class="QWidget" name="horizontalLayoutWidget">
    <property name="geometry">
     <rect>
-     <x>112</x>
-     <y>247</y>
-     <width>93</width>
-     <height>28</height>
+     <x>10</x>
+     <y>230</y>
+     <width>321</width>
+     <height>41</height>
     </rect>
    </property>
-   <property name="text">
-    <string>OK</string>
-   </property>
-  </widget>
-  <widget class="QPushButton" name="cmdCancel">
-   <property name="geometry">
-    <rect>
-     <x>12</x>
-     <y>247</y>
-     <width>93</width>
-     <height>28</height>
-    </rect>
-   </property>
-   <property name="text">
-    <string>Cancel</string>
-   </property>
+   <layout class="QHBoxLayout" name="horizontalLayout_2">
+    <item>
+     <spacer name="horizontalSpacer">
+      <property name="orientation">
+       <enum>Qt::Horizontal</enum>
+      </property>
+      <property name="sizeHint" stdset="0">
+       <size>
+        <width>40</width>
+        <height>20</height>
+       </size>
+      </property>
+     </spacer>
+    </item>
+    <item>
+     <widget class="QPushButton" name="cmdOK">
+      <property name="text">
+       <string>OK</string>
+      </property>
+     </widget>
+    </item>
+    <item>
+     <widget class="QPushButton" name="cmdCancel">
+      <property name="text">
+       <string>Cancel</string>
+      </property>
+     </widget>
+    </item>
+   </layout>
   </widget>
  </widget>
  <resources/>

--- a/src/sas/qtgui/MainWindow/UI/DataExplorerUI.ui
+++ b/src/sas/qtgui/MainWindow/UI/DataExplorerUI.ui
@@ -532,6 +532,14 @@
     <string>Deselect items</string>
    </property>
   </action>
+  <action name="actionChangeName">
+   <property name="text">
+    <string>Change Name</string>
+   </property>
+   <property name="toolTip">
+    <string>Change Display Name</string>
+   </property>
+  </action>
  </widget>
  <resources/>
  <connections/>

--- a/src/sas/qtgui/MainWindow/UnitTesting/DataExplorerTest.py
+++ b/src/sas/qtgui/MainWindow/UnitTesting/DataExplorerTest.py
@@ -755,6 +755,95 @@ class DataExplorerTest(unittest.TestCase):
         # See that the menu has been shown
         self.form.context_menu.exec_.assert_called_once()
 
+    def testNameChange(self):
+        """
+        Test the display name change routines
+        """
+        # Define Constants
+        FILE_NAME = "cyl_400_20.txt"
+        TEST_STRING_1 = "test value change"
+        TEST_STRING_2 = "TEST VALUE CHANGE"
+        # Test base state of the name change window
+        self.assertTrue(hasattr(self.form, "nameChangeBox"))
+        self.assertEqual(self.form.nameChangeBox.windowTitle(), "Display Name Change")
+        self.assertFalse(self.form.nameChangeBox.isVisible())
+        self.assertIsNone(self.form.nameChangeBox.data)
+        self.assertIsNone(self.form.nameChangeBox.model_item)
+        self.assertFalse(self.form.nameChangeBox.txtCurrentName.isEnabled())
+        self.assertFalse(self.form.nameChangeBox.txtDataName.isEnabled())
+        self.assertFalse(self.form.nameChangeBox.txtFileName.isEnabled())
+        self.assertFalse(self.form.nameChangeBox.txtNewCategory.isEnabled())
+        self.assertEqual(self.form.nameChangeBox.txtCurrentName.text(), "")
+        self.assertEqual(self.form.nameChangeBox.txtDataName.text(), "")
+        self.assertEqual(self.form.nameChangeBox.txtFileName.text(), "")
+        self.assertEqual(self.form.nameChangeBox.txtNewCategory.text(), "")
+
+        # Get Data1D
+        p_file=[FILE_NAME]
+        # Read in the file
+        output, message = self.form.readData(p_file)
+        key = list(output.keys())
+        output[key[0]].title = TEST_STRING_1
+        self.form.loadComplete((output, message))
+
+        # select the data and run name change routine
+        self.form.treeView.selectAll()
+        self.form.changeName()
+
+        # Test window state after adding data
+        self.assertTrue(self.form.nameChangeBox.isVisible())
+        self.assertIsNotNone(self.form.nameChangeBox.data)
+        self.assertIsNotNone(self.form.nameChangeBox.model_item)
+        self.assertEqual(self.form.nameChangeBox.txtCurrentName.text(), FILE_NAME)
+        self.assertEqual(self.form.nameChangeBox.txtDataName.text(), TEST_STRING_1)
+        self.assertEqual(self.form.nameChangeBox.txtFileName.text(), FILE_NAME)
+        self.assertTrue(self.form.nameChangeBox.rbExisting.isChecked())
+        self.assertFalse(self.form.nameChangeBox.rbDataName.isChecked())
+        self.assertFalse(self.form.nameChangeBox.rbFileName.isChecked())
+        self.assertFalse(self.form.nameChangeBox.rbNew.isChecked())
+
+        # Take the existing name
+        self.form.nameChangeBox.cmdOK.click()
+
+        # Take the title
+        self.form.changeName()
+        self.assertEqual(self.form.nameChangeBox.txtCurrentName.text(), FILE_NAME)
+        self.form.nameChangeBox.rbDataName.setChecked(True)
+        self.assertFalse(self.form.nameChangeBox.rbExisting.isChecked())
+        self.form.nameChangeBox.cmdOK.click()
+
+        # Take the file name again
+        self.form.changeName()
+        self.assertEqual(self.form.nameChangeBox.txtCurrentName.text(), TEST_STRING_1)
+        self.form.nameChangeBox.rbFileName.setChecked(True)
+        self.assertFalse(self.form.nameChangeBox.rbExisting.isChecked())
+        self.form.nameChangeBox.cmdOK.click()
+
+        # Take the user-defined name, which is empty - should retain existing value
+        self.form.changeName()
+        self.assertEqual(self.form.nameChangeBox.txtCurrentName.text(), FILE_NAME)
+        self.form.nameChangeBox.rbNew.setChecked(True)
+        self.assertFalse(self.form.nameChangeBox.rbExisting.isChecked())
+        self.form.nameChangeBox.cmdOK.click()
+
+        # Take a different user-defined name
+        self.form.changeName()
+        self.assertEqual(self.form.nameChangeBox.txtCurrentName.text(), FILE_NAME)
+        self.form.nameChangeBox.rbNew.setChecked(True)
+        self.form.nameChangeBox.txtNewCategory.setText(TEST_STRING_2)
+        self.assertFalse(self.form.nameChangeBox.rbExisting.isChecked())
+        self.form.nameChangeBox.cmdOK.click()
+
+        # Test cancel button
+        self.form.changeName()
+        self.assertEqual(self.form.nameChangeBox.txtCurrentName.text(), TEST_STRING_2)
+        self.form.nameChangeBox.rbNew.setChecked(True)
+        self.form.nameChangeBox.txtNewCategory.setText(TEST_STRING_1)
+        self.form.nameChangeBox.cmdCancel.click()
+        self.form.changeName()
+        self.assertEqual(self.form.nameChangeBox.txtCurrentName.text(), TEST_STRING_2)
+        self.form.nameChangeBox.cmdOK.click()
+
     def testShowDataInfo(self):
         """
         Test of the showDataInfo method

--- a/src/sas/qtgui/MainWindow/UnitTesting/DataExplorerTest.py
+++ b/src/sas/qtgui/MainWindow/UnitTesting/DataExplorerTest.py
@@ -780,6 +780,7 @@ class DataExplorerTest(unittest.TestCase):
         """
         # Define Constants
         FILE_NAME = "cyl_400_20.txt"
+        FILE_NAME_APPENDED = FILE_NAME + " [1]"
         TEST_STRING_1 = "test value change"
         TEST_STRING_2 = "TEST VALUE CHANGE"
         # Test base state of the name change window
@@ -825,14 +826,14 @@ class DataExplorerTest(unittest.TestCase):
         self.assertFalse(self.form.nameChangeBox.rbExisting.isChecked())
         self.form.nameChangeBox.cmdOK.click()
         self.form.changeName()
-        self.assertEqual(self.form.nameChangeBox.txtCurrentName.text(), FILE_NAME)
+        self.assertEqual(self.form.nameChangeBox.txtCurrentName.text(), FILE_NAME_APPENDED)
 
         # Take the user-defined name, which is empty - should retain existing value
         self.form.nameChangeBox.rbNew.setChecked(True)
         self.assertFalse(self.form.nameChangeBox.rbExisting.isChecked())
         self.form.nameChangeBox.cmdOK.click()
         self.form.changeName()
-        self.assertEqual(self.form.nameChangeBox.txtCurrentName.text(), FILE_NAME)
+        self.assertEqual(self.form.nameChangeBox.txtCurrentName.text(), FILE_NAME_APPENDED)
 
         # Take a different user-defined name
         self.form.nameChangeBox.rbNew.setChecked(True)

--- a/src/sas/qtgui/MainWindow/UnitTesting/DataExplorerTest.py
+++ b/src/sas/qtgui/MainWindow/UnitTesting/DataExplorerTest.py
@@ -755,16 +755,12 @@ class DataExplorerTest(unittest.TestCase):
         # See that the menu has been shown
         self.form.context_menu.exec_.assert_called_once()
 
-    def testNameChange(self):
+    def baseNameStateCheck(self):
         """
-        Test the display name change routines
+        Helper method for the Name Change Tests Below - Check the base state of the window
         """
-        # Define Constants
-        FILE_NAME = "cyl_400_20.txt"
-        TEST_STRING_1 = "test value change"
-        TEST_STRING_2 = "TEST VALUE CHANGE"
-        # Test base state of the name change window
         self.assertTrue(hasattr(self.form, "nameChangeBox"))
+        self.assertTrue(self.form.nameChangeBox.isModal())
         self.assertEqual(self.form.nameChangeBox.windowTitle(), "Display Name Change")
         self.assertFalse(self.form.nameChangeBox.isVisible())
         self.assertIsNone(self.form.nameChangeBox.data)
@@ -778,6 +774,16 @@ class DataExplorerTest(unittest.TestCase):
         self.assertEqual(self.form.nameChangeBox.txtFileName.text(), "")
         self.assertEqual(self.form.nameChangeBox.txtNewCategory.text(), "")
 
+    def testNameChange(self):
+        """
+        Test the display name change routines
+        """
+        # Define Constants
+        FILE_NAME = "cyl_400_20.txt"
+        TEST_STRING_1 = "test value change"
+        TEST_STRING_2 = "TEST VALUE CHANGE"
+        # Test base state of the name change window
+        self.baseNameStateCheck()
         # Get Data1D
         p_file=[FILE_NAME]
         # Read in the file
@@ -804,45 +810,51 @@ class DataExplorerTest(unittest.TestCase):
 
         # Take the existing name
         self.form.nameChangeBox.cmdOK.click()
-
-        # Take the title
         self.form.changeName()
         self.assertEqual(self.form.nameChangeBox.txtCurrentName.text(), FILE_NAME)
+
+        # Take the title
         self.form.nameChangeBox.rbDataName.setChecked(True)
         self.assertFalse(self.form.nameChangeBox.rbExisting.isChecked())
         self.form.nameChangeBox.cmdOK.click()
-
-        # Take the file name again
         self.form.changeName()
         self.assertEqual(self.form.nameChangeBox.txtCurrentName.text(), TEST_STRING_1)
+
+        # Take the file name again
         self.form.nameChangeBox.rbFileName.setChecked(True)
         self.assertFalse(self.form.nameChangeBox.rbExisting.isChecked())
         self.form.nameChangeBox.cmdOK.click()
-
-        # Take the user-defined name, which is empty - should retain existing value
         self.form.changeName()
         self.assertEqual(self.form.nameChangeBox.txtCurrentName.text(), FILE_NAME)
+
+        # Take the user-defined name, which is empty - should retain existing value
         self.form.nameChangeBox.rbNew.setChecked(True)
         self.assertFalse(self.form.nameChangeBox.rbExisting.isChecked())
         self.form.nameChangeBox.cmdOK.click()
-
-        # Take a different user-defined name
         self.form.changeName()
         self.assertEqual(self.form.nameChangeBox.txtCurrentName.text(), FILE_NAME)
+
+        # Take a different user-defined name
         self.form.nameChangeBox.rbNew.setChecked(True)
         self.form.nameChangeBox.txtNewCategory.setText(TEST_STRING_2)
         self.assertFalse(self.form.nameChangeBox.rbExisting.isChecked())
         self.form.nameChangeBox.cmdOK.click()
-
-        # Test cancel button
         self.form.changeName()
         self.assertEqual(self.form.nameChangeBox.txtCurrentName.text(), TEST_STRING_2)
+
+        # Test cancel button
         self.form.nameChangeBox.rbNew.setChecked(True)
         self.form.nameChangeBox.txtNewCategory.setText(TEST_STRING_1)
         self.form.nameChangeBox.cmdCancel.click()
         self.form.changeName()
         self.assertEqual(self.form.nameChangeBox.txtCurrentName.text(), TEST_STRING_2)
         self.form.nameChangeBox.cmdOK.click()
+
+        # Test delete data
+        self.form.nameChangeBox.removeData(None)  # Nothing should happen
+        self.assertEqual(self.form.nameChangeBox.txtCurrentName.text(), TEST_STRING_2)
+        self.form.nameChangeBox.removeData([self.form.nameChangeBox.model_item])  # Should return to base state
+        self.baseNameStateCheck()
 
     def testShowDataInfo(self):
         """


### PR DESCRIPTION
A new option was added to the data explorer context menu allowing users to change the display name for a data set. The option opens a window offering 4 options: Keep the existing name, change to the data tile, change to the data file name, or change to any name the user would like. Unit tests were added to check base functionality and catch a few odd edge cases.

This fixes #1701 and closes #1702.