### PR TITLE
Remove Invariant plots when extrapolations turned off

### DIFF
--- a/src/sas/qtgui/Perspectives/Invariant/InvariantPerspective.py
+++ b/src/sas/qtgui/Perspectives/Invariant/InvariantPerspective.py
@@ -398,7 +398,7 @@ class InvariantWindow(QtWidgets.QDialog, Ui_tabbedInvariantUI):
             power_low = self._calculator.get_extrapolation_power(range='low')
 
             # Plot the chart
-            title = "Low-Q extrapolation"
+            title = f"Low-Q extrapolation: {self._data.name}"
 
             # Convert the data into plottable
             self.low_extrapolation_plot = self._manager.createGuiData(extrapolated_data)
@@ -427,7 +427,7 @@ class InvariantWindow(QtWidgets.QDialog, Ui_tabbedInvariantUI):
             high_out_data = self._calculator.get_extra_data_high(q_end=qmax_plot, npts=500)
 
             # Plot the chart
-            title = "High-Q extrapolation"
+            title = f"High-Q extrapolation: {self._data.name}"
 
             # Convert the data into plottable
             self.high_extrapolation_plot = self._manager.createGuiData(high_out_data)

--- a/src/sas/qtgui/Perspectives/Invariant/InvariantPerspective.py
+++ b/src/sas/qtgui/Perspectives/Invariant/InvariantPerspective.py
@@ -311,6 +311,15 @@ class InvariantWindow(QtWidgets.QDialog, Ui_tabbedInvariantUI):
                 logging.warning('Low-q calculation failed: {}'.format(str(ex)))
                 qstar_low = "ERROR"
                 qstar_low_err = "ERROR"
+        elif self.low_extrapolation_plot:
+            # Remove the existing extrapolation plot
+            model_items = GuiUtils.getChildrenFromItem(self._model_item)
+            for item in model_items:
+                if item.text() == self.low_extrapolation_plot.title:
+                    reactor.callFromThread(self._manager.filesWidget.closePlotsForItem, item)
+                    reactor.callFromThread(self._model_item.removeRow, item.row())
+                    break
+            self.low_extrapolation_plot = None
         reactor.callFromThread(self.updateModelFromThread, WIDGETS.D_LOW_QSTAR, qstar_low)
         reactor.callFromThread(self.updateModelFromThread, WIDGETS.D_LOW_QSTAR_ERR, qstar_low_err)
 
@@ -329,6 +338,15 @@ class InvariantWindow(QtWidgets.QDialog, Ui_tabbedInvariantUI):
                 logging.warning('High-q calculation failed: {}'.format(str(ex)))
                 qstar_high = "ERROR"
                 qstar_high_err = "ERROR"
+        elif self.high_extrapolation_plot:
+            # Remove the existing extrapolation plot
+            model_items = GuiUtils.getChildrenFromItem(self._model_item)
+            for item in model_items:
+                if item.text() == self.high_extrapolation_plot.title:
+                    reactor.callFromThread(self._manager.filesWidget.closePlotsForItem, item)
+                    reactor.callFromThread(self._model_item.removeRow, item.row())
+                    break
+            self.high_extrapolation_plot = None
         reactor.callFromThread(self.updateModelFromThread, WIDGETS.D_HIGH_QSTAR, qstar_high)
         reactor.callFromThread(self.updateModelFromThread, WIDGETS.D_HIGH_QSTAR_ERR, qstar_high_err)
 


### PR DESCRIPTION
This forces the deletion of the high-q and/or low-q Invariant extrapolation plots when one has been previously calculated, but the user runs another calculation without that particular extrapolation selected.

This is the 4th PR in a chain of PRs for the invariant perspective: This -> #1716 -> #1715 -> #1709

fixes #1607