### PR TITLE
Run tests using GitHub Actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,144 @@
+name: Test
+
+on:
+  [push, pull_request]
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  test:
+
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [macos-latest, ubuntu-latest, windows-latest]
+        python-version: [3.6, 3.7, 3.8]
+
+    steps:
+
+    - name: Obtain SasView source from git
+      uses: actions/checkout@v1
+
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v1
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    ### Caching of pip downloads and local wheel builds
+
+    - name: Obtain pip cache (Linux)
+      uses: actions/cache@v2
+      if: startsWith(runner.os, 'Linux')
+      with:
+        path: ~/.cache/pip
+        key: ${{ runner.os }}-pip-${{ matrix.python-version }}-${{ hashFiles('**/test.yml') }}
+        restore-keys: |
+          ${{ runner.os }}-pip-${{ matrix.python-version }}-
+          ${{ runner.os }}-pip-
+
+    - name: Obtain pip cache (macOS)
+      uses: actions/cache@v2
+      if: startsWith(runner.os, 'macOS')
+      with:
+        path: ~/Library/Caches/pip
+        key: ${{ runner.os }}-pip-${{ matrix.python-version }}-${{ hashFiles('**/test.yml') }}
+        restore-keys: |
+          ${{ runner.os }}-pip-${{ matrix.python-version }}-
+          ${{ runner.os }}-pip-
+
+    - name: Obtain pip cache (Windows)
+      uses: actions/cache@v2
+      if: startsWith(runner.os, 'Windows')
+      with:
+        path: ~\AppData\Local\pip\Cache
+        key: ${{ runner.os }}-pip-${{ matrix.python-version }}-${{ hashFiles('**/test.yml') }}
+        restore-keys: |
+          ${{ runner.os }}-pip-${{ matrix.python-version }}-
+          ${{ runner.os }}-pip-
+
+    ### Installation of build-dependencies
+
+    - name: Install packaged dependencies (Linux)
+      if: ${{ matrix.os == 'ubuntu-latest' }}
+      run: |
+        sudo apt-get update
+        sudo apt-get install opencl-headers ocl-icd-opencl-dev libpocl2 xvfb pyqt5-dev-tools
+
+    - name: Install Python dependencies
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install wheel setuptools
+        python -m pip install numpy scipy matplotlib docutils "pytest<6" sphinx unittest-xml-reporting tinycc lxml h5py sphinx pyparsing html5lib reportlab pybind11 appdirs six numba mako ipython qtconsole xhtml2pdf unittest-xml-reporting pylint qt5reactor periodictable PyQt5
+
+    - name: Install pyopencl (Linux + macOS)
+      if: ${{ matrix.os != 'windows-latest' }}
+      run: |
+        python -m pip install pyopencl
+
+    - name: Install pyopencl (Windows)
+      if: ${{ matrix.os == 'windows-latest' }}
+      run: |
+        python -m pip install pytools mako cffi
+        choco install opencl-intel-cpu-runtime
+        python -m pip install --only-binary=pyopencl --find-links http://www.silx.org/pub/wheelhouse/ --trusted-host www.silx.org pyopencl
+
+    - name: Fetch sources for sibling projects
+      run: |
+        git clone --depth=50 --branch=master https://github.com/SasView/sasmodels.git ../sasmodels
+        git clone --depth=50 --branch=master https://github.com/bumps/bumps.git ../bumps
+
+    - name: Build and install sasmodels
+      run: |
+        cd ../sasmodels
+        rm -rf build
+        rm -rf dist
+        python setup.py clean
+        python setup.py build
+        python -m pip install .
+
+    - name: Build and install bumps
+      run: |
+        cd ../bumps
+        rm -rf build
+        rm -rf dist
+        python setup.py clean
+        python setup.py build
+        python -m pip install .
+
+    ### Actual building/testing of sasview
+
+    - name: Build sasview
+      run: |
+        # SET SASVIEW GITHASH
+        githash=$( git rev-parse HEAD )
+        sed -i.bak s/GIT_COMMIT/$githash/g src/sas/sasview/__init__.py
+        # BUILD SASVIEW
+        python setup.py clean
+        python setup.py build
+        python -m pip install .
+
+    - name: Build sasview docs
+      if: ${{ matrix.os == 'ubuntu-latest' }}
+      run: |
+        NUM=4
+        mkdir -p ~/.sasmodels/compiled_models
+        make -j $NUM -C ../bumps/doc html || true
+        make -j $NUM -C ../sasmodels/doc html || true
+        cd docs/sphinx-docs/
+        python build_sphinx.py || true
+
+    - name: Test with pytest
+      env:
+        PYOPENCL_COMPILER_OUTPUT: 1
+      run: |
+        python -m pytest -v -s test
+
+    - name: Test GUI (Linux)
+      if: ${{ matrix.os == 'ubuntu-latest' }}
+      env:
+        PYOPENCL_COMPILER_OUTPUT: 1
+      run: |
+        cd src/sas/qtgui
+        xvfb-run -a --server-args="-screen 0 1024x768x24" python3 GUITests.py || true

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+norecursedirs=test/sasrealspace test/calculatorview test/sasguiframe src/sas/sasgui
+addopts=--ignore test/utest_sasview.py
+python_files='u*py'


### PR DESCRIPTION
As a starting point for #1644, here's a reimplementation of the existing .travis.yml as GitHub Actions. I started this as a proof of concept as part of the Hackathon... however, it is at feature parity with the travis testing at this point so it's probably ready for us to switch from Travis-CI to GitHub Actions right now. 

What it does:

- builds SasView, builds the documentation and runs tests on Ubuntu, Windows and macOS.
- install packages via pip (conda is not used); pip wheels are cached 
- runs GUI tests under Linux

What it does not yet do that travis does:
- report status to Slack - this looks easy enough to add but needs a slack workspace admin to do set up the web hook secrets

What it does not _yet_ do but travis doesn't either:
- build the Qt GUI under MacOS (wheels for pyuic5 are not currently available it seems)
- enforce that the GUI tests pass; they don't currently pass (but we obviously should have that as a goal)
- run GUI tests under MacOS and Windows
(shouldn't be blockers for merging)

As noted in #1644, future development could extend these actions/add additional actions to build/test installers and even publish installers and wheels for the packages.

Limitations that need fixing prior to merging:
- the known errors in building the docs are currently suppressed as the SasView documentation doesn't currently build (see https://github.com/bumps/bumps/pull/45 and https://github.com/SasView/sasmodels/pull/441). Prior to merging, we should remove the `|| true` where the docs are built. 

Are there any other thoughts, comments, desires or suggestions?