### PR TITLE
Minor improvements to GitHub actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -130,7 +130,7 @@ jobs:
       if: ${{ matrix.os == 'ubuntu-latest' }}
       run: |
         cd docs/sphinx-docs/
-        python build_sphinx.py || true
+        xvfb-run -a --server-args="-screen 0 1024x768x24" python build_sphinx.py || true
 
     - name: Test with pytest
       env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -119,13 +119,16 @@ jobs:
         python setup.py build
         python -m pip install .
 
-    - name: Build sasview docs
+    - name: Build sasmodels and bumps docs (Linux only)
       if: ${{ matrix.os == 'ubuntu-latest' }}
       run: |
-        NUM=4
         mkdir -p ~/.sasmodels/compiled_models
-        make -j $NUM -C ../bumps/doc html || true
-        make -j $NUM -C ../sasmodels/doc html || true
+        make -j4 -C ../sasmodels/doc html || true
+        make -C ../bumps/doc html || true
+
+    - name: Build sasview docs (Linux only)
+      if: ${{ matrix.os == 'ubuntu-latest' }}
+      run: |
         cd docs/sphinx-docs/
         python build_sphinx.py || true
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -122,9 +122,9 @@ jobs:
     - name: Build sasmodels and bumps docs (Linux only)
       if: ${{ matrix.os == 'ubuntu-latest' }}
       run: |
+        make -C ../bumps/doc html || true
         mkdir -p ~/.sasmodels/compiled_models
         make -j4 -C ../sasmodels/doc html || true
-        make -C ../bumps/doc html || true
 
     - name: Build sasview docs (Linux only)
       if: ${{ matrix.os == 'ubuntu-latest' }}
@@ -144,4 +144,4 @@ jobs:
         PYOPENCL_COMPILER_OUTPUT: 1
       run: |
         cd src/sas/qtgui
-        xvfb-run -a --server-args="-screen 0 1024x768x24" python3 GUITests.py || true
+        xvfb-run -a --server-args="-screen 0 1024x768x24" python GUITests.py || true


### PR DESCRIPTION
A few minor tweaks to the new GitHub Actions 'test.yml' 

-  make it easier to spot problems in the documentation building (splitting the sasmodels and bumps doc builds from the sasview doc build); sphinx output is so long that being able to use the Actions bookmarks in it to view just the desired part is helpful
- make sure DISPLAY is set when building the SasView docs so that importing PyQt5 works