### PR TITLE
Doc building fixes

### DIFF
--- a/docs/sphinx-docs/build_sphinx.py
+++ b/docs/sphinx-docs/build_sphinx.py
@@ -70,14 +70,14 @@ def inplace_change(filename, old_string, new_string):
 # Thanks to http://stackoverflow.com/questions/4128144/replace-string-within-file-contents
         s=open(filename).read()
         if old_string in s:
-                print('Changing "{old_string}" to "{new_string}"'.format(**locals()))
+                print('Changing "{old_string}" to "{new_string}" in {filename}'.format(**locals()))
                 s=s.replace(old_string, new_string)
                 f=open(filename, 'w')
                 f.write(s)
                 f.flush()
                 f.close()
         else:
-                print('No occurrences of "{old_string}" found.'.format(**locals()))
+                print('No occurrences of "{old_string}" found in {filename}.'.format(**locals()))
 
 def _remove_dir(dir_path):
     """Removes the given directory."""

--- a/docs/sphinx-docs/source/conf.py
+++ b/docs/sphinx-docs/source/conf.py
@@ -228,6 +228,7 @@ LATEX_PREAMBLE=r"""
 \newcommand{\gt}{>}              % HTML needs \gt rather than >
 \renewcommand{\AA}{\text{\r{A}}} % Allow \AA in math mode
 \DeclareUnicodeCharacter {212B} {\AA}                  % Angstrom
+\DeclareUnicodeCharacter {0393} {\ensuremath{\Gamma}}  % Gamma
 \DeclareUnicodeCharacter {00B7} {\ensuremath{\cdot}}   % cdot
 \DeclareUnicodeCharacter {00B0} {\ensuremath{^\circ}}  % degrees
 """

--- a/src/sas/qtgui/Calculators/DataOperationUtilityPanel.py
+++ b/src/sas/qtgui/Calculators/DataOperationUtilityPanel.py
@@ -267,7 +267,7 @@ class DataOperationUtilityPanel(QtWidgets.QDialog, Ui_DataOperationUtility):
         if self.txtNumber.isModified():
             input_to_check = str(self.txtNumber.text())
 
-            if input_to_check is None or input_to_check is '':
+            if input_to_check is None or input_to_check == '':
                 msg = 'DataOperation: Number requires a float number'
                 logging.warning(msg)
                 self.txtNumber.setStyleSheet(BG_RED)

--- a/src/sas/qtgui/Perspectives/Fitting/FittingPerspective.py
+++ b/src/sas/qtgui/Perspectives/Fitting/FittingPerspective.py
@@ -549,7 +549,7 @@ class FittingWindow(QtWidgets.QTabWidget):
         """
         Returns the tab with with attribute name *name*
         """
-        assert(name, str)
+        assert isinstance(name, str)
         for tab in self.tabs:
             if tab.modelName() == name:
                 return tab

--- a/src/sas/sascalc/fit/Loader.py
+++ b/src/sas/sascalc/fit/Loader.py
@@ -1,6 +1,6 @@
 from __future__ import print_function
 
-# class Loader  to load any king of file
+# class Loader  to load any kind of file
 #import wx
 #import string
 import numpy as np


### PR DESCRIPTION
The major reason for the current failure to build the sasview docs is sasmodels being monkeypatched into `sas.models`. Having loaded all the classes, sphinx knows that `sas.models` should exist but then can't actually load any source for them. That results in the rather odd errors that we have been seeing:

```
WARNING: autodoc: failed to import class 'sas.models.FlexCylEllipXModel' from module 'sas.sascalc.fit'; the following exception was raised:
…
AttributeError: module 'sas.sascalc.fit' has no attribute 'sas'                                                                                                                                                                         
```

Note that this PR is not enough to actually make the documentation build cleanly, with the following 19 warnings/errors still emitted:

```
…/sasmodels/sasmodels/resolution.py:docstring of sasmodels.resolution.eval_form:3: WARNING: Unknown interpreted text role "fun".
…/sasview/src/sas/qtgui/Calculators/GenericScatteringCalculator.py:docstring of sas.qtgui.Calculators.GenericScatteringCalculator.GenericScatteringCalculator._create_default_1d_data:4: WARNING: Unexpected indentation.                                                                                                                                                                                                
…/sasview/src/sas/qtgui/Calculators/GenericScatteringCalculator.py:docstring of sas.qtgui.Calculators.GenericScatteringCalculator.GenericScatteringCalculator._create_default_1d_data:5: WARNING: Block quote ends without a blank line; unexpected unindent.                                                                                                                                                            
…/sasview/src/sas/qtgui/MainWindow/DataManager.py:docstring of sas.qtgui.MainWindow.DataManager.DataManager.__init__:3: WARNING: Unexpected indentation.
…/sasview/src/sas/qtgui/MainWindow/DataManager.py:docstring of sas.qtgui.MainWindow.DataManager.DataManager.__init__:4: WARNING: Block quote ends without a blank line; unexpected unindent.                                                                                                                                                                                                                             
…/sasview/src/sas/qtgui/MainWindow/DataManager.py:docstring of sas.qtgui.MainWindow.DataManager.DataManager.__init__:5: WARNING: Field list ends without a blank line; unexpected unindent.                                                                                                                                                                                                                              
…/sasview/src/sas/qtgui/Plotting/Arrow3D.py:docstring of sas.qtgui.Plotting.Arrow3D.Arrow3D.__init__:7: WARNING: Field list ends without a blank line; unexpected unindent.
…/sasview/src/sas/qtgui/Plotting/Binder.py:docstring of sas.qtgui.Plotting.Binder.BindArtist.__call__:34: WARNING: Unexpected indentation.
…/sasview/src/sas/qtgui/Plotting/Binder.py:docstring of sas.qtgui.Plotting.Binder.BindArtist.__call__:35: WARNING: Block quote ends without a blank line; unexpected unindent.
…/sasview/src/sas/qtgui/Plotting/Binder.py:docstring of sas.qtgui.Plotting.Binder.BindArtist.__call__:40: WARNING: Unexpected indentation.
…/sasview/src/sas/qtgui/Plotting/Binder.py:docstring of sas.qtgui.Plotting.Binder.BindArtist.__call__:53: WARNING: Unexpected indentation.
…/sasview/src/sas/qtgui/Plotting/Binder.py:docstring of sas.qtgui.Plotting.Binder.BindArtist.__call__:54: WARNING: Block quote ends without a blank line; unexpected unindent.
…/sasview/src/sas/sascalc/data_util/nxsunit.py:docstring of sas.sascalc.data_util.nxsunit._build_metric_units:3: WARNING: Unexpected indentation.
…/sasview/src/sas/sascalc/data_util/nxsunit.py:docstring of sas.sascalc.data_util.nxsunit._build_metric_units:6: WARNING: Block quote ends without a blank line; unexpected unindent.                                                                                                                                                                                                                                    
…/sasview/src/sas/sascalc/dataloader/manipulations.py:docstring of sas.sascalc.dataloader.manipulations._Sector.__init__:2: WARNING: Field list ends without a blank line; unexpected unindent.                                                                                                                                                                                                                          
…/sasview/src/sas/sascalc/fit/models.py:docstring of sas.sascalc.fit.models._check_plugin:4: WARNING: Field list ends without a blank line; unexpected unindent.
…/sasview/src/sas/sascalc/invariant/invariant.py:docstring of sas.sascalc.invariant.invariant.InvariantCalculator._fit:9: WARNING: Field list ends without a blank line; unexpected unindent.                                                                                                                                                                                                                            
…/sasview/src/sas/sascalc/invariant/invariant.py:docstring of sas.sascalc.invariant.invariant.InvariantCalculator._get_data:4: WARNING: Inline emphasis start-string without end-string.                                                                                                                                                                                                                                 
…/sasview/src/sas/sascalc/invariant/invariant.py:docstring of sas.sascalc.invariant.invariant.InvariantCalculator._get_qstar_uncertainty:6: WARNING: Literal block ends without a blank line; unexpected unindent.                                                                                 
```

Given that there are several PRs that touch those files already waiting to be merged, touching those files now will just create merge conflicts and so these problems need to be fixed later.

(There's also a handful of other misc fixes that I spotted while chasing this failure over the past few days.)