### PR TITLE
Make new child plots unselected by default

### DIFF
--- a/src/sas/qtgui/Plotting/SlicerParameters.py
+++ b/src/sas/qtgui/Plotting/SlicerParameters.py
@@ -352,7 +352,6 @@ class SlicerParameters(QtWidgets.QDialog, Ui_SlicerParametersUI):
                 # Add plot to the DataExplorer tree
                 new_name, _ = os.path.splitext(os.path.basename(filepath))
                 new_item = GuiUtils.createModelItemWithPlot(data, name=new_name)
-                new_item.setCheckState(QtCore.Qt.Unchecked)
                 self.parent.manager.updateModelFromPerspective(new_item)
 
                 items_for_fit.append(new_item)

--- a/src/sas/qtgui/Utilities/GuiUtils.py
+++ b/src/sas/qtgui/Utilities/GuiUtils.py
@@ -411,7 +411,7 @@ def createModelItemWithPlot(update_data, name=""):
 
     checkbox_item = HashableStandardItem()
     checkbox_item.setCheckable(True)
-    checkbox_item.setCheckState(QtCore.Qt.Checked)
+    checkbox_item.setCheckState(QtCore.Qt.Unchecked)
     checkbox_item.setText(name)
 
     # Add "Info" item


### PR DESCRIPTION
Any perspective creating child data and adding them to the datamanager now default to them being unselected. The user can unroll the tree and check whichever plots they would like to work with.

If a perspective needs to have the child plot it is creating and sending to the data manager selected instantly it will need to deliberately set the checkstate at Checked.  This should normally be avoided as it causes no end of confusion to the user.

This should resolve issue #1566.  I suspect this will reduce confusion on the Invariant as well and maybe other places.

Note to Reviewers. This also reverts the last commit in the slicer series PR #1721 that was merged a few days ago which did a manual force uncheck. That is no longer needed.  This was tested on win 10 only.