### PR TITLE
Slicer extension 1344

### DIFF
--- a/src/sas/qtgui/Plotting/Slicers/BoxSlicer.py
+++ b/src/sas/qtgui/Plotting/Slicers/BoxSlicer.py
@@ -233,6 +233,7 @@ class BoxInteractor(BaseInteractor, SlicerModel):
         params["x_max"] = numpy.fabs(self.vertical_lines.x)
         params["y_max"] = numpy.fabs(self.horizontal_lines.y)
         params["nbins"] = self.nbins
+        params["fold"]= self.fold
         return params
 
     def setParams(self, params):
@@ -246,6 +247,7 @@ class BoxInteractor(BaseInteractor, SlicerModel):
         self.x = float(numpy.fabs(params["x_max"]))
         self.y = float(numpy.fabs(params["y_max"]))
         self.nbins = params["nbins"]
+        self.fold = params["fold"]
 
         self.horizontal_lines.update(x=self.x, y=self.y)
         self.vertical_lines.update(x=self.x, y=self.y)

--- a/src/sas/sascalc/dataloader/manipulations.py
+++ b/src/sas/sascalc/dataloader/manipulations.py
@@ -309,7 +309,7 @@ class _Slab(object):
     """
 
     def __init__(self, x_min=0.0, x_max=0.0, y_min=0.0,
-                 y_max=0.0, bin_width=0.001):
+                 y_max=0.0, bin_width=0.001, fold = False):
         # Minimum Qx value [A-1]
         self.x_min = x_min
         # Maximum Qx value [A-1]
@@ -322,7 +322,7 @@ class _Slab(object):
         self.bin_width = bin_width
         # If True, I(|Q|) will be return, otherwise,
         # negative q-values are allowed
-        self.fold = False
+        self.fold = fold
 
     def __call__(self, data2D):
         return NotImplemented


### PR DESCRIPTION
This is a start at addressing #1344.  It only addresses the "folding" issue, and only for the boxslicer the code for which, as stated in the issue, was already present but was hard coded to `fold = True` in the GUI and `fold = False` in sascalc.

The GUI is particularly ugly at present in that the slicer parameter editor assumes all parameters are floats.  This works since any number other than 0 is true and 0 is false but ultimately allowing for a parameter by parameter editor would be the right answer making the fold boolean a checkbox.  This also is probably not possible for 5.0.4-rc1 in which case I would recommend that we merge this but keep the branch active. It still allows the functionality to be changed and should be a benign change?