### PR TITLE
Define proper signatures for validate methods. Fixes #1766

### DIFF
--- a/src/sas/qtgui/Plotting/Plotter2D.py
+++ b/src/sas/qtgui/Plotting/Plotter2D.py
@@ -246,7 +246,7 @@ class Plotter2DWidget(PlotterBase):
 
         self.param_model = None
         validator = None
-        if self.slicer is not None:
+        if self.slicer is not None and not isinstance(self.slicer, BoxSumCalculator):
             self.param_model = self.slicer.model()
             validator = self.slicer.validate
         # Pass the model to the Slicer Parameters widget

--- a/src/sas/qtgui/Plotting/Slicers/BoxSlicer.py
+++ b/src/sas/qtgui/Plotting/Slicers/BoxSlicer.py
@@ -18,7 +18,7 @@ class BoxInteractor(BaseInteractor, SlicerModel):
         self.markers = []
         self.axes = axes
         self._item = item
-        #connecting artist
+        # connecting artist
         self.connect = self.base.connect
         # which direction is the preferred interaction direction
         self.direction = None
@@ -168,13 +168,13 @@ class BoxInteractor(BaseInteractor, SlicerModel):
         new_plot.dxl = dxl
         new_plot.dxw = dxw
         new_plot.name = str(self.averager.__name__) + \
-                        "(" + self.data.name + ")"
+            "(" + self.data.name + ")"
         new_plot.title = str(self.averager.__name__) + \
-                        "(" + self.data.name + ")"
+            "(" + self.data.name + ")"
         new_plot.source = self.data.source
         new_plot.interactive = True
         new_plot.detector = self.data.detector
-        # # If the data file does not tell us what the axes are, just assume...
+        # If the data file does not tell us what the axes are, just assume...
         new_plot.xaxis("\\rm{Q}", "A^{-1}")
         new_plot.yaxis("\\rm{Intensity} ", "cm^{-1}")
 
@@ -184,7 +184,6 @@ class BoxInteractor(BaseInteractor, SlicerModel):
             new_plot.ytransform = 'y'
             new_plot.yaxis("\\rm{Residuals} ", "/")
 
-        #new_plot. = "2daverage" + self.data.name
         new_plot.id = (self.averager.__name__) + self.data.name
         new_plot.group_id = new_plot.id
         new_plot.is_data = True
@@ -488,6 +487,13 @@ class BoxInteractorX(BoxInteractor):
         from sas.sascalc.dataloader.manipulations import SlabX
         self.post_data(SlabX, direction="X")
 
+    def validate(self, param_name, param_value):
+        """
+        Validate input from user.
+        Values get checked at apply time.
+        """
+        return True
+
 
 class BoxInteractorY(BoxInteractor):
     """
@@ -505,3 +511,9 @@ class BoxInteractorY(BoxInteractor):
         from sas.sascalc.dataloader.manipulations import SlabY
         self.post_data(SlabY, direction="Y")
 
+    def validate(self, param_name, param_value):
+        """
+        Validate input from user
+        Values get checked at apply time.
+        """
+        return True


### PR DESCRIPTION
`box x` and `box y` interactors didn't have correct signatures for the `validate` method. Actual validation is not required at this stage, since values will be checked at apply time in the slicers and if incorrect, a meaningful message is displayed.
However, we need to at least define those methods properly...
