### PR TITLE
Try to run tests everywhere rather than fast-fail

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,6 +15,7 @@ jobs:
       matrix:
         os: [macos-latest, ubuntu-latest, windows-latest]
         python-version: [3.6, 3.7, 3.8]
+      fail-fast: false
 
     steps:
 


### PR DESCRIPTION
At the moment, pyopencl breakage on macos is preventing the tests being run on other platforms as the test matrix uses fast-fail by default.