### PR TITLE
Retain graph range on redraws

### DIFF
--- a/src/sas/qtgui/Plotting/LinearFit.py
+++ b/src/sas/qtgui/Plotting/LinearFit.py
@@ -39,6 +39,9 @@ class LinearFit(QtWidgets.QDialog, Ui_LinearFitUI):
         self.parent = parent
 
         self.max_range = max_range
+        # Set fit minimum to 0.0 if below zero
+        if fit_range[0] < 0.0:
+            fit_range = (0.0, fit_range[1])
         self.fit_range = fit_range
         self.xLabel = xlabel
         self.yLabel = ylabel
@@ -110,7 +113,8 @@ class LinearFit(QtWidgets.QDialog, Ui_LinearFitUI):
         self.lblRange.setText(label)
 
     def range(self):
-        return (float(self.txtFitRangeMin.text()), float(self.txtFitRangeMax.text()))
+        return (float(self.txtFitRangeMin.text()) if float(self.txtFitRangeMin.text()) > 0 else 0.0,
+                float(self.txtFitRangeMax.text()))
 
     def fit(self, event):
         """

--- a/src/sas/qtgui/Plotting/Plotter.py
+++ b/src/sas/qtgui/Plotting/Plotter.py
@@ -70,7 +70,7 @@ class PlotterWidget(PlotterBase):
 
         # Data container for the linear fit
         self.fit_result = Data1D(x=[], y=[], dy=None)
-        self.fit_result.symbol = 13
+        self.fit_result.symbol = 17
         self.fit_result.name = "Fit"
 
         parent.geometry()
@@ -507,9 +507,14 @@ class PlotterWidget(PlotterBase):
         new_plot.custom_color = selected_plot.custom_color
         new_plot.markersize = selected_plot.markersize
         new_plot.symbol = selected_plot.symbol
+        x_bounds = (self.ax.viewLim.xmin, self.ax.viewLim.xmax)
+        y_bounds = (self.ax.viewLim.ymin, self.ax.viewLim.ymax)
 
         self.removePlot(id)
         self.plot(data=new_plot)
+
+        self.ax.set_xbound(x_bounds[0], x_bounds[1])
+        self.ax.set_ybound(y_bounds[0], y_bounds[1])
 
     def onRemovePlot(self, id):
         """
@@ -652,9 +657,6 @@ class PlotterWidget(PlotterBase):
         self.fit_result.dx = None
         self.fit_result.dy = None
 
-        #Remove another Fit, if exists
-        self.removePlot("Fit")
-
         self.fit_result.reset_view()
         #self.offset_graph()
 
@@ -663,8 +665,12 @@ class PlotterWidget(PlotterBase):
         self.fit_result.title = 'Fit'
         self.fit_result.name = 'Fit'
 
-        # Plot the line
-        self.plot(data=self.fit_result, marker='-', hide_error=True)
+        if self.fit_result.name in self.plot_dict.keys():
+            # Replace an existing Fit
+            self.replacePlot("Fit", new_plot=self.fit_result)
+        else:
+            # Otherwise, Plot a new line
+            self.plot(data=self.fit_result, marker='-', hide_error=True)
 
     def onToggleLegend(self):
         """

--- a/src/sas/qtgui/Plotting/SetGraphRange.py
+++ b/src/sas/qtgui/Plotting/SetGraphRange.py
@@ -32,6 +32,8 @@ class SetGraphRange(QtWidgets.QDialog, Ui_setGraphRangeUI):
         self.txtYmin.setText(str(y_range[0]))
         self.txtYmax.setText(str(y_range[1]))
 
+        self.rangeModified = False
+
     def xrange(self):
         """
         Return a tuple with line edit content of (xmin, xmax)


### PR DESCRIPTION
This PR retains the graph range when data are replotted, e.g. after a second fit, and ensures the minimum value of a linear fit is always non-negative.

I built this off of `release_5.0.4` and am currently pointing this PR there, but this could also go into `main`.

Fixes #1750 