### PR TITLE
Linear Fit Rg*Qmin & Rg*Qmax

### DIFF
--- a/src/sas/qtgui/Plotting/LinearFit.py
+++ b/src/sas/qtgui/Plotting/LinearFit.py
@@ -48,14 +48,14 @@ class LinearFit(QtWidgets.QDialog, Ui_LinearFitUI):
         self.bg_on = False
 
         # Scale dependent content
-        self.guiner_box.setVisible(False)
+        self.guinier_box.setVisible(False)
         if (self.yLabel == "ln(y)" or self.yLabel == "ln(y*x)") and \
                 (self.xLabel == "x^(2)"):
             if self.yLabel == "ln(y*x)":
                 self.label_12.setText('<html><head/><body><p>Rod diameter [Å]</p></body></html>')
                 self.rg_yx = True
             self.rg_on = True
-            self.guiner_box.setVisible(True)
+            self.guinier_box.setVisible(True)
 
         if (self.xLabel == "x^(4)") and (self.yLabel == "y*x^(4)"):
             self.bg_on = True
@@ -201,11 +201,11 @@ class LinearFit(QtWidgets.QDialog, Ui_LinearFitUI):
         self.txtBerr.setText(formatNumber(self.ErrBvalue))
         self.txtChi2.setText(formatNumber(self.Chivalue))
 
-        # Possibly Guiner analysis
+        # Possibly Guinier analysis
         i0 = numpy.exp(cstB)
-        self.txtGuiner_1.setText(formatNumber(i0))
+        self.txtGuinier_1.setText(formatNumber(i0))
         err = numpy.abs(numpy.exp(cstB) * errB)
-        self.txtGuiner1_Err.setText(formatNumber(err))
+        self.txtGuinier1_Err.setText(formatNumber(err))
 
         if self.rg_yx:
             rg = numpy.sqrt(-2 * float(cstA))
@@ -224,13 +224,13 @@ class LinearFit(QtWidgets.QDialog, Ui_LinearFitUI):
             else:
                 err = ''
 
-        self.txtGuiner_2.setText(value)
-        self.txtGuiner2_Err.setText(err)
+        self.txtGuinier_2.setText(value)
+        self.txtGuinier2_Err.setText(err)
 
         value = formatNumber(rg * self.floatInvTransform(self.xminFit))
-        self.txtGuiner_3.setText(value)
+        self.txtGuinier_4.setText(value)
         value = formatNumber(rg * self.floatInvTransform(self.xmaxFit))
-        self.txtGuiner_4.setText(value)
+        self.txtGuinier_3.setText(value)
 
         tempx = numpy.array(tempx)
         tempy = numpy.array(tempy)

--- a/src/sas/qtgui/Plotting/UI/LinearFitUI.ui
+++ b/src/sas/qtgui/Plotting/UI/LinearFitUI.ui
@@ -257,12 +257,12 @@
     </widget>
    </item>
    <item row="3" column="0" colspan="2">
-    <widget class="QGroupBox" name="guiner_box">
+    <widget class="QGroupBox" name="guinier_box">
      <property name="enabled">
       <bool>true</bool>
      </property>
      <property name="title">
-      <string>Guiner analysis </string>
+      <string>Guinier analysis </string>
      </property>
      <layout class="QGridLayout" name="gridLayout_4">
       <item row="0" column="0">
@@ -275,7 +275,7 @@
          </widget>
         </item>
         <item row="0" column="1">
-         <widget class="QLineEdit" name="txtGuiner_1">
+         <widget class="QLineEdit" name="txtGuinier_1">
           <property name="enabled">
            <bool>false</bool>
           </property>
@@ -292,7 +292,7 @@
          </widget>
         </item>
         <item row="1" column="1">
-         <widget class="QLineEdit" name="txtGuiner_2">
+         <widget class="QLineEdit" name="txtGuinier_2">
           <property name="enabled">
            <bool>false</bool>
           </property>
@@ -309,7 +309,7 @@
          </widget>
         </item>
         <item row="2" column="1">
-         <widget class="QLineEdit" name="txtGuiner_3">
+         <widget class="QLineEdit" name="txtGuinier_3">
           <property name="enabled">
            <bool>false</bool>
           </property>
@@ -326,7 +326,7 @@
          </widget>
         </item>
         <item row="3" column="1">
-         <widget class="QLineEdit" name="txtGuiner_4">
+         <widget class="QLineEdit" name="txtGuinier_4">
           <property name="enabled">
            <bool>false</bool>
           </property>
@@ -347,7 +347,7 @@
          </widget>
         </item>
         <item row="0" column="1">
-         <widget class="QLineEdit" name="txtGuiner1_Err">
+         <widget class="QLineEdit" name="txtGuinier1_Err">
           <property name="enabled">
            <bool>false</bool>
           </property>
@@ -370,7 +370,7 @@
          </widget>
         </item>
         <item row="1" column="1">
-         <widget class="QLineEdit" name="txtGuiner2_Err">
+         <widget class="QLineEdit" name="txtGuinier2_Err">
           <property name="enabled">
            <bool>false</bool>
           </property>
@@ -446,7 +446,7 @@
     </layout>
    </item>
   </layout>
-  <zorder>guiner_box</zorder>
+  <zorder>guinier_box</zorder>
   <zorder>label</zorder>
   <zorder>groupBox_2</zorder>
   <zorder>groupBox</zorder>


### PR DESCRIPTION
The Rg*Qmin and Rg*Qmax are now displaying in the correct text boxes in the Linear Fit window. I also corrected the spelling of Guinier (from Guiner) in the window.

I have this pointing to main for the next release after 5.0.4.

Fixes #1782