### PR TITLE
Batch Slicer: Save Most Recent Slice

### DIFF
--- a/src/sas/qtgui/Plotting/SlicerParameters.py
+++ b/src/sas/qtgui/Plotting/SlicerParameters.py
@@ -340,7 +340,7 @@ class SlicerParameters(QtWidgets.QDialog, Ui_SlicerParametersUI):
         items_for_fit = []
         for plot in plots:
             for item in self.active_plots.keys():
-                data = self.active_plots[item].data[0]
+                data = self.active_plots[item].data[-1]
                 if not isinstance(data, Data1D):
                     continue
                 if plot not in data.name:


### PR DESCRIPTION
The batch slicer was taking the first item in the `plot.data` list for 1D slicer plots when saving data. This would save data with the default slicer parameters.

This highlights a potential issue - the `plot.data` list for 1D plots is getting appended to every time slicers are redrawn without removing previous slices. I haven't had a chance to see if this extends to other 1D plots, but data is supposed to get purged from this list when data is updated.

This change should not affect functionality if the list is purged in the future. `list[-1] == list[0]` when `len(list) == 1`.

Fixes [point 14](https://github.com/SasView/sasview/issues/1772#issuecomment-776089648) in #1772 