### PR TITLE
Always show path selection on installation

### DIFF
--- a/installers/installer.iss
+++ b/installers/installer.iss
@@ -21,6 +21,7 @@ AppUpdatesURL={#MyAppURL}
 DefaultDirName=c:\{#MyAppName}-{#MyAppVersion}
 DefaultGroupName={#MyAppName}-{#MyAppVersion}
 DisableProgramGroupPage=yes
+DisableDirPage=no
 UsedUserAreasWarning=no
 LicenseFile=license.txt
 ArchitecturesInstallIn64BitMode=x64

--- a/installers/installer_generator64.py
+++ b/installers/installer_generator64.py
@@ -32,6 +32,7 @@ OutputBaseFilename = local_config.OutputBaseFilename
 SetupIconFile = local_config.SetupIconFile_win
 LicenseFile = 'license.txt'
 DisableProgramGroupPage = 'yes'
+DisableDirPage = 'no'
 Compression = 'lzma'
 SolidCompression = 'yes'
 PrivilegesRequired = 'none'
@@ -345,6 +346,7 @@ def generate_installer():
     TEMPLATE += "DefaultDirName=%s\n" % str(DefaultDirName)
     TEMPLATE += "DefaultGroupName=%s\n" % str(DefaultGroupName)
     TEMPLATE += "DisableProgramGroupPage=%s\n" % str(DisableProgramGroupPage)
+    TEMPLATE += "DisableDirPage=%s\n" % str(DisableDirPage)
     TEMPLATE += "LicenseFile=%s\n" % str(LicenseFile)
     TEMPLATE += "OutputBaseFilename=%s\n" % str(OutputBaseFilename)
     TEMPLATE += "SetupIconFile=%s\n" % str(SetupIconFile)


### PR DESCRIPTION
This changes the INNO setup to always allow the user to select an installation path. This fixes [point 2](https://github.com/SasView/sasview/issues/1772#issue-795052995) of #1772.

Documentation on the flag I am adding: [DisableDirPage](https://jrsoftware.org/ishelp/index.php?topic=setup_disabledirpage)

The windows build server will need to be back online before this can be verified.