### PR TITLE
Limit adding [n] to name on data load and name change

### DIFF
--- a/src/sas/qtgui/MainWindow/DataManager.py
+++ b/src/sas/qtgui/MainWindow/DataManager.py
@@ -149,10 +149,11 @@ class DataManager(object):
         name = name[0:max_char]
 
         if name not in self.data_name_dict:
-            self.data_name_dict[name] = 0
+            self.data_name_dict[name] = [0]
         else:
-            self.data_name_dict[name] += 1
-            name = name + " [" + str(self.data_name_dict[name]) + "]"
+            number = max(self.data_name_dict[name]) + 1
+            self.data_name_dict[name].append(number)
+            name = f"{name} [{number}]"
         return name
 
 
@@ -263,14 +264,21 @@ class DataManager(object):
         for d_id in data_id:
             if d_id in list(self.stored_data.keys()):
                 data_state = self.stored_data[d_id]
-                if data_state.data.name in self.data_name_dict:
-                    del self.data_name_dict[data_state.data.name]
+                self.remove_item_from_data_name_dict(data_state.data.name)
                 del self.stored_data[d_id]
 
         self.delete_theory(data_id, theory_id)
         if delete_all:
             self.stored_data = {}
             self.data_name_dict = {}
+
+    def remove_item_from_data_name_dict(self, name):
+        data_name_split = name.split()
+        if data_name_split[0] in self.data_name_dict:
+            number = int(data_name_split[1][1:-1]) if len(data_name_split) > 1 else 0
+            self.data_name_dict[data_name_split[0]].remove(number)
+            if len(self.data_name_dict[data_name_split[0]]) == 0:
+                del self.data_name_dict[data_name_split[0]]
 
     def delete_theory(self, data_id, theory_id):
         """
@@ -318,8 +326,11 @@ class DataManager(object):
             # Take the copy of current, possibly shorter stored_data dict
             stored_data = copy.deepcopy(self.stored_data)
             for idx in list(stored_data.keys()):
-                if str(selected_name) in str(idx):
+                idx_split = str(idx).split("]")
+                if ((len(idx_split) == 1 and str(idx).startswith(str(selected_name)))
+                        or (len(idx_split) > 1 and str(selected_name).startswith(str(idx_split[0])))):
                     del self.stored_data[idx]
+                    self.remove_item_from_data_name_dict(selected_name)
 
     def get_data_state(self, data_id):
         """

--- a/src/sas/qtgui/MainWindow/DataManager.py
+++ b/src/sas/qtgui/MainWindow/DataManager.py
@@ -148,6 +148,7 @@ class DataManager(object):
             max_char = len(name)
         name = name[0:max_char]
 
+        # data_name_dict: {'baseName': [0, 1, .. n]}
         if name not in self.data_name_dict:
             self.data_name_dict[name] = [0]
         else:
@@ -273,6 +274,10 @@ class DataManager(object):
             self.data_name_dict = {}
 
     def remove_item_from_data_name_dict(self, name):
+        """
+        Remove 'name' or 'name [n]' from data_name_dict
+        """
+        # Split on whitespace - split 'name [n]<id>' into list of len() == 2
         data_name_split = name.split()
         if data_name_split[0] in self.data_name_dict:
             number = int(data_name_split[1][1:-1]) if len(data_name_split) > 1 else 0
@@ -327,8 +332,10 @@ class DataManager(object):
             stored_data = copy.deepcopy(self.stored_data)
             for idx in list(stored_data.keys()):
                 idx_split = str(idx).split("]")
+                # Ensure 'name' does not match 'name [1]'
                 if ((len(idx_split) == 1 and str(idx).startswith(str(selected_name)))
                         or (len(idx_split) > 1 and str(selected_name).startswith(str(idx_split[0])))):
+                    # Delete data if name matches
                     del self.stored_data[idx]
                     self.remove_item_from_data_name_dict(selected_name)
 

--- a/src/sas/qtgui/MainWindow/NameChanger.py
+++ b/src/sas/qtgui/MainWindow/NameChanger.py
@@ -82,9 +82,10 @@ class ChangeName(QtWidgets.QDialog, Ui_ChangeCategoryUI):
         textValues = [self.txtDataName.text(), self.txtFileName.text(), self.txtNewCategory.text()]
         newValues = [textValues[i] for i, value in enumerate(textValues) if buttonStates[i]]
         # Create a unique name based on the value set - Set name to "" if multiple boxes somehow checked
-        new_name = self.manager.rename(newValues[0]) if len(newValues) == 1 else ""
         # Only rename if there is something to add.
-        if new_name:
+        if len(newValues) == 1:
+            self.manager.remove_item_from_data_name_dict(self._data.name)
+            new_name = self.manager.rename(newValues[0])
             self._data.name = new_name
             self._model_item.setData(self._data)
             self._model_item.setText(new_name)

--- a/src/sas/qtgui/MainWindow/NameChanger.py
+++ b/src/sas/qtgui/MainWindow/NameChanger.py
@@ -76,15 +76,16 @@ class ChangeName(QtWidgets.QDialog, Ui_ChangeCategoryUI):
         Find the radio button that is selected and find its associated textbox
         """
         if self.rbExisting.isChecked() or (self.rbNew.isChecked() and not str(self.txtNewCategory.text())):
-            # Do not attempt to change the name if the existing name is selected and an empty new string is sent
+            # Do not attempt to change the name if existing name is selected or new string is blank
             return
         buttonStates = [self.rbDataName.isChecked(), self.rbFileName.isChecked(), self.rbNew.isChecked()]
         textValues = [self.txtDataName.text(), self.txtFileName.text(), self.txtNewCategory.text()]
         newValues = [textValues[i] for i, value in enumerate(textValues) if buttonStates[i]]
-        # Create a unique name based on the value set - Set name to "" if multiple boxes somehow checked
-        # Only rename if there is something to add.
+        # Only rename if there is a single value returned.
         if len(newValues) == 1:
+            # Remove name from data name dictionary to prevent infinite [n] generation
             self.manager.remove_item_from_data_name_dict(self._data.name)
+            # Create a unique name based on the value set
             new_name = self.manager.rename(newValues[0])
             self._data.name = new_name
             self._model_item.setData(self._data)

--- a/src/sas/qtgui/MainWindow/UnitTesting/DataExplorerTest.py
+++ b/src/sas/qtgui/MainWindow/UnitTesting/DataExplorerTest.py
@@ -780,7 +780,6 @@ class DataExplorerTest(unittest.TestCase):
         """
         # Define Constants
         FILE_NAME = "cyl_400_20.txt"
-        FILE_NAME_APPENDED = FILE_NAME + " [1]"
         TEST_STRING_1 = "test value change"
         TEST_STRING_2 = "TEST VALUE CHANGE"
         # Test base state of the name change window
@@ -826,14 +825,14 @@ class DataExplorerTest(unittest.TestCase):
         self.assertFalse(self.form.nameChangeBox.rbExisting.isChecked())
         self.form.nameChangeBox.cmdOK.click()
         self.form.changeName()
-        self.assertEqual(self.form.nameChangeBox.txtCurrentName.text(), FILE_NAME_APPENDED)
+        self.assertEqual(self.form.nameChangeBox.txtCurrentName.text(), FILE_NAME)
 
         # Take the user-defined name, which is empty - should retain existing value
         self.form.nameChangeBox.rbNew.setChecked(True)
         self.assertFalse(self.form.nameChangeBox.rbExisting.isChecked())
         self.form.nameChangeBox.cmdOK.click()
         self.form.changeName()
-        self.assertEqual(self.form.nameChangeBox.txtCurrentName.text(), FILE_NAME_APPENDED)
+        self.assertEqual(self.form.nameChangeBox.txtCurrentName.text(), FILE_NAME)
 
         # Take a different user-defined name
         self.form.nameChangeBox.rbNew.setChecked(True)


### PR DESCRIPTION
The display name dictionary `DataManager.data_name_dict` was changed from `{str: int}` to `{str: [int]}` to better track display names. The dictionary is now purged whenever data is deleted or a display name is changed. Unit tests were updated to account for this change.

Fixes #1757 and [point 5](https://github.com/SasView/sasview/issues/1772#issuecomment-768257509) of #1772.

This could wait until post 5.0.4 final, but this branch is based of `release_5.0.4`.