### PR TITLE
Close theory plots on theory deletion

### DIFF
--- a/src/sas/qtgui/MainWindow/DataExplorer.py
+++ b/src/sas/qtgui/MainWindow/DataExplorer.py
@@ -760,6 +760,7 @@ class DataExplorerWindow(DroppableDataLoadWidget):
                 # Delete these rows from the model
                 deleted_names.append(str(self.theory_model.item(ind).text()))
                 deleted_items.append(item)
+                self.closePlotsForItem(item)
 
                 self.theory_model.removeRow(ind)
                 # Decrement index since we just deleted it

--- a/src/sas/qtgui/MainWindow/UnitTesting/DataExplorerTest.py
+++ b/src/sas/qtgui/MainWindow/UnitTesting/DataExplorerTest.py
@@ -246,12 +246,12 @@ class DataExplorerTest(unittest.TestCase):
         QMessageBox.question = MagicMock(return_value=QMessageBox.No)
 
         # Populate the model
-        item1 = QStandardItem(True)
+        item1 = HashableStandardItem(True)
         item1.setCheckable(True)
         item1.setCheckState(Qt.Checked)
         item1.setText("item 1")
         self.form.theory_model.appendRow(item1)
-        item2 = QStandardItem(True)
+        item2 = HashableStandardItem(True)
         item2.setCheckable(True)
         item2.setCheckState(Qt.Unchecked)
         item2.setText("item 2")


### PR DESCRIPTION
Theory plots are now closed when theory data is deleted.

Fixes #1754 (last remaining issue related to the ticket)