### PR TITLE
Add CSV Writer and Allow freeform file extensions

### DIFF
--- a/src/sas/qtgui/MainWindow/UnitTesting/DataExplorerTest.py
+++ b/src/sas/qtgui/MainWindow/UnitTesting/DataExplorerTest.py
@@ -924,7 +924,7 @@ class DataExplorerTest(unittest.TestCase):
         self.form.saveDataAs()
         QFileDialog.getSaveFileName.assert_called_with(
                                 caption="Save As",
-                                filter='IGOR/DAT 2D file in Q_map (*.dat);;NXcanSAS files (*.h5)',
+                                filter='IGOR/DAT 2D file in Q_map (*.dat);;NXcanSAS files (*.h5);;All files (*.*)',
                                 options=16,
                                 parent=None)
         QFileDialog.getSaveFileName.assert_called_once()

--- a/src/sas/qtgui/MainWindow/UnitTesting/DataExplorerTest.py
+++ b/src/sas/qtgui/MainWindow/UnitTesting/DataExplorerTest.py
@@ -898,9 +898,10 @@ class DataExplorerTest(unittest.TestCase):
 
         # Call the tested method
         self.form.saveDataAs()
+        filter = 'Text files (*.txt);;Comma separated value files (*.csv);;CanSAS 1D files (*.xml);;NXcanSAS files (*.h5);;All files (*.*)'
         QFileDialog.getSaveFileName.assert_called_with(
                                 caption="Save As",
-                                filter='Text files (*.txt);;CanSAS 1D files(*.xml);;NXcanSAS files (*.h5)',
+                                filter=filter,
                                 options=16,
                                 parent=None)
         QFileDialog.getSaveFileName.assert_called_once()

--- a/src/sas/qtgui/MainWindow/media/data_formats_help.rst
+++ b/src/sas/qtgui/MainWindow/media/data_formats_help.rst
@@ -18,23 +18,22 @@ SasView reads several different 1D SAS (*I(Q) vs Q*), 2D SAS(*I(Qx,Qy) vs (Qx,Qy
 1D SAS Formats
 --------------
 
-SasView will read ASCII ('text') files with 2 to 4 columns of numbers in the following order: 
-
-    *Q, I(Q), ( dI(Q), dQ(Q) )*
-    
-where *dQ(Q)* is the instrumental resolution in *Q* and assumed to have originated 
-from pinhole geometry.
-
-Numbers can be separated by spaces or commas.
-
-SasView recognises the following file extensions which are not case-sensitive:
+SasView recognizes 1D data in ASCII, CSV, CanSAS XML, NXCanSAS, and AntonPaar SAXSESS formats with the following extensions:
 
 *  .TXT
 *  .ASC
 *  .DAT
-*  .XML (in canSAS format v1.0 and 1.1)
+*  .XML, or .COR (in canSAS XML v1.0 and v1.1 formats)
+*  .CSV
+*  .H5, .NXS, or .HDF (in NXcanSAS v1.0 and v1.1 formats)
+*  .PDH
 
-If using CSV output from, for example, a spreadsheet, ensure that it is not using commas as delimiters for thousands.
+SasView will read ASCII ('text') files with 2 to 4 columns of numbers in the following order:
+
+    *Q, I(Q), ( dI(Q), dQ(Q) )*
+    
+where *dQ(Q)* is the instrumental resolution in *Q* and assumed to have originated 
+from pinhole geometry. Numbers can be separated by spaces or commas. If using CSV output from, for example, a spreadsheet, ensure that it is not using commas as delimiters for thousands.
 
 The SasView :ref:`File_Converter_Tool` available in SasView 4.1 onwards can be used to convert data sets with separated *I(Q)* and *Q* files (for example, BSL/OTOKO, and some output from FIT2D and other SAXS-oriented software) into either the canSAS SASXML (XML) format or the NeXus NXcanSAS (HDF5) format.
 
@@ -60,9 +59,9 @@ http://www.diamond.ac.uk/Beamlines/Soft-Condensed-Matter/small-angle/SAXS-Softwa
 2D SAS Formats
 --------------
 
-SasView will read ASCII ('text') files in the NIST 2D format (with the extensions .ASC or .DAT) or files in the NeXus NXcanSAS (HDF5) format (with the extension .H5). File extensions are not case-sensitive. Both of these formats are written by the `Mantid Framework <http://www.mantidproject.org/>`_.
+SasView will read ASCII ('text') files in the NIST 2D format (with the extensions .ASC or .DAT) or files in the NeXus NXcanSAS (HDF5) format (with the extension .H5, .HDF, or .NXS). File extensions are not case-sensitive. Both of these formats are written by the `Mantid Framework <http://www.mantidproject.org/>`_.
 
-Most of the header lines in the NIST 2D format can actually be removed except the last line, and only the first three columns (*Qx, Qy,* and *I(Qx,Qy)*) are actually required.
+Most of the header lines in the NIST 2D format can be removed except the last line, and only the first three columns (*Qx, Qy,* and *I(Qx,Qy)*) are required.
 
 The SasView :ref:`File_Converter_Tool` available in SasView 4.1 onwards can be used to convert data sets in the 2D BSL/OTOKO format into the NeXus NXcanSAS (HDF5) format.
 

--- a/src/sas/qtgui/MainWindow/media/data_formats_help.rst
+++ b/src/sas/qtgui/MainWindow/media/data_formats_help.rst
@@ -25,7 +25,7 @@ SasView recognizes 1D data in ASCII, CSV, CanSAS XML, NXCanSAS, and AntonPaar SA
 *  .DAT
 *  .XML, or .COR (in canSAS XML v1.0 and v1.1 formats)
 *  .CSV
-*  .H5, .NXS, or .HDF (in NXcanSAS v1.0 and v1.1 formats)
+*  .H5, .NXS, .HDF, or .HDF5 (in NXcanSAS v1.0 and v1.1 formats)
 *  .PDH
 
 SasView will read ASCII ('text') files with 2 to 4 columns of numbers in the following order:

--- a/src/sas/qtgui/MainWindow/media/data_formats_help.rst
+++ b/src/sas/qtgui/MainWindow/media/data_formats_help.rst
@@ -59,7 +59,7 @@ http://www.diamond.ac.uk/Beamlines/Soft-Condensed-Matter/small-angle/SAXS-Softwa
 2D SAS Formats
 --------------
 
-SasView will read ASCII ('text') files in the NIST 2D format (with the extensions .ASC or .DAT) or files in the NeXus NXcanSAS (HDF5) format (with the extension .H5, .HDF, or .NXS). File extensions are not case-sensitive. Both of these formats are written by the `Mantid Framework <http://www.mantidproject.org/>`_.
+SasView will read ASCII ('text') files in the NIST 2D format (with the extensions .ASC or .DAT) or files in the NeXus NXcanSAS (HDF5) format (with the extension .H5, .NXS, .HDF, or .HDF5). File extensions are not case-sensitive. Both of these formats are written by the `Mantid Framework <http://www.mantidproject.org/>`_.
 
 Most of the header lines in the NIST 2D format can be removed except the last line, and only the first three columns (*Qx, Qy,* and *I(Qx,Qy)*) are required.
 

--- a/src/sas/qtgui/Utilities/GuiUtils.py
+++ b/src/sas/qtgui/Utilities/GuiUtils.py
@@ -773,65 +773,34 @@ def retrieveData2d(data):
 
     return text
 
-def onTXTSave(data, path, sep=" "):
+def onTXTSave(data, path):
     """
     Save file as formatted txt
     """
-    # FIXME: This could be greatly simplified...
-    with open(path,'w') as out:
-        has_errors = True
-        if data.dy is None or not data.dy.any():
-            has_errors = False
-        # Sanity check
-        if has_errors:
-            try:
-                if len(data.y) != len(data.dy):
-                    has_errors = False
-            except:
-                has_errors = False
-        if has_errors:
-            if data.dx is not None and data.dx.any():
-                out.write("<X>"+sep+"<Y>"+sep+"<dY>"+sep+"<dX>\n")
-            else:
-                out.write("<X>"+sep+"<Y>"+sep+"<dY>\n")
-        else:
-            out.write("<X>"+sep+"<Y>\n")
-
-        for i in range(len(data.x)):
-            if has_errors:
-                if data.dx is not None and data.dx.any():
-                    if data.dx[i] is not None:
-                        out.write("%.15e%s%.15e%s%.15e%s%.15e\n" % (
-                            data.x[i], sep, data.y[i], sep, data.dy[i], sep, data.dx[i]))
-                    else:
-                        out.write("%.15e%s%.15e%s%.15e\n" % (
-                            data.x[i], sep, data.y[i], sep, data.dy[i]))
-                else:
-                    out.write("%.15e%s%.15e%s%.15e\n" % (
-                        data.x[i], sep, data.y[i], sep, data.dy[i]))
-            else:
-                out.write("%.15e%s%.15e\n" % (
-                    data.x[i], sep, data.y[i]))
+    from sas.sascalc.dataloader.readers.ascii_reader import Reader as ASCIIReader
+    reader = ASCIIReader()
+    reader.write(path, data)
 
 def saveData1D(data):
     """
     Save 1D data points
     """
-    default_name = os.path.basename(data.filename)
-    default_name, extension = os.path.splitext(default_name)
-    if not extension:
-        extension = ".txt"
-    default_name += "_out" + extension
 
-    wildcard = "Text files (*.txt);;"\
-               "Comma separated value files (*.csv);;"\
-               "CanSAS 1D files(*.xml);;"\
-               "NXcanSAS files (*.h5);;"\
-               "All files (*.*)"
+    wildcard_dict = {
+        "Text files": ".txt",
+        "Comma separated value files": ".csv",
+        "CanSAS 1D files": ".xml",
+        "NXcanSAS file": ".h5"
+    }
+
+    wildcards = ""
+    for wildcard in list(wildcard_dict.keys()):
+        wildcards += f"{wildcard} (*{wildcard_dict[wildcard]});;"
+    wildcards += "All Files (*.*)"
+
     kwargs = {
         'caption'   : 'Save As',
-        #'directory' : default_name,
-        'filter'    : wildcard,
+        'filter'    : wildcards,
         'parent'    : None,
         'options'   : QtWidgets.QFileDialog.DontUseNativeDialog
     }
@@ -845,29 +814,19 @@ def saveData1D(data):
 
     # Check/add extension regardless
     ext = filename_tuple[1]
-    if 'Text files' in ext:
-        filename += '.txt'
-    elif 'Comma separated' in ext:
-        filename += '.csv'
-    elif 'CanSAS' in ext:
-        filename += '.xml'
-    elif 'NXcanSAS' in ext:
-        filename += '.h5'
-    else:
-        # Default to text writer
-        pass
+    for wildcard in list(wildcard_dict.keys()):
+        if wildcard in ext:
+            filename += wildcard_dict[wildcard]
+            break
 
-    # FIXME: Test and add unit tests.
-    if os.path.splitext(filename)[1].lower() in [".txt", ".csv"]:
-        sep = " " if os.path.splitext(filename)[1].lower() == '.txt' else ", "
-        onTXTSave(data, filename, sep)
-    elif os.path.splitext(filename)[1].lower() in [".xml", ".h5"]:
-        #Instantiate a loader
-        loader = Loader()
+    # Instantiate a loader
+    loader = Loader()
+    try:
         loader.save(filename, data, os.path.splitext(filename)[1].lower())
-    else:
-        onTXTSave(data, filename)
+    except KeyError:
+        # If the base loader is unable to save the file, fallback to text file.
         logger.warning("Unexpected file extension found on saving. Saving as text")
+        onTXTSave(data, filename)
 
 def saveData2D(data):
     """

--- a/src/sas/qtgui/Utilities/GuiUtils.py
+++ b/src/sas/qtgui/Utilities/GuiUtils.py
@@ -797,8 +797,9 @@ def onTXTSave(data, path):
 def saveData1D(data):
     """
     Save 1D data points
-    """
 
+    :param data: Data1D object the data will be taken from
+    """
     wildcard_dict = {
         "Text files": ".txt",
         "Comma separated value files": ".csv",
@@ -810,9 +811,10 @@ def saveData1D(data):
 
 def saveData2D(data):
     """
-    Save data2d dialog
-    """
+    Save data2d data points
 
+    :param data: Data2D object the data will be taken from
+    """
     wildcard_dict = {
         "IGOR/DAT 2D file in Q_map": ".dat",
         "NXcanSAS files": ".h5"
@@ -820,7 +822,17 @@ def saveData2D(data):
     saveAnyData(data, wildcard_dict)
 
 
-def saveAnyData(data, wildcard_dict):
+def saveAnyData(data, wildcard_dict=None):
+    """
+    Generic file save routine called by SaveData1D and SaveData2D
+
+    :param data: Data 1D or Data2D object the data will be taken from
+    :param wildcard_dict: Dictionary in format {"Display Text": ".ext"}
+    """
+    # Ensure wildcard_dict is a dictionary
+    if wildcard_dict is None or not isinstance(wildcard_dict, dict):
+        wildcard_dict = {}
+    # Construct wildcard string based on dictionary passed in
     wildcards = ""
     for wildcard in list(wildcard_dict.keys()):
         wildcards += f"{wildcard} (*{wildcard_dict[wildcard]});;"
@@ -836,17 +848,18 @@ def saveAnyData(data, wildcard_dict):
     filename_tuple = QtWidgets.QFileDialog.getSaveFileName(**kwargs)
     filename = filename_tuple[0]
 
-    # User cancelled.
+    # User cancelled or did not enter a filename
     if not filename:
         return
 
-    # Check/add extension regardless
+    # Check for selected file format
     ext = filename_tuple[1]
     for wildcard in list(wildcard_dict.keys()):
         if wildcard in ext:
             # Specify save format, while allowing free-form file extensions
             file_format = wildcard_dict[wildcard]
-            # Append extension if not typed into box by user
+            # Append selected extension if no extension typed into box by user
+            # Do not append if any extension typed to allow freeform extensions
             if len(filename.split(".")) == 1:
                 filename += wildcard_dict[wildcard]
             break

--- a/src/sas/qtgui/Utilities/GuiUtils.py
+++ b/src/sas/qtgui/Utilities/GuiUtils.py
@@ -790,13 +790,13 @@ def saveData1D(data):
         "Text files": ".txt",
         "Comma separated value files": ".csv",
         "CanSAS 1D files": ".xml",
-        "NXcanSAS file": ".h5"
+        "NXcanSAS files": ".h5"
     }
 
     wildcards = ""
     for wildcard in list(wildcard_dict.keys()):
         wildcards += f"{wildcard} (*{wildcard_dict[wildcard]});;"
-    wildcards += "All Files (*.*)"
+    wildcards += "All files (*.*)"
 
     kwargs = {
         'caption'   : 'Save As',
@@ -816,16 +816,23 @@ def saveData1D(data):
     ext = filename_tuple[1]
     for wildcard in list(wildcard_dict.keys()):
         if wildcard in ext:
-            filename += wildcard_dict[wildcard]
+            # Specify save format, while allowing free-form file extensions
+            file_format = wildcard_dict[wildcard]
+            # Append extension if not typed into box by user
+            if len(filename.split(".")) == 1:
+                filename += wildcard_dict[wildcard]
             break
+    else:
+        # Set file_format to None if 'All files (*.*)' selected
+        file_format = None
 
     # Instantiate a loader
     loader = Loader()
     try:
-        loader.save(filename, data, os.path.splitext(filename)[1].lower())
-    except KeyError:
+        loader.save(filename, data, file_format)
+    except (KeyError, ValueError):
         # If the base loader is unable to save the file, fallback to text file.
-        logger.warning("Unexpected file extension found on saving. Saving as text")
+        logger.warning(f"Unknown file type specified when saving {filename}. Saving as text.")
         onTXTSave(data, filename)
 
 def saveData2D(data):

--- a/src/sas/qtgui/Utilities/UnitTesting/GuiUtilsTest.py
+++ b/src/sas/qtgui/Utilities/UnitTesting/GuiUtilsTest.py
@@ -309,10 +309,10 @@ class GuiUtilsTest(unittest.TestCase):
         with open(path,'r') as out:
             data_read = out.read()
             expected = \
-            "<X>                    <Y>\n"+\
-            "1.000000000000000e+00  1.000000000000000e+01\n" +\
-            "2.000000000000000e+00  1.100000000000000e+01\n" +\
-            "3.000000000000000e+00  1.200000000000000e+01\n"
+            "<X> <Y>\n"+\
+            "1.000000000000000e+00 1.000000000000000e+01\n" +\
+            "2.000000000000000e+00 1.100000000000000e+01\n" +\
+            "3.000000000000000e+00 1.200000000000000e+01\n"
 
             self.assertEqual(expected, data_read)
 
@@ -326,10 +326,10 @@ class GuiUtilsTest(unittest.TestCase):
         onTXTSave(data, path)
         with open(path,'r') as out:
             data_read = out.read()
-            self.assertIn("<X>                    <Y>                    <dY>                    <dX>\n", data_read)
-            self.assertIn("1.000000000000000e+00  1.000000000000000e+01  1.000000000000000e-01  1.000000000000000e-01\n", data_read)
-            self.assertIn("2.000000000000000e+00  1.100000000000000e+01  2.000000000000000e-01  2.000000000000000e-01\n", data_read)
-            self.assertIn("3.000000000000000e+00  1.200000000000000e+01  3.000000000000000e-01  3.000000000000000e-01\n", data_read)
+            self.assertIn("<X> <Y> <dY> <dX>\n", data_read)
+            self.assertIn("1.000000000000000e+00 1.000000000000000e+01 1.000000000000000e-01 1.000000000000000e-01\n", data_read)
+            self.assertIn("2.000000000000000e+00 1.100000000000000e+01 2.000000000000000e-01 2.000000000000000e-01\n", data_read)
+            self.assertIn("3.000000000000000e+00 1.200000000000000e+01 3.000000000000000e-01 3.000000000000000e-01\n", data_read)
 
         if os.path.isfile(path):
             os.remove(path)
@@ -338,6 +338,7 @@ class GuiUtilsTest(unittest.TestCase):
         """
         Test the 1D file save method
         """
+        # FIXME: Move/create tests to sascalc for txt save
         data = Data1D(x=[1.0, 2.0, 3.0], y=[10.0, 11.0, 12.0],
                       dx=[0.1, 0.2, 0.3], dy=[0.1, 0.2, 0.3])
 

--- a/src/sas/qtgui/Utilities/UnitTesting/GuiUtilsTest.py
+++ b/src/sas/qtgui/Utilities/UnitTesting/GuiUtilsTest.py
@@ -292,8 +292,11 @@ class GuiUtilsTest(unittest.TestCase):
         Test the file writer for saving 1d/2d data
         """
         path = "test123"
+        save_path = path + ".txt"
         if os.path.isfile(path):
             os.remove(path)
+        if os.path.isfile(save_path):
+            os.remove(save_path)
 
         # Broken data
         data = Data1D(x=[1.0, 2.0, 3.0], y=[])
@@ -305,8 +308,8 @@ class GuiUtilsTest(unittest.TestCase):
         data = Data1D(x=[1.0, 2.0, 3.0], y=[10.0, 11.0, 12.0])
         onTXTSave(data, path)
 
-        self.assertTrue(os.path.isfile(path))
-        with open(path,'r') as out:
+        self.assertTrue(os.path.isfile(save_path))
+        with open(save_path,'r') as out:
             data_read = out.read()
             expected = \
             "<X> <Y>\n"+\
@@ -316,23 +319,23 @@ class GuiUtilsTest(unittest.TestCase):
 
             self.assertEqual(expected, data_read)
 
-        if os.path.isfile(path):
-            os.remove(path)
+        if os.path.isfile(save_path):
+            os.remove(save_path)
 
         # Good data - with dX/dY
         data = Data1D(x=[1.0, 2.0, 3.0], y=[10.0, 11.0, 12.0],
                       dx=[0.1, 0.2, 0.3], dy=[0.1, 0.2, 0.3])
 
         onTXTSave(data, path)
-        with open(path,'r') as out:
+        with open(save_path,'r') as out:
             data_read = out.read()
             self.assertIn("<X> <Y> <dY> <dX>\n", data_read)
             self.assertIn("1.000000000000000e+00 1.000000000000000e+01 1.000000000000000e-01 1.000000000000000e-01\n", data_read)
             self.assertIn("2.000000000000000e+00 1.100000000000000e+01 2.000000000000000e-01 2.000000000000000e-01\n", data_read)
             self.assertIn("3.000000000000000e+00 1.200000000000000e+01 3.000000000000000e-01 3.000000000000000e-01\n", data_read)
 
-        if os.path.isfile(path):
-            os.remove(path)
+        if os.path.isfile(save_path):
+            os.remove(save_path)
 
     def testSaveData1D(self):
         """

--- a/src/sas/qtgui/Utilities/UnitTesting/GuiUtilsTest.py
+++ b/src/sas/qtgui/Utilities/UnitTesting/GuiUtilsTest.py
@@ -338,7 +338,6 @@ class GuiUtilsTest(unittest.TestCase):
         """
         Test the 1D file save method
         """
-        # FIXME: Move/create tests to sascalc for txt save
         data = Data1D(x=[1.0, 2.0, 3.0], y=[10.0, 11.0, 12.0],
                       dx=[0.1, 0.2, 0.3], dy=[0.1, 0.2, 0.3])
 
@@ -349,6 +348,7 @@ class GuiUtilsTest(unittest.TestCase):
         saveData1D(data)
         self.assertTrue(os.path.isfile(file_name))
         os.remove(file_name)
+        self.assertFalse(os.path.isfile(file_name))
 
         # Test the .xml format
         file_name = "test123_out.xml"
@@ -357,6 +357,7 @@ class GuiUtilsTest(unittest.TestCase):
         saveData1D(data)
         self.assertTrue(os.path.isfile(file_name))
         os.remove(file_name)
+        self.assertFalse(os.path.isfile(file_name))
 
         # Test the wrong format
         file_name = "test123_out.mp3"
@@ -365,6 +366,8 @@ class GuiUtilsTest(unittest.TestCase):
         saveData1D(data)
         # Will save as text
         self.assertTrue(os.path.isfile(file_name))
+        os.remove(file_name)
+        self.assertFalse(os.path.isfile(file_name))
 
     def testSaveData2D(self):
         """
@@ -388,8 +391,10 @@ class GuiUtilsTest(unittest.TestCase):
         QtWidgets.QFileDialog.getSaveFileName = MagicMock(return_value=(file_name,''))
         data.filename = "test123.mp3"
         saveData2D(data)
-        # Will save as a text file
+        # Will save in IGOR Red2D format
         self.assertTrue(os.path.isfile(file_name))
+        os.remove(file_name)
+        self.assertFalse(os.path.isfile(file_name))
 
     def testXYTransform(self):
         """ Assure the unit/legend transformation is correct"""

--- a/src/sas/qtgui/Utilities/UnitTesting/GuiUtilsTest.py
+++ b/src/sas/qtgui/Utilities/UnitTesting/GuiUtilsTest.py
@@ -362,7 +362,8 @@ class GuiUtilsTest(unittest.TestCase):
         QtWidgets.QFileDialog.getSaveFileName = MagicMock(return_value=(file_name,''))
         data.filename = "test123.mp3"
         saveData1D(data)
-        self.assertFalse(os.path.isfile(file_name))
+        # Will save as text
+        self.assertTrue(os.path.isfile(file_name))
 
     def testSaveData2D(self):
         """
@@ -386,7 +387,8 @@ class GuiUtilsTest(unittest.TestCase):
         QtWidgets.QFileDialog.getSaveFileName = MagicMock(return_value=(file_name,''))
         data.filename = "test123.mp3"
         saveData2D(data)
-        self.assertFalse(os.path.isfile(file_name))
+        # Will save as a text file
+        self.assertTrue(os.path.isfile(file_name))
 
     def testXYTransform(self):
         """ Assure the unit/legend transformation is correct"""

--- a/src/sas/sascalc/dataloader/readers/ascii_reader.py
+++ b/src/sas/sascalc/dataloader/readers/ascii_reader.py
@@ -12,6 +12,7 @@
 # copyright 2008, University of Tennessee
 #############################################################################
 
+import os
 import logging
 from sas.sascalc.dataloader.file_reader_base_class import FileReader
 from sas.sascalc.dataloader.data_info import DataInfo, plottable_1D
@@ -161,3 +162,21 @@ class Reader(FileReader):
         # Store loading process information
         self.current_datainfo.meta_data['loader'] = self.type_name
         self.send_to_output()
+
+    def write(self, filename, dataset):
+        sep = ", " if os.path.splitext(filename)[1].lower() == '.csv' else " "
+        with open(filename, 'w') as out:
+            dx = dy = dy_i = dx_i = ""
+            # Sanity check
+            if dataset.dy is not None and dataset.dy.any() and len(dataset.y) == len(dataset.dy):
+                dy = f"{sep}<dY>"
+            if dataset.dx is not None and dataset.dx.any() and len(dataset.x) == len(dataset.dx):
+                dx = f"{sep}<dX>"
+            out.write(f"<X>{sep}<Y>{dy}{dx}\n")
+
+            for i in range(len(dataset.x)):
+                if dy != "" and len(dataset.dy) > i:
+                    dy_i = f"{sep}{dataset.dy[i]:.15e}"
+                if dx != "" and len(dataset.dx) > i:
+                    dx_i = f"{sep}{dataset.dx[i]:.15e}"
+                out.write(f"{dataset.x[i]:.15e}{sep}{dataset.y[i]:.15e}{dy_i}{dx_i}\n")

--- a/src/sas/sascalc/dataloader/readers/ascii_reader.py
+++ b/src/sas/sascalc/dataloader/readers/ascii_reader.py
@@ -163,8 +163,7 @@ class Reader(FileReader):
         self.current_datainfo.meta_data['loader'] = self.type_name
         self.send_to_output()
 
-    def write(self, filename, dataset):
-        sep = ", " if os.path.splitext(filename)[1].lower() == '.csv' else " "
+    def write(self, filename, dataset, sep=" "):
         with open(filename, 'w') as out:
             dx = dy = dy_i = dx_i = ""
             # Sanity check

--- a/src/sas/sascalc/dataloader/readers/ascii_reader.py
+++ b/src/sas/sascalc/dataloader/readers/ascii_reader.py
@@ -164,6 +164,14 @@ class Reader(FileReader):
         self.send_to_output()
 
     def write(self, filename, dataset, sep=" "):
+        """
+        Output data in ascii or similar format, depending on the separator provided
+
+        :param filename: Full file name and path where the file will be saved
+        :param dataset: Data1D object that will be saved
+        :param sep: Separator between data items, default is a single space
+        """
+        assert isinstance(dataset, plottable_1D)
         with open(filename, 'w') as out:
             dx = dy = dy_i = dx_i = ""
             # Sanity check

--- a/src/sas/sascalc/dataloader/readers/associations.py
+++ b/src/sas/sascalc/dataloader/readers/associations.py
@@ -23,6 +23,7 @@ FILE_ASSOCIATIONS = {
     ".ses": "sesans_reader",
     ".h5": "cansas_reader_HDF5",
     ".hdf": "cansas_reader_HDF5",
+    ".hdf5": "cansas_reader_HDF5",
     ".nxs": "cansas_reader_HDF5",
     ".txt": "ascii_reader",
     ".csv": "csv_reader",

--- a/src/sas/sascalc/dataloader/readers/associations.py
+++ b/src/sas/sascalc/dataloader/readers/associations.py
@@ -25,6 +25,7 @@ FILE_ASSOCIATIONS = {
     ".hdf": "cansas_reader_HDF5",
     ".nxs": "cansas_reader_HDF5",
     ".txt": "ascii_reader",
+    ".csv": "csv_reader",
     ".dat": "red2d_reader",
     ".abs": "abs_reader",
     ".cor": "abs_reader",

--- a/src/sas/sascalc/dataloader/readers/cansas_reader_HDF5.py
+++ b/src/sas/sascalc/dataloader/readers/cansas_reader_HDF5.py
@@ -9,11 +9,12 @@ import re
 import os
 import traceback
 
-from ..data_info import plottable_1D, plottable_2D,\
+from sas.sascalc.dataloader.data_info import plottable_1D, plottable_2D,\
     Data1D, Data2D, DataInfo, Process, Aperture, Collimation, \
     TransmissionSpectrum, Detector
-from ..loader_exceptions import FileContentsException, DefaultReaderException
-from ..file_reader_base_class import FileReader, decode
+from sas.sascalc.dataloader.loader_exceptions import FileContentsException, DefaultReaderException
+from sas.sascalc.dataloader.file_reader_base_class import FileReader, decode
+from sas.sascalc.file_converter.nxcansas_writer import NXcanSASWriter
 
 try:
   basestring
@@ -760,3 +761,14 @@ class Reader(FileReader):
         if unit is None:
             unit = h5attr(value, u'unit')
         return unit
+
+    def write(self, filename, dataset):
+        """
+        Export data in NXcanSAS format
+
+        :param filename: File path where the data will be saved
+        :param dataset: DataInfo object that will be converted to NXcanSAS
+        :return: None
+        """
+        writer = NXcanSASWriter()
+        writer.write(dataset=[dataset], filename=filename)

--- a/src/sas/sascalc/dataloader/readers/csv_reader.py
+++ b/src/sas/sascalc/dataloader/readers/csv_reader.py
@@ -1,5 +1,5 @@
 """
-    Generic multi-column ASCII data reader
+    CSV-specific multi-column ASCII data reader
 """
 
 import logging
@@ -10,7 +10,9 @@ logger = logging.getLogger(__name__)
 
 class Reader(ASCIIReader):
     """
-    Class to load ascii files (2, 3 or 4 columns).
+    Class to load CSV files (2, 3 or 4 columns) built off the ASCII reader.
+
+    All reading is done by the ASCIIReader. The writer calls the ASCII writer with a different separator.
     """
     # File type
     type_name = "CSV"
@@ -21,5 +23,12 @@ class Reader(ASCIIReader):
     # data unless that is the only data
     min_data_pts = 5
 
-    def write(self, filename, dataset, sep=""):
-        ASCIIReader.write(self, filename=filename, dataset=dataset, sep=", ")
+    def write(self, filename, dataset, sep=", "):
+        """
+        Output data csv format using the ASCII reader
+
+        :param filename: Full file name and path where the file will be saved
+        :param dataset: Data1D object that will be saved
+        :param sep: Separator between data items, default is a comma followed by a single space
+        """
+        ASCIIReader.write(self, filename=filename, dataset=dataset, sep=sep)

--- a/src/sas/sascalc/dataloader/readers/csv_reader.py
+++ b/src/sas/sascalc/dataloader/readers/csv_reader.py
@@ -1,0 +1,25 @@
+"""
+    Generic multi-column ASCII data reader
+"""
+
+import logging
+from sas.sascalc.dataloader.readers.ascii_reader import Reader as ASCIIReader
+
+logger = logging.getLogger(__name__)
+
+
+class Reader(ASCIIReader):
+    """
+    Class to load ascii files (2, 3 or 4 columns).
+    """
+    # File type
+    type_name = "CSV"
+    # Wildcards
+    type = ["CSV files (*.csv)|*.csv"]
+    # List of allowed extensions
+    ext = ['.csv']
+    # data unless that is the only data
+    min_data_pts = 5
+
+    def write(self, filename, dataset, sep=""):
+        ASCIIReader.write(self, filename=filename, dataset=dataset, sep=", ")

--- a/src/sas/sascalc/file_converter/nxcansas_writer.py
+++ b/src/sas/sascalc/file_converter/nxcansas_writer.py
@@ -5,7 +5,6 @@
 import h5py
 import numpy as np
 
-from sas.sascalc.dataloader.readers.cansas_reader_HDF5 import Reader
 from sas.sascalc.dataloader.data_info import Data1D, Data2D
 
 PROBES = ['neutron', 'x-ray', 'muon', 'electron', 'ultraviolet',
@@ -16,7 +15,7 @@ TYPES = ['Spallation Neutron Source', 'UV Plasma Source', 'Free-Electron Laser',
          'Rotating Anode X-ray', 'Optical Laser', 'Fixed Tube X-ray']
 
 
-class NXcanSASWriter(Reader):
+class NXcanSASWriter:
     """
     A class for writing in NXcanSAS data files. Any number of data sets may be
     written to the file. Currently 1D and 2D SAS data sets are supported

--- a/test/sasdataloader/utest_ascii.py
+++ b/test/sasdataloader/utest_ascii.py
@@ -147,6 +147,34 @@ class ABSReaderTests(unittest.TestCase):
         self.assertEqual(data_set.x_unit, 'A^{-1}')
         self.assertEqual(data_set.y_unit, 'cm^{-1}')
 
+    def test_save_ascii(self):
+        f_name = "test_f1_output.txt"
+        f_name_csv = "test_f1_output.csv"
+        # Save and load text file
+        self.loader.save(f_name, self.f1, None)
+        self.assertTrue(os.path.isfile(f_name))
+        reload = self.loader.load(f_name)
+        f1_reload = reload[0]
+        # Compare data from saved text file to previously loaded data
+        self.assertEqual(len(self.f1.x), len(f1_reload.x))
+        self.assertEqual(len(self.f1.y), len(f1_reload.y))
+        self.assertEqual(self.f1.y[0], f1_reload.y[0])
+        # Save and load csv file
+        self.loader.save(f_name_csv, self.f1, None)
+        self.assertTrue(os.path.isfile(f_name_csv))
+        reload_csv = self.loader.load(f_name_csv)
+        f1_reload_csv = reload_csv[0]
+        # Compare data from saved csv file to previously loaded data
+        self.assertEqual(len(self.f1.x), len(f1_reload_csv.x))
+        self.assertEqual(len(self.f1.y), len(f1_reload_csv.y))
+        self.assertEqual(self.f1.y[0], f1_reload_csv.y[0])
+        # Destroy generated files
+        os.remove(f_name)
+        self.assertFalse(os.path.isfile(f_name))
+        os.remove(f_name_csv)
+        self.assertFalse(os.path.isfile(f_name_csv))
+
+
 if __name__ == '__main__':
     unittest.main()
    


### PR DESCRIPTION
Data1D can now be output in CSV format, and freeform file extensions can be provided by the user regardless of the file type selected in the save menu. Unit tests and documentation were modified and expanded to account for the changes I made.

Fixes #1780 