### PR TITLE
Batch Fitting Fixes for Options and Plotting Issues

### DIFF
--- a/src/sas/qtgui/Perspectives/Fitting/FittingWidget.py
+++ b/src/sas/qtgui/Perspectives/Fitting/FittingWidget.py
@@ -210,6 +210,8 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
             for data_item in value:
                 logic = FittingLogic(data=GuiUtils.dataFromItem(data_item))
                 self._logic.append(logic)
+            # Option widget logic was destroyed - reestablish
+            self.options_widget.logic = self._logic[0]
             # update the ordering tab
             self.order_widget.updateData(self.all_data)
 
@@ -1758,9 +1760,6 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
 
             # Switch indexes
             self.data_index = res_index
-            # Recompute Q ranges
-            if self.data_is_loaded:
-                self.q_range_min, self.q_range_max, self.npts = self.logic.computeDataRange()
 
             # Recalculate theories
             method = self.complete1D if isinstance(self.data, Data1D) else self.complete2D

--- a/src/sas/qtgui/Perspectives/Fitting/OrderWidget.py
+++ b/src/sas/qtgui/Perspectives/Fitting/OrderWidget.py
@@ -35,7 +35,7 @@ class OrderWidget(QtWidgets.QWidget, Ui_OrderWidgetUI):
             if not hasattr(item, 'data'): continue
             dataset = GuiUtils.dataFromItem(item)
             if dataset is None: continue
-            dataset_name = dataset.filename
+            dataset_name = dataset.name
             self.order[dataset_name] = item
             self.lstOrder.addItem(dataset_name)
 

--- a/src/sas/qtgui/Utilities/GridPanel.py
+++ b/src/sas/qtgui/Utilities/GridPanel.py
@@ -356,11 +356,11 @@ class BatchOutputPanel(QtWidgets.QMainWindow, Ui_GridPanelUI):
         for i_row, row in enumerate(data):
             # each row corresponds to a single fit
             chi2 = row[0].fitness
-            filename = ""
+            name = ""
             if hasattr(row[0].data, "sas_data"):
-                filename = row[0].data.sas_data.filename
+                name = row[0].data.sas_data.name
             widget.setItem(i_row, 0, QtWidgets.QTableWidgetItem(GuiUtils.formatNumber(chi2, high=True)))
-            widget.setItem(i_row, 1, QtWidgets.QTableWidgetItem(str(filename)))
+            widget.setItem(i_row, 1, QtWidgets.QTableWidgetItem(str(name)))
             # Now, all the parameters
             for i_col, param in enumerate(param_list[2:]):
                 if param in row[0].param_list:


### PR DESCRIPTION
This PR ensures the batch fit page logic element isn't orphaned when a batch fit page is created which rendered all Q range and dI options useless. This work also ensures the q-range isn't improperly reset after a batch fit. Plots can also now be found when clicking the Plot button from the batch fit window.

Fixes #1796
Fixes #1795
Fixes #1794
Fixes #1446