### PR TITLE
Add Compute Button and Limit Fitting Computations

### DIFF
--- a/src/sas/qtgui/Perspectives/Fitting/FittingWidget.py
+++ b/src/sas/qtgui/Perspectives/Fitting/FittingWidget.py
@@ -598,6 +598,9 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         self._poly_model.dataChanged.connect(self.onPolyModelChange)
         self._magnet_model.dataChanged.connect(self.onMagnetModelChange)
         self.lstParams.selectionModel().selectionChanged.connect(self.onSelectionChanged)
+        self.lstParams.installEventFilter(self)
+        self.lstPoly.installEventFilter(self)
+        self.lstMagnetic.installEventFilter(self)
 
         # Local signals
         self.batchFittingFinishedSignal.connect(self.batchFitComplete)
@@ -624,6 +627,13 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
     def keyPressEvent(self, event):
         super(FittingWidget, self).keyPressEvent(event)
         self.keyPressedSignal.emit(event)
+
+    def eventFilter(self, obj, event):
+        # Catch enter key presses when editing model params
+        if obj in [self.lstParams, self.lstPoly, self.lstMagnetic]:
+            if event.type() == QtCore.QEvent.KeyPress and event.key() in [QtCore.Qt.Key_Return, QtCore.Qt.Key_Enter]:
+                self.onKey(event)
+        return True
 
     def modelName(self):
         """

--- a/src/sas/qtgui/Perspectives/Fitting/FittingWidget.py
+++ b/src/sas/qtgui/Perspectives/Fitting/FittingWidget.py
@@ -556,7 +556,6 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         self.cbFileNames.setVisible(False)
         self.cmdFit.setEnabled(False)
         self.cmdPlot.setEnabled(False)
-        self.cmdCompute.setEnabled(False)
         self.chkPolydispersity.setEnabled(True)
         self.chkPolydispersity.setCheckState(False)
         self.chk2DView.setEnabled(True)
@@ -591,7 +590,6 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         # Buttons
         self.cmdFit.clicked.connect(self.onFit)
         self.cmdPlot.clicked.connect(self.onPlot)
-        self.cmdCompute.clicked.connect(self.recalculatePlotData)
         self.cmdHelp.clicked.connect(self.onHelp)
         self.cmdMagneticDisplay.clicked.connect(self.onDisplayMagneticAngles)
 
@@ -1392,7 +1390,7 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         """
         # Update the chart
         if self.data_is_loaded:
-            self.cmdPlot.setText("Show Plot")
+            self.cmdPlot.setText("Compute/Plot")
             self.calculateQGridForModel()
         else:
             self.cmdPlot.setText("Calculate")
@@ -1589,9 +1587,6 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
             self.kernel_module.details[parameter_name][pos] = value
         else:
             self.magnet_params[parameter_name] = value
-            #self.kernel_module.setParam(parameter_name) = value
-            # Force the chart update when actual parameters changed
-            #self.recalculatePlotData()
 
         # Update state stack
         self.updateUndo()
@@ -2167,7 +2162,7 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         Plot the current set of data
         """
         # Regardless of previous state, this should now be `plot show` functionality only
-        self.cmdPlot.setText("Show Plot")
+        self.cmdPlot.setText("Compute/Plot")
         # Force data recalculation so existing charts are updated
         if not self.data_is_loaded:
             self.showTheoryPlot()
@@ -2177,7 +2172,7 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         # This allows charts to be properly updated in order
         # of plots being applied.
         QtWidgets.QApplication.processEvents()
-        self.recalculatePlotData() # recalc+plot theory again (2nd)
+        self.recalculatePlotData()  # recalc+plot theory again (2nd)
 
     def onSmearingOptionsUpdate(self):
         """
@@ -2189,7 +2184,7 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         self.calculateQGridForModel()
 
     def onKey(self, event):
-        if event.key() in [QtCore.Qt.Key_Enter, QtCore.Qt.Key_Return] and self.cmdCompute.isEnabled():
+        if event.key() in [QtCore.Qt.Key_Enter, QtCore.Qt.Key_Return] and self.cmdPlot.isEnabled():
             self.recalculatePlotData()
 
     def recalculatePlotData(self):
@@ -2249,7 +2244,6 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         # set Q range labels on the main tab
         self.lblMinRangeDef.setText(GuiUtils.formatNumber(self.q_range_min, high=True))
         self.lblMaxRangeDef.setText(GuiUtils.formatNumber(self.q_range_max, high=True))
-        #self.recalculatePlotData()
 
     def setDefaultStructureCombo(self):
         """
@@ -2660,10 +2654,6 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         # handle display of effective radius parameter according to radius_effective_mode; pass ER into model if
         # necessary
         self.processEffectiveRadius()
-
-        # Force the chart update when actual parameters changed
-        #if model_column == 1:
-            #self.recalculatePlotData()
 
         # Update state stack
         self.updateUndo()
@@ -3628,7 +3618,6 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
             self.cbStructureFactor.setEnabled(enabled)
 
         self.cmdPlot.setEnabled(enabled)
-        self.cmdCompute.setEnabled(enabled)
 
     def enableInteractiveElements(self):
         """

--- a/src/sas/qtgui/Perspectives/Fitting/FittingWidget.py
+++ b/src/sas/qtgui/Perspectives/Fitting/FittingWidget.py
@@ -2185,7 +2185,7 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
 
     def onKey(self, event):
         if event.key() in [QtCore.Qt.Key_Enter, QtCore.Qt.Key_Return] and self.cmdPlot.isEnabled():
-            self.recalculatePlotData()
+            self.onPlot()
 
     def recalculatePlotData(self):
         """

--- a/src/sas/qtgui/Perspectives/Fitting/UI/FittingWidgetUI.ui
+++ b/src/sas/qtgui/Perspectives/Fitting/UI/FittingWidgetUI.ui
@@ -467,6 +467,19 @@ angles</string>
       </widget>
      </item>
      <item>
+      <widget class="QPushButton" name="cmdCompute">
+       <property name="minimumSize">
+        <size>
+         <width>93</width>
+         <height>28</height>
+        </size>
+       </property>
+       <property name="text">
+        <string>Compute</string>
+       </property>
+      </widget>
+     </item>
+     <item>
       <widget class="QPushButton" name="cmdFit">
        <property name="sizePolicy">
         <sizepolicy hsizetype="Fixed" vsizetype="Fixed">

--- a/src/sas/qtgui/Perspectives/Fitting/UI/FittingWidgetUI.ui
+++ b/src/sas/qtgui/Perspectives/Fitting/UI/FittingWidgetUI.ui
@@ -461,21 +461,11 @@ angles</string>
          <height>28</height>
         </size>
        </property>
-       <property name="text">
-        <string>Show Plot</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QPushButton" name="cmdCompute">
-       <property name="minimumSize">
-        <size>
-         <width>93</width>
-         <height>28</height>
-        </size>
+       <property name="toolTip">
+        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Perform a single computation of the model using the parameters as-entered and subsequently plot the result.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
        </property>
        <property name="text">
-        <string>Compute</string>
+        <string>Compute/Plot</string>
        </property>
       </widget>
      </item>

--- a/src/sas/qtgui/Perspectives/Fitting/UnitTesting/FittingWidgetTest.py
+++ b/src/sas/qtgui/Perspectives/Fitting/UnitTesting/FittingWidgetTest.py
@@ -1624,7 +1624,8 @@ class FittingWidgetTest(unittest.TestCase):
         self.widget.cbModel.setCurrentIndex(model_index)
 
         # see if radius is the same as set
-        self.assertTrue(self.widget._model_model.item(5, 1).text() == "333.0")
+        row = self.widget.getRowFromName("radius")
+        self.assertEqual(self.widget._model_model.item(row, 1).text(), "333")
 
         # Now, change not just model but a category as well
         # cylinder / cylinder
@@ -1635,7 +1636,8 @@ class FittingWidgetTest(unittest.TestCase):
         self.widget.cbModel.setCurrentIndex(model_index)
 
         # see if radius is still the same
-        self.assertTrue(int(self.widget._model_model.item(5, 1).text()) == 333)
+        row = self.widget.getRowFromName("radius")
+        self.assertEqual(int(self.widget._model_model.item(row, 1).text()), 333)
 
     def testOnParameterPaste(self):
         """


### PR DESCRIPTION
This PR adds a 'Compute' button to fit pages and limits recalculation to when the user presses this button, or hits the Enter or Return keys. This matches the behavior in 4.2.2.

Refs #1767