### PR TITLE
Various P(r) GUI Fixes

### DIFF
--- a/src/sas/qtgui/Perspectives/Inversion/InversionPerspective.py
+++ b/src/sas/qtgui/Perspectives/Inversion/InversionPerspective.py
@@ -331,15 +331,11 @@ class InversionWindow(QtWidgets.QDialog, Ui_PrInversion):
         self.calculateThisButton.setEnabled(self.logic.data_is_loaded
                                             and not self.isBatch
                                             and not self.isCalculating)
-        self.removeButton.setEnabled(self.logic.data_is_loaded)
-        self.explorerButton.setEnabled(self.logic.data_is_loaded)
+        self.removeButton.setEnabled(self.logic.data_is_loaded and not self.isCalculating)
+        self.explorerButton.setEnabled(self.logic.data_is_loaded and not self.isCalculating)
         self.stopButton.setVisible(self.isCalculating)
-        self.regConstantSuggestionButton.setEnabled(
-            self.logic.data_is_loaded and
-            self._calculator.suggested_alpha != self._calculator.alpha)
-        self.noOfTermsSuggestionButton.setEnabled(
-            self.logic.data_is_loaded and
-            self._calculator.nfunc != self.nTermsSuggested)
+        self.regConstantSuggestionButton.setEnabled(self.logic.data_is_loaded and not self.isCalculating)
+        self.noOfTermsSuggestionButton.setEnabled(self.logic.data_is_loaded and not self.isCalculating)
 
     def populateDataComboBox(self, name, data_ref):
         """
@@ -377,7 +373,7 @@ class InversionWindow(QtWidgets.QDialog, Ui_PrInversion):
         self.set_background(self.backgroundInput.text())
 
     def set_background(self, value):
-        self._calculator.background = is_float(value)
+        self._calculator.background = float(value)
 
     def model_changed(self):
         """Update the values when user makes changes"""
@@ -409,16 +405,15 @@ class InversionWindow(QtWidgets.QDialog, Ui_PrInversion):
         """
         Toggle the background between manual and estimated
         """
-        if self.estimateBgd.isChecked():
-            self.manualBgd.setChecked(False)
-            self.backgroundInput.setEnabled(False)
-            self._calculator.set_est_bck = True
-        elif self.manualBgd.isChecked():
-            self.estimateBgd.setChecked(False)
-            self.backgroundInput.setEnabled(True)
-            self._calculator.set_est_bck = False
-        else:
-            pass
+        self.model.blockSignals(True)
+        value = 1 if self.estimateBgd.isChecked() else 0
+        itemt = QtGui.QStandardItem(str(value == 1).lower())
+        self.model.setItem(WIDGETS.W_ESTIMATE, itemt)
+        itemt = QtGui.QStandardItem(str(value == 0).lower())
+        self.model.setItem(WIDGETS.W_MANUAL_INPUT, itemt)
+        self._calculator.set_est_bck(value)
+        self.backgroundInput.setEnabled(self._calculator.est_bck == 0)
+        self.model.blockSignals(False)
 
     def openExplorerWindow(self):
         """

--- a/src/sas/qtgui/Perspectives/Inversion/UnitTesting/InversionPerspectiveTest.py
+++ b/src/sas/qtgui/Perspectives/Inversion/UnitTesting/InversionPerspectiveTest.py
@@ -1,8 +1,5 @@
-import time
 import unittest
 from unittest.mock import MagicMock
-
-from PyQt5 import QtGui, QtWidgets
 
 from sas.qtgui.Utilities.GuiUtils import *
 from sas.qtgui.Perspectives.Inversion.InversionPerspective import InversionWindow
@@ -52,7 +49,7 @@ class InversionTest(unittest.TestCase):
 
     def removeAllData(self):
         """ Cleanup method to restore widget to its base state """
-        if len(self.widget.dataList) > 0:
+        while len(self.widget.dataList) > 0:
             remove_me = list(self.widget._dataList.keys())
             self.widget.removeData(remove_me)
 
@@ -221,7 +218,7 @@ class InversionTest(unittest.TestCase):
     def testGetNFunc(self):
         """ test nfunc getter """
         # Float
-        self.widget.noOfTermsInput.setText("10.0")
+        self.widget.noOfTermsInput.setText("10")
         self.assertEqual(self.widget.getNFunc(), 10)
         # Int
         self.widget.noOfTermsInput.setText("980")
@@ -267,30 +264,29 @@ class InversionTest(unittest.TestCase):
         self.assertEqual(self.widget._calculator.slit_width, 0.0)
         self.assertEqual(self.widget._calculator.alpha, 0.0001)
         # Set new values
-        self.widget.maxDistanceInput.setText("1.0")
-        self.widget.maxQInput.setText("3.0")
-        self.widget.minQInput.setText("5.0")
+        # Min Q must always be less than max Q - Set max Q first
+        self.widget.maxQInput.setText("5.0")
+        self.widget.check_q_high()
+        self.widget.minQInput.setText("3.0")
+        self.widget.check_q_low()
         self.widget.slitHeightInput.setText("7.0")
         self.widget.slitWidthInput.setText("9.0")
         self.widget.regularizationConstantInput.setText("11.0")
+        self.widget.maxDistanceInput.setText("1.0")
         # Check new values
         self.assertEqual(self.widget._calculator.get_dmax(), 1.0)
-        self.assertEqual(self.widget._calculator.get_qmax(), 3.0)
-        self.assertEqual(self.widget._calculator.get_qmin(), 5.0)
+        self.assertEqual(self.widget._calculator.get_qmin(), 3.0)
+        self.assertEqual(self.widget._calculator.get_qmax(), 5.0)
         self.assertEqual(self.widget._calculator.slit_height, 7.0)
         self.assertEqual(self.widget._calculator.slit_width, 9.0)
         self.assertEqual(self.widget._calculator.alpha, 11.0)
         # Change model directly
         self.widget.model.setItem(WIDGETS.W_MAX_DIST, QtGui.QStandardItem("2.0"))
-        self.widget.model.setItem(WIDGETS.W_QMIN, QtGui.QStandardItem("4.0"))
-        self.widget.model.setItem(WIDGETS.W_QMAX, QtGui.QStandardItem("6.0"))
         self.widget.model.setItem(WIDGETS.W_SLIT_HEIGHT, QtGui.QStandardItem("8.0"))
         self.widget.model.setItem(WIDGETS.W_SLIT_WIDTH, QtGui.QStandardItem("10.0"))
         self.widget.model.setItem(WIDGETS.W_REGULARIZATION, QtGui.QStandardItem("12.0"))
         # Check values
         self.assertEqual(self.widget._calculator.get_dmax(), 2.0)
-        self.assertEqual(self.widget._calculator.get_qmin(), 4.0)
-        self.assertEqual(self.widget._calculator.get_qmax(), 6.0)
         self.assertEqual(self.widget._calculator.slit_height, 8.0)
         self.assertEqual(self.widget._calculator.slit_width, 10.0)
         self.assertEqual(self.widget._calculator.alpha, 12.0)


### PR DESCRIPTION
This PR fixes a handful of bugs associated with the P(r) Inversion perspective.

- The logic for activating the parameter buttons (No. of Terms and Reg. Constant) has been simplified. They are active whenever data is loaded and no calculation is occurring. Fixes #1742 
- The manual background input is now accepted and the toggle is not switched to manual input after every fit. Fixes #1765
- A few unticketed save/load issues, namely values not being updated properly, were also fixed.
- A few of the unit tests were fixed or updated but a couple of tests in the `inversionPerspectiveSuite` are throwing errors that I was unable to fix here. Refs #1732

This branch was built off of `release_5.0.4`, but this PR could wait until after 5.0.4 final.