### PR TITLE
Pin versions of qtconsole and PyZMQ to enable QtConsole.

### DIFF
--- a/build_tools/conda_qt5_win_commercial.yml
+++ b/build_tools/conda_qt5_win_commercial.yml
@@ -21,7 +21,8 @@ dependencies:
  - numba=0.39
  - setuptools=44.0.0
  - numpy=1.14.2
- - qtconsole
+ - qtconsole=4.75
+ - pyzmq=19.0.1
  - mkl=2020.0
  - pip:
    - matplotlib==2.2.3


### PR DESCRIPTION
qtconsole=4.7.5
pyzmq=19.0.1

probably a bit too conservative, but this is what ran fine on 5.0.3
