### PR TITLE
Adding pip dependency to yml file so that conda doesn't complain

### DIFF
--- a/build_tools/conda_qt5_min_osx.yml
+++ b/build_tools/conda_qt5_min_osx.yml
@@ -26,6 +26,7 @@ dependencies:
  - numpy=1.15.1=py36_blas_openblashd3ea46f_1
  - openssl
  - packaging
+ - pip
  - pycrypto
  - pyinstaller
  - pyqt

--- a/build_tools/conda_qt5_min_ubuntu.yml
+++ b/build_tools/conda_qt5_min_ubuntu.yml
@@ -13,6 +13,7 @@ dependencies:
  - lxml=4.6.3
  - sphinx=1.8.5
  - cython=0.28.3
+ - pip
  - pytest
  - mako=1.0.7
  - pyinstaller=3.3.1

--- a/build_tools/conda_qt5_win_commercial.yml
+++ b/build_tools/conda_qt5_win_commercial.yml
@@ -2,6 +2,7 @@ name: qt5_win
 channels:
   - conda-forge
 dependencies:
+ - pip
  - alabaster
  - colorama
  - ipykernel


### PR DESCRIPTION
When trying to create env from yml file with recent versions of conda it throws thousands of warnings:
`Warning: you have pip-installed dependencies in your environment file, but you do not list pip itself as one of your conda dependencies.  Conda may not use the correct pip to install your packages, and they may end up in the wrong place.  Please add an explicit pip dependency.  I'm adding one for you, but still nagging you.`

I observed it on OSX and added pip to developers build (min file). It needs to be explored for other platforms.