### PR TITLE
Add py3.9 remove py3.6 from github actions

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: [3.8]
+        python-version: [3.9]
 
     steps:
 

--- a/.github/workflows/installers.yml
+++ b/.github/workflows/installers.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         os: [windows-latest]
-        python-version: [3.8]
+        python-version: [3.9]
 
     steps:
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         os: [macos-latest, ubuntu-latest, windows-latest]
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.7, 3.8, 3.9]
       fail-fast: false
 
     steps:


### PR DESCRIPTION
First step towards #1855 is to see what we can already do in the GitHub Actions CI for tests, docs and installer, which this PR does.

 * the pytest tests pass (with the usual failures not actually causing the tests to fail!)
 * the GUI tests still fail in the normal ways and that failure is suppressed
 * building the docs succeeds
 * building the installer succeeds (but that is not the same as saying that the installer works)

The installer is at https://github.com/llimeht/sasview/actions/runs/852749020 if windows and mac users would like to test it out.
