### PR TITLE
Fixes missing plugin models from structure factor combo box

### DIFF
--- a/src/sas/qtgui/Perspectives/Fitting/FittingWidget.py
+++ b/src/sas/qtgui/Perspectives/Fitting/FittingWidget.py
@@ -2292,6 +2292,10 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
             plugin_list.append([name, True])
         if plugin_list:
             self.master_category_dict[CATEGORY_CUSTOM] = plugin_list
+        # Adding plugins classified as structure factor to 'CATEGORY_STRUCTURE' list
+        plugin_structure_list = [[name, True] for name, plug in self.custom_models.items() if plug.is_structure_factor]
+        if plugin_structure_list:
+            self.master_category_dict[CATEGORY_STRUCTURE].extend(plugin_structure_list)
 
     def regenerateModelDict(self):
         """

--- a/src/sas/qtgui/Perspectives/Fitting/FittingWidget.py
+++ b/src/sas/qtgui/Perspectives/Fitting/FittingWidget.py
@@ -2293,7 +2293,11 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         if plugin_list:
             self.master_category_dict[CATEGORY_CUSTOM] = plugin_list
         # Adding plugins classified as structure factor to 'CATEGORY_STRUCTURE' list
-        plugin_structure_list = [[name, True] for name, plug in self.custom_models.items() if plug.is_structure_factor]
+        plugin_structure_list = [
+            [name, True] for name, plug in self.custom_models.items()
+            if plug.is_structure_factor
+            and [name, True] not in self.master_category_dict[CATEGORY_STRUCTURE]
+        ]
         if plugin_structure_list:
             self.master_category_dict[CATEGORY_STRUCTURE].extend(plugin_structure_list)
 

--- a/src/sas/qtgui/Perspectives/Fitting/UnitTesting/FittingWidgetTest.py
+++ b/src/sas/qtgui/Perspectives/Fitting/UnitTesting/FittingWidgetTest.py
@@ -4,6 +4,7 @@ import time
 import logging
 import os
 import inspect
+import glob
 
 from PyQt5 import QtGui
 from PyQt5 import QtWidgets
@@ -66,8 +67,10 @@ def find_plugin_models_mod():
     'sas/qtgui/Perspectives/Fitting/plugin_models'
     Modified to test handling of plugin models.
     """
-    qtgui_dir = os.getcwd()[:os.getcwd().find('qtgui')]
-    plugins_dir = os.path.abspath(os.path.join(qtgui_dir, 'qtgui/Perspectives/Fitting/plugin_models'))
+    plugins_dir = [
+        os.path.abspath(path) for path in glob.glob("**/plugin_models",recursive=True)
+        if os.path.normpath("qtgui/Perspectives/Fitting/plugin_models") in os.path.abspath(path)
+    ][0]
 
     plugins = {}
     for filename in os.listdir(plugins_dir):

--- a/src/sas/qtgui/Perspectives/Fitting/plugin_models/__init__.py
+++ b/src/sas/qtgui/Perspectives/Fitting/plugin_models/__init__.py
@@ -1,5 +1,4 @@
 """
 Example plugin models to be added to the SasView plugin directory on startup
 if no plugins are present.
-This is currently empty.
 """

--- a/src/sas/qtgui/Perspectives/Fitting/plugin_models/plugin_structure_template.py
+++ b/src/sas/qtgui/Perspectives/Fitting/plugin_models/plugin_structure_template.py
@@ -1,0 +1,64 @@
+r"""
+Definition
+----------
+
+This template can be used to develop your plugin structure factor.
+
+.. math::
+
+    I(q) = mq+b
+
+where *m* is the slope and *b* is the intercept.
+
+Validation
+----------
+
+
+References
+----------
+
+#. A LastNameA and B. LastNameB, *Title*, Journal, MoreInfo, (YEAR)
+
+Authorship and Verification
+----------------------------
+
+* **Author:** Your Name Here
+* **Last Modified by:**
+* **Last Reviewed by:** Reviewer Name Here **Date:** Date Here
+"""
+
+import numpy as np
+from numpy import inf
+
+name = "plugin_structure_template"
+title = 'Template Plugin Structure Factor'
+description = """\
+I(q) = mq + b
+    m: slope of line
+    b: intercept of line
+"""
+category = "plugin"
+structure_factor = True
+
+#             ["name", "units", default, [lower, upper], "type","description"],
+parameters = [["m", "Ang/cm", 2, [-inf, inf], "", "slope of the line"],
+              ["b", "1/cm", 1, [-inf, inf], "", "intercept of the line"]
+             ]
+
+def Iq(q, m=2, b=1):
+    """
+    Parameters:
+        q:      input scattering vectors, units 1/Ang
+        m:      slope of line, units Ang/cm, default value=2
+        b:      intercept of line, units 1/cm, default value=1
+    Returns:
+        I(q):   1D scattering intensity at q, units 1/cm
+    """
+    iq = m*q + b
+    return iq
+
+# include tests for your model
+# tests = [
+#     [{'m': 2.0, 'b' : 1.0}, [q1, q2], [expected_Iq1, expected_Iq2]],
+#     [{'m': 3.0, 'b' : 5.0}, [q3, q4], [expected_Iq3, expected_Iq4]],
+# ]

--- a/src/sas/qtgui/Perspectives/Fitting/plugin_models/plugin_template.py
+++ b/src/sas/qtgui/Perspectives/Fitting/plugin_models/plugin_template.py
@@ -1,0 +1,64 @@
+r"""
+Definition
+----------
+
+This template can be used to develop your plugin model.
+
+.. math::
+
+    I(q) = mq+b
+
+where *m* is the slope and *b* is the intercept.
+
+Validation
+----------
+
+
+References
+----------
+
+#. A LastNameA and B. LastNameB, *Title*, Journal, MoreInfo, (YEAR)
+
+Authorship and Verification
+----------------------------
+
+* **Author:** Your Name Here
+* **Last Modified by:**
+* **Last Reviewed by:** Reviewer Name Here **Date:** Date Here
+"""
+
+import numpy as np
+from numpy import inf
+
+name = "plugin_template"
+title = 'Template Plugin Model'
+description = """\
+I(q) = mq + b
+    m: slope of line
+    b: intercept of line
+"""
+category = "plugin"
+structure_factor = False
+
+#             ["name", "units", default, [lower, upper], "type","description"],
+parameters = [["m", "Ang/cm", 2, [-inf, inf], "", "slope of the line"],
+              ["b", "1/cm", 1, [-inf, inf], "", "intercept of the line"]
+             ]
+
+def Iq(q, m=2, b=1):
+    """
+    Parameters:
+        q:      input scattering vectors, units 1/Ang
+        m:      slope of line, units Ang/cm, default value=2
+        b:      intercept of line, units 1/cm, default value=1
+    Returns:
+        I(q):   1D scattering intensity at q, units 1/cm
+    """
+    iq = m*q + b
+    return iq
+
+# include tests for your model
+# tests = [
+#     [{'m': 2.0, 'b' : 1.0}, [q1, q2], [expected_Iq1, expected_Iq2]],
+#     [{'m': 3.0, 'b' : 5.0}, [q3, q4], [expected_Iq3, expected_Iq4]],
+# ]


### PR DESCRIPTION
Fixes the bug in SasView v5 that resulted in the structure factor combo box of the gui not listing plugin models also labeled as a structure factor. This was described in issue [#1852](https://github.com/SasView/sasview/issues/1852). 
