### PR TITLE
Adding h5py=3.1 as a pip package

### DIFF
--- a/build_tools/conda_qt5_min_ubuntu.yml
+++ b/build_tools/conda_qt5_min_ubuntu.yml
@@ -5,7 +5,6 @@ dependencies:
  - matplotlib=2.2.2
  - scipy=1.1.0
  - hdf5=1.10.1
- - h5py=3.1
  - ipython=6
  - ipykernel=4.9
  - jupyter
@@ -31,3 +30,4 @@ dependencies:
    - xhtml2pdf==0.2.2
    - qt5reactor==0.5
    - pillow==8.1.2
+   - h5py==3.1

--- a/build_tools/conda_qt5_win_commercial.yml
+++ b/build_tools/conda_qt5_win_commercial.yml
@@ -12,7 +12,6 @@ dependencies:
  - pyopencl=2018.2.2
  - scipy=1.2.0
  - hdf5=1.10.4
- - h5py=3.1
  - lxml=4.6.3
  - twisted=18.9.0
  - sphinx=1.8.5
@@ -35,3 +34,4 @@ dependencies:
    - qt5reactor==0.5
    - tinycc==1.1
    - pillow==8.1.2
+   - h5py==3.1


### PR DESCRIPTION
Since conda package is conflicting and cannot be resolved I am trying with pip installable package