### PR TITLE
minor change to sas_gen.py which should fix #1886

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,6 +58,7 @@ default_categories.json
 /test/sasdataloader/data/isis_1_0_write_test.xml
 /test/sasdataloader/data/isis_1_1_write_test.xml
 /test/sasdataloader/data/write_test.xml
+/test/sascalculator/data/write_test.sld
 /test/fileconverter/data/export2d.h5
 **/logs
 tests.log

--- a/src/sas/sascalc/calculator/sas_gen.py
+++ b/src/sas/sascalc/calculator/sas_gen.py
@@ -673,7 +673,7 @@ class SLDReader(object):
         else:
             mx, my, mz = data.sld_mx, data.sld_my, data.sld_mz
         vol = data.vol_pix if data.vol_pix is not None else np.ones_like(x)
-        columns = np.vstack((x, y, z, sld_n, mx, my, mz, vol))
+        columns = np.column_stack((x, y, z, sld_n, mx, my, mz, vol))
         with open(path, 'w') as out:
             # First Line: Column names
             out.write("X  Y  Z  SLDN SLDMx  SLDMy  SLDMz VOLUMEpix\n")

--- a/test/sascalculator/utest_sas_gen.py
+++ b/test/sascalculator/utest_sas_gen.py
@@ -31,6 +31,27 @@ class sas_gen_test(unittest.TestCase):
         self.assertEqual(f.pos_x[0], -40.5)
         self.assertEqual(f.pos_y[0], -13.5)
         self.assertEqual(f.pos_z[0], -13.5)
+    
+    def test_sldwriter(self):
+        """
+        Test .sld file is written correctly
+        """
+        # load in a sample sld file then resave it
+        f = self.sldloader.read(find("sld_file.sld"))
+        self.sldloader.write(find("write_test.sld"), f)
+        # load in the saved file to confirm that Sasview does not reject it within its
+        # own loading function
+        g = self.sldloader.read(find("write_test.sld"))
+        # confirm that the first row of data is as expected
+        self.assertEqual(f.pos_x[0], g.pos_x[0])
+        self.assertEqual(f.pos_y[0], g.pos_y[0])
+        self.assertEqual(f.pos_z[0], g.pos_z[0])
+        self.assertEqual(f.sld_n[0], g.sld_n[0])
+        self.assertEqual(f.sld_mx[0], g.sld_mx[0])
+        self.assertEqual(f.sld_my[0], g.sld_my[0])
+        self.assertEqual(f.sld_mz[0], g.sld_mz[0])
+        self.assertEqual(f.vol_pix[0], g.vol_pix[0])
+
 
     def test_pdbreader(self):
         """


### PR DESCRIPTION
Use np.column_stack() to correctly arrange the outputted data for the sld file, so that it is in the correct order.