### PR TITLE
Ticket 1825 scattering calc

### DIFF
--- a/src/sas/qtgui/Calculators/GenericScatteringCalculator.py
+++ b/src/sas/qtgui/Calculators/GenericScatteringCalculator.py
@@ -657,27 +657,6 @@ class GenericScatteringCalculator(QtWidgets.QDialog, Ui_GenericScatteringCalcula
             self.lbl_unitz.setText(mesh_unit)
             self.lbl_unitVolume.setText(mesh_unit+"^3")
 
-    def format_value(self, value):
-        """Formats certain data for the GUI.
-        
-        Some data stored by the sld file is a numpy array - in which case the average is formatted.
-        Other data is a single value in which case the value is formatted. The formatting is done
-        by GuiUtils.formatNumber(). If the value is `None` then the string "NaN" is returned
-
-        :param value: The value to be formatted
-        :type value: int, float, numpy.array
-        :return: The formatted value
-        :rtype: str
-        """
-        if value is None:
-            return "NaN"
-        else:
-            if isinstance(value, numpy.ndarray):
-                value = str(GuiUtils.formatNumber(numpy.average(value), True))
-            else:
-                value = str(GuiUtils.formatNumber(value, True))
-            return value
-
     def update_gui(self):
         """Update the interface and model with values from loaded data
         
@@ -718,25 +697,25 @@ class GenericScatteringCalculator(QtWidgets.QDialog, Ui_GenericScatteringCalcula
 
         # Fill right hand side of GUI
         if self.is_mag:
-            self.txtMx.setText(self.format_value(self.mag_sld_data.sld_mx))
-            self.txtMy.setText(self.format_value(self.mag_sld_data.sld_my))
-            self.txtMz.setText(self.format_value(self.mag_sld_data.sld_mz))
+            self.txtMx.setText(GuiUtils.formatValue(self.mag_sld_data.sld_mx))
+            self.txtMy.setText(GuiUtils.formatValue(self.mag_sld_data.sld_my))
+            self.txtMz.setText(GuiUtils.formatValue(self.mag_sld_data.sld_mz))
         if self.is_nuc:
-            self.txtNucl.setText(self.format_value(self.nuc_sld_data.sld_n))
-            self.txtXnodes.setText(self.format_value(self.nuc_sld_data.xnodes))
-            self.txtYnodes.setText(self.format_value(self.nuc_sld_data.ynodes))
-            self.txtZnodes.setText(self.format_value(self.nuc_sld_data.znodes))
-            self.txtXstepsize.setText(self.format_value(self.nuc_sld_data.xstepsize))
-            self.txtYstepsize.setText(self.format_value(self.nuc_sld_data.ystepsize))
-            self.txtZstepsize.setText(self.format_value(self.nuc_sld_data.zstepsize))
+            self.txtNucl.setText(GuiUtils.formatValue(self.nuc_sld_data.sld_n))
+            self.txtXnodes.setText(GuiUtils.formatValue(self.nuc_sld_data.xnodes))
+            self.txtYnodes.setText(GuiUtils.formatValue(self.nuc_sld_data.ynodes))
+            self.txtZnodes.setText(GuiUtils.formatValue(self.nuc_sld_data.znodes))
+            self.txtXstepsize.setText(GuiUtils.formatValue(self.nuc_sld_data.xstepsize))
+            self.txtYstepsize.setText(GuiUtils.formatValue(self.nuc_sld_data.ystepsize))
+            self.txtZstepsize.setText(GuiUtils.formatValue(self.nuc_sld_data.zstepsize))
         if self.is_mag and ((not self.is_nuc) or self.txtXnodes.text() == "NaN"):
             # If unable to get node data from nuclear system (not enabled or not present)
-            self.txtXnodes.setText(self.format_value(self.mag_sld_data.xnodes))
-            self.txtYnodes.setText(self.format_value(self.mag_sld_data.ynodes))
-            self.txtZnodes.setText(self.format_value(self.mag_sld_data.znodes))
-            self.txtXstepsize.setText(self.format_value(self.mag_sld_data.xstepsize))
-            self.txtYstepsize.setText(self.format_value(self.mag_sld_data.ystepsize))
-            self.txtZstepsize.setText(self.format_value(self.mag_sld_data.zstepsize))
+            self.txtXnodes.setText(GuiUtils.formatValue(self.mag_sld_data.xnodes))
+            self.txtYnodes.setText(GuiUtils.formatValue(self.mag_sld_data.ynodes))
+            self.txtZnodes.setText(GuiUtils.formatValue(self.mag_sld_data.znodes))
+            self.txtXstepsize.setText(GuiUtils.formatValue(self.mag_sld_data.xstepsize))
+            self.txtYstepsize.setText(GuiUtils.formatValue(self.mag_sld_data.ystepsize))
+            self.txtZstepsize.setText(GuiUtils.formatValue(self.mag_sld_data.zstepsize))
         # otherwise leave as set since editable by user
 
         # If nodes or stepsize changed then this may effect what values are allowed

--- a/src/sas/qtgui/Calculators/GenericScatteringCalculator.py
+++ b/src/sas/qtgui/Calculators/GenericScatteringCalculator.py
@@ -1234,8 +1234,7 @@ class GenericScatteringCalculator(QtWidgets.QDialog, Ui_GenericScatteringCalcula
 
             self.graph_num += 1
         else:
-            numpy.nan_to_num(self.data_to_plot)
-            data = Data2D(image=self.data_to_plot,
+            data = Data2D(image=numpy.nan_to_num(self.data_to_plot),
                           qx_data=self.data.qx_data,
                           qy_data=self.data.qy_data,
                           q_data=self.data.q_data,

--- a/src/sas/qtgui/Calculators/GenericScatteringCalculator.py
+++ b/src/sas/qtgui/Calculators/GenericScatteringCalculator.py
@@ -425,7 +425,13 @@ class GenericScatteringCalculator(QtWidgets.QDialog, Ui_GenericScatteringCalcula
         self.txtMx.setEnabled(not self.is_mag)
         self.txtMy.setEnabled(not self.is_mag)
         self.txtMz.setEnabled(not self.is_mag)
+        if not self.is_mag:
+            self.txtMx.setText("0")
+            self.txtMy.setText("0")
+            self.txtMz.setText("0")
         self.txtNucl.setEnabled(not self.is_nuc)
+        if not self.is_nuc:
+            self.txtNucl.setText("0")
         # The ability to change the number of nodes and stepsizes only if no laoded data file enabled
         both_disabled =  (not self.is_mag) and (not self.is_nuc)
         if both_disabled:

--- a/src/sas/qtgui/Calculators/GenericScatteringCalculator.py
+++ b/src/sas/qtgui/Calculators/GenericScatteringCalculator.py
@@ -111,8 +111,8 @@ class GenericScatteringCalculator(QtWidgets.QDialog, Ui_GenericScatteringCalcula
         self.cmdClose.clicked.connect(self.accept)
         self.cmdHelp.clicked.connect(self.onHelp)
 
-        self.cmdNucLoad.clicked.connect(lambda: self.loadFile(load_nuc=True))
-        self.cmdMagLoad.clicked.connect(lambda: self.loadFile(load_nuc=False))
+        self.cmdNucLoad.clicked.connect(self.loadFile)
+        self.cmdMagLoad.clicked.connect(self.loadFile)
         self.cmdCompute.clicked.connect(self.onCompute)
         self.cmdReset.clicked.connect(self.onReset)
         self.cmdSave.clicked.connect(self.onSaveFile)
@@ -464,7 +464,7 @@ class GenericScatteringCalculator(QtWidgets.QDialog, Ui_GenericScatteringCalcula
             self.txtMy.setEnabled(True)
             self.txtMz.setEnabled(True)
 
-    def loadFile(self, load_nuc=True):
+    def loadFile(self):
         """Opens a menu to choose the datafile to load
 
         Opens a file dialog to allow the user to select a datafile to be loaded.
@@ -483,6 +483,7 @@ class GenericScatteringCalculator(QtWidgets.QDialog, Ui_GenericScatteringCalcula
         :type load_nuc: bool
         """
         try:
+            load_nuc = self.sender() == self.cmdNucLoad
             # request a file from the user
             if load_nuc:
                 self.datafile = QtWidgets.QFileDialog.getOpenFileName(

--- a/src/sas/qtgui/Calculators/GenericScatteringCalculator.py
+++ b/src/sas/qtgui/Calculators/GenericScatteringCalculator.py
@@ -48,16 +48,16 @@ class GenericScatteringCalculator(QtWidgets.QDialog, Ui_GenericScatteringCalcula
         self.sld_reader = sas_gen.SLDReader()
         self.pdb_reader = sas_gen.PDBReader()
         self.reader = None
-        #sld data for nuclear and magnetic cases
+        # sld data for nuclear and magnetic cases
         self.nuc_sld_data = None
         self.mag_sld_data = None
-        #verification information to avoid recalculating
-        #verification carried out whenever files are selected/deselected
-        #verification reset whenever a new files loaded
+        # verification information to avoid recalculating
+        # verification carried out whenever files are selected/deselected
+        # verification reset whenever a new files loaded
         self.verification_occurred = False # has verification happened on these files
         self.verified = False # was the verification successsful
         # verification error label
-        #prevent layout shifting when widget hidden (could this be placed i nthe .ui file?)
+        # prevent layout shifting when widget hidden (could this be placed i nthe .ui file?)
         sizePolicy = self.lblVerifyError.sizePolicy()
         sizePolicy.setRetainSizeWhenHidden(True)
         self.lblVerifyError.setSizePolicy(sizePolicy)
@@ -73,28 +73,28 @@ class GenericScatteringCalculator(QtWidgets.QDialog, Ui_GenericScatteringCalcula
         self.is_nuc = False
         self.is_mag = False
         self.data_to_plot = None
-        self.graph_num = 1  # index for name of graph
+        self.graph_num = 1      # index for name of graph
 
         # combox box
         self.cbOptionsCalc.currentIndexChanged.connect(self.change_is_avg)
-        #prevent layout shifting when widget hidden (could this be placed i nthe .ui file?)
+        # prevent layout shifting when widget hidden (could this be placed i nthe .ui file?)
         sizePolicy = self.cbOptionsCalc.sizePolicy()
         sizePolicy.setRetainSizeWhenHidden(True)
         self.cbOptionsCalc.setSizePolicy(sizePolicy)
 
 
-        #code to automatically restore the last valid value if a user leaves a textbox blank (or otherwise in an invalid state)
+        # code to automatically restore the last valid value if a user leaves a textbox blank (or otherwise in an invalid state)
         self.textEdited = False # variable to ensure only programmatic changes are automatically allowed
-        #list of lineEdits to be checked
+        # list of lineEdits to be checked
         self.lineEdits = [self.txtUpFracIn, self.txtUpFracOut, self.txtUpTheta, self.txtUpPhi, self.txtBackground,
                             self.txtScale, self.txtSolventSLD, self.txtTotalVolume, self.txtNoQBins, self.txtQxMax,
                             self.txtMx, self.txtMy, self.txtMz, self.txtNucl, self.txtXnodes, self.txtYnodes,
                             self.txtZnodes, self.txtXstepsize, self.txtYstepsize, self.txtZstepsize]
-        self.last_acceptable_values = {} #dictionary of the last set of valid values
+        self.last_acceptable_values = {}        # dictionary of the last set of valid values
         for lineEdit in self.lineEdits:
             self.last_acceptable_values[lineEdit] = lineEdit.text()
-            lineEdit.textEdited.connect(self.set_text_edited) # when user edits the text - called before textChanged signal
-            lineEdit.textChanged.connect(self.gui_text_changed)#when text is changed
+            lineEdit.textEdited.connect(self.set_text_edited)       # when user edits the text - called before textChanged signal
+            lineEdit.textChanged.connect(self.gui_text_changed)     # when text is changed
             lineEdit.editingFinished.connect(self.gui_text_changed)
             # event filter catches when a widget loses focus - required because editingFinished only
             # catches the user exiting the box if the validation is acceptable, because we want to catch
@@ -112,14 +112,14 @@ class GenericScatteringCalculator(QtWidgets.QDialog, Ui_GenericScatteringCalcula
         self.cmdReset.clicked.connect(self.onReset)
         self.cmdSave.clicked.connect(self.onSaveFile)
 
-        #checkboxes
+        # checkboxes
         self.checkboxNucData.stateChanged.connect(self.change_data_type)
         self.checkboxMagData.stateChanged.connect(self.change_data_type)
 
         self.cmdDraw.clicked.connect(lambda: self.plot3d(has_arrow=True))
         self.cmdDrawpoints.clicked.connect(lambda: self.plot3d(has_arrow=False))
 
-        #update pixel no./total volume when changed in GUI
+        # update pixel no./total volume when changed in GUI
         self.txtXnodes.textChanged.connect(self.update_geometry_effects)
         self.txtYnodes.textChanged.connect(self.update_geometry_effects)
         self.txtZnodes.textChanged.connect(self.update_geometry_effects)
@@ -127,7 +127,7 @@ class GenericScatteringCalculator(QtWidgets.QDialog, Ui_GenericScatteringCalcula
         self.txtYstepsize.textChanged.connect(self.update_geometry_effects)
         self.txtZstepsize.textChanged.connect(self.update_geometry_effects)
 
-        #setup initial configuration
+        # setup initial configuration
         self.checkboxNucData.setEnabled(False)
         self.checkboxMagData.setEnabled(False)
         self.change_data_type()
@@ -179,14 +179,14 @@ class GenericScatteringCalculator(QtWidgets.QDialog, Ui_GenericScatteringCalcula
         validat_regex_q = QtCore.QRegExp('^1000$|^[+]?(\d{1,3}([.]\d+)?)$')
         self.txtQxMax.setValidator(QtGui.QRegExpValidator(validat_regex_q,
                                                           self.txtQxMax))
-        #check for max q cut-off
+        # check for max q cut-off
         self.txtQxMax.textChanged.connect(self.check_value) 
 
         # 2 <= Qbin and nodes integers < 1000
         validat_regex_int = QtCore.QRegExp('^[2-9]|[1-9]\d{1,2}$')        
         self.txtNoQBins.setValidator(QtGui.QRegExpValidator(validat_regex_int,
                                                             self.txtNoQBins))
-        #check for min q resolution
+        # check for min q resolution
         self.txtNoQBins.textChanged.connect(self.check_value) 
 
         self.txtXnodes.setValidator(
@@ -240,13 +240,13 @@ class GenericScatteringCalculator(QtWidgets.QDialog, Ui_GenericScatteringCalcula
                 self.last_acceptable_values[target] = target.text()
             else:
                 target.setText(self.last_acceptable_values[target])
-        #return false so that event is still handled by widget
+        # return false so that event is still handled by widget
         return False
 
     def gui_text_changed(self):
         """update the last valid value stored in a lineEdit if it is updated programmatically
         """
-        #if text changed programatically then update value
+        # if text changed programatically then update value
         if not self.textEdited:
             self.last_acceptable_values[self.sender()] = self.sender().text()
         self.textEdited = False
@@ -279,18 +279,18 @@ class GenericScatteringCalculator(QtWidgets.QDialog, Ui_GenericScatteringCalcula
             changed.
         :type msg: str or None
         """
-        #disable necessary buttons to prevent the attempted merging of incompatible files
+        # disable necessary buttons to prevent the attempted merging of incompatible files
         self.cmdDraw.setEnabled(False)
         self.cmdDrawpoints.setEnabled(False)
         self.cmdSave.setEnabled(False)
         self.cmdCompute.setEnabled(False)
-        #alter the error message if a new message is provided
-        #verification is only carried out once so if msg=None do not set the msg to ""
-        #   but simply don't alter it - this means the message is preserved and re-verification
-        #   is not called when the files have not been changed
+        # alter the error message if a new message is provided
+        # verification is only carried out once so if msg=None do not set the msg to ""
+        # but simply don't alter it - this means the message is preserved and re-verification
+        # s not called when the files have not been changed
         if msg is not None:
             self.lblVerifyError.setText('<font color="#FF0000">' + msg + '</font>')
-        #display the message
+        # display the message
         self.lblVerifyError.setVisible(True)
 
     def enable_verification_error_functionality(self):
@@ -303,12 +303,12 @@ class GenericScatteringCalculator(QtWidgets.QDialog, Ui_GenericScatteringCalcula
         by disable_verification_error_functionality(), i.e. save, draw and compute.
         It also hides the error message from the user.
         """
-        #reenable necessary buttons
+        # reenable necessary buttons
         self.cmdDraw.setEnabled(True)
         self.cmdDrawpoints.setEnabled(True)
         self.cmdSave.setEnabled(True)
         self.cmdCompute.setEnabled(True)
-        #hide error message
+        # hide error message
         self.lblVerifyError.setVisible(False)
 
     def verify_files_match(self):
@@ -323,7 +323,7 @@ class GenericScatteringCalculator(QtWidgets.QDialog, Ui_GenericScatteringCalcula
         files.
         """
         if not (self.is_mag and self.is_nuc):
-            #no conflicts if only 1/0 file(s) loaded - therefore restore functionality
+            # no conflicts if only 1/0 file(s) loaded - therefore restore functionality
             self.enable_verification_error_functionality()
             return
         # check if files already verified
@@ -339,11 +339,12 @@ class GenericScatteringCalculator(QtWidgets.QDialog, Ui_GenericScatteringCalcula
             self.verification_occurred = True
             self.verified = False
             return
-        #check the coords match up 1-to-1
+        # check the coords match up 1-to-1
         nuc_coords = numpy.array(numpy.column_stack((self.nuc_sld_data.pos_x, self.nuc_sld_data.pos_y, self.nuc_sld_data.pos_z)))
         mag_coords = numpy.array(numpy.column_stack((self.mag_sld_data.pos_x, self.mag_sld_data.pos_y, self.mag_sld_data.pos_z)))
-        if numpy.array_equal(nuc_coords, mag_coords): #should this have a floating point tolerance??
-            #arrays are already sorted in the same order, so files match
+        # TODO: should this have a floating point tolerance??
+        if numpy.array_equal(nuc_coords, mag_coords):
+            # arrays are already sorted in the same order, so files match
             self.enable_verification_error_functionality()
             self.verification_occurred = True
             self.verified = True
@@ -353,27 +354,27 @@ class GenericScatteringCalculator(QtWidgets.QDialog, Ui_GenericScatteringCalcula
         mag_sort_order = numpy.lexsort((self.mag_sld_data.pos_z, self.mag_sld_data.pos_y, self.mag_sld_data.pos_x))
         nuc_coords = nuc_coords[nuc_sort_order]
         mag_coords = mag_coords[mag_sort_order]
-        #check if sorted data points are equal
+        # check if sorted data points are equal
         if numpy.array_equal(nuc_coords, mag_coords):
-            #if data points are equal then resort both lists into the same order
-            #is this too time consuming for long lists? logging info?
-            #1) coords
+            # if data points are equal then resort both lists into the same order
+            # is this too time consuming for long lists? logging info?
+            # 1) coords
             self.nuc_sld_data.pos_x, self.nuc_sld_data.pos_y, self.nuc_sld_data.pos_z = numpy.hsplit(nuc_coords, 3)
             self.mag_sld_data.pos_x, self.mag_sld_data.pos_y, self.mag_sld_data.pos_z = numpy.hsplit(mag_coords, 3)
-            #2) other array params that must be in same order as coords
+            # 2) other array params that must be in same order as coords
             params = ["sld_n", "sld_mx", "sld_my", "sld_mz", "vol_pix", "pix_symbol"]
             for item in params:
                 nuc_val = getattr(self.nuc_sld_data, item)
                 if nuc_val is not None:
-                    #data should already be a numpy array, we cast to an ndarray as a check
-                    #very fast if data is already an instance of ndarray as expected becuase function
-                    #returns the array as-is
+                    # data should already be a numpy array, we cast to an ndarray as a check
+                    # very fast if data is already an instance of ndarray as expected becuase function
+                    # returns the array as-is
                     setattr(self.nuc_sld_data, item, numpy.asanyarray(nuc_val)[nuc_sort_order])
                 mag_val = getattr(self.mag_sld_data, item)
                 if nuc_val is not None:
                     setattr(self.mag_sld_data, item, numpy.asanyarray(mag_val)[mag_sort_order])
-            #Do NOT need to edit CONECT data (line_x, line_y, line_z as these lines are given by
-            #absolute positions not references to pos_x, pos_y, pos_z).
+            # Do NOT need to edit CONECT data (line_x, line_y, line_z as these lines are given by
+            # absolute positions not references to pos_x, pos_y, pos_z).
             self.enable_verification_error_functionality()
             self.verification_occurred = True
             self.verified = True
@@ -397,19 +398,19 @@ class GenericScatteringCalculator(QtWidgets.QDialog, Ui_GenericScatteringCalcula
         all points. If no data files are loaded then the node and stepsize textboxes are
         enabled to allow the user to specify a simple rectangular lattice.
         """
-        #update information on which files are enabled
+        # update information on which files are enabled
         self.is_nuc = self.checkboxNucData.isChecked()
         self.is_mag = self.checkboxMagData.isChecked()
-        #enable the corresponding text displays to show this to the user clearly
+        # enable the corresponding text displays to show this to the user clearly
         self.txtNucData.setEnabled(self.is_nuc)
         self.txtMagData.setEnabled(self.is_mag)
-        #only allow editing of mean values if no data file for that vlaue has been loaded
-        #user provided mean values are taken as a constant across all points
+        # only allow editing of mean values if no data file for that vlaue has been loaded
+        # user provided mean values are taken as a constant across all points
         self.txtMx.setEnabled(not self.is_mag)
         self.txtMy.setEnabled(not self.is_mag)
         self.txtMz.setEnabled(not self.is_mag)
         self.txtNucl.setEnabled(not self.is_nuc)
-        #The ability to change the number of nodes and stepsizes only if no laoded data file enabled
+        # The ability to change the number of nodes and stepsizes only if no laoded data file enabled
         both_disabled =  (not self.is_mag) and (not self.is_nuc)
         self.txtXnodes.setEnabled(both_disabled)
         self.txtYnodes.setEnabled(both_disabled)
@@ -417,13 +418,13 @@ class GenericScatteringCalculator(QtWidgets.QDialog, Ui_GenericScatteringCalcula
         self.txtXstepsize.setEnabled(both_disabled)
         self.txtYstepsize.setEnabled(both_disabled)
         self.txtZstepsize.setEnabled(both_disabled)
-        #Only allow 1D averaging if no magnetic data
+        # Only allow 1D averaging if no magnetic data
         self.cbOptionsCalc.setVisible(not self.is_mag)
         if (not self.is_mag):
-            #A helper function to set up the averaging system
+            # A helper function to set up the averaging system
             self.change_is_avg()
         else:
-            #If magnetic data present then no averaging is allowed
+            # If magnetic data present then no averaging is allowed
             self.is_avg = False
         # update the gui with new values - sets the average values from enabled files
         self.update_gui()
@@ -440,11 +441,11 @@ class GenericScatteringCalculator(QtWidgets.QDialog, Ui_GenericScatteringCalcula
         This function is called whenever different files are enabled or the user edits the
         averaging combobox.
         """
-        #update the averaging option fromthe button on the GUI
-        #required as the button may have been previously hidden with
-        #any value, and preserves this - we must update the variable to match the GUI
+        # update the averaging option fromthe button on the GUI
+        # required as the button may have been previously hidden with
+        # any value, and preserves this - we must update the variable to match the GUI
         self.is_avg = (self.cbOptionsCalc.currentIndex() == 1)
-        #If averaging then set to 0 and diable the magnetic SLD textboxes
+        # If averaging then set to 0 and diable the magnetic SLD textboxes
         if self.is_avg:
             self.txtMx.setEnabled(False)
             self.txtMy.setEnabled(False)
@@ -452,7 +453,7 @@ class GenericScatteringCalculator(QtWidgets.QDialog, Ui_GenericScatteringCalcula
             self.txtMx.setText("0")
             self.txtMy.setText("0")
             self.txtMz.setText("0")
-        #If not averaging then re-enable the magnetic sld textboxes
+        # If not averaging then re-enable the magnetic sld textboxes
         else:
             self.txtMx.setEnabled(True)
             self.txtMy.setEnabled(True)
@@ -477,7 +478,7 @@ class GenericScatteringCalculator(QtWidgets.QDialog, Ui_GenericScatteringCalcula
         :type load_nuc: bool
         """
         try:
-            #request a file from the user
+            # request a file from the user
             if load_nuc:
                 self.datafile = QtWidgets.QFileDialog.getOpenFileName(
                     self, "Choose a file", "","All supported files (*.SLD *.sld *.pdb *.PDB);;"
@@ -492,18 +493,18 @@ class GenericScatteringCalculator(QtWidgets.QDialog, Ui_GenericScatteringCalcula
                                             "All files (*.*)")[0]
             # If a file has been sucessfully chosen
             if self.datafile:
-                #set basic data about the file
+                # set basic data about the file
                 self.default_shape = str(self.cbShape.currentText())
                 self.file_name = os.path.basename(str(self.datafile))
                 self.ext = os.path.splitext(str(self.datafile))[1]
-                #select the required loader for the data format
+                # select the required loader for the data format
                 if self.ext in self.omf_reader.ext and (not load_nuc):
-                    #only load omf files for magnetic data
+                    # only load omf files for magnetic data
                     loader = self.omf_reader
                 elif self.ext in self.sld_reader.ext:
                     loader = self.sld_reader
                 elif self.ext in self.pdb_reader.ext and load_nuc:
-                    #only load pdb files for nuclear data
+                    # only load pdb files for nuclear data
                     loader = self.pdb_reader
                 else:
                     loader = None
@@ -587,7 +588,7 @@ class GenericScatteringCalculator(QtWidgets.QDialog, Ui_GenericScatteringCalcula
             if self.ext in self.omf_reader.ext:
                 gen = sas_gen.OMF2SLD()
                 gen.set_data(data)
-                #only magnetic data can be read from omf files
+                # only magnetic data can be read from omf files
                 self.mag_sld_data = gen.get_magsld()
                 self.check_units()
             elif self.ext in self.sld_reader.ext:
@@ -596,7 +597,7 @@ class GenericScatteringCalculator(QtWidgets.QDialog, Ui_GenericScatteringCalcula
                 else:
                     self.mag_sld_data = data
             elif self.ext in self.pdb_reader.ext:
-                #only nuclear data can be read from pdb files
+                # only nuclear data can be read from pdb files
                 self.nuc_sld_data = data
                 is_pdbdata = True
         except IOError:
@@ -609,7 +610,7 @@ class GenericScatteringCalculator(QtWidgets.QDialog, Ui_GenericScatteringCalcula
             logging.info(log_msg)
             raise
         logging.info("Load Complete")
-        #Once data files are loaded allow them to be enabled
+        # Once data files are loaded allow them to be enabled
         if load_nuc:
             self.checkboxNucData.setEnabled(True)
         else:
@@ -628,7 +629,7 @@ class GenericScatteringCalculator(QtWidgets.QDialog, Ui_GenericScatteringCalcula
         displayed on the interface.
         If not, modify the GUI with the correct unit
         """
-        #  TODO: adopt the convention of font and symbol for the updated values
+        # TODO: adopt the convention of font and symbol for the updated values
         if sas_gen.OMFData().valueunit != 'A^(-2)':
             value_unit = sas_gen.OMFData().valueunit
             self.lbl_unitMx.setText(value_unit)
@@ -678,7 +679,7 @@ class GenericScatteringCalculator(QtWidgets.QDialog, Ui_GenericScatteringCalcula
             znodes = float(self.txtZnodes.text())
             value = float(str(self.txtNoQBins.text()))
             max_step =  3*max(xnodes, ynodes, znodes) 
-                #limits qmin > maxq / nodes                 
+                # limits qmin > maxq / nodes                 
             if value < 2 or value > max_step:
                 self.txtNoQBins.setStyleSheet('background-color: rgb(255, 182, 193);')
             else:
@@ -739,7 +740,7 @@ class GenericScatteringCalculator(QtWidgets.QDialog, Ui_GenericScatteringCalcula
         self.txtUpTheta.setText(str(self.model.params['Up_theta']))
         self.txtUpPhi.setText(str(self.model.params['Up_phi']))
 
-        #update the number of pixels with values from the loaded data or GUI if no datafiles enabled
+        # update the number of pixels with values from the loaded data or GUI if no datafiles enabled
         if self.is_nuc:
             self.txtNoPixels.setText(str(len(self.nuc_sld_data.sld_n)))
         elif self.is_mag:
@@ -771,9 +772,9 @@ class GenericScatteringCalculator(QtWidgets.QDialog, Ui_GenericScatteringCalcula
             self.txtXstepsize.setText(self.format_value(self.mag_sld_data.xstepsize))
             self.txtYstepsize.setText(self.format_value(self.mag_sld_data.ystepsize))
             self.txtZstepsize.setText(self.format_value(self.mag_sld_data.zstepsize))
-        #otherwise leave as set since editable by user
+        # otherwise leave as set since editable by user
 
-        #If nodes or stepsize changed then this may effect what values are allowed
+        # If nodes or stepsize changed then this may effect what values are allowed
         self.check_value(update_all=True)
     
     def update_geometry_effects(self):
@@ -783,23 +784,23 @@ class GenericScatteringCalculator(QtWidgets.QDialog, Ui_GenericScatteringCalcula
         volume may be set differently by the data from the file.
         """
         if self.is_mag or self.is_nuc:
-            #don't change the number if this is being set from a file as then the number of pixels may differ
+            # don't change the number if this is being set from a file as then the number of pixels may differ
             return
         if self.txtXnodes.text() == "" or self.txtYnodes.text() == "" or self.txtZnodes.text() == "":
-            #do not try to update if textbox blank - this will throw an error in update_gui() anyway if left blank
-            #user is most likely just removing the value to change it
+            # do not try to update if textbox blank - this will throw an error in update_gui() anyway if left blank
+            # user is most likely just removing the value to change it
             return
         self.txtNoPixels.setText(str(int(float(self.txtXnodes.text())
                                          * float(self.txtYnodes.text()) * float(self.txtZnodes.text()))))
         if self.txtXstepsize.text() == "" or self.txtYstepsize.text() == "" or self.txtZstepsize.text() == "":
-            #do not try to update if textbox blank - this will throw an error in update_gui() anyway if left blank
-            #user is most likely just removing the value to change it
+            # do not try to update if textbox blank - this will throw an error in update_gui() anyway if left blank
+            # user is most likely just removing the value to change it
             return
         self.model.params['total_volume'] = (float(self.txtXstepsize.text()) * float(self.txtYstepsize.text())
                                                  * float(self.txtZstepsize.text()) * float(self.txtXnodes.text())
                                                  * float(self.txtYnodes.text()) * float(self.txtZnodes.text()))
         self.txtTotalVolume.setText(str(self.model.params['total_volume']))
-        #If nodes or stepsize changed then this may effect what values are allowed
+        # If nodes or stepsize changed then this may effect what values are allowed
         self.check_value(update_all=True)
 
     def write_new_values_from_gui(self):
@@ -877,7 +878,7 @@ class GenericScatteringCalculator(QtWidgets.QDialog, Ui_GenericScatteringCalcula
             self.txtXstepsize.setText("6")
             self.txtYstepsize.setText("6")
             self.txtZstepsize.setText("6")
-            #re-enable any options disabled by failed verification
+            # re-enable any options disabled by failed verification
             self.verification_occurred = False
             self.verified = False
             self.enable_verification_error_functionality()
@@ -896,17 +897,17 @@ class GenericScatteringCalculator(QtWidgets.QDialog, Ui_GenericScatteringCalcula
             self.txtMagData.setText('No File Loaded')
             self.cmdMagLoad.setEnabled(True)
             self.cmdMagLoad.setText('Load')
-            #disable all file checkboxes, as no files are now loaded
+            # disable all file checkboxes, as no files are now loaded
             self.checkboxNucData.setEnabled(False)
             self.checkboxMagData.setEnabled(False)
             self.checkboxNucData.setChecked(False)
             self.checkboxMagData.setChecked(False)
-            #reset all file data to its default empty state
+            # reset all file data to its default empty state
             self.is_nuc = False
             self.is_mag = False
             self.nuc_sld_data = None
             self.mag_sld_data = None
-            #update the gui for the no files loaded case
+            # update the gui for the no files loaded case
             self.change_data_type()
 
 
@@ -925,7 +926,7 @@ class GenericScatteringCalculator(QtWidgets.QDialog, Ui_GenericScatteringCalcula
         self.npts_x = int(self.txtNoQBins.text())
         self.data = Data2D()
         self.data.is_data = False
-        # # Default values
+        # Default values
         self.data.detector.append(Detector())
         index = len(self.data.detector) - 1
         self.data.detector[index].distance = 8000  # mm
@@ -1000,7 +1001,7 @@ class GenericScatteringCalculator(QtWidgets.QDialog, Ui_GenericScatteringCalcula
         """
         self.qmax_x = float(self.txtQxMax.text())
         self.npts_x = int(self.txtNoQBins.text())
-        #  Default values
+        # Default values
         xmax = self.qmax_x
         xmin = self.qmax_x * _Q1D_MIN
         qstep = self.npts_x
@@ -1026,11 +1027,11 @@ class GenericScatteringCalculator(QtWidgets.QDialog, Ui_GenericScatteringCalcula
         :return: The full sld data created from the various different sources
         :rtype: MagSLD
         """
-        #CARRY OUT COMPATIBILITY CHECK - ELSE RETURN None
+        # CARRY OUT COMPATIBILITY CHECK - ELSE RETURN None
         # Set default data when nothing loaded yet
         omfdata = sas_gen.OMFData()
-        #load in user chosen position data
-        #If no file given this will be used to generate the position data
+        # load in user chosen position data
+        # If no file given this will be used to generate the position data
         if (not self.is_mag) and (not self.is_nuc):
             omfdata.xnodes = int(self.txtXnodes.text())
             omfdata.ynodes = int(self.txtYnodes.text())
@@ -1038,13 +1039,13 @@ class GenericScatteringCalculator(QtWidgets.QDialog, Ui_GenericScatteringCalcula
             omfdata.xstepsize = float(self.txtXstepsize.text())
             omfdata.ystepsize = float(self.txtYstepsize.text())
             omfdata.zstepsize = float(self.txtZstepsize.text())
-        #convert into sld format
+        # convert into sld format
         omf2sld = sas_gen.OMF2SLD()
         omf2sld.set_data(omfdata, self.default_shape)
         sld_data = omf2sld.get_output()
 
-        #only to be done once - load in the position data of the atoms
-        #verification ensures that this is the same across nuclear and magnetic datafiles
+        # only to be done once - load in the position data of the atoms
+        # verification ensures that this is the same across nuclear and magnetic datafiles
         if self.is_nuc:
             sld_data.vol_pix = self.nuc_sld_data.vol_pix
             sld_data.pos_x = self.nuc_sld_data.pos_x
@@ -1056,7 +1057,7 @@ class GenericScatteringCalculator(QtWidgets.QDialog, Ui_GenericScatteringCalcula
             sld_data.pos_y = self.mag_sld_data.pos_y
             sld_data.pos_z = self.mag_sld_data.pos_z
 
-        #set the sld data from the required model file/GUI textbox
+        # set the sld data from the required model file/GUI textbox
         if (self.is_nuc):
             sld_data.set_sldn(self.nuc_sld_data.sld_n)
         else:
@@ -1067,10 +1068,10 @@ class GenericScatteringCalculator(QtWidgets.QDialog, Ui_GenericScatteringCalcula
             sld_data.set_sldms(float(self.txtMx.text()),
                                float(self.txtMy.text()),
                                float(self.txtMz.text()))
-        #Provide data giving connections between atoms for 3D drawing
-        #This SHOULD only occur in nuclear data files as it is a feature of
-        #pdb files - however the option for it to be drawn from magnetic files
-        #if present is given in case the sld file format is expanded to include them
+        # Provide data giving connections between atoms for 3D drawing
+        # This SHOULD only occur in nuclear data files as it is a feature of
+        # pdb files - however the option for it to be drawn from magnetic files
+        # if present is given in case the sld file format is expanded to include them
         if self.is_nuc:
             if self.nuc_sld_data.has_conect:
                 sld_data.has_conect=True
@@ -1084,7 +1085,7 @@ class GenericScatteringCalculator(QtWidgets.QDialog, Ui_GenericScatteringCalcula
                     sld_data.line_y = self.mag_sld_data.line_y
                     sld_data.line_z = self.mag_sld_data.line_z
         
-        #take pixel data from nuclear sld as preference because may contatin atom types from pdb files
+        # take pixel data from nuclear sld as preference because may contatin atom types from pdb files
         if self.is_nuc:
             sld_data.pix_type = self.nuc_sld_data.pix_type
             sld_data.pix_symbol = self.nuc_sld_data.pix_symbol
@@ -1100,11 +1101,11 @@ class GenericScatteringCalculator(QtWidgets.QDialog, Ui_GenericScatteringCalcula
         Copied from previous version
         """
         try:
-            #create the combined sld data and update from gui
+            # create the combined sld data and update from gui
             sld_data = self.create_full_sld_data()
             self.model.set_sld_data(sld_data)
             self.write_new_values_from_gui()
-            #create 2D or 1D data as appropriate
+            # create 2D or 1D data as appropriate
             if self.is_avg or self.is_avg is None:
                 self._create_default_1d_data()
                 inputs = [self.data.x, []]
@@ -1116,7 +1117,7 @@ class GenericScatteringCalculator(QtWidgets.QDialog, Ui_GenericScatteringCalcula
             self.cmdCompute.setEnabled(False)
             d = threads.deferToThread(self.complete, inputs, self._update)
             # Add deferred callback for call return
-            #d.addCallback(self.plot_1_2d)
+            # d.addCallback(self.plot_1_2d)
             d.addCallback(self.calculateComplete)
             d.addErrback(self.calculateFailed)
         except Exception:
@@ -1158,7 +1159,7 @@ class GenericScatteringCalculator(QtWidgets.QDialog, Ui_GenericScatteringCalcula
         :type input: list
         """
         timer = timeit.default_timer
-        update_rate = 1.0 # seconds between updates
+        update_rate = 1.0       # seconds between updates
         next_update = timer() + update_rate if update is not None else numpy.inf
         nq = len(input[0])
         chunk_size = 32 if self.is_avg else 256
@@ -1281,7 +1282,7 @@ class Plotter3DWidget(PlotterBase):
         if not data:
             return
         self.data = data
-        #assert(self._data)
+        # assert(self._data)
         # Prepare and show the plot
         self.showPlot(data=self.data, has_arrow=has_arrow)
 

--- a/src/sas/qtgui/Calculators/GenericScatteringCalculator.py
+++ b/src/sas/qtgui/Calculators/GenericScatteringCalculator.py
@@ -700,12 +700,17 @@ class GenericScatteringCalculator(QtWidgets.QDialog, Ui_GenericScatteringCalcula
 
         # Volume to write to interface: npts x volume of first pixel
         self.txtTotalVolume.setText(str(self.model.params['total_volume']))
+        # Chagne capitalisation for consistency with other values
+        if self.txtTotalVolume.text() == "nan":
+            self.txtTotalVolume.setText("NaN")
 
         # update the number of pixels with values from the loaded data or GUI if no datafiles enabled
         if self.is_nuc:
             self.txtNoPixels.setText(str(len(self.nuc_sld_data.sld_n)))
         elif self.is_mag:
             self.txtNoPixels.setText(str(len(self.mag_sld_data.sld_mx)))
+        elif not(self.txtXnodes.hasAcceptableInput() and self.txtYnodes.hasAcceptableInput() and self.txtZnodes.hasAcceptableInput()):
+            self.txtNoPixels.setText("NaN")
         else:
             self.txtNoPixels.setText(str(int(float(self.txtXnodes.text())
                                          * float(self.txtYnodes.text()) * float(self.txtZnodes.text()))))
@@ -747,15 +752,16 @@ class GenericScatteringCalculator(QtWidgets.QDialog, Ui_GenericScatteringCalcula
         if self.is_mag or self.is_nuc:
             # don't change the number if this is being set from a file as then the number of pixels may differ
             return
-        if self.txtXnodes.text() == "" or self.txtYnodes.text() == "" or self.txtZnodes.text() == "":
-            # do not try to update if textbox blank - this will throw an error in update_gui() anyway if left blank
-            # user is most likely just removing the value to change it
+        if not(self.txtXnodes.hasAcceptableInput() and self.txtYnodes.hasAcceptableInput() and self.txtZnodes.hasAcceptableInput()):
+            # do not try to update if textbox invalid - this cannot be used for computation anyway
+            self.txtNoPixels.setText("NaN")
+            self.txtTotalVolume.setText("NaN")
             return
         self.txtNoPixels.setText(str(int(float(self.txtXnodes.text())
                                          * float(self.txtYnodes.text()) * float(self.txtZnodes.text()))))
-        if self.txtXstepsize.text() == "" or self.txtYstepsize.text() == "" or self.txtZstepsize.text() == "":
-            # do not try to update if textbox blank - this will throw an error in update_gui() anyway if left blank
-            # user is most likely just removing the value to change it
+        if not(self.txtXstepsize.hasAcceptableInput() and self.txtYstepsize.hasAcceptableInput() and self.txtZstepsize.hasAcceptableInput()):
+            # do not try to update if textbox invalid - this cannot be used for computation anyway
+            self.txtTotalVolume.setText("NaN")
             return
         self.model.params['total_volume'] = (float(self.txtXstepsize.text()) * float(self.txtYstepsize.text())
                                                  * float(self.txtZstepsize.text()) * float(self.txtXnodes.text())

--- a/src/sas/qtgui/Calculators/GenericScatteringCalculator.py
+++ b/src/sas/qtgui/Calculators/GenericScatteringCalculator.py
@@ -600,28 +600,32 @@ class GenericScatteringCalculator(QtWidgets.QDialog, Ui_GenericScatteringCalcula
         """
 
         text_edit = self.sender()
-        sld_data = self.create_full_sld_data()
         if update_all:
             self.txtQxMax.setStyleSheet('background-color: rgb(255, 255, 255);')
             self.txtNoQBins.setStyleSheet('background-color: rgb(255, 255, 255);')
         else:
             text_edit.setStyleSheet('background-color: rgb(255, 255, 255);')
-        if (sld_data != None):
-            if (text_edit == self.txtQxMax or update_all) and self.txtQxMax.text():
-                value = float(str(self.txtQxMax.text()))
-                max_q = numpy.pi / (max(sld_data.xstepsize, sld_data.ystepsize, sld_data.zstepsize) )                   
-                if value <= 0 or value > max_q:
-                    self.txtQxMax.setStyleSheet('background-color: rgb(255, 182, 193);')
-                else:
-                    self.txtQxMax.setStyleSheet('background-color: rgb(255, 255, 255);')
-            if (text_edit == self.txtNoQBins or update_all) and self.txtNoQBins.text():
-                value = float(str(self.txtNoQBins.text()))
-                max_step =  3*max(sld_data.xnodes, sld_data.ynodes, sld_data.znodes) 
-                    #limits qmin > maxq / nodes                 
-                if value < 2 or value > max_step:
-                    self.txtNoQBins.setStyleSheet('background-color: rgb(255, 182, 193);')
-                else:
-                    self.txtNoQBins.setStyleSheet('background-color: rgb(255, 255, 255);')
+        if (text_edit == self.txtQxMax or update_all) and self.txtQxMax.text():
+            xstepsize = float(self.txtXstepsize.text())
+            ystepsize = float(self.txtYstepsize.text())
+            zstepsize = float(self.txtZstepsize.text())
+            value = float(str(self.txtQxMax.text()))
+            max_q = numpy.pi / (max(xstepsize, ystepsize, zstepsize))                   
+            if value <= 0 or value > max_q:
+                self.txtQxMax.setStyleSheet('background-color: rgb(255, 182, 193);')
+            else:
+                self.txtQxMax.setStyleSheet('background-color: rgb(255, 255, 255);')
+        if (text_edit == self.txtNoQBins or update_all) and self.txtNoQBins.text():
+            xnodes = int(self.txtXnodes.text())
+            ynodes = int(self.txtYnodes.text())
+            znodes = int(self.txtZnodes.text())
+            value = float(str(self.txtNoQBins.text()))
+            max_step =  3*max(xnodes, ynodes, znodes) 
+                #limits qmin > maxq / nodes                 
+            if value < 2 or value > max_step:
+                self.txtNoQBins.setStyleSheet('background-color: rgb(255, 182, 193);')
+            else:
+                self.txtNoQBins.setStyleSheet('background-color: rgb(255, 255, 255);')
 
     def format_value(self, value):
         """Formats certain data for the GUI.
@@ -970,13 +974,13 @@ class GenericScatteringCalculator(QtWidgets.QDialog, Ui_GenericScatteringCalcula
         omfdata = sas_gen.OMFData()
         #load in user chosen position data
         #If no file given this will be used to generate the position data
-        #Otherwise it is still used as part of the verification process in check_value()
-        omfdata.xnodes = int(self.txtXnodes.text())
-        omfdata.ynodes = int(self.txtYnodes.text())
-        omfdata.znodes = int(self.txtZnodes.text())
-        omfdata.xstepsize = float(self.txtXstepsize.text())
-        omfdata.ystepsize = float(self.txtYstepsize.text())
-        omfdata.zstepsize = float(self.txtZstepsize.text())
+        if (not self.is_mag) and (not self.is_nuc):
+            omfdata.xnodes = int(self.txtXnodes.text())
+            omfdata.ynodes = int(self.txtYnodes.text())
+            omfdata.znodes = int(self.txtZnodes.text())
+            omfdata.xstepsize = float(self.txtXstepsize.text())
+            omfdata.ystepsize = float(self.txtYstepsize.text())
+            omfdata.zstepsize = float(self.txtZstepsize.text())
         #convert into sld format
         omf2sld = sas_gen.OMF2SLD()
         omf2sld.set_data(omfdata, self.default_shape)

--- a/src/sas/qtgui/Calculators/GenericScatteringCalculator.py
+++ b/src/sas/qtgui/Calculators/GenericScatteringCalculator.py
@@ -607,7 +607,6 @@ class GenericScatteringCalculator(QtWidgets.QDialog, Ui_GenericScatteringCalcula
         else:
             text_edit.setStyleSheet('background-color: rgb(255, 255, 255);')
         if (sld_data != None):
-            print(bool(self.txtQxMax.text()))
             if (text_edit == self.txtQxMax or update_all) and self.txtQxMax.text():
                 value = float(str(self.txtQxMax.text()))
                 max_q = numpy.pi / (max(sld_data.xstepsize, sld_data.ystepsize, sld_data.zstepsize) )                   

--- a/src/sas/qtgui/Calculators/GenericScatteringCalculator.py
+++ b/src/sas/qtgui/Calculators/GenericScatteringCalculator.py
@@ -64,7 +64,6 @@ class GenericScatteringCalculator(QtWidgets.QDialog, Ui_GenericScatteringCalcula
         self.graph_num = 1  # index for name of graph
 
         # combox box
-        self.cbOptionsCalc.setVisible(False)
         self.cbOptionsCalc.currentIndexChanged.connect(self.change_is_avg)
 
         # push buttons
@@ -542,19 +541,31 @@ class GenericScatteringCalculator(QtWidgets.QDialog, Ui_GenericScatteringCalcula
             self.txtXstepsize.setText("6")
             self.txtYstepsize.setText("6")
             self.txtZstepsize.setText("6")
-            # reset Load button and textedit
-            self.txtData.setText('Default SLD Profile')
-            self.cmdLoad.setEnabled(True)
-            self.cmdLoad.setText('Load')
             # reset option for calculation
             self.cbOptionsCalc.setCurrentIndex(0)
-            self.cbOptionsCalc.setVisible(False)
             # reset shape button
             self.cbShape.setCurrentIndex(0)
             self.cbShape.setEnabled(True)
             # reset compute button
             self.cmdCompute.setText('Compute')
             self.cmdCompute.setEnabled(True)
+            # reset Load button and textedit
+            self.txtNucData.setText('No File Loaded')
+            self.cmdNucLoad.setEnabled(True)
+            self.cmdNucLoad.setText('Load')
+            self.txtMagData.setText('No File Loaded')
+            self.cmdMagLoad.setEnabled(True)
+            self.cmdMagLoad.setText('Load')
+            self.checkboxNucData.setEnabled(False)
+            self.checkboxMagData.setEnabled(False)
+            self.checkboxNucData.setChecked(False)
+            self.checkboxMagData.setChecked(False)
+            self.is_nuc = False
+            self.is_mag = False
+            self.nuc_sld_data = None
+            self.mag_sld_data = None
+            self.change_data_type()
+
 
         finally:
             pass
@@ -659,8 +670,6 @@ class GenericScatteringCalculator(QtWidgets.QDialog, Ui_GenericScatteringCalcula
         the required data for sas_gen and 3D plotting.
 
         It uses the current setup of the interface 
-
-        :returns: MagSLD
         """
         #CARRY OUT COMPATIBILITY CHECK - ELSE RETURN None
         # Set default data when nothing loaded yet
@@ -822,8 +831,7 @@ class GenericScatteringCalculator(QtWidgets.QDialog, Ui_GenericScatteringCalcula
                 _, extension = os.path.splitext(filename)
                 if not extension:
                     filename = '.'.join((filename, 'sld'))
-                sld_data = self.create_full_sld_data()
-                sas_gen.SLDReader().write(filename, sld_data)
+                sas_gen.SLDReader().write(filename, self.sld_data)
             except Exception:
                 raise
 

--- a/src/sas/qtgui/Calculators/GenericScatteringCalculator.py
+++ b/src/sas/qtgui/Calculators/GenericScatteringCalculator.py
@@ -124,6 +124,11 @@ class GenericScatteringCalculator(QtWidgets.QDialog, Ui_GenericScatteringCalcula
         self.txtYstepsize.textChanged.connect(self.update_geometry_effects)
         self.txtZstepsize.textChanged.connect(self.update_geometry_effects)
 
+        #check for presence of magnetism
+        self.txtMx.textChanged.connect(self.check_for_magnetic_controls)
+        self.txtMy.textChanged.connect(self.check_for_magnetic_controls)
+        self.txtMz.textChanged.connect(self.check_for_magnetic_controls)
+
         # setup initial configuration
         self.checkboxNucData.setEnabled(False)
         self.checkboxMagData.setEnabled(False)
@@ -439,6 +444,7 @@ class GenericScatteringCalculator(QtWidgets.QDialog, Ui_GenericScatteringCalcula
             self.is_avg = False
         # update the gui with new values - sets the average values from enabled files
         self.update_gui()
+        self.check_for_magnetic_controls()
         # verify that the new enabled files are compatible
         self.verify_files_match()
         
@@ -469,6 +475,19 @@ class GenericScatteringCalculator(QtWidgets.QDialog, Ui_GenericScatteringCalcula
             self.txtMx.setEnabled(True)
             self.txtMy.setEnabled(True)
             self.txtMz.setEnabled(True)
+    
+    def check_for_magnetic_controls(self):
+        if self.txtMx.hasAcceptableInput() and self.txtMy.hasAcceptableInput() and self.txtMz.hasAcceptableInput():
+            if (not self.is_mag) and float(self.txtMx.text()) == 0 and float(self.txtMy.text()) == 0 and float(self.txtMy.text()) == 0:
+                self.txtUpFracIn.setEnabled(False)
+                self.txtUpFracOut.setEnabled(False)
+                self.txtUpTheta.setEnabled(False)
+                self.txtUpPhi.setEnabled(False)
+                return
+        self.txtUpFracIn.setEnabled(True)
+        self.txtUpFracOut.setEnabled(True)
+        self.txtUpTheta.setEnabled(True)
+        self.txtUpPhi.setEnabled(True)
 
     def loadFile(self):
         """Opens a menu to choose the datafile to load

--- a/src/sas/qtgui/Calculators/GenericScatteringCalculator.py
+++ b/src/sas/qtgui/Calculators/GenericScatteringCalculator.py
@@ -671,9 +671,9 @@ class GenericScatteringCalculator(QtWidgets.QDialog, Ui_GenericScatteringCalcula
             else:
                 self.txtQxMax.setStyleSheet('background-color: rgb(255, 255, 255);')
         if (text_edit == self.txtNoQBins or update_all) and self.txtNoQBins.text():
-            xnodes = int(self.txtXnodes.text())
-            ynodes = int(self.txtYnodes.text())
-            znodes = int(self.txtZnodes.text())
+            xnodes = float(self.txtXnodes.text())
+            ynodes = float(self.txtYnodes.text())
+            znodes = float(self.txtZnodes.text())
             value = float(str(self.txtNoQBins.text()))
             max_step =  3*max(xnodes, ynodes, znodes) 
                 #limits qmin > maxq / nodes                 

--- a/src/sas/qtgui/Calculators/GenericScatteringCalculator.py
+++ b/src/sas/qtgui/Calculators/GenericScatteringCalculator.py
@@ -831,7 +831,8 @@ class GenericScatteringCalculator(QtWidgets.QDialog, Ui_GenericScatteringCalcula
                 _, extension = os.path.splitext(filename)
                 if not extension:
                     filename = '.'.join((filename, 'sld'))
-                sas_gen.SLDReader().write(filename, self.sld_data)
+                sld_data = self.create_full_sld_data()
+                sas_gen.SLDReader().write(filename, sld_data)
             except Exception:
                 raise
 

--- a/src/sas/qtgui/Calculators/GenericScatteringCalculator.py
+++ b/src/sas/qtgui/Calculators/GenericScatteringCalculator.py
@@ -659,6 +659,8 @@ class GenericScatteringCalculator(QtWidgets.QDialog, Ui_GenericScatteringCalcula
         the required data for sas_gen and 3D plotting.
 
         It uses the current setup of the interface 
+
+        :returns: MagSLD
         """
         #CARRY OUT COMPATIBILITY CHECK - ELSE RETURN None
         # Set default data when nothing loaded yet
@@ -820,7 +822,8 @@ class GenericScatteringCalculator(QtWidgets.QDialog, Ui_GenericScatteringCalcula
                 _, extension = os.path.splitext(filename)
                 if not extension:
                     filename = '.'.join((filename, 'sld'))
-                sas_gen.SLDReader().write(filename, self.sld_data)
+                sld_data = self.create_full_sld_data()
+                sas_gen.SLDReader().write(filename, sld_data)
             except Exception:
                 raise
 

--- a/src/sas/qtgui/Calculators/GenericScatteringCalculator.py
+++ b/src/sas/qtgui/Calculators/GenericScatteringCalculator.py
@@ -78,7 +78,8 @@ class GenericScatteringCalculator(QtWidgets.QDialog, Ui_GenericScatteringCalcula
 
         # combox box
         self.cbOptionsCalc.currentIndexChanged.connect(self.change_is_avg)
-        # prevent layout shifting when widget hidden (could this be placed i nthe .ui file?)
+        # prevent layout shifting when widget hidden
+        # TODO: Is there a way to lcoate this policy in the ui file?
         sizePolicy = self.cbOptionsCalc.sizePolicy()
         sizePolicy.setRetainSizeWhenHidden(True)
         self.cbOptionsCalc.setSizePolicy(sizePolicy)

--- a/src/sas/qtgui/Calculators/GenericScatteringCalculator.py
+++ b/src/sas/qtgui/Calculators/GenericScatteringCalculator.py
@@ -35,6 +35,9 @@ class GenericScatteringCalculator(QtWidgets.QDialog, Ui_GenericScatteringCalcula
     calculationFinishedSignal = QtCore.pyqtSignal()
     loadingFinishedSignal = QtCore.pyqtSignal(list, bool)
 
+    TEXTBOX_DEFAULT_STYLESTRING = 'background-color: rgb(255, 255, 255);'
+    TEXTBOX_ERROR_STYLESTRING = 'background-color: rgb(255, 182, 193);'
+
     def __init__(self, parent=None):
         super(GenericScatteringCalculator, self).__init__()
         self.setupUi(self)
@@ -661,10 +664,10 @@ class GenericScatteringCalculator(QtWidgets.QDialog, Ui_GenericScatteringCalcula
 
         text_edit = self.sender()
         if update_all:
-            self.txtQxMax.setStyleSheet('background-color: rgb(255, 255, 255);')
-            self.txtNoQBins.setStyleSheet('background-color: rgb(255, 255, 255);')
+            self.txtQxMax.setStyleSheet(self.TEXTBOX_DEFAULT_STYLESTRING)
+            self.txtNoQBins.setStyleSheet(self.TEXTBOX_DEFAULT_STYLESTRING)
         else:
-            text_edit.setStyleSheet('background-color: rgb(255, 255, 255);')
+            text_edit.setStyleSheet(self.TEXTBOX_DEFAULT_STYLESTRING)
         if (text_edit == self.txtQxMax or update_all) and self.txtQxMax.text():
             xstepsize = float(self.txtXstepsize.text())
             ystepsize = float(self.txtYstepsize.text())
@@ -672,9 +675,9 @@ class GenericScatteringCalculator(QtWidgets.QDialog, Ui_GenericScatteringCalcula
             value = float(str(self.txtQxMax.text()))
             max_q = numpy.pi / (max(xstepsize, ystepsize, zstepsize))                   
             if value <= 0 or value > max_q:
-                self.txtQxMax.setStyleSheet('background-color: rgb(255, 182, 193);')
+                self.txtQxMax.setStyleSheet(self.TEXTBOX_ERROR_STYLESTRING)
             else:
-                self.txtQxMax.setStyleSheet('background-color: rgb(255, 255, 255);')
+                self.txtQxMax.setStyleSheet(self.TEXTBOX_DEFAULT_STYLESTRING)
         if (text_edit == self.txtNoQBins or update_all) and self.txtNoQBins.text():
             xnodes = float(self.txtXnodes.text())
             ynodes = float(self.txtYnodes.text())
@@ -683,9 +686,9 @@ class GenericScatteringCalculator(QtWidgets.QDialog, Ui_GenericScatteringCalcula
             max_step =  3*max(xnodes, ynodes, znodes) 
                 # limits qmin > maxq / nodes                 
             if value < 2 or value > max_step:
-                self.txtNoQBins.setStyleSheet('background-color: rgb(255, 182, 193);')
+                self.txtNoQBins.setStyleSheet(self.TEXTBOX_ERROR_STYLESTRING)
             else:
-                self.txtNoQBins.setStyleSheet('background-color: rgb(255, 255, 255);')
+                self.txtNoQBins.setStyleSheet(self.TEXTBOX_DEFAULT_STYLESTRING)
 
     def format_value(self, value):
         """Formats certain data for the GUI.

--- a/src/sas/qtgui/Calculators/GenericScatteringCalculator.py
+++ b/src/sas/qtgui/Calculators/GenericScatteringCalculator.py
@@ -757,7 +757,6 @@ class GenericScatteringCalculator(QtWidgets.QDialog, Ui_GenericScatteringCalcula
             self.txtMz.setText(self.format_value(self.mag_sld_data.sld_mz))
         if self.is_nuc:
             self.txtNucl.setText(self.format_value(self.nuc_sld_data.sld_n))
-        if self.is_nuc:
             self.txtXnodes.setText(self.format_value(self.nuc_sld_data.xnodes))
             self.txtYnodes.setText(self.format_value(self.nuc_sld_data.ynodes))
             self.txtZnodes.setText(self.format_value(self.nuc_sld_data.znodes))

--- a/src/sas/qtgui/Calculators/GenericScatteringCalculator.py
+++ b/src/sas/qtgui/Calculators/GenericScatteringCalculator.py
@@ -853,8 +853,8 @@ class GenericScatteringCalculator(QtWidgets.QDialog, Ui_GenericScatteringCalcula
         Copied from previous version
         Execute the computation of I(qx, qy)
         """
-        sld_data = self.create_full_sld_data()
         try:
+            sld_data = self.create_full_sld_data()
             self.model.set_sld_data(sld_data)
             self.write_new_values_from_gui()
             if self.is_avg or self.is_avg is None:

--- a/src/sas/qtgui/Calculators/GenericScatteringCalculator.py
+++ b/src/sas/qtgui/Calculators/GenericScatteringCalculator.py
@@ -570,6 +570,14 @@ class GenericScatteringCalculator(QtWidgets.QDialog, Ui_GenericScatteringCalcula
         assert len(data)==1
         data = data[0]
         self.cbShape.setEnabled(False)
+        self.cmdNucLoad.setEnabled(True)
+        self.cmdNucLoad.setText('Load')
+        self.cmdMagLoad.setEnabled(True)
+        self.cmdMagLoad.setText('Load')
+        self.cmdCompute.setEnabled(True)
+        self.cmdCompute.setText('Compute')
+        if data is None:
+            return
         try:
             is_pdbdata = False
             if load_nuc:
@@ -601,12 +609,6 @@ class GenericScatteringCalculator(QtWidgets.QDialog, Ui_GenericScatteringCalcula
             logging.info(log_msg)
             raise
         logging.info("Load Complete")
-        self.cmdNucLoad.setEnabled(True)
-        self.cmdNucLoad.setText('Load')
-        self.cmdMagLoad.setEnabled(True)
-        self.cmdMagLoad.setText('Load')
-        self.cmdCompute.setEnabled(True)
-        self.cmdCompute.setText('Compute')
         #Once data files are loaded allow them to be enabled
         if load_nuc:
             self.checkboxNucData.setEnabled(True)

--- a/src/sas/qtgui/Calculators/GenericScatteringCalculator.py
+++ b/src/sas/qtgui/Calculators/GenericScatteringCalculator.py
@@ -349,6 +349,9 @@ class GenericScatteringCalculator(QtWidgets.QDialog, Ui_GenericScatteringCalcula
             self.checkboxNucData.setEnabled(True)
         else:
             self.checkboxMagData.setEnabled(True)
+        # update GUI if these files are already enabled
+        if (load_nuc and self.is_nuc) or ((not load_nuc) and self.is_mag):
+            self.update_gui()
 
     def check_units(self):
         """
@@ -374,16 +377,17 @@ class GenericScatteringCalculator(QtWidgets.QDialog, Ui_GenericScatteringCalcula
         """Check range of text edits for QMax and Number of Qbins """
         text_edit = self.sender()
         text_edit.setStyleSheet('background-color: rgb(255, 255, 255);')
-        if (text_edit.text() and self.sld_data != None):
+        sld_data = self.create_full_sld_data()
+        if (text_edit.text() and sld_data != None):
             value = float(str(text_edit.text()))
             if text_edit == self.txtQxMax:
-                max_q = numpy.pi / (max(self.sld_data.xstepsize, self.sld_data.ystepsize, self.sld_data.zstepsize) )                   
+                max_q = numpy.pi / (max(sld_data.xstepsize, sld_data.ystepsize, sld_data.zstepsize) )                   
                 if value <= 0 or value > max_q:
                     text_edit.setStyleSheet('background-color: rgb(255, 182, 193);')
                 else:
                     text_edit.setStyleSheet('background-color: rgb(255, 255, 255);')
             elif text_edit == self.txtNoQBins:
-                max_step =  3*max(self.sld_data.xnodes, self.sld_data.ynodes, self.sld_data.znodes) 
+                max_step =  3*max(sld_data.xnodes, sld_data.ynodes, sld_data.znodes) 
                     #limits qmin > maxq / nodes                 
                 if value < 2 or value > max_step:
                     self.txtNoQBins.setStyleSheet('background-color: rgb(255, 182, 193);')

--- a/src/sas/qtgui/Calculators/GenericScatteringCalculator.py
+++ b/src/sas/qtgui/Calculators/GenericScatteringCalculator.py
@@ -819,7 +819,7 @@ class GenericScatteringCalculator(QtWidgets.QDialog, Ui_GenericScatteringCalcula
         if (self.is_nuc):
             sld_data.set_sldn(self.nuc_sld_data.sld_n)
         else:
-            sld_data.set_sldn(float(self.txtNucl.text()))
+            sld_data.set_sldn(float(self.txtNucl.text()), non_zero_mag_only=False)
         if (self.is_mag):
             sld_data.set_sldms(self.mag_sld_data.sld_mx, self.mag_sld_data.sld_my, self.mag_sld_data.sld_mz)
         else:

--- a/src/sas/qtgui/Calculators/GenericScatteringCalculator.py
+++ b/src/sas/qtgui/Calculators/GenericScatteringCalculator.py
@@ -428,6 +428,17 @@ class GenericScatteringCalculator(QtWidgets.QDialog, Ui_GenericScatteringCalcula
         self.txtNucl.setEnabled(not self.is_nuc)
         # The ability to change the number of nodes and stepsizes only if no laoded data file enabled
         both_disabled =  (not self.is_mag) and (not self.is_nuc)
+        if both_disabled:
+            self.txtMx.setText("0")
+            self.txtMy.setText("0")
+            self.txtMz.setText("0")
+            self.txtNucl.setText("6.97e-06")
+            self.txtXnodes.setText("10")
+            self.txtYnodes.setText("10")
+            self.txtZnodes.setText("10")
+            self.txtXstepsize.setText("6")
+            self.txtYstepsize.setText("6")
+            self.txtZstepsize.setText("6")
         self.txtXnodes.setEnabled(both_disabled)
         self.txtYnodes.setEnabled(both_disabled)
         self.txtZnodes.setEnabled(both_disabled)

--- a/src/sas/qtgui/Calculators/GenericScatteringCalculator.py
+++ b/src/sas/qtgui/Calculators/GenericScatteringCalculator.py
@@ -57,7 +57,8 @@ class GenericScatteringCalculator(QtWidgets.QDialog, Ui_GenericScatteringCalcula
         self.verification_occurred = False # has verification happened on these files
         self.verified = False # was the verification successsful
         # verification error label
-        # prevent layout shifting when widget hidden (could this be placed i nthe .ui file?)
+        # prevent layout shifting when widget hidden
+        # TODO: Is there a way to lcoate this policy in the ui file?
         sizePolicy = self.lblVerifyError.sizePolicy()
         sizePolicy.setRetainSizeWhenHidden(True)
         self.lblVerifyError.setSizePolicy(sizePolicy)
@@ -1077,6 +1078,9 @@ class GenericScatteringCalculator(QtWidgets.QDialog, Ui_GenericScatteringCalcula
                 sld_data.line_x = self.nuc_sld_data.line_x
                 sld_data.line_y = self.nuc_sld_data.line_y
                 sld_data.line_z = self.nuc_sld_data.line_z
+            # If the nuclear data does not contain conect data try to find it in the magnetic data.
+            # TODO: combine both lists properly. Probably only necessary if a filetype for magnetic data
+            #       is used which can contain such data.
             elif self.is_mag:
                 if self.mag_sld_data.has_conect:
                     sld_data.has_conect=True

--- a/src/sas/qtgui/Calculators/GenericScatteringCalculator.py
+++ b/src/sas/qtgui/Calculators/GenericScatteringCalculator.py
@@ -510,18 +510,15 @@ class GenericScatteringCalculator(QtWidgets.QDialog, Ui_GenericScatteringCalcula
         """Opens a menu to choose the datafile to load
 
         Opens a file dialog to allow the user to select a datafile to be loaded.
-        If a nuclear sld datafile is loaded then the allowed file types are:
-            .SLD .sld .PDB .pdb
-        If a magnetic sld datafile is loaded then the allowed file types are:
-            .SLD .sld .OMF .omf
+        If a nuclear sld datafile is loaded then the allowed file types are: .SLD .sld .PDB .pdb
+        If a magnetic sld datafile is loaded then the allowed file types are: .SLD .sld .OMF .omf
         This function then loads in the requested datafile, but does not enable it.
         If no previous datafile of this type was loaded then the checkbox to enable
         this file is enabled.
 
-        :param load_nuc: Specifies whether the loaded file is nuclear or magnetic
-            data. Defaults to `True`.
-            `load_nuc=True` gives nuclear sld data.
-            `load_nuc=False` gives magnetic sld data.
+        :param load_nuc: Specifies whether the loaded file is nuclear or magnetic data. Defaults to `True`.
+                        `load_nuc=True` gives nuclear sld data.
+                        `load_nuc=False` gives magnetic sld data.
         :type load_nuc: bool
         """
         try:
@@ -974,11 +971,11 @@ class GenericScatteringCalculator(QtWidgets.QDialog, Ui_GenericScatteringCalcula
 
         :warning: This data is never plotted.
 
-                    residuals.x = data_copy.x[index]
-            residuals.dy = numpy.ones(len(residuals.y))
-            residuals.dx = None
-            residuals.dxl = None
-            residuals.dxw = None
+        residuals.x = data_copy.x[index]
+        residuals.dy = numpy.ones(len(residuals.y))
+        residuals.dx = None
+        residuals.dxl = None
+        residuals.dxw = None
         """
         self.qmax_x = float(self.txtQxMax.text())
         self.npts_x = int(self.txtNoQBins.text())

--- a/src/sas/qtgui/Calculators/GenericScatteringCalculator.py
+++ b/src/sas/qtgui/Calculators/GenericScatteringCalculator.py
@@ -812,7 +812,7 @@ class GenericScatteringCalculator(QtWidgets.QDialog, Ui_GenericScatteringCalcula
             self.txtScale.setText("1.0")
             self.txtSolventSLD.setText("0.0")
             self.txtTotalVolume.setText("216000.0")
-            self.txtNoQBins.setText("50")
+            self.txtNoQBins.setText("30")
             self.txtQxMax.setText("0.3")
             self.txtNoPixels.setText("1000")
             self.txtMx.setText("0")

--- a/src/sas/qtgui/Calculators/GenericScatteringCalculator.py
+++ b/src/sas/qtgui/Calculators/GenericScatteringCalculator.py
@@ -624,14 +624,14 @@ class GenericScatteringCalculator(QtWidgets.QDialog, Ui_GenericScatteringCalcula
             logging.info(log_msg)
             raise
         logging.info("Load Complete")
-        # Once data files are loaded allow them to be enabled
+        # Once data files are loaded allow them to be enabled and then enable them
         if load_nuc:
             self.checkboxNucData.setEnabled(True)
+            self.checkboxNucData.setChecked(True)
         else:
             self.checkboxMagData.setEnabled(True)
-        # update GUI if these files are already enabled
-        if (load_nuc and self.is_nuc) or ((not load_nuc) and self.is_mag):
-            self.update_gui()
+            self.checkboxMagData.setChecked(True)
+        self.update_gui()
         # reset verification now we have loaded new files
         self.verification_occurred = False
         self.verified = False

--- a/src/sas/qtgui/Calculators/GenericScatteringCalculator.py
+++ b/src/sas/qtgui/Calculators/GenericScatteringCalculator.py
@@ -373,7 +373,7 @@ class GenericScatteringCalculator(QtWidgets.QDialog, Ui_GenericScatteringCalcula
                     # returns the array as-is
                     setattr(self.nuc_sld_data, item, numpy.asanyarray(nuc_val)[nuc_sort_order])
                 mag_val = getattr(self.mag_sld_data, item)
-                if nuc_val is not None:
+                if mag_val is not None:
                     setattr(self.mag_sld_data, item, numpy.asanyarray(mag_val)[mag_sort_order])
             # Do NOT need to edit CONECT data (line_x, line_y, line_z as these lines are given by
             # absolute positions not references to pos_x, pos_y, pos_z).

--- a/src/sas/qtgui/Calculators/GenericScatteringCalculator.py
+++ b/src/sas/qtgui/Calculators/GenericScatteringCalculator.py
@@ -513,7 +513,8 @@ class GenericScatteringCalculator(QtWidgets.QDialog, Ui_GenericScatteringCalcula
                     # only load pdb files for nuclear data
                     loader = self.pdb_reader
                 else:
-                    loader = None
+                    logging.error("The selected file does not have a suitable file extension")
+                    return
 
                 if self.reader is not None and self.reader.isrunning():
                     self.reader.stop()

--- a/src/sas/qtgui/Calculators/UI/GenericScatteringCalculator.ui
+++ b/src/sas/qtgui/Calculators/UI/GenericScatteringCalculator.ui
@@ -1310,7 +1310,7 @@ Not editable.</string>
            </font>
           </property>
           <property name="toolTip">
-           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Default total volume calculated from the pizel information (or natural density for pdb file)&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Default total volume calculated from the pixel information (or natural density for pdb file)&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
           </property>
           <property name="text">
            <string>216000.0</string>

--- a/src/sas/qtgui/Calculators/UI/GenericScatteringCalculator.ui
+++ b/src/sas/qtgui/Calculators/UI/GenericScatteringCalculator.ui
@@ -1682,6 +1682,28 @@ Number of Qbins &amp;isin; [2, 1000].</string>
      </item>
     </layout>
    </item>
+   <item row="7" column="5">
+    <widget class="QLabel" name="lblVerifyError">
+      <property name="font">
+        <font>
+        <weight>50</weight>
+        <bold>false</bold>
+        </font>
+      </property>
+      <property name="toolTip">
+        <string>Verification Error</string>
+      </property>
+      <property name="text">
+        <string></string>
+      </property>
+      <property name="wordWrap">
+        <bool>true</bool>
+      </property>
+      <property name="alignment">
+        <enum>Qt::AlignHCenter</enum>
+      </property>
+    </widget>
+   </item>
   </layout>
  </widget>
  <resources/>

--- a/src/sas/qtgui/Calculators/UI/GenericScatteringCalculator.ui
+++ b/src/sas/qtgui/Calculators/UI/GenericScatteringCalculator.ui
@@ -97,7 +97,7 @@
            <string>Display name of loaded datafile.</string>
           </property>
           <property name="text">
-           <string>Default SLD Profile</string>
+           <string>No File Loaded</string>
           </property>
          </widget>
         </item>
@@ -179,7 +179,7 @@
            <string>Display name of loaded datafile.</string>
           </property>
           <property name="text">
-           <string>Default SLD Profile</string>
+           <string>No File Loaded</string>
           </property>
          </widget>
         </item>

--- a/src/sas/qtgui/Calculators/UI/GenericScatteringCalculator.ui
+++ b/src/sas/qtgui/Calculators/UI/GenericScatteringCalculator.ui
@@ -1434,7 +1434,7 @@ Number of Qbins &amp;isin; [2, 1000].</string>
            </font>
           </property>
           <property name="text">
-           <string>50</string>
+           <string>30</string>
           </property>
          </widget>
         </item>

--- a/src/sas/qtgui/Calculators/UI/GenericScatteringCalculator.ui
+++ b/src/sas/qtgui/Calculators/UI/GenericScatteringCalculator.ui
@@ -51,7 +51,7 @@
       <item row="0" column="0">
        <layout class="QGridLayout" name="gridLayout">
         <item row="0" column="0">
-         <widget class="QLabel" name="lblData">
+         <widget class="QLabel" name="lblNucData">
           <property name="font">
            <font>
             <weight>50</weight>
@@ -59,15 +59,22 @@
            </font>
           </property>
           <property name="toolTip">
-           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Data used to simulate SANS.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Nuclear data used to simulate SANS.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
           </property>
           <property name="text">
-           <string>Data</string>
+           <string>Nuclear Data</string>
           </property>
          </widget>
         </item>
         <item row="0" column="1">
-         <widget class="QLineEdit" name="txtData">
+         <widget class="QCheckBox" name="checkboxNucData">
+          <property name="text">
+           <string></string>
+          </property>
+         </widget>
+        </item>
+        <item row="0" column="2">
+         <widget class="QLineEdit" name="txtNucData">
           <property name="sizePolicy">
            <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
             <horstretch>0</horstretch>
@@ -94,8 +101,8 @@
           </property>
          </widget>
         </item>
-        <item row="0" column="2">
-         <widget class="QPushButton" name="cmdLoad">
+        <item row="0" column="3">
+         <widget class="QPushButton" name="cmdNucLoad">
           <property name="sizePolicy">
            <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
             <horstretch>0</horstretch>
@@ -115,7 +122,7 @@
            </font>
           </property>
           <property name="toolTip">
-           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Only .txt, .omf, .sld and .pdb datafile formats are supported. &lt;/p&gt;&lt;p&gt;Load data and generate 3D plots in real space.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Only .txt, .sld and .pdb datafile formats are supported. &lt;/p&gt;&lt;p&gt;Load Nuclear sld data.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
           </property>
           <property name="text">
            <string>Load</string>
@@ -126,6 +133,88 @@
          </widget>
         </item>
         <item row="1" column="0">
+         <widget class="QLabel" name="lblMagData">
+          <property name="font">
+           <font>
+            <weight>50</weight>
+            <bold>false</bold>
+           </font>
+          </property>
+          <property name="toolTip">
+           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Magnetic data used to simulate SANS.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+          </property>
+          <property name="text">
+           <string>Magnetic Data</string>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="1">
+         <widget class="QCheckBox" name="checkboxMagData">
+          <property name="text">
+           <string></string>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="2">
+         <widget class="QLineEdit" name="txtMagData">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="minimumSize">
+           <size>
+            <width>151</width>
+            <height>0</height>
+           </size>
+          </property>
+          <property name="font">
+           <font>
+            <weight>50</weight>
+            <bold>false</bold>
+           </font>
+          </property>
+          <property name="toolTip">
+           <string>Display name of loaded datafile.</string>
+          </property>
+          <property name="text">
+           <string>Default SLD Profile</string>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="3">
+         <widget class="QPushButton" name="cmdMagLoad">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="minimumSize">
+           <size>
+            <width>80</width>
+            <height>23</height>
+           </size>
+          </property>
+          <property name="font">
+           <font>
+            <weight>50</weight>
+            <bold>false</bold>
+           </font>
+          </property>
+          <property name="toolTip">
+           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Only .txt, .omf and.sld datafile formats are supported. &lt;/p&gt;&lt;p&gt;Load Magnetic sld data.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+          </property>
+          <property name="text">
+           <string>Load</string>
+          </property>
+          <property name="autoDefault">
+           <bool>false</bool>
+          </property>
+         </widget>
+        </item>
+        <item row="2" column="0">
          <widget class="QLabel" name="lblShape">
           <property name="font">
            <font>
@@ -141,7 +230,7 @@
           </property>
          </widget>
         </item>
-        <item row="1" column="1">
+        <item row="2" column="2">
          <widget class="QComboBox" name="cbShape">
           <property name="sizePolicy">
            <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
@@ -165,7 +254,7 @@
           </item>
          </widget>
         </item>
-        <item row="1" column="2">
+        <item row="2" column="3">
          <widget class="QPushButton" name="cmdDraw">
           <property name="enabled">
            <bool>false</bool>

--- a/src/sas/qtgui/Calculators/UI/GenericScatteringCalculator.ui
+++ b/src/sas/qtgui/Calculators/UI/GenericScatteringCalculator.ui
@@ -257,7 +257,7 @@
         <item row="2" column="3">
          <widget class="QPushButton" name="cmdDraw">
           <property name="enabled">
-           <bool>false</bool>
+           <bool>true</bool>
           </property>
           <property name="sizePolicy">
            <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
@@ -859,7 +859,7 @@ Not editable.</string>
       <item row="5" column="0" colspan="2">
        <widget class="QPushButton" name="cmdDrawpoints">
         <property name="enabled">
-         <bool>false</bool>
+         <bool>true</bool>
         </property>
         <property name="sizePolicy">
          <sizepolicy hsizetype="Minimum" vsizetype="Fixed">

--- a/src/sas/qtgui/Calculators/UI/GenericScatteringCalculator.ui
+++ b/src/sas/qtgui/Calculators/UI/GenericScatteringCalculator.ui
@@ -1702,6 +1702,12 @@ Number of Qbins &amp;isin; [2, 1000].</string>
       <property name="alignment">
         <enum>Qt::AlignHCenter</enum>
       </property>
+      <property name="minimumSize">
+        <size>
+        <width>0</width>
+        <height>30</height>
+        </size>
+      </property>
     </widget>
    </item>
   </layout>

--- a/src/sas/qtgui/Utilities/GuiUtils.py
+++ b/src/sas/qtgui/Utilities/GuiUtils.py
@@ -12,6 +12,7 @@ import webbrowser
 import urllib.parse
 import json
 import types
+import numpy
 from io import BytesIO
 
 import numpy as np
@@ -1026,6 +1027,29 @@ def formatNumber(value, high=False):
     else:
         output = "%-5.3g" % value
     return output.lstrip().rstrip()
+
+def formatValue(value):
+    """Formats specific data types for the GUI.
+    
+    This function accepts three types of data: numeric data castable to float, a numpy.ndarray of type
+    castable to float, or None. Numeric data is returned in human-readable format by formatNumber(), numpy
+    arrays are averaged over all axes, and the mean returned in human-readable format. If `value=None` then
+    the string "NaN" is returned.
+
+    :param value: The value to be formatted
+    :type value: float, numeric type castable to float, numpy.ndarray, None
+    :return: The formatted value
+    :rtype: str
+    """
+    # type must be castable to float because this is what is required by formatNumber()
+    if value is None:
+        return "NaN"
+    else:
+        if isinstance(value, numpy.ndarray):
+            value = str(formatNumber(numpy.average(value), True))
+        else:
+            value = str(formatNumber(value, True))
+        return value
 
 def replaceHTMLwithUTF8(html):
     """

--- a/src/sas/sascalc/calculator/geni.py
+++ b/src/sas/sascalc/calculator/geni.py
@@ -168,8 +168,8 @@ else:
         return np.asarray(Iq).reshape(qx.shape)
 _calc_Iqxy.__doc__ = """
     Compute I(q) for a set of points (x, y).
-    Uses::
-        I(q) = |sum V(r) rho(r) e^(1j q.r)|^2 / sum V(r)
+    
+    Uses: I(q) = \|sum V(r) rho(r) e^(1j q.r)\|^2 / sum V(r)
     Since qz is zero for SAS, only need 2D vectors q = (qx, qy) and r = (x, y).
     """
 
@@ -177,10 +177,9 @@ _calc_Iqxy.__doc__ = """
 def _calc_Iqxy_magnetic(
         qx, qy, x, y, rho, vol, rho_m,
         up_frac_i=1, up_frac_f=1, up_angle=0., up_phi=0.):
-    """
-    Compute I(q) for a set of points (x, y), with magnetism on each point.
-    Uses::
-        I(q) = sum_xs w_xs |sum V(r) rho(q, r, xs) e^(1j q.r)|^2 / sum V(r)
+    """Compute I(q) for a set of points (x, y), with magnetism on each point.
+
+    Uses: I(q) = sum_xs w_xs \|sum V(r) rho(q, r, xs) e^(1j q.r)\|^2 / sum V(r)
     where rho is adjusted for the particular q and polarization cross section.
     The cross section weights depends on the polarizer and analyzer
     efficiency of the measurement.  For example, with polarization up at 100%

--- a/src/sas/sascalc/calculator/sas_gen.py
+++ b/src/sas/sascalc/calculator/sas_gen.py
@@ -839,15 +839,16 @@ class MagSLD(object):
         """
         self.pix_type = pix_type
 
-    def set_sldn(self, sld_n):
+    def set_sldn(self, sld_n, non_mag_only=True):
         """
         Sets neutron SLD.
 
         Warning: if *sld_n* is a scalar and attribute *is_data* is True, then
-        only pixels with non-zero magnetism will be set.
+        only pixels with non-zero magnetism will be set by default. Use
+        the argument non_Mag_only=False to change this
         """
         if isinstance(sld_n, float):
-            if self.is_data:
+            if self.is_data and non_mag_only:
                 # For data, put the value to only the pixels w non-zero M
                 is_nonzero = (np.fabs(self.sld_mx) +
                               np.fabs(self.sld_my) +

--- a/src/sas/sascalc/calculator/sas_gen.py
+++ b/src/sas/sascalc/calculator/sas_gen.py
@@ -26,7 +26,7 @@ else:
 MFACTOR_AM = 2.90636E-12
 MFACTOR_MT = 2.3128E-9
 METER2ANG = 1.0E+10
-#Avogadro constant [1/mol]
+# Avogadro constant [1/mol]
 NA = 6.02214129e+23
 
 def mag2sld(mag, v_unit=None):
@@ -72,7 +72,7 @@ class GenSAS(object):
         self.data_mx = None
         self.data_my = None
         self.data_mz = None
-        self.data_vol = None #[A^3]
+        self.data_vol = None # [A^3]
         self.is_avg = False
         ## Name of the model
         self.name = "GenSAS"
@@ -271,7 +271,7 @@ class OMF2SLD(object):
             self.mz = np.zeros(length)
 
         self._check_data_length(length)
-        #self.remove_null_points(True, False)
+        # self.remove_null_points(True, False)
         mask = np.ones(len(self.sld_n), dtype=bool)
         if shape.lower() == 'ellipsoid':
             try:
@@ -397,7 +397,7 @@ class OMFReader(object):
                         # Skip non-data lines
                         logging.error(str(exc)+" when processing %r"%line)
                 elif line:
-                #Reading Header; Segment count ignored
+                # Reading Header; Segment count ignored
                     s_line = line.split(":", 1)
                     if s_line[0].lower().count("oommf") > 0:
                         oommf = s_line[1].lstrip()
@@ -582,7 +582,7 @@ class PDBReader(object):
                             if int_val == 0:
                                 break
                             val_list.append(int_val)
-                        #need val_list ordered
+                        # need val_list ordered
                         for val in val_list:
                             index = val - 1
                             if (pos_x[index], pos_x[num]) in x_line and \
@@ -980,7 +980,7 @@ class MagSLD(object):
                     if zpos_pre != z_pos:
                         self.zstepsize = np.fabs(z_pos - zpos_pre)
                         break
-                #default pix volume
+                # default pix volume
                 self.vol_pix = np.ones(len(self.pos_x))
                 vol = self.xstepsize * self.ystepsize * self.zstepsize
                 self.set_pixel_volumes(vol)

--- a/src/sas/sascalc/calculator/sas_gen.py
+++ b/src/sas/sascalc/calculator/sas_gen.py
@@ -620,16 +620,17 @@ class PDBReader(object):
         print("Not implemented... ")
 
 class SLDReader(object):
-    """
-    SLD reader for text files.
+    """SLD reader for text files.
 
     format:
     1 line of header - may give any information
     n lines of data points of the form:
-        4 columns: x        y       z       sld
-    or: 6 columns: x        y       z       mx      my      mz
-    or: 7 columns: x        y       z       sld     mx      my      mz
-    or: 8 columns: x        y       z       sld     mx      my      mz      volume
+
+    4 columns: x        y       z       sld
+    6 columns: x        y       z       mx      my      mz
+    7 columns: x        y       z       sld     mx      my      mz
+    8 columns: x        y       z       sld     mx      my      mz      volume
+    
     where all n lines have the same format.
     """
     ## File type

--- a/src/sas/sascalc/calculator/sas_gen.py
+++ b/src/sas/sascalc/calculator/sas_gen.py
@@ -299,6 +299,7 @@ class OMF2SLD(object):
                              self.mx[mask], self.my[mask], self.mz[mask])
         self.output.set_pix_type('pixel')
         self.output.set_pixel_symbols('pixel')
+        self.output.filename = omfdata.filename
 
     def get_omfdata(self):
         """

--- a/src/sas/sascalc/calculator/sas_gen.py
+++ b/src/sas/sascalc/calculator/sas_gen.py
@@ -839,16 +839,16 @@ class MagSLD(object):
         """
         self.pix_type = pix_type
 
-    def set_sldn(self, sld_n, non_mag_only=True):
+    def set_sldn(self, sld_n, non_zero_mag_only=True):
         """
         Sets neutron SLD.
 
         Warning: if *sld_n* is a scalar and attribute *is_data* is True, then
         only pixels with non-zero magnetism will be set by default. Use
-        the argument non_Mag_only=False to change this
+        the argument non_zero_mag_only=False to change this
         """
         if isinstance(sld_n, float):
-            if self.is_data and non_mag_only:
+            if self.is_data and non_zero_mag_only:
                 # For data, put the value to only the pixels w non-zero M
                 is_nonzero = (np.fabs(self.sld_mx) +
                               np.fabs(self.sld_my) +

--- a/src/sas/sascalc/calculator/sas_gen.py
+++ b/src/sas/sascalc/calculator/sas_gen.py
@@ -16,8 +16,6 @@ from periodictable import formula, nsf
 
 from .geni import Iq, Iqxy
 
-logger = logging.getLogger(__name__)
-
 if sys.version_info[0] < 3:
     def decode(s):
         return s
@@ -295,7 +293,7 @@ class OMF2SLD(object):
                 z_dir2 *= z_dir2
                 mask = (x_dir2 + y_dir2 + z_dir2) <= 1.0
             except Exception as exc:
-                logger.error(exc)
+                logging.error(exc)
         self.output = MagSLD(self.pos_x[mask], self.pos_y[mask],
                              self.pos_z[mask], self.sld_n[mask],
                              self.mx[mask], self.my[mask], self.mz[mask])
@@ -397,7 +395,7 @@ class OMFReader(object):
                         mz = np.append(mz, _mz)
                     except Exception as exc:
                         # Skip non-data lines
-                        logger.error(str(exc)+" when processing %r"%line)
+                        logging.error(str(exc)+" when processing %r"%line)
                 elif line:
                 #Reading Header; Segment count ignored
                     s_line = line.split(":", 1)
@@ -491,7 +489,8 @@ class OMFReader(object):
         except Exception:
             msg = "%s is not supported: \n" % path
             msg += "We accept only Text format OMF file."
-            raise RuntimeError(msg)
+            logging.error(msg)
+            return None
 
 class PDBReader(object):
     """
@@ -565,7 +564,7 @@ class PDBReader(object):
                             vol = 1.0e+24 * atom.mass / atom.density / NA
                             vol_pix = np.append(vol_pix, vol)
                         except Exception:
-                            logger.error("Error: set the sld of %s to zero"% atom_name)
+                            logging.info("Error: set the sld of %s to zero"% atom_name)
                             sld_n = np.append(sld_n, 0.0)
                         sld_mx = np.append(sld_mx, 0)
                         sld_my = np.append(sld_my, 0)
@@ -598,7 +597,7 @@ class PDBReader(object):
                         y_lines.append(y_line)
                         z_lines.append(z_line)
                 except Exception as exc:
-                    logger.error(exc)
+                    logging.error(exc)
 
             output = MagSLD(pos_x, pos_y, pos_z, sld_n, sld_mx, sld_my, sld_mz)
             output.set_conect_lines(x_line, y_line, z_line)
@@ -610,7 +609,8 @@ class PDBReader(object):
             output.sld_unit = '1/A^(2)'
             return output
         except Exception:
-            raise RuntimeError("%s is not a sld file" % path)
+            logging.error("%s is not a pdb file" % path)
+            return None
 
     def write(self, path, data):
         """
@@ -653,7 +653,8 @@ class SLDReader(object):
         except Exception:
             data = None
         if data is None or data.shape[0] not in (4, 6, 7, 8):
-            raise RuntimeError("%r is not a sld file" % path)
+            logging.error("%r is not an sld file" % path)
+            return None
         if data.shape[0] == 4:
             x, y, z, sld = data[:4]
             mx = np.zeros_like(sld)
@@ -1485,7 +1486,7 @@ def _setup_realspace_path():
                                  '..', '..', '..', '..', '..',
                                  'sasmodels', 'explore'))
         sys.path.insert(0, path)
-        logger.info("inserting %r into python path for realspace", path)
+        logging.info("inserting %r into python path for realspace", path)
 
 if __name__ == "__main__":
     _setup_realspace_path()


### PR DESCRIPTION
This branch contains commits to resolve #1825 . The primary changes are to allow the user to select nuclear and magnetic data from two separate files, and carry out a full calculation of the expected scattering pattern given this. As part of this the following key functionality was added:
 - The ability to load in two separate files for nuclear and magnetic SLD data, along with verification that the two files contain data about the same points in 3D space.
 - The ability to select a constant value for an sld which is not loaded as a file. For example a magnetic sld datafile can be loaded and a constant nuclear scattering value given to each point.
 - Small tweaks to the gui to make it more responsive to the user - e.g. empty textboxes now reset to their last valid value if they lose focus, as in the fitting interface.