### PR TITLE
Ticket 1406 cancel calculation

### DIFF
--- a/src/sas/qtgui/Calculators/GenericScatteringCalculator.py
+++ b/src/sas/qtgui/Calculators/GenericScatteringCalculator.py
@@ -609,8 +609,11 @@ class GenericScatteringCalculator(QtWidgets.QDialog, Ui_GenericScatteringCalcula
                 self._create_default_2d_data()
                 inputs = [self.data.qx_data, self.data.qy_data]
             logging.info("Computation is in progress...")
-            self.cmdCompute.setText('Wait...')
-            self.cmdCompute.setEnabled(False)
+            self.cmdCompute.setText('Cancel')
+            self.cmdCompute.clicked.disconnect()
+            self.cmdCompute.clicked.connect(self.onCancel)
+            self.cancelCalculation = False
+            #self.cmdCompute.setEnabled(False)
             d = threads.deferToThread(self.complete, inputs, self._update)
             # Add deferred callback for call return
             #d.addCallback(self.plot_1_2d)
@@ -620,6 +623,12 @@ class GenericScatteringCalculator(QtWidgets.QDialog, Ui_GenericScatteringCalcula
             log_msg = "{}. stop".format(sys.exc_info()[1])
             logging.info(log_msg)
         return
+    
+    def onCancel(self):
+        """Notify the calculation thread that the user has cancelled the calculation.
+        """
+        self.cancelCalculation = True
+        self.cmdCompute.setEnabled(False) # don't allow user to start a new calculation until this one finishes cancelling
 
     def _update(self, time=None, percentage=None):
         """
@@ -668,10 +677,22 @@ class GenericScatteringCalculator(QtWidgets.QDialog, Ui_GenericScatteringCalcula
                           input[1][ind:ind + chunk_size]]
                 outi = self.model.runXY(inputi)
             out.append(outi)
+            if self.cancelCalculation:
+                update(time=t, percentage=100*(ind + chunk_size)/nq) # ensure final progress shown
+                self.data_to_plot = numpy.full(nq, numpy.nan)
+                self.data_to_plot[:ind + chunk_size] = numpy.hstack(out)
+                logging.info('Gen computation cancelled.')
+                self.cmdCompute.setText('Compute')
+                self.cmdCompute.clicked.disconnect()
+                self.cmdCompute.clicked.connect(self.onCompute)
+                self.cmdCompute.setEnabled(True)
+                return
         out = numpy.hstack(out)
         self.data_to_plot = out
         logging.info('Gen computation completed.')
         self.cmdCompute.setText('Compute')
+        self.cmdCompute.clicked.disconnect()
+        self.cmdCompute.clicked.connect(self.onCompute)
         self.cmdCompute.setEnabled(True)
         return
 

--- a/src/sas/qtgui/Calculators/GenericScatteringCalculator.py
+++ b/src/sas/qtgui/Calculators/GenericScatteringCalculator.py
@@ -610,6 +610,7 @@ class GenericScatteringCalculator(QtWidgets.QDialog, Ui_GenericScatteringCalcula
                 inputs = [self.data.qx_data, self.data.qy_data]
             logging.info("Computation is in progress...")
             self.cmdCompute.setText('Cancel')
+            self.cmdCompute.setToolTip("<html><head/><body><p>Cancel the computation of the scattering calculation.</p></body></html>")
             self.cmdCompute.clicked.disconnect()
             self.cmdCompute.clicked.connect(self.onCancel)
             self.cancelCalculation = False
@@ -682,15 +683,13 @@ class GenericScatteringCalculator(QtWidgets.QDialog, Ui_GenericScatteringCalcula
                 self.data_to_plot = numpy.full(nq, numpy.nan)
                 self.data_to_plot[:ind + chunk_size] = numpy.hstack(out)
                 logging.info('Gen computation cancelled.')
-                self.cmdCompute.setText('Compute')
-                self.cmdCompute.clicked.disconnect()
-                self.cmdCompute.clicked.connect(self.onCompute)
-                self.cmdCompute.setEnabled(True)
-                return
-        out = numpy.hstack(out)
-        self.data_to_plot = out
-        logging.info('Gen computation completed.')
+                break
+        else:
+            out = numpy.hstack(out)
+            self.data_to_plot = out
+            logging.info('Gen computation completed.')
         self.cmdCompute.setText('Compute')
+        self.cmdCompute.setToolTip("<html><head/><body><p>Compute the scattering pattern and display 1D or 2D plot depending on the settings.</p></body></html>")
         self.cmdCompute.clicked.disconnect()
         self.cmdCompute.clicked.connect(self.onCompute)
         self.cmdCompute.setEnabled(True)


### PR DESCRIPTION
This PR adds a cancel button to the generic scattering calculator to cancel computations between each chunk of Q values. If the computation is cancelled the remainder of the Iq values are filled in with `NaN`. The ticket for this request suggests using `calcthread.isquit()`, however the current code uses twisted.internet threads as opposed to the calcthread class in sasview. As far as I can tell there is no inbuilt way to detect an interruption in these threads, so a boolean flag is used. Upon cancelling the calculation the compute/cancel button becomes disabled until the current chunk of Q values have been computed.

Currently the areas of the graph with `NaN` values are simply not updated, which can cause odd effects on the graph when cancelling a calculation. This is because the `numpy.nan_to_num` function in the current code is not correctly implemented, an issue fixed in https://github.com/SasView/sasview/pull/1888.

fixes #1406 