### PR TITLE
Allow output of scattering calculator to be used as a theory curve

### DIFF
--- a/src/sas/qtgui/Utilities/GuiUtils.py
+++ b/src/sas/qtgui/Utilities/GuiUtils.py
@@ -411,6 +411,7 @@ def createModelItemWithPlot(update_data, name=""):
     Adds 'update_data' to that row.
     """
     py_update_data = update_data
+    py_update_data.name = name # name must match title due to how plots are referenced
 
     checkbox_item = HashableStandardItem()
     checkbox_item.setCheckable(True)


### PR DESCRIPTION
The current code already sends the output of the generic scattering calculator to the data explorer window where it can be used for fitting in the same way as any data loaded from a file, a large part of the functionality requested by this ticket. The results of this fitting could not be plotted however. This was due to a mismatch in the name of the data and the corresponding plot. This pull request ensures the name of the plot matches the name of the data rather than being left as the default `"Data1D"`/`"Data2D"`, and hence allows models and residuals to be plotted as would be expected.