### PR TITLE
Fix Color Map Slider in 2D plots

### DIFF
--- a/src/sas/qtgui/Plotting/ColorMap.py
+++ b/src/sas/qtgui/Plotting/ColorMap.py
@@ -22,7 +22,7 @@ from sas.qtgui.Plotting.UI.ColorMapUI import Ui_ColorMapUI
 
 class ColorMap(QtWidgets.QDialog, Ui_ColorMapUI):
     apply_signal = QtCore.pyqtSignal(tuple, str)
-    def __init__(self, parent=None, cmap=None, vmin=0.0, vmax=100.0, data=None):
+    def __init__(self, parent=None, cmap=None, xmin=-1,xmax=10, ymin=-1.0, ymax=15.0, vmin=0.0, vmax=100.0, data=None):
         super(ColorMap, self).__init__()
 
         self.setupUi(self)
@@ -38,6 +38,12 @@ class ColorMap(QtWidgets.QDialog, Ui_ColorMapUI):
 
         self.vmin = self.vmin_orig = vmin
         self.vmax = self.vmax_orig = vmax
+
+        self.data.xmin = xmin
+        self.data.xmax = xmax
+
+        self.data.ymin = ymin
+        self.data.ymax = ymax
 
         # Initialize detector labels
         self.initDetectorData()
@@ -175,7 +181,7 @@ class ColorMap(QtWidgets.QDialog, Ui_ColorMapUI):
             self.updateMap()
 
         self.slider.lowValueChanged.connect(set_vmin)
-        self.slider.highValueChanged.connect(set_vmin)
+        self.slider.highValueChanged.connect(set_vmax)
 
     def updateMap(self):
         self._norm = mpl.colors.Normalize(vmin=self.vmin, vmax=self.vmax)

--- a/src/sas/qtgui/Plotting/ColorMap.py
+++ b/src/sas/qtgui/Plotting/ColorMap.py
@@ -22,7 +22,7 @@ from sas.qtgui.Plotting.UI.ColorMapUI import Ui_ColorMapUI
 
 class ColorMap(QtWidgets.QDialog, Ui_ColorMapUI):
     apply_signal = QtCore.pyqtSignal(tuple, str)
-    def __init__(self, parent=None, cmap=None, xmin=-1,xmax=10, ymin=-1.0, ymax=15.0, vmin=0.0, vmax=100.0, data=None):
+    def __init__(self, parent=None, cmap=None, vmin=0.0, vmax=100.0, data=None):
         super(ColorMap, self).__init__()
 
         self.setupUi(self)
@@ -38,12 +38,6 @@ class ColorMap(QtWidgets.QDialog, Ui_ColorMapUI):
 
         self.vmin = self.vmin_orig = vmin
         self.vmax = self.vmax_orig = vmax
-
-        self.data.xmin = xmin
-        self.data.xmax = xmax
-
-        self.data.ymin = ymin
-        self.data.ymax = ymax
 
         # Initialize detector labels
         self.initDetectorData()

--- a/src/sas/qtgui/Plotting/UnitTesting/ColorMapTest.py
+++ b/src/sas/qtgui/Plotting/UnitTesting/ColorMapTest.py
@@ -56,7 +56,7 @@ class ColorMapTest(unittest.TestCase):
 
         self.assertEqual(self.widget.lblWidth.text(), "0")
         self.assertEqual(self.widget.lblHeight.text(), "0")
-        self.assertEqual(self.widget.lblQmax.text(), "15.8")
+        self.assertEqual(self.widget.lblQmax.text(), "18")
         self.assertEqual(self.widget.lblStopRadius.text(), "-1")
         self.assertFalse(self.widget.chkReverse.isChecked())
         self.assertEqual(self.widget.cbColorMap.count(), 75)
@@ -139,7 +139,7 @@ class ColorMapTest(unittest.TestCase):
         # Emit new high value
         self.widget.slider.highValueChanged.emit(45)
         # Assure the widget received changes
-        self.assertEqual(self.widget.txtMinAmplitude.text(), "45")
+        self.assertEqual(self.widget.txtMaxAmplitude.text(), "45")
 
     def testOnMapIndexChange(self):
         '''Test the response to the combo box index change'''

--- a/src/sas/qtgui/Plotting/rangeSlider.py
+++ b/src/sas/qtgui/Plotting/rangeSlider.py
@@ -80,7 +80,7 @@ class RangeSlider(QtWidgets.QSlider):
         self.update()
 
         if self.hasTracking():
-            self.lowValueChanged.emit(self._high)
+            self.highValueChanged.emit(self._high)
         
     def paintEvent(self, event):
         # based on http://qt.gitorious.org/qt/qt/blobs/master/src/gui/widgets/qslider.cpp


### PR DESCRIPTION
This pull request fixes ticket 1928. The right slider to change the maximum value of the colour range in 2D plots was linked to the minimum values. Effectively both sliders did the same. The behaviour is now also checked correctly in the ColorMapTest.