### PR TITLE
Add .sesans extension to associations.py

### DIFF
--- a/src/sas/sascalc/dataloader/readers/associations.py
+++ b/src/sas/sascalc/dataloader/readers/associations.py
@@ -21,6 +21,7 @@ logger = logging.getLogger(__name__)
 FILE_ASSOCIATIONS = {
     ".xml": "cansas_reader",
     ".ses": "sesans_reader",
+    ".sesans": "sesans_reader",
     ".h5": "cansas_reader_HDF5",
     ".hdf": "cansas_reader_HDF5",
     ".hdf5": "cansas_reader_HDF5",


### PR DESCRIPTION
Noted in [PR #1933](https://github.com/SasView/sasview/pull/1933#discussion_r739280429), the .sesans file extension is not associated with the sesans reader. This fixes the issue.

I would be willing to add a unit test if desired.