### PR TITLE
Q-Range slider fix for linear fits

### DIFF
--- a/src/sas/qtgui/Plotting/QRangeSlider.py
+++ b/src/sas/qtgui/Plotting/QRangeSlider.py
@@ -310,7 +310,7 @@ class LineInteractor(BaseInteractor):
         # type: () -> None
         """ Disconnect the input and clear the callbacks """
         if self.input:
-            self.input.textChanged.disconnect(self.inputChanged)
+            self.input.editingFinished.disconnect(self.inputChanged)
         self.setter = None
         self.getter = None
         self.input = None


### PR DESCRIPTION
This fixes the issue noted in slack regarding an error when running a linear fit. This same error was also thrown when closing any plot with q-range sliders.

The signal used to link the GUI input to the sliders was changed from `textChanged` to `editingFinished`, but the disconnection was not changed to match.