### PR TITLE
Re-create toc entry for sesans_fitting in sasview

### DIFF
--- a/src/sas/qtgui/Perspectives/Fitting/media/fitting.rst
+++ b/src/sas/qtgui/Perspectives/Fitting/media/fitting.rst
@@ -25,6 +25,8 @@ Fitting Documentation
    Information on the SasView Optimisers <optimizer>
 
    Conversion of SANS to SESANS for Fitting <sesans/sans_to_sesans>
+   
+   Fitting SESANS using the Old GUI from he <sesans/sesans_fitting.rst>
 
    Writing a Plugin Model <plugin>
 


### PR DESCRIPTION
This PR pushes a fix for failing doc builds because of : sasview/docs/sphinx-docs/source-temp/user/qtgui/Perspectives/Fitting/sesans/sesans_fitting.rst: WARNING: document isn't included in any toctree