### PR TITLE
Use version parsing package for MPL version check

### DIFF
--- a/src/sas/qtgui/Plotting/Plotter.py
+++ b/src/sas/qtgui/Plotting/Plotter.py
@@ -7,6 +7,7 @@ import sys
 import matplotlib as mpl
 import numpy as np
 from matplotlib.font_manager import FontProperties
+from packaging import version
 
 from sas.qtgui.Plotting.PlotterData import Data1D
 from sas.qtgui.Plotting.PlotterBase import PlotterBase
@@ -178,7 +179,7 @@ class PlotterWidget(PlotterBase):
         markersize = data.markersize
 
         # Include scaling (log vs. linear)
-        if mpl.__version__ < "3.3":
+        if version.parse(mpl.__version__) < version.parse("3.3"):
             ax.set_xscale(self.xscale, nonposx='clip') if self.xscale != 'linear' else self.ax.set_xscale(self.xscale)
             ax.set_yscale(self.yscale, nonposy='clip') if self.yscale != 'linear' else self.ax.set_yscale(self.yscale)
         else:

--- a/src/sas/qtgui/Plotting/PlotterBase.py
+++ b/src/sas/qtgui/Plotting/PlotterBase.py
@@ -11,6 +11,8 @@ import matplotlib.pyplot as plt
 import matplotlib as mpl
 from matplotlib import rcParams
 
+from packaging import version
+
 DEFAULT_CMAP = mpl.cm.jet
 from sas.qtgui.Plotting.PlotterData import Data1D
 
@@ -180,7 +182,7 @@ class PlotterBase(QtWidgets.QWidget):
     @yscale.setter
     def yscale(self, scale='linear'):
         """ Y-axis scale setter """
-        if mpl.__version__ < "3.3":
+        if version.parse(mpl.__version__) < version.parse("3.3"):
             self.ax.set_yscale(scale, nonposy='clip') if scale != 'linear' else self.ax.set_yscale(scale)
         else:
             self.ax.set_yscale(scale, nonpositive='clip') if scale != 'linear' else self.ax.set_yscale(scale)
@@ -195,7 +197,10 @@ class PlotterBase(QtWidgets.QWidget):
     def xscale(self, scale='linear'):
         """ X-axis scale setter """
         self.ax.cla()
-        self.ax.set_xscale(scale)
+        if version.parse(mpl.__version__) < version.parse("3.3"):
+            self.ax.set_xscale(scale, nonposx='clip') if scale != 'linear' else self.ax.set_xscale(scale)
+        else:
+            self.ax.set_xscale(scale, nonpositive='clip') if scale != 'linear' else self.ax.set_xscale(scale)
         self._xscale = scale
 
     @property


### PR DESCRIPTION
This uses a version parsing package bundled with setuptools (no extra dependencies) to help fix the 'nonposy' issue in MPL version > 3.3 that is used for the Github actions build.