### PR TITLE
Fix for removed _activeQue in newer Matplotlib

### DIFF
--- a/src/sas/qtgui/Utilities/PlotView.py
+++ b/src/sas/qtgui/Utilities/PlotView.py
@@ -204,7 +204,7 @@ class PlotView(QtWidgets.QWidget, _PlotViewShared):
             self.title = kw['title']
 
         # Instantiate a figure object that will contain our plots.
-        figure = Figure(figsize=(1,1), dpi=72)
+        figure = Figure(figsize=(10,10), dpi=72)
 
         # Initialize the figure canvas, mapping the figure object to the plot
         # engine backend.

--- a/src/sas/qtgui/Utilities/PlotView.py
+++ b/src/sas/qtgui/Utilities/PlotView.py
@@ -65,12 +65,14 @@ class EmbeddedPylab(object):
     def __exit__(self, *args, **kw):
         # delay loading pylab until matplotlib.use() is called
         from matplotlib._pylab_helpers import Gcf
-        Gcf._activeQue = [f for f in Gcf._activeQue if f is not self.fm]
-        try:
-            del Gcf.figs[-1]
-        except KeyError:
-            pass
-
+        if hasattr(Gcf, '_activeQue'):  # CRUFT: MPL < 3.3.1
+            Gcf._activeQue = [f for f in Gcf._activeQue if f is not self.fm]
+            try:
+                del Gcf.figs[-1]
+            except KeyError:
+                pass
+        else:
+            Gcf.figs.pop(self.fm.num, None)
 
 class _PlotViewShared(object):
     title = 'Plot'


### PR DESCRIPTION
handle newer versions (>3.3.1) of matplotlib, where _activeQue is not defined