### PR TITLE
Gh actions artifacts

### DIFF
--- a/.github/workflows/installers.yml
+++ b/.github/workflows/installers.yml
@@ -170,7 +170,6 @@ jobs:
         if-no-files-found: error
 
     - name: Upload zipped offline app installer to GitHub releases (non-master branch)
-      if: github.event_name == 'push' && env.BRANCH_NAME != 'main'
       uses: ncipollo/release-action@v1
       with:
         draft: true
@@ -179,5 +178,3 @@ jobs:
         replacesArtifacts: true
         token: ${{ secrets.GITHUB_TOKEN }}
         artifacts: "SasView-Installer-*.zip"
-        name: ${{ env.BRANCH_NAME }}
-        tag: ${{ env.BRANCH_NAME }}

--- a/.github/workflows/installers.yml
+++ b/.github/workflows/installers.yml
@@ -170,7 +170,7 @@ jobs:
         if-no-files-found: error
 
     - name: Upload zipped offline app installer to GitHub releases (non-master branch)
-      if: github.event_name == 'push' && env.BRANCH_NAME != 'master'
+      if: github.event_name == 'push' && env.BRANCH_NAME != 'main'
       uses: ncipollo/release-action@v1
       with:
         draft: true

--- a/.github/workflows/installers.yml
+++ b/.github/workflows/installers.yml
@@ -168,3 +168,16 @@ jobs:
         name: SasView-Installer-${{ matrix.os }}-${{ matrix.python-version }}-${{ github.sha }}
         path: installers/dist/SasView5.dmg
         if-no-files-found: error
+
+    - name: Upload zipped offline app installer to GitHub releases (non-master branch)
+      if: github.event_name == 'push' && env.BRANCH_NAME != 'master'
+      uses: ncipollo/release-action@v1
+      with:
+        draft: true
+        prerelease: true
+        allowUpdates: true
+        replacesArtifacts: true
+        token: ${{ secrets.GITHUB_TOKEN }}
+        artifacts: "${{ env.DISTRIBUTION_PATH }}/SasView-Installer-*.zip"
+        tag: ${{ env.BRANCH_NAME }}
+        name: ${{ env.BRANCH_NAME }}

--- a/.github/workflows/installers.yml
+++ b/.github/workflows/installers.yml
@@ -179,7 +179,9 @@ jobs:
       shell: bash
       run: echo "BRANCH_NAME=$GITHUB_HEAD_REF" >> $GITHUB_ENV
 
-    - name: Upload zipped offline app installer to GitHub releases
+    - name: Upload installer to GitHub releases
+      #Release and main branch will be treated differently
+      if: env.BRANCH_NAME != 'main' && env.BRANCH_NAME != 'release*'
       uses: ncipollo/release-action@v1
       with:
         draft: true

--- a/.github/workflows/installers.yml
+++ b/.github/workflows/installers.yml
@@ -169,7 +169,17 @@ jobs:
         path: installers/dist/SasView5.dmg
         if-no-files-found: error
 
-    - name: Upload zipped offline app installer to GitHub releases (non-master branch)
+    - name: Declare env variables on push only
+      if: github.event_name == 'push'
+      shell: bash
+      run: echo "BRANCH_NAME=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
+
+    - name: Declare env variables on pull_request only
+      if: github.event_name == 'pull_request'
+      shell: bash
+      run: echo "BRANCH_NAME=$GITHUB_HEAD_REF" >> $GITHUB_ENV
+
+    - name: Upload zipped offline app installer to GitHub releases
       uses: ncipollo/release-action@v1
       with:
         draft: true
@@ -178,3 +188,5 @@ jobs:
         replacesArtifacts: true
         token: ${{ secrets.GITHUB_TOKEN }}
         artifacts: "SasView-Installer-*.zip"
+        name: ${{ env.BRANCH_NAME }}
+        tag: ${{ env.BRANCH_NAME }}

--- a/.github/workflows/installers.yml
+++ b/.github/workflows/installers.yml
@@ -187,6 +187,6 @@ jobs:
         allowUpdates: true
         replacesArtifacts: true
         token: ${{ secrets.GITHUB_TOKEN }}
-        artifacts: "SasView-Installer-*.zip"
+        artifacts: "installers/dist/SasView5.dmg, installers/Output/setupSasView.exe"
         name: ${{ env.BRANCH_NAME }}
         tag: ${{ env.BRANCH_NAME }}

--- a/.github/workflows/installers.yml
+++ b/.github/workflows/installers.yml
@@ -180,3 +180,4 @@ jobs:
         token: ${{ secrets.GITHUB_TOKEN }}
         artifacts: "SasView-Installer-*.zip"
         name: ${{ env.BRANCH_NAME }}
+        tag: ${{ env.BRANCH_NAME }}

--- a/.github/workflows/installers.yml
+++ b/.github/workflows/installers.yml
@@ -179,5 +179,4 @@ jobs:
         replacesArtifacts: true
         token: ${{ secrets.GITHUB_TOKEN }}
         artifacts: "${{ env.DISTRIBUTION_PATH }}/SasView-Installer-*.zip"
-        tag: ${{ env.BRANCH_NAME }}
         name: ${{ env.BRANCH_NAME }}

--- a/.github/workflows/installers.yml
+++ b/.github/workflows/installers.yml
@@ -178,5 +178,5 @@ jobs:
         allowUpdates: true
         replacesArtifacts: true
         token: ${{ secrets.GITHUB_TOKEN }}
-        artifacts: "${{ env.DISTRIBUTION_PATH }}/SasView-Installer-*.zip"
+        artifacts: "${{ env.DISTRIBUTION_PATH }}/$SasView-Installer-*.zip"
         name: ${{ env.BRANCH_NAME }}

--- a/.github/workflows/installers.yml
+++ b/.github/workflows/installers.yml
@@ -178,5 +178,5 @@ jobs:
         allowUpdates: true
         replacesArtifacts: true
         token: ${{ secrets.GITHUB_TOKEN }}
-        artifacts: "${{ env.DISTRIBUTION_PATH }}/$SasView-Installer-*.zip"
+        artifacts: "SasView-Installer-*.zip"
         name: ${{ env.BRANCH_NAME }}


### PR DESCRIPTION
Addition to gh actions installer to store artifacts on https://github.com/SasView/sasview/releases
Drafts are avaialable only for logged in users (and I believe bellonging to SasView organization). Regular users will see releases and pre-releases as before. Artifacts will be stored for each branch and will be updated once new change is pushed to the code, which could keep the list of managable size. As discussed with @butlerpd after merging branch entry on the list should be removed (currently plan to do it manualy but can probably be also done through gh actions). 