### PR TITLE
Call magnetic angles up_theta 

### DIFF
--- a/src/sas/qtgui/Perspectives/Fitting/UnitTesting/FittingWidgetTest.py
+++ b/src/sas/qtgui/Perspectives/Fitting/UnitTesting/FittingWidgetTest.py
@@ -221,7 +221,7 @@ class FittingWidgetTest(unittest.TestCase):
         mag_index = fittingWindow.lstMagnetic.model().index(1,0)
         self.assertEqual(mag_index.data(), "up_frac_f")
         mag_index = fittingWindow.lstMagnetic.model().index(2,0)
-        self.assertEqual(mag_index.data(), "up_angle")
+        self.assertEqual(mag_index.data(), "up_theta")
         mag_index = fittingWindow.lstMagnetic.model().index(3,0)
         self.assertEqual(mag_index.data(), "up_phi")
         mag_index = fittingWindow.lstMagnetic.model().index(4,0)

--- a/src/sas/sascalc/calculator/geni.py
+++ b/src/sas/sascalc/calculator/geni.py
@@ -176,7 +176,7 @@ _calc_Iqxy.__doc__ = """
 
 def _calc_Iqxy_magnetic(
         qx, qy, x, y, rho, vol, rho_m,
-        up_frac_i=1, up_frac_f=1, up_angle=0., up_phi=0.):
+        up_frac_i=1, up_frac_f=1, up_theta=0., up_phi=0.):
     """Compute I(q) for a set of points (x, y), with magnetism on each point.
 
     Uses: I(q) = sum_xs w_xs \|sum V(r) rho(q, r, xs) e^(1j q.r)\|^2 / sum V(r)
@@ -191,8 +191,8 @@ def _calc_Iqxy_magnetic(
     dd, du, ud, uu = _spin_weights(up_frac_i, up_frac_f)
 
     # Precompute helper values
-    up_angle = np.radians(up_angle)
-    cos_spin, sin_spin = np.cos(up_angle), np.sin(up_angle)
+    up_theta = np.radians(up_theta)
+    cos_spin, sin_spin = np.cos(up_theta), np.sin(up_theta)
 
     up_phi = np.radians(up_phi)
     cos_phi, sin_phi = np.cos(up_phi), np.sin(up_phi)

--- a/src/sas/sascalc/calculator/sas_gen.py
+++ b/src/sas/sascalc/calculator/sas_gen.py
@@ -1266,7 +1266,7 @@ def realspace_Iq(self, qx, qy):
         if is_magnetic:
             I_out = calc_Iq_magnetic(
                 qx, qy, rho, rho_m, points, volume,
-                up_frac_i=in_spin, up_frac_f=out_spin, up_angle=s_theta, up_phi=s_phi,
+                up_frac_i=in_spin, up_frac_f=out_spin, up_theta=s_theta, up_phi=s_phi,
                 )
         else:
             I_out = calc_Iqxy(qx, qy, rho, points, volume=volume, dtype='d')
@@ -1484,12 +1484,12 @@ def demo_shape(shape='ellip', samples=2000, nq=100, view=(60, 30, 0),
         rho, rho_m, points = shape.sample_magnetic(sampling_density)
         rho, rho_m = rho*1e-6, rho_m*1e-6
         mx, my, mz = rho_m
-        up_i, up_f, up_angle, up_phi = shape.spin
+        up_i, up_f, up_theta, up_phi = shape.spin
     else:
         rho, points = shape.sample(sampling_density)
         rho = rho*1e-6
         mx = my = mz = None
-        up_i, up_f, up_angle, up_phi = 0.5, 0.5, 90.0, 0.0
+        up_i, up_f, up_theta, up_phi = 0.5, 0.5, 90.0, 0.0
     points = realspace.apply_view(points, view)
     volume = shape.volume / len(points)
     #print("shape, pixel volume", shape.volume, shape.volume/len(points))
@@ -1504,7 +1504,7 @@ def demo_shape(shape='ellip', samples=2000, nq=100, view=(60, 30, 0),
     model.params['background'] = 1e-2
     model.params['Up_frac_in'] = up_i
     model.params['Up_frac_out'] = up_f
-    model.params['Up_theta'] = up_angle
+    model.params['Up_theta'] = up_theta
     model.params['Up_phi'] = up_phi
     if use_2d or shape.is_magnetic:
         q = np.linspace(-qmax, qmax, nq)
@@ -1540,7 +1540,7 @@ def demo():
         # Shape + qrange + magnetism (only for ellip).
         #shape='ellip', rab=125, rc=50, qmax=0.1,
         #shape='ellip', rab=25, rc=50, qmax=0.1,
-        shape='ellip', rab=125, rc=50, qmax=0.05, rho_m=5, theta_m=20, phi_m=30, up_i=1, up_f=0, up_angle=35, up_phi=35,
+        shape='ellip', rab=125, rc=50, qmax=0.05, rho_m=5, theta_m=20, phi_m=30, up_i=1, up_f=0, up_theta=35, up_phi=35,
 
         # 1D or 2D curve (ignored for magnetism).
         #use_2d=False,


### PR DESCRIPTION
Orientation angles are θ, φ, ψ  but magnetic orientation uses up_angle and up_phi. Rename up_angle to up_theta for consistency

Verify that θ, φ use the same orientation system as the particle axis, both for applied field and for orientation of the magnetism within the particle.
