### PR TITLE
New plotting option iq

### DIFF
--- a/src/sas/qtgui/MainWindow/GuiManager.py
+++ b/src/sas/qtgui/MainWindow/GuiManager.py
@@ -359,6 +359,10 @@ class GuiManager(object):
                 self._current_perspective.name] = self._current_perspective
             self._workspace.workspace.removeSubWindow(self._current_perspective)
             self._workspace.workspace.removeSubWindow(self.subwindow)
+        import PyQt5
+        PyQt5.QtCore.pyqtRemoveInputHook()
+        import pdb;
+        pdb.set_trace()
         # Get new perspective
         self._current_perspective = self.loadedPerspectives[str(perspective_name)]
 

--- a/src/sas/qtgui/MainWindow/GuiManager.py
+++ b/src/sas/qtgui/MainWindow/GuiManager.py
@@ -359,10 +359,6 @@ class GuiManager(object):
                 self._current_perspective.name] = self._current_perspective
             self._workspace.workspace.removeSubWindow(self._current_perspective)
             self._workspace.workspace.removeSubWindow(self.subwindow)
-        import PyQt5
-        PyQt5.QtCore.pyqtRemoveInputHook()
-        import pdb;
-        pdb.set_trace()
         # Get new perspective
         self._current_perspective = self.loadedPerspectives[str(perspective_name)]
 

--- a/src/sas/qtgui/Perspectives/Fitting/FittingWidget.py
+++ b/src/sas/qtgui/Perspectives/Fitting/FittingWidget.py
@@ -265,8 +265,6 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         self.q_range_max = OptionsWidget.QMAX_DEFAULT
         self.npts = OptionsWidget.NPTS_DEFAULT
         self.I_exponent = OptionsWidget.I_EXP_DEFAULT
-        # TEMPORARY
-        self.I_exponent = 2.0
         self.log_points = False
         self.weighting = 0
         self.chi2 = None
@@ -460,6 +458,7 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         else:
             self.lblFilename.setText(self.logic.data.filename)
         self.updateQRange()
+        self.updateIExp()
         # Switch off Data2D control
         self.chk2DView.setEnabled(False)
         self.chk2DView.setVisible(False)
@@ -577,6 +576,7 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         self.smearing_widget.updateData(self.data)
         # Line edits in the option tab
         self.updateQRange()
+        self.updateIExp()
 
     def initializeSignals(self):
         """
@@ -1290,6 +1290,7 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         """
         self.data_index = data_index
         self.updateQRange()
+        self.updateIExp()
 
     def onSelectStructureFactor(self):
         """
@@ -2262,7 +2263,7 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         """
         Update local option values and replot
         """
-        self.q_range_min, self.q_range_max, self.npts, self.log_points, self.weighting = \
+        self.q_range_min, self.q_range_max, self.npts, self.log_points, self.weighting, self.I_exponent = \
             self.options_widget.state()
         # set Q range labels on the main tab
         self.lblMinRangeDef.setText(GuiUtils.formatNumber(self.q_range_min, high=True))
@@ -2403,6 +2404,12 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
 
         # set Q range labels on the options tab
         self.options_widget.updateQRange(self.q_range_min, self.q_range_max, self.npts)
+
+    def updateIExp(self):
+        """
+        Updates Q Range display
+        """
+        self.options_widget.updateIExp(self.I_exponent)
 
     def SASModelToQModel(self, model_name, structure_factor=None):
         """
@@ -4249,6 +4256,8 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
                         break
         except ValueError:
             pass
+
+        self.options_widget.updateIExp(self.I_exponent)
 
         self.updateFullModel(context)
         self.updateFullPolyModel(context)

--- a/src/sas/qtgui/Perspectives/Fitting/FittingWidget.py
+++ b/src/sas/qtgui/Perspectives/Fitting/FittingWidget.py
@@ -617,7 +617,7 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         self.options_widget.plot_signal.connect(self.onOptionsUpdate)
         self.options_widget.txtMinRange.editingFinished.connect(self.options_widget.updateMinQ)
         self.options_widget.txtMaxRange.editingFinished.connect(self.options_widget.updateMaxQ)
-        self.options_widget.txtIntensityExponent.editingFinished.connect(self.options_widget.updateYExp)
+        self.options_widget.txtCustomYaxisExpression.editingFinished.connect(self.options_widget.updateYExp)
 
         # Signals from other widgets
         self.communicate.customModelDirectoryChanged.connect(self.onCustomModelChange)

--- a/src/sas/qtgui/Perspectives/Fitting/FittingWidget.py
+++ b/src/sas/qtgui/Perspectives/Fitting/FittingWidget.py
@@ -619,6 +619,12 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         self.options_widget.txtMaxRange.editingFinished.connect(self.options_widget.updateMaxQ)
         self.options_widget.txtCustomYaxisExpression.editingFinished.connect(self.options_widget.updateYExp)
 
+        # Hide custom options
+        self.options_widget.txtCustomYaxisExpression.hide()
+        self.options_widget.label_2.hide()
+        self.options_widget.txtYAxisTitle.hide()
+        self.options_widget.label_3.hide()
+
         # Signals from other widgets
         self.communicate.customModelDirectoryChanged.connect(self.onCustomModelChange)
         self.smearing_widget.smearingChangedSignal.connect(self.onSmearingOptionsUpdate)

--- a/src/sas/qtgui/Perspectives/Fitting/FittingWidget.py
+++ b/src/sas/qtgui/Perspectives/Fitting/FittingWidget.py
@@ -264,7 +264,7 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         self.q_range_min = OptionsWidget.QMIN_DEFAULT
         self.q_range_max = OptionsWidget.QMAX_DEFAULT
         self.npts = OptionsWidget.NPTS_DEFAULT
-        self.I_exponent = OptionsWidget.I_EXP_DEFAULT
+        self.Y_expression = OptionsWidget.Y_EXP_DEFAULT
         self.log_points = False
         self.weighting = 0
         self.chi2 = None
@@ -458,7 +458,7 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         else:
             self.lblFilename.setText(self.logic.data.filename)
         self.updateQRange()
-        self.updateIExp()
+        self.updateYExp()
         # Switch off Data2D control
         self.chk2DView.setEnabled(False)
         self.chk2DView.setVisible(False)
@@ -576,7 +576,7 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         self.smearing_widget.updateData(self.data)
         # Line edits in the option tab
         self.updateQRange()
-        self.updateIExp()
+        self.updateYExp()
 
     def initializeSignals(self):
         """
@@ -617,7 +617,7 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         self.options_widget.plot_signal.connect(self.onOptionsUpdate)
         self.options_widget.txtMinRange.editingFinished.connect(self.options_widget.updateMinQ)
         self.options_widget.txtMaxRange.editingFinished.connect(self.options_widget.updateMaxQ)
-        self.options_widget.txtIntensityExponent.editingFinished.connect(self.options_widget.updateIExp)
+        self.options_widget.txtIntensityExponent.editingFinished.connect(self.options_widget.updateYExp)
 
         # Signals from other widgets
         self.communicate.customModelDirectoryChanged.connect(self.onCustomModelChange)
@@ -1290,7 +1290,7 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         """
         self.data_index = data_index
         self.updateQRange()
-        self.updateIExp()
+        self.updateYExp()
 
     def onSelectStructureFactor(self):
         """
@@ -1888,7 +1888,7 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         model = copy.deepcopy(self.kernel_module)
         qmin = self.q_range_min
         qmax = self.q_range_max
-        I_exp = self.I_exponent
+        Y_exp = self.Y_expression
 
         params_to_fit = copy.deepcopy(self.main_params_to_fit)
         if self.chkPolydispersity.isChecked():
@@ -1925,7 +1925,7 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
             # pdb.set_trace()
             try:
                 fitter_single.set_model(model, fit_id, params_to_fit, data=weighted_data,
-                             constraints=constraints, I_exp=I_exp)
+                             constraints=constraints, Y_exp=Y_exp)
             except ValueError as ex:
                 raise ValueError("Setting model parameters failed with: %s" % ex)
 
@@ -2263,7 +2263,7 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         """
         Update local option values and replot
         """
-        self.q_range_min, self.q_range_max, self.npts, self.log_points, self.weighting, self.I_exponent = \
+        self.q_range_min, self.q_range_max, self.npts, self.log_points, self.weighting, self.Y_expression = \
             self.options_widget.state()
         # set Q range labels on the main tab
         self.lblMinRangeDef.setText(GuiUtils.formatNumber(self.q_range_min, high=True))
@@ -2405,11 +2405,11 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         # set Q range labels on the options tab
         self.options_widget.updateQRange(self.q_range_min, self.q_range_max, self.npts)
 
-    def updateIExp(self):
+    def updateYExp(self):
         """
         Updates Q Range display
         """
-        self.options_widget.updateIExp(self.I_exponent)
+        self.options_widget.updateYExp(self.Y_expression)
 
     def SASModelToQModel(self, model_name, structure_factor=None):
         """
@@ -2905,20 +2905,20 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         self.disableInteractiveElementsOnCalculate()
         # Awful API to a backend method.
         calc_thread = self.methodCalculateForData()(data=data,
-                                               model=model,
-                                               page_id=0,
-                                               qmin=self.q_range_min,
-                                               qmax=self.q_range_max,
-                                               smearer=smearer,
-                                               state=None,
-                                               weight=weight,
-                                               fid=None,
-                                               toggle_mode_on=False,
-                                               completefn=completefn,
-                                               update_chisqr=True,
-                                               exception_handler=self.calcException,
-                                               source=None,
-                                               I_exp=self.I_exponent)
+                                                    model=model,
+                                                    page_id=0,
+                                                    qmin=self.q_range_min,
+                                                    qmax=self.q_range_max,
+                                                    smearer=smearer,
+                                                    state=None,
+                                                    weight=weight,
+                                                    fid=None,
+                                                    toggle_mode_on=False,
+                                                    completefn=completefn,
+                                                    update_chisqr=True,
+                                                    exception_handler=self.calcException,
+                                                    source=None,
+                                                    Y_exp=self.Y_expression)
         if use_threads:
             if LocalConfig.USING_TWISTED:
                 # start the thread with twisted
@@ -3719,7 +3719,7 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         self.npts = fp.fit_options[fp.NPTS]
         self.log_points = fp.fit_options[fp.LOG_POINTS]
         self.weighting = fp.fit_options[fp.WEIGHTING]
-        self.I_exponent = fp.fit_options[fp.I_EXP]
+        self.Y_expression = fp.fit_options[fp.Y_EXP]
 
         # Models
         self._model_model = fp.model_model
@@ -3779,7 +3779,7 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         fp.fit_options[fp.NPTS_FIT] = self.npts_fit
         fp.fit_options[fp.LOG_POINTS] = self.log_points
         fp.fit_options[fp.WEIGHTING] = self.weighting
-        fp.fit_options[fp.I_EXP] = self.I_exponent
+        fp.fit_options[fp.Y_EXP] = self.Y_expression
 
         # Resolution tab
         smearing, accuracy, smearing_min, smearing_max = self.smearing_widget.state()
@@ -4000,7 +4000,7 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         param_list.append(['q_range_max', str(self.q_range_max)])
         param_list.append(['q_weighting', str(self.weighting)])
         param_list.append(['weighting', str(self.options_widget.weighting)])
-        param_list.append(['I_exponent', str(self.I_exponent)])
+        param_list.append(['Y_expression', str(self.Y_expression)])
 
         # resolution
         smearing, accuracy, smearing_min, smearing_max = self.smearing_widget.state()
@@ -4257,7 +4257,7 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         except ValueError:
             pass
 
-        self.options_widget.updateIExp(self.I_exponent)
+        self.options_widget.updateYExp(self.Y_expression)
 
         self.updateFullModel(context)
         self.updateFullPolyModel(context)
@@ -4453,7 +4453,7 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         state.qmin = self.q_range_min
         state.qmax = self.q_range_max
         state.npts = self.npts
-        state.I_exp = self.I_exponent
+        state.Y_exp = self.Y_expression
 
         p = self.model_parameters
         # save checkbutton state and txtcrtl values

--- a/src/sas/qtgui/Perspectives/Fitting/ModelThread.py
+++ b/src/sas/qtgui/Perspectives/Fitting/ModelThread.py
@@ -168,7 +168,6 @@ class Calc1D(CalcThread):
         self.starttime = time.time()
         output = numpy.zeros((len(self.data.x)))
         index = (self.qmin <= self.data.x) & (self.data.x <= self.qmax)
-        self.model.set_exponent(2.0)
 
         intermediate_results = None
 

--- a/src/sas/qtgui/Perspectives/Fitting/ModelThread.py
+++ b/src/sas/qtgui/Perspectives/Fitting/ModelThread.py
@@ -161,13 +161,10 @@ class Calc1D(CalcThread):
         """
         Compute model 1d value given qmin , qmax , x value
         """
-        # import PyQt5
-        # PyQt5.QtCore.pyqtRemoveInputHook()
-        # import pdb;
-        # pdb.set_trace()
         self.starttime = time.time()
         output = numpy.zeros((len(self.data.x)))
         index = (self.qmin <= self.data.x) & (self.data.x <= self.qmax)
+        self.model.set_exponent(self.I_exp)
 
         intermediate_results = None
 

--- a/src/sas/qtgui/Perspectives/Fitting/ModelThread.py
+++ b/src/sas/qtgui/Perspectives/Fitting/ModelThread.py
@@ -33,6 +33,7 @@ class Calc2D(CalcThread):
                             exception_handler=exception_handler)
         self.qmin = qmin
         self.qmax = qmax
+        self.I_exp = 2.0
         self.weight = weight
         self.fid = fid
         #self.qstep = qstep
@@ -134,7 +135,7 @@ class Calc1D(CalcThread):
                  yieldtime=0.01,
                  worktime=0.01,
                  exception_handler=None,
-                 ):
+                 I_exp=0.0):
         """
         """
         CalcThread.__init__(self, completefn, updatefn, yieldtime, worktime,
@@ -154,14 +155,20 @@ class Calc1D(CalcThread):
         self.source = source
         self.out = None
         self.index = None
+        self.I_exp = I_exp
 
     def compute(self):
         """
         Compute model 1d value given qmin , qmax , x value
         """
+        # import PyQt5
+        # PyQt5.QtCore.pyqtRemoveInputHook()
+        # import pdb;
+        # pdb.set_trace()
         self.starttime = time.time()
         output = numpy.zeros((len(self.data.x)))
         index = (self.qmin <= self.data.x) & (self.data.x <= self.qmax)
+        self.model.set_exponent(2.0)
 
         intermediate_results = None
 

--- a/src/sas/qtgui/Perspectives/Fitting/ModelThread.py
+++ b/src/sas/qtgui/Perspectives/Fitting/ModelThread.py
@@ -33,7 +33,7 @@ class Calc2D(CalcThread):
                             exception_handler=exception_handler)
         self.qmin = qmin
         self.qmax = qmax
-        self.I_exp = 2.0
+        self.Y_exp = "I"
         self.weight = weight
         self.fid = fid
         #self.qstep = qstep
@@ -135,7 +135,7 @@ class Calc1D(CalcThread):
                  yieldtime=0.01,
                  worktime=0.01,
                  exception_handler=None,
-                 I_exp=0.0):
+                 Y_exp="I"):
         """
         """
         CalcThread.__init__(self, completefn, updatefn, yieldtime, worktime,
@@ -155,7 +155,7 @@ class Calc1D(CalcThread):
         self.source = source
         self.out = None
         self.index = None
-        self.I_exp = I_exp
+        self.Y_exp = Y_exp
 
     def compute(self):
         """
@@ -164,7 +164,7 @@ class Calc1D(CalcThread):
         self.starttime = time.time()
         output = numpy.zeros((len(self.data.x)))
         index = (self.qmin <= self.data.x) & (self.data.x <= self.qmax)
-        self.model.set_exponent(self.I_exp)
+        self.model.set_expression(self.Y_exp)
 
         intermediate_results = None
 

--- a/src/sas/qtgui/Perspectives/Fitting/OptionsWidget.py
+++ b/src/sas/qtgui/Perspectives/Fitting/OptionsWidget.py
@@ -43,7 +43,8 @@ class OptionsWidget(QtWidgets.QWidget, Ui_tabOptions):
         'NPTS',
         'NPTS_FIT',
         'LOG_SPACED',
-        'Y_EXP']
+        'Y_EXP',
+        'CUSTOM_Y_EXP_CHK']
 
     def __init__(self, parent=None, logic=None):
         super(OptionsWidget, self).__init__()
@@ -80,6 +81,7 @@ class OptionsWidget(QtWidgets.QWidget, Ui_tabOptions):
         self.cmdReset.clicked.connect(self.onRangeReset)
         self.cmdMaskEdit.clicked.connect(self.onMaskEdit)
         self.chkLogData.stateChanged.connect(self.toggleLogData)
+        self.chkCustomYData.stateChanged.connect(self.toggleCustomYData)
         # Button groups
         self.weightingGroup.buttonClicked.connect(self.onWeightingChoice)
 
@@ -132,6 +134,7 @@ class OptionsWidget(QtWidgets.QWidget, Ui_tabOptions):
         self.mapper.addMapping(self.txtNptsFit,  self.MODEL.index('NPTS_FIT'))
         self.mapper.addMapping(self.chkLogData,  self.MODEL.index('LOG_SPACED'))
         self.mapper.addMapping(self.comboBoxYaxisExpression, self.MODEL.index('Y_EXP'))
+        self.mapper.addMapping(self.chkCustomYData, self.MODEL.index('CUSTOM_Y_EXP_CHK'))
         self.mapper.addMapping(self.txtCustomYaxisExpression, self.MODEL.index('Y_EXP'))
 
         self.mapper.toFirst()
@@ -139,6 +142,19 @@ class OptionsWidget(QtWidgets.QWidget, Ui_tabOptions):
     def toggleLogData(self, isChecked):
         """ Toggles between log and linear data sets """
         pass
+
+    def toggleCustomYData(self, isChecked):
+        """ Toggles between custom and default Y-axis data """
+        if isChecked == 0:
+            self.txtCustomYaxisExpression.hide()
+            self.label_2.hide()
+            self.txtYAxisTitle.hide()
+            self.label_3.hide()
+        elif isChecked == 2:
+            self.txtCustomYaxisExpression.show()
+            self.label_2.show()
+            self.txtYAxisTitle.show()
+            self.label_3.show()
 
     def onMaskEdit(self):
         """

--- a/src/sas/qtgui/Perspectives/Fitting/OptionsWidget.py
+++ b/src/sas/qtgui/Perspectives/Fitting/OptionsWidget.py
@@ -99,7 +99,7 @@ class OptionsWidget(QtWidgets.QWidget, Ui_tabOptions):
         self.txtMinRange.setText(str(self.qmin))
         self.txtNpts.setText(str(self.npts))
         self.txtNptsFit.setText(str(self.npts_fit))
-        self.txtIntensityExponent.setText(str(self.Y_exp))
+        self.txtCustomYaxisExpression.setText("")
         self.updateYExp(self.Y_exp)
         self.model.blockSignals(False)
 
@@ -131,7 +131,8 @@ class OptionsWidget(QtWidgets.QWidget, Ui_tabOptions):
         self.mapper.addMapping(self.txtNpts,     self.MODEL.index('NPTS'))
         self.mapper.addMapping(self.txtNptsFit,  self.MODEL.index('NPTS_FIT'))
         self.mapper.addMapping(self.chkLogData,  self.MODEL.index('LOG_SPACED'))
-        self.mapper.addMapping(self.txtIntensityExponent, self.MODEL.index('Y_EXP'))
+        self.mapper.addMapping(self.comboBoxYaxisExpression, self.MODEL.index('Y_EXP'))
+        self.mapper.addMapping(self.txtCustomYaxisExpression, self.MODEL.index('Y_EXP'))
 
         self.mapper.toFirst()
 

--- a/src/sas/qtgui/Perspectives/Fitting/OptionsWidget.py
+++ b/src/sas/qtgui/Perspectives/Fitting/OptionsWidget.py
@@ -36,14 +36,14 @@ class OptionsWidget(QtWidgets.QWidget, Ui_tabOptions):
     QMIN_DEFAULT = 0.0005
     QMAX_DEFAULT = 0.5
     NPTS_DEFAULT = 50
-    I_EXP_DEFAULT = 0
+    Y_EXP_DEFAULT = "I"
     MODEL = [
         'MIN_RANGE',
         'MAX_RANGE',
         'NPTS',
         'NPTS_FIT',
         'LOG_SPACED',
-        'I_EXP']
+        'Y_EXP']
 
     def __init__(self, parent=None, logic=None):
         super(OptionsWidget, self).__init__()
@@ -70,7 +70,6 @@ class OptionsWidget(QtWidgets.QWidget, Ui_tabOptions):
         # Let only floats in the range edits
         self.txtMinRange.setValidator(GuiUtils.DoubleValidator())
         self.txtMaxRange.setValidator(GuiUtils.DoubleValidator())
-        self.txtIntensityExponent.setValidator(GuiUtils.DoubleValidator())
         # Let only ints in the number of points edit
         self.txtNpts.setValidator(QtGui.QIntValidator())
 
@@ -88,7 +87,7 @@ class OptionsWidget(QtWidgets.QWidget, Ui_tabOptions):
         self.qmax = self.QMAX_DEFAULT
         self.npts = self.NPTS_DEFAULT
         self.npts_fit = self.NPTS_DEFAULT
-        self.I_exp = self.I_EXP_DEFAULT
+        self.Y_exp = self.Y_EXP_DEFAULT
         if self.logic.data_is_loaded:
             self.qmin, self.qmax, self.npts = self.logic.computeDataRange()
             self.npts_fit = self.npts2fit(data=self.logic.data)
@@ -100,8 +99,8 @@ class OptionsWidget(QtWidgets.QWidget, Ui_tabOptions):
         self.txtMinRange.setText(str(self.qmin))
         self.txtNpts.setText(str(self.npts))
         self.txtNptsFit.setText(str(self.npts_fit))
-        self.txtIntensityExponent.setText(str(self.I_exp))
-        self.updateIExp(self.I_exp)
+        self.txtIntensityExponent.setText(str(self.Y_exp))
+        self.updateYExp(self.Y_exp)
         self.model.blockSignals(False)
 
         new_font = 'font-family: -apple-system, "Helvetica Neue", "Ubuntu";'
@@ -132,7 +131,7 @@ class OptionsWidget(QtWidgets.QWidget, Ui_tabOptions):
         self.mapper.addMapping(self.txtNpts,     self.MODEL.index('NPTS'))
         self.mapper.addMapping(self.txtNptsFit,  self.MODEL.index('NPTS_FIT'))
         self.mapper.addMapping(self.chkLogData,  self.MODEL.index('LOG_SPACED'))
-        self.mapper.addMapping(self.txtIntensityExponent, self.MODEL.index('I_EXP'))
+        self.mapper.addMapping(self.txtIntensityExponent, self.MODEL.index('Y_EXP'))
 
         self.mapper.toFirst()
 
@@ -249,9 +248,8 @@ class OptionsWidget(QtWidgets.QWidget, Ui_tabOptions):
         npts_fit = self.npts2fit(self.logic.data)
         self.model.item(self.MODEL.index('NPTS_FIT')).setText(str(npts_fit))
 
-    def updateIExp(self, I_exp=0.0):
-        self.model.item(self.MODEL.index('I_EXP'))
-        self.I_exp = I_exp
+    def updateYExp(self, Y_exp="I"):
+        self.Y_exp = Y_exp
 
     def state(self):
         """
@@ -262,15 +260,11 @@ class OptionsWidget(QtWidgets.QWidget, Ui_tabOptions):
         npts = int(self.model.item(self.MODEL.index('NPTS')).text())
         npts_fit = int(self.model.item(self.MODEL.index('NPTS_FIT')).text())
         log_points = str(self.model.item(self.MODEL.index('LOG_SPACED')).text()) == 'true'
-        # import PyQt5
-        # PyQt5.QtCore.pyqtRemoveInputHook()
-        # import pdb;
-        # pdb.set_trace()
-        if self.model.item(self.MODEL.index('I_EXP')).text() != '':
-            I_exp = float(self.model.item(self.MODEL.index('I_EXP')).text())
+        if self.model.item(self.MODEL.index('Y_EXP')).text() != '':
+            Y_exp = self.model.item(self.MODEL.index('Y_EXP')).text()
         else:
-            I_exp = self.I_exp
-        return (q_range_min, q_range_max, npts, log_points, self.weighting, I_exp)
+            Y_exp = self.Y_exp
+        return (q_range_min, q_range_max, npts, log_points, self.weighting, Y_exp)
 
     def npts2fit(self, data=None, qmin=None, qmax=None, npts=None):
         """

--- a/src/sas/qtgui/Perspectives/Fitting/OptionsWidget.py
+++ b/src/sas/qtgui/Perspectives/Fitting/OptionsWidget.py
@@ -250,7 +250,6 @@ class OptionsWidget(QtWidgets.QWidget, Ui_tabOptions):
         self.model.item(self.MODEL.index('NPTS_FIT')).setText(str(npts_fit))
 
     def updateIExp(self, I_exp=0.0):
-        self.txtIntensityExponent.setText(str(I_exp))
         self.model.item(self.MODEL.index('I_EXP'))
         self.I_exp = I_exp
 

--- a/src/sas/qtgui/Perspectives/Fitting/OptionsWidget.py
+++ b/src/sas/qtgui/Perspectives/Fitting/OptionsWidget.py
@@ -101,6 +101,7 @@ class OptionsWidget(QtWidgets.QWidget, Ui_tabOptions):
         self.txtNpts.setText(str(self.npts))
         self.txtNptsFit.setText(str(self.npts_fit))
         self.txtIntensityExponent.setText(str(self.I_exp))
+        self.updateIExp(self.I_exp)
         self.model.blockSignals(False)
 
         new_font = 'font-family: -apple-system, "Helvetica Neue", "Ubuntu";'
@@ -249,7 +250,7 @@ class OptionsWidget(QtWidgets.QWidget, Ui_tabOptions):
         self.model.item(self.MODEL.index('NPTS_FIT')).setText(str(npts_fit))
 
     def updateIExp(self, I_exp=0.0):
-        self.txtIntensityExponent.setText(I_exp)
+        self.txtIntensityExponent.setText(str(I_exp))
         self.model.item(self.MODEL.index('I_EXP'))
         self.I_exp = I_exp
 
@@ -262,9 +263,15 @@ class OptionsWidget(QtWidgets.QWidget, Ui_tabOptions):
         npts = int(self.model.item(self.MODEL.index('NPTS')).text())
         npts_fit = int(self.model.item(self.MODEL.index('NPTS_FIT')).text())
         log_points = str(self.model.item(self.MODEL.index('LOG_SPACED')).text()) == 'true'
-        I_exponent = float(self.model.item(self.MODEL.index('I_EXP')).text())
-
-        return (q_range_min, q_range_max, npts, log_points, self.weighting, I_exponent)
+        # import PyQt5
+        # PyQt5.QtCore.pyqtRemoveInputHook()
+        # import pdb;
+        # pdb.set_trace()
+        if self.model.item(self.MODEL.index('I_EXP')).text() != '':
+            I_exp = float(self.model.item(self.MODEL.index('I_EXP')).text())
+        else:
+            I_exp = self.I_exp
+        return (q_range_min, q_range_max, npts, log_points, self.weighting, I_exp)
 
     def npts2fit(self, data=None, qmin=None, qmax=None, npts=None):
         """

--- a/src/sas/qtgui/Perspectives/Fitting/OptionsWidget.py
+++ b/src/sas/qtgui/Perspectives/Fitting/OptionsWidget.py
@@ -36,12 +36,14 @@ class OptionsWidget(QtWidgets.QWidget, Ui_tabOptions):
     QMIN_DEFAULT = 0.0005
     QMAX_DEFAULT = 0.5
     NPTS_DEFAULT = 50
+    I_EXP_DEFAULT = 0
     MODEL = [
         'MIN_RANGE',
         'MAX_RANGE',
         'NPTS',
         'NPTS_FIT',
-        'LOG_SPACED']
+        'LOG_SPACED',
+        'I_EXP']
 
     def __init__(self, parent=None, logic=None):
         super(OptionsWidget, self).__init__()
@@ -68,6 +70,7 @@ class OptionsWidget(QtWidgets.QWidget, Ui_tabOptions):
         # Let only floats in the range edits
         self.txtMinRange.setValidator(GuiUtils.DoubleValidator())
         self.txtMaxRange.setValidator(GuiUtils.DoubleValidator())
+        self.txtIntensityExponent.setValidator(GuiUtils.DoubleValidator())
         # Let only ints in the number of points edit
         self.txtNpts.setValidator(QtGui.QIntValidator())
 
@@ -85,6 +88,7 @@ class OptionsWidget(QtWidgets.QWidget, Ui_tabOptions):
         self.qmax = self.QMAX_DEFAULT
         self.npts = self.NPTS_DEFAULT
         self.npts_fit = self.NPTS_DEFAULT
+        self.I_exp = self.I_EXP_DEFAULT
         if self.logic.data_is_loaded:
             self.qmin, self.qmax, self.npts = self.logic.computeDataRange()
             self.npts_fit = self.npts2fit(data=self.logic.data)
@@ -96,6 +100,7 @@ class OptionsWidget(QtWidgets.QWidget, Ui_tabOptions):
         self.txtMinRange.setText(str(self.qmin))
         self.txtNpts.setText(str(self.npts))
         self.txtNptsFit.setText(str(self.npts_fit))
+        self.txtIntensityExponent.setText(str(self.I_exp))
         self.model.blockSignals(False)
 
         new_font = 'font-family: -apple-system, "Helvetica Neue", "Ubuntu";'
@@ -126,6 +131,7 @@ class OptionsWidget(QtWidgets.QWidget, Ui_tabOptions):
         self.mapper.addMapping(self.txtNpts,     self.MODEL.index('NPTS'))
         self.mapper.addMapping(self.txtNptsFit,  self.MODEL.index('NPTS_FIT'))
         self.mapper.addMapping(self.chkLogData,  self.MODEL.index('LOG_SPACED'))
+        self.mapper.addMapping(self.txtIntensityExponent, self.MODEL.index('I_EXP'))
 
         self.mapper.toFirst()
 
@@ -165,7 +171,7 @@ class OptionsWidget(QtWidgets.QWidget, Ui_tabOptions):
             return
         # Update the npts/fit value
         if top.row() in [0, 1, 2]:
-            qmin, qmax, npts, _, _ = self.state()
+            qmin, qmax, npts, _, _, _ = self.state()
             # if this is a Q value, update NPt/fit
             value = float(item_text)
             if top.row() == 0:
@@ -242,6 +248,11 @@ class OptionsWidget(QtWidgets.QWidget, Ui_tabOptions):
         npts_fit = self.npts2fit(self.logic.data)
         self.model.item(self.MODEL.index('NPTS_FIT')).setText(str(npts_fit))
 
+    def updateIExp(self, I_exp=0.0):
+        self.txtIntensityExponent.setText(I_exp)
+        self.model.item(self.MODEL.index('I_EXP'))
+        self.I_exp = I_exp
+
     def state(self):
         """
         Returns current state of controls
@@ -251,8 +262,9 @@ class OptionsWidget(QtWidgets.QWidget, Ui_tabOptions):
         npts = int(self.model.item(self.MODEL.index('NPTS')).text())
         npts_fit = int(self.model.item(self.MODEL.index('NPTS_FIT')).text())
         log_points = str(self.model.item(self.MODEL.index('LOG_SPACED')).text()) == 'true'
+        I_exponent = float(self.model.item(self.MODEL.index('I_EXP')).text())
 
-        return (q_range_min, q_range_max, npts, log_points, self.weighting)
+        return (q_range_min, q_range_max, npts, log_points, self.weighting, I_exponent)
 
     def npts2fit(self, data=None, qmin=None, qmax=None, npts=None):
         """

--- a/src/sas/qtgui/Perspectives/Fitting/UI/OptionsWidgetUI.ui
+++ b/src/sas/qtgui/Perspectives/Fitting/UI/OptionsWidgetUI.ui
@@ -7,14 +7,14 @@
     <x>0</x>
     <y>0</y>
     <width>522</width>
-    <height>462</height>
+    <height>616</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>Fit Options</string>
   </property>
   <layout class="QGridLayout" name="gridLayout_3">
-   <item row="0" column="0" colspan="3">
+   <item row="0" column="0" colspan="2">
     <widget class="QGroupBox" name="groupBox_4">
      <property name="title">
       <string>Fitting range</string>
@@ -111,7 +111,7 @@
      </layout>
     </widget>
    </item>
-   <item row="1" column="0" colspan="3">
+   <item row="1" column="0" colspan="2">
     <widget class="QGroupBox" name="groupBox_5">
      <property name="title">
       <string>Data points</string>
@@ -229,25 +229,15 @@
      </property>
      <layout class="QGridLayout" name="gridLayout_2">
       <item row="0" column="0">
-       <layout class="QGridLayout" name="gridLayout">
-        <item row="0" column="0">
+       <layout class="QHBoxLayout" name="horizontalLayout">
+        <item>
          <widget class="QLabel" name="label">
           <property name="text">
            <string>Y-axis Data</string>
           </property>
          </widget>
         </item>
-        <item row="1" column="0" colspan="2">
-         <widget class="QLabel" name="label_2">
-          <property name="text">
-           <string>Custom  Y-axis Data</string>
-          </property>
-         </widget>
-        </item>
-        <item row="1" column="2">
-         <widget class="QLineEdit" name="txtCustomYaxisExpression"/>
-        </item>
-        <item row="0" column="2">
+        <item>
          <widget class="QComboBox" name="comboBoxYaxisExpression">
           <item>
            <property name="text">
@@ -269,44 +259,56 @@
             <string>I * (Q ** 4)</string>
            </property>
           </item>
-          <item>
-           <property name="text">
-            <string>Custom</string>
-           </property>
-          </item>
          </widget>
         </item>
-       </layout>
-      </item>
-      <item row="1" column="0">
-       <layout class="QHBoxLayout" name="horizontalLayout">
         <item>
-         <widget class="QLabel" name="label_3">
+         <widget class="QCheckBox" name="chkCustomYData">
           <property name="text">
-           <string>Y-axis Title</string>
+           <string>Custom?</string>
           </property>
          </widget>
         </item>
         <item>
-         <widget class="QLineEdit" name="lineEdit_2"/>
+         <spacer name="horizontalSpacer">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>40</width>
+            <height>20</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+       </layout>
+      </item>
+      <item row="1" column="0">
+       <layout class="QGridLayout" name="gridLayout">
+        <item row="0" column="0">
+         <widget class="QLabel" name="label_2">
+          <property name="text">
+           <string>Custom  Y-axis Data</string>
+          </property>
+         </widget>
+        </item>
+        <item row="0" column="1">
+         <widget class="QLineEdit" name="txtCustomYaxisExpression"/>
+        </item>
+        <item row="1" column="0">
+         <widget class="QLabel" name="label_3">
+          <property name="text">
+           <string>Custom Y-axis Title</string>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="1">
+         <widget class="QLineEdit" name="txtYAxisTitle"/>
         </item>
        </layout>
       </item>
      </layout>
     </widget>
-   </item>
-   <item row="3" column="2">
-    <spacer name="horizontalSpacer">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>260</width>
-       <height>20</height>
-      </size>
-     </property>
-    </spacer>
    </item>
    <item row="4" column="1">
     <spacer name="verticalSpacer">
@@ -316,7 +318,7 @@
      <property name="sizeHint" stdset="0">
       <size>
        <width>20</width>
-       <height>21</height>
+       <height>175</height>
       </size>
      </property>
     </spacer>

--- a/src/sas/qtgui/Perspectives/Fitting/UI/OptionsWidgetUI.ui
+++ b/src/sas/qtgui/Perspectives/Fitting/UI/OptionsWidgetUI.ui
@@ -13,8 +13,8 @@
   <property name="windowTitle">
    <string>Fit Options</string>
   </property>
-  <layout class="QGridLayout" name="gridLayout_23">
-   <item row="0" column="0">
+  <layout class="QGridLayout" name="gridLayout_2">
+   <item row="0" column="0" colspan="2">
     <widget class="QGroupBox" name="groupBox_4">
      <property name="title">
       <string>Fitting range</string>
@@ -111,7 +111,7 @@
      </layout>
     </widget>
    </item>
-   <item row="1" column="0">
+   <item row="1" column="0" colspan="2">
     <widget class="QGroupBox" name="groupBox_5">
      <property name="title">
       <string>Data points</string>
@@ -222,7 +222,43 @@
      </layout>
     </widget>
    </item>
-   <item row="3" column="0">
+   <item row="3" column="0" colspan="2">
+    <widget class="QGroupBox" name="groupBox">
+     <property name="title">
+      <string>Y-axis</string>
+     </property>
+     <layout class="QGridLayout" name="gridLayout">
+      <item row="0" column="0">
+       <layout class="QHBoxLayout" name="horizontalLayout">
+        <item>
+         <widget class="QLabel" name="label">
+          <property name="text">
+           <string>Q Exponent</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QLineEdit" name="txtIntensityExponent"/>
+        </item>
+        <item>
+         <spacer name="horizontalSpacer">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>40</width>
+            <height>20</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+       </layout>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item row="4" column="1">
     <spacer name="verticalSpacer">
      <property name="orientation">
       <enum>Qt::Vertical</enum>
@@ -230,7 +266,7 @@
      <property name="sizeHint" stdset="0">
       <size>
        <width>20</width>
-       <height>312</height>
+       <height>68</height>
       </size>
      </property>
     </spacer>

--- a/src/sas/qtgui/Perspectives/Fitting/UI/OptionsWidgetUI.ui
+++ b/src/sas/qtgui/Perspectives/Fitting/UI/OptionsWidgetUI.ui
@@ -7,21 +7,71 @@
     <x>0</x>
     <y>0</y>
     <width>522</width>
-    <height>455</height>
+    <height>462</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>Fit Options</string>
   </property>
-  <layout class="QGridLayout" name="gridLayout_2">
-   <item row="0" column="0" colspan="2">
+  <layout class="QGridLayout" name="gridLayout_3">
+   <item row="0" column="0" colspan="3">
     <widget class="QGroupBox" name="groupBox_4">
      <property name="title">
       <string>Fitting range</string>
      </property>
      <layout class="QGridLayout" name="gridLayout_11">
+      <item row="0" column="1" rowspan="2">
+       <spacer name="horizontalSpacer_8">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>217</width>
+          <height>20</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+      <item row="0" column="2">
+       <widget class="QPushButton" name="cmdReset">
+        <property name="toolTip">
+         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Reset the Q range to the default.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+        </property>
+        <property name="text">
+         <string>Reset</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="2">
+       <widget class="QPushButton" name="cmdMaskEdit">
+        <property name="text">
+         <string>Mask Editor</string>
+        </property>
+       </widget>
+      </item>
       <item row="0" column="0" rowspan="2">
        <layout class="QGridLayout" name="gridLayout_13">
+        <item row="1" column="2">
+         <widget class="QLabel" name="label_15">
+          <property name="text">
+           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Å&lt;span style=&quot; vertical-align:super;&quot;&gt;-1&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="1">
+         <widget class="QLineEdit" name="txtMaxRange">
+          <property name="minimumSize">
+           <size>
+            <width>80</width>
+            <height>0</height>
+           </size>
+          </property>
+          <property name="toolTip">
+           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Maximum value of Q.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+          </property>
+         </widget>
+        </item>
         <item row="0" column="0">
          <widget class="QLabel" name="label_9">
           <property name="text">
@@ -56,62 +106,12 @@
           </property>
          </widget>
         </item>
-        <item row="1" column="1">
-         <widget class="QLineEdit" name="txtMaxRange">
-          <property name="minimumSize">
-           <size>
-            <width>80</width>
-            <height>0</height>
-           </size>
-          </property>
-          <property name="toolTip">
-           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Maximum value of Q.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-          </property>
-         </widget>
-        </item>
-        <item row="1" column="2">
-         <widget class="QLabel" name="label_15">
-          <property name="text">
-           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Å&lt;span style=&quot; vertical-align:super;&quot;&gt;-1&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-          </property>
-         </widget>
-        </item>
        </layout>
-      </item>
-      <item row="0" column="1" rowspan="2">
-       <spacer name="horizontalSpacer_8">
-        <property name="orientation">
-         <enum>Qt::Horizontal</enum>
-        </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>217</width>
-          <height>20</height>
-         </size>
-        </property>
-       </spacer>
-      </item>
-      <item row="0" column="2">
-       <widget class="QPushButton" name="cmdReset">
-        <property name="toolTip">
-         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Reset the Q range to the default.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-        </property>
-        <property name="text">
-         <string>Reset</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="2">
-       <widget class="QPushButton" name="cmdMaskEdit">
-        <property name="text">
-         <string>Mask Editor</string>
-        </property>
-       </widget>
       </item>
      </layout>
     </widget>
    </item>
-   <item row="1" column="0" colspan="2">
+   <item row="1" column="0" colspan="3">
     <widget class="QGroupBox" name="groupBox_5">
      <property name="title">
       <string>Data points</string>
@@ -227,36 +227,86 @@
      <property name="title">
       <string>Y-axis</string>
      </property>
-     <layout class="QGridLayout" name="gridLayout">
+     <layout class="QGridLayout" name="gridLayout_2">
       <item row="0" column="0">
-       <layout class="QHBoxLayout" name="horizontalLayout">
-        <item>
+       <layout class="QGridLayout" name="gridLayout">
+        <item row="0" column="0">
          <widget class="QLabel" name="label">
           <property name="text">
-           <string>Q Exponent</string>
+           <string>Y-axis Data</string>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="0" colspan="2">
+         <widget class="QLabel" name="label_2">
+          <property name="text">
+           <string>Custom  Y-axis Data</string>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="2">
+         <widget class="QLineEdit" name="txtCustomYaxisExpression"/>
+        </item>
+        <item row="0" column="2">
+         <widget class="QComboBox" name="comboBoxYaxisExpression">
+          <item>
+           <property name="text">
+            <string>I</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>I ** 2</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>I * (Q ** 2)</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>I * (Q ** 4)</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>Custom</string>
+           </property>
+          </item>
+         </widget>
+        </item>
+       </layout>
+      </item>
+      <item row="1" column="0">
+       <layout class="QHBoxLayout" name="horizontalLayout">
+        <item>
+         <widget class="QLabel" name="label_3">
+          <property name="text">
+           <string>Y-axis Title</string>
           </property>
          </widget>
         </item>
         <item>
-         <widget class="QLineEdit" name="txtIntensityExponent"/>
-        </item>
-        <item>
-         <spacer name="horizontalSpacer">
-          <property name="orientation">
-           <enum>Qt::Horizontal</enum>
-          </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>40</width>
-            <height>20</height>
-           </size>
-          </property>
-         </spacer>
+         <widget class="QLineEdit" name="lineEdit_2"/>
         </item>
        </layout>
       </item>
      </layout>
     </widget>
+   </item>
+   <item row="3" column="2">
+    <spacer name="horizontalSpacer">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>260</width>
+       <height>20</height>
+      </size>
+     </property>
+    </spacer>
    </item>
    <item row="4" column="1">
     <spacer name="verticalSpacer">
@@ -266,7 +316,7 @@
      <property name="sizeHint" stdset="0">
       <size>
        <width>20</width>
-       <height>68</height>
+       <height>21</height>
       </size>
      </property>
     </spacer>

--- a/src/sas/sascalc/fit/AbstractFitEngine.py
+++ b/src/sas/sascalc/fit/AbstractFitEngine.py
@@ -396,7 +396,7 @@ class FitEngine:
         self.fit_arrange_dict = {}
         self.fitter_id = None
 
-    def set_model(self, model, id, pars=[], constraints=[], data=None):
+    def set_model(self, model, id, pars=[], constraints=[], data=None, I_exp=0):
         """
         set a model on a given  in the fit engine.
 
@@ -438,6 +438,8 @@ class FitEngine:
         self.fit_arrange_dict[id].pars = pars
         self.fit_arrange_dict[id].vals = [sasmodel.getParam(name) for name in pars]
         self.fit_arrange_dict[id].constraints = constraints
+        self.fit_arrange_dict[id].model.model.set_exponent(I_exp)
+
 
     def set_data(self, data, id, smearer=None, qmin=None, qmax=None):
         """

--- a/src/sas/sascalc/fit/AbstractFitEngine.py
+++ b/src/sas/sascalc/fit/AbstractFitEngine.py
@@ -396,7 +396,7 @@ class FitEngine:
         self.fit_arrange_dict = {}
         self.fitter_id = None
 
-    def set_model(self, model, id, pars=[], constraints=[], data=None, I_exp=0):
+    def set_model(self, model, id, pars=[], constraints=[], data=None, Y_exp=0):
         """
         set a model on a given  in the fit engine.
 
@@ -438,7 +438,7 @@ class FitEngine:
         self.fit_arrange_dict[id].pars = pars
         self.fit_arrange_dict[id].vals = [sasmodel.getParam(name) for name in pars]
         self.fit_arrange_dict[id].constraints = constraints
-        self.fit_arrange_dict[id].model.model.set_exponent(I_exp)
+        self.fit_arrange_dict[id].model.model.set_expression(Y_exp)
 
 
     def set_data(self, data, id, smearer=None, qmin=None, qmax=None):


### PR DESCRIPTION
This pull request allows the user to specify what is plotted on the y-axis. For example they may have Q against I(Q^2) data. The user can specify this in the “Fit Options” tab.
![image](https://user-images.githubusercontent.com/88383842/143056327-ce491dbc-b558-4739-a5c6-2c75159d8da1.png)
Currently there are 4 default options, [I, I^2, I(Q^2), I(Q^4)], but there is an option for users to define their own equation using I and Q, along with python mathematical operators. 
Requires https://github.com/SasView/sasmodels/pull/491 to function
