### PR TITLE
fix handedness of magnetic structures in mag SLD

### DIFF
--- a/src/sas/sascalc/calculator/geni.py
+++ b/src/sas/sascalc/calculator/geni.py
@@ -223,6 +223,12 @@ def _calc_Iqxy_magnetic_helper(
         dd, du, ud, uu):
     # Process each qx, qy
     # Note: enumerating a pair is slower than direct indexing in numba
+
+    p_hat = np.array([sin_spin * cos_phi, sin_spin * sin_phi, cos_spin ])
+    #two unit vectors spanning up the plane perpendicular to polarisation for SF scattering
+    perpy_hat = np.array([-sin_phi, cos_phi, 0 ])
+    perpz_hat = np.array([-cos_spin * cos_phi, -cos_spin * sin_phi, sin_spin ])    
+
     for k in range(len(qx)):
         qxk, qyk = qx[k], qy[k]
 
@@ -235,10 +241,6 @@ def _calc_Iqxy_magnetic_helper(
             # with Nij the demagnetisation tensor (Belleggia JMMM 263, L1, 2003).
             q_hat = np.sqrt(np.array([0.5, 0.5, 0]))
 
-        p_hat = np.array([sin_spin * cos_phi, sin_spin * sin_phi, cos_spin ])
-        #two unit vectors spanning up the plane perpendicular to polarisation for SF scattering
-        perpy_hat = np.array([-sin_phi, cos_phi, 0 ])
-        perpz_hat = np.array([-cos_spin * cos_phi, -cos_spin * sin_phi, sin_spin ])
         M_perp = orth(M, q_hat)
 
         perpx = p_hat @ M_perp

--- a/src/sas/sascalc/calculator/geni.py
+++ b/src/sas/sascalc/calculator/geni.py
@@ -215,12 +215,7 @@ def _calc_Iqxy_magnetic(
 @njit
 def orth(A, b): # A = 3 x n, and b_hat unit vector
     return A - np.outer(b, b)@A
-
-
-@njit
-def basis_vector(A, B): # A = 3 x n, and B = 3 x n
-    vec = np.cross(A, B)
-    return vec / np.sqrt(np.dot(vec, vec))   
+ 
 
 @njit("(" + "f8[:], "*7 + "f8[:,::1], "+ "f8, "*8 + ")")
 def _calc_Iqxy_magnetic_helper(
@@ -241,16 +236,16 @@ def _calc_Iqxy_magnetic_helper(
             q_hat = np.sqrt(np.array([0.5, 0.5, 0]))
 
         p_hat = np.array([sin_spin * cos_phi, sin_spin * sin_phi, cos_spin ])
-
+        #two unit vectors spanning up the plane perpendicular to polarisation for SF scattering
+        perpy_hat = np.array([-sin_phi, cos_phi, 0 ])
+        perpz_hat = np.array([-cos_spin * cos_phi, -cos_spin * sin_phi, sin_spin ])
         M_perp = orth(M, q_hat)
-        q_perp = orth(q_hat, p_hat)
-        q_perp = q_perp / np.sqrt(np.dot(q_perp, q_perp)) 
 
         perpx = p_hat @ M_perp
         # einsum is faster than sumsq in numpy but not supported in numba
         #perpy = np.sqrt(np.einsum('ji,ji->i', M_perpP_perpQ, M_perpP_perpQ))
-        perpy = basis_vector(q_hat, p_hat) @ M_perp
-        perpz = q_perp @ M_perp
+        perpy = perpy_hat @ M_perp
+        perpz = perpz_hat @ M_perp
 
         ephase = vol * np.exp(1j * (qxk * x + qyk * y))
         if dd > 1e-10:

--- a/src/sas/sascalc/calculator/geni.py
+++ b/src/sas/sascalc/calculator/geni.py
@@ -216,6 +216,12 @@ def _calc_Iqxy_magnetic(
 def orth(A, b): # A = 3 x n, and b_hat unit vector
     return A - np.outer(b, b)@A
 
+
+@njit
+def basis_vector(A, B): # A = 3 x n, and B = 3 x n
+    vec = np.cross(A, B)
+    return vec / np.sqrt(np.inner(vec, vec))   
+
 @njit("(" + "f8[:], "*7 + "f8[:,::1], "+ "f8, "*8 + ")")
 def _calc_Iqxy_magnetic_helper(
         Iq, qx, qy, x, y, rho, vol, M, cos_spin, sin_spin, cos_phi, sin_phi,
@@ -243,7 +249,7 @@ def _calc_Iqxy_magnetic_helper(
         perpx = p_hat @ M_perp
         # einsum is faster than sumsq in numpy but not supported in numba
         #perpy = np.sqrt(np.einsum('ji,ji->i', M_perpP_perpQ, M_perpP_perpQ))
-        perpy = np.sqrt(np.sum(M_perpP_perpQ**2, axis=0))
+        perpy = basis_vector(q_hat, p_hat) @ M_perpP_perpQ
         perpz = q_hat @ M_perpP
 
         ephase = vol * np.exp(1j * (qxk * x + qyk * y))

--- a/src/sas/sascalc/calculator/geni.py
+++ b/src/sas/sascalc/calculator/geni.py
@@ -220,7 +220,7 @@ def orth(A, b): # A = 3 x n, and b_hat unit vector
 @njit
 def basis_vector(A, B): # A = 3 x n, and B = 3 x n
     vec = np.cross(A, B)
-    return vec / np.sqrt(np.inner(vec, vec))   
+    return vec / np.sqrt(np.dot(vec, vec))   
 
 @njit("(" + "f8[:], "*7 + "f8[:,::1], "+ "f8, "*8 + ")")
 def _calc_Iqxy_magnetic_helper(
@@ -243,14 +243,14 @@ def _calc_Iqxy_magnetic_helper(
         p_hat = np.array([sin_spin * cos_phi, sin_spin * sin_phi, cos_spin ])
 
         M_perp = orth(M, q_hat)
-        M_perpP = orth(M_perp, p_hat)
-        M_perpP_perpQ = orth(M_perpP, q_hat)
+        q_perp = orth(q_hat, p_hat)
+        q_perp = q_perp / np.sqrt(np.dot(q_perp, q_perp)) 
 
         perpx = p_hat @ M_perp
         # einsum is faster than sumsq in numpy but not supported in numba
         #perpy = np.sqrt(np.einsum('ji,ji->i', M_perpP_perpQ, M_perpP_perpQ))
-        perpy = basis_vector(q_hat, p_hat) @ M_perpP_perpQ
-        perpz = q_hat @ M_perpP
+        perpy = basis_vector(q_hat, p_hat) @ M_perp
+        perpz = q_perp @ M_perp
 
         ephase = vol * np.exp(1j * (qxk * x + qyk * y))
         if dd > 1e-10:


### PR DESCRIPTION
The calculation of the magnetic scattering length density does not conserve handedness. The magnetic scattering length assumes always a positive magnetisation in the magnetic scattering component for the SF channel. This is fine for collinear structures, but might run into issue for some non-symmetric cases, when M(-x)=-M(x). 