### PR TITLE
Remove global variable LOADED_PERSPECTIVES

### DIFF
--- a/src/sas/qtgui/MainWindow/GuiManager.py
+++ b/src/sas/qtgui/MainWindow/GuiManager.py
@@ -61,9 +61,6 @@ from sas.qtgui.Utilities.FileConverter import FileConverterWidget
 
 logger = logging.getLogger(__name__)
 
-# Expose the loaded perspectives for easy linking between perspective methods/inputs and plots
-LOADED_PERSPECTIVES = {}
-
 
 class GuiManager(object):
     """
@@ -196,8 +193,6 @@ class GuiManager(object):
             except Exception as e:
                 logger.warning(f"Unable to load {name} perspective.\n{e}")
         self.loadedPerspectives = loaded_dict
-        global LOADED_PERSPECTIVES
-        LOADED_PERSPECTIVES = self.loadedPerspectives
 
     def closeAllPerspectives(self):
         # Close all perspectives if they are open
@@ -211,8 +206,6 @@ class GuiManager(object):
                 except Exception as e:
                     logger.warning(f"Unable to close {name} perspective\n{e}")
         self.loadedPerspectives = {}
-        global LOADED_PERSPECTIVES
-        LOADED_PERSPECTIVES = self.loadedPerspectives
         self._current_perspective = None
 
     def addCategories(self):

--- a/src/sas/qtgui/Plotting/QRangeSlider.py
+++ b/src/sas/qtgui/Plotting/QRangeSlider.py
@@ -137,14 +137,13 @@ class LineInteractor(BaseInteractor):
         self.draw(zorder)
         # Is the slider able to move
         self.has_move = True
-        if not perspective:
-            # The perspective this slider is actively tied to
+        try:
+            self.perspective = self.base.base.parent.manager.parent.loadedPerspectives.get(perspective, None)
+        except AttributeError:
+            # QRangeSlider is disconnected from GuiManager for testing
             self.perspective = None
+        if self.perspective is None:
             return
-        # Import on demand to prevent circular import
-        from sas.qtgui.MainWindow.GuiManager import LOADED_PERSPECTIVES
-        # Map GUI input to x value so slider and input update each other
-        self.perspective = LOADED_PERSPECTIVES.get(perspective, None)
         if tab and hasattr(self.perspective, 'getTabByName'):
             # If the perspective is tabbed, set the perspective to the tab this slider in associated with
             self.perspective = self.perspective.getTabByName(tab)

--- a/src/sas/qtgui/Plotting/QRangeSlider.py
+++ b/src/sas/qtgui/Plotting/QRangeSlider.py
@@ -6,6 +6,7 @@ from PyQt5.QtWidgets import QLineEdit, QTextEdit
 
 from sas.qtgui.Plotting.PlotterData import Data1D
 from sas.qtgui.Plotting.Slicers.BaseInteractor import BaseInteractor
+import sas.qtgui.Utilities.ObjectLibrary as ol
 
 
 class QRangeSlider(BaseInteractor):
@@ -138,7 +139,8 @@ class LineInteractor(BaseInteractor):
         # Is the slider able to move
         self.has_move = True
         try:
-            self.perspective = self.base.base.parent.manager.parent.loadedPerspectives.get(perspective, None)
+            data_explorer = ol.getObject('DataExplorer')
+            self.perspective = data_explorer.parent.loadedPerspectives.get(perspective, None)
         except AttributeError:
             # QRangeSlider is disconnected from GuiManager for testing
             self.perspective = None

--- a/src/sas/qtgui/Plotting/UnitTesting/QRangeSliderTests.py
+++ b/src/sas/qtgui/Plotting/UnitTesting/QRangeSliderTests.py
@@ -34,7 +34,7 @@ class QRangeSlidersTest(unittest.TestCase):
                 self.setCentralWidget(self.workspace)
 
         self.manager = GuiManager(MainWindow(None))
-        self.plotter = Plotter.Plotter(None, quickplot=True)
+        self.plotter = Plotter.Plotter(self.manager.filesWidget, quickplot=True)
         self.data = Data1D(x=[0.001,0.1,0.2,0.3,0.4], y=[1000,100,10,1,0.1])
         self.data.name = "Test QRangeSliders class"
         self.data.show_q_range_sliders = True
@@ -109,7 +109,7 @@ class QRangeSlidersTest(unittest.TestCase):
         self.assertAlmostEqual(5, float(widget.txtNptsHighQ.text()))
         # Move npts and check slider
         widget.txtNptsHighQ.setText('2')
-        self.assertAlmostEqual(self.data.x[2], self.slider.line_min.x)
+        self.assertAlmostEqual(self.data.x[1], self.slider.line_min.x)
 
     def testInversionSliders(self):
         '''Test the QRangeSlider class within the context of the Inversion perspective'''
@@ -117,6 +117,7 @@ class QRangeSlidersTest(unittest.TestCase):
         self.current_perspective = 'Inversion'
         self.manager.perspectiveChanged(self.current_perspective)
         widget = self.manager.perspective()
+        self.manager.filesWidget.sendData()
         # Create slider on base data set
         self.data.slider_perspective_name = self.current_perspective
         self.data.slider_low_q_input = ['minQInput']


### PR DESCRIPTION
This PR removes the global variable LOADED_PERSPECTIVES introduced since the release of 5.0.4. The perspective is found from the parental hierarchy of the Plotter class, instead. Unit tests were updated to account for the change.

fixes #1972