### PR TITLE
GitHub: Freezing MPL to 2.2.5 on windows

### DIFF
--- a/.github/workflows/installers.yml
+++ b/.github/workflows/installers.yml
@@ -58,25 +58,26 @@ jobs:
           ${{ runner.os }}-pip-
 
     ### Installation of build-dependencies
+    - name: Install lxml and MPL (Linux + Win)
+      if: ${{ matrix.os != 'macos-latest' }}
+      run: |
+        python -m pip install matplotlib==2.2.5
+        python -m pip install lxml
 
     - name: Install Python dependencies
       run: |
         python -m pip install --upgrade pip
         python -m pip install wheel setuptools
 
-        python -m pip install numpy scipy matplotlib==2.2.5 docutils "pytest<6" sphinx unittest-xml-reporting
+        python -m pip install numpy scipy docutils "pytest<6" sphinx unittest-xml-reporting
         python -m pip install tinycc h5py sphinx pyparsing html5lib reportlab pybind11 appdirs
         python -m pip install six numba mako ipython qtconsole xhtml2pdf unittest-xml-reporting pylint
         python -m pip install qt5reactor periodictable PyQt5 uncertainties debugpy
 
-    - name: Install lxml (Linux + Win)
-      if: ${{ matrix.os != 'macos-latest' }}
-      run: |
-        python -m pip install lxml
-
-    - name: Install lxml (OSX)
+    - name: Install lxml and MPL (OSX)
       if: ${{ matrix.os == 'macos-latest' }}
       run: |
+        python -m pip install matplotlib
         python -m pip install --no-binary lxml lxml
 
     - name: Install pyopencl (Windows)

--- a/.github/workflows/installers.yml
+++ b/.github/workflows/installers.yml
@@ -64,7 +64,7 @@ jobs:
         python -m pip install --upgrade pip
         python -m pip install wheel setuptools
 
-        python -m pip install numpy scipy matplotlib==2.2.3 docutils "pytest<6" sphinx unittest-xml-reporting
+        python -m pip install numpy scipy matplotlib==2.2.5 docutils "pytest<6" sphinx unittest-xml-reporting
         python -m pip install tinycc h5py sphinx pyparsing html5lib reportlab pybind11 appdirs
         python -m pip install six numba mako ipython qtconsole xhtml2pdf unittest-xml-reporting pylint
         python -m pip install qt5reactor periodictable PyQt5 uncertainties debugpy

--- a/.github/workflows/installers.yml
+++ b/.github/workflows/installers.yml
@@ -64,7 +64,7 @@ jobs:
         python -m pip install --upgrade pip
         python -m pip install wheel setuptools
 
-        python -m pip install numpy scipy matplotlib==3.4.3 docutils "pytest<6" sphinx unittest-xml-reporting
+        python -m pip install numpy scipy matplotlib==2.2.3 docutils "pytest<6" sphinx unittest-xml-reporting
         python -m pip install tinycc h5py sphinx pyparsing html5lib reportlab pybind11 appdirs
         python -m pip install six numba mako ipython qtconsole xhtml2pdf unittest-xml-reporting pylint
         python -m pip install qt5reactor periodictable PyQt5 uncertainties debugpy

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,6 +60,12 @@ jobs:
 
     ### Installation of build-dependencies
 
+    - name: Install lxml and MPL (Linux + Win)
+      if: ${{ matrix.os != 'macos-latest' }}
+      run: |
+        python -m pip install matplotlib==2.2.5
+        python -m pip install lxml
+
     - name: Install Python dependencies
       run: |
         python -m pip install --upgrade pip
@@ -70,14 +76,10 @@ jobs:
         python -m pip install six numba mako ipython qtconsole xhtml2pdf unittest-xml-reporting pylint
         python -m pip install qt5reactor periodictable PyQt5 uncertainties debugpy
 
-    - name: Install lxml (Linux + Win)
-      if: ${{ matrix.os != 'macos-latest' }}
-      run: |
-        python -m pip install lxml
-
     - name: Install lxml (OSX)
       if: ${{ matrix.os == 'macos-latest' }}
       run: |
+        python -m pip install matplotlib
         python -m pip install --no-binary lxml lxml
 
     - name: Install pyopencl (Windows)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,7 +65,7 @@ jobs:
         python -m pip install --upgrade pip
         python -m pip install wheel setuptools
 
-        python -m pip install numpy scipy matplotlib==2.2.3 docutils "pytest<6" sphinx unittest-xml-reporting
+        python -m pip install numpy scipy matplotlib==2.2.5 docutils "pytest<6" sphinx unittest-xml-reporting
         python -m pip install tinycc h5py sphinx pyparsing html5lib reportlab pybind11 appdirs
         python -m pip install six numba mako ipython qtconsole xhtml2pdf unittest-xml-reporting pylint
         python -m pip install qt5reactor periodictable PyQt5 uncertainties debugpy

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,7 +65,7 @@ jobs:
         python -m pip install --upgrade pip
         python -m pip install wheel setuptools
 
-        python -m pip install numpy scipy matplotlib==3.4.3 docutils "pytest<6" sphinx unittest-xml-reporting
+        python -m pip install numpy scipy matplotlib==2.2.3 docutils "pytest<6" sphinx unittest-xml-reporting
         python -m pip install tinycc h5py sphinx pyparsing html5lib reportlab pybind11 appdirs
         python -m pip install six numba mako ipython qtconsole xhtml2pdf unittest-xml-reporting pylint
         python -m pip install qt5reactor periodictable PyQt5 uncertainties debugpy

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,7 +71,7 @@ jobs:
         python -m pip install --upgrade pip
         python -m pip install wheel setuptools
 
-        python -m pip install numpy scipy matplotlib==2.2.5 docutils "pytest<6" sphinx unittest-xml-reporting
+        python -m pip install numpy scipy docutils "pytest<6" sphinx unittest-xml-reporting
         python -m pip install tinycc h5py sphinx pyparsing html5lib reportlab pybind11 appdirs
         python -m pip install six numba mako ipython qtconsole xhtml2pdf unittest-xml-reporting pylint
         python -m pip install qt5reactor periodictable PyQt5 uncertainties debugpy


### PR DESCRIPTION
This is done so the plotting works as expected.
Apparently the observed plot disappearance is a windows-only issue.
