### PR TITLE
Save project: Properly handle scalars

### DIFF
--- a/src/sas/qtgui/Utilities/GuiUtils.py
+++ b/src/sas/qtgui/Utilities/GuiUtils.py
@@ -2,7 +2,7 @@
 """
 Global defaults and various utility functions usable by the general GUI
 """
-
+import numbers
 import os
 import re
 import sys
@@ -1266,9 +1266,11 @@ def saveData(fp, data):
             content = o.__dict__.copy()
             return add_type(content, type(o))
 
-        if np.isscalar(o):
-            # scalar quantity - no default necessary
-            return None
+        if isinstance(o, numbers.Integral):
+            return int(o)
+
+        if isinstance(o, numbers.Real):
+            return float(o)
 
         # not supported
         logging.info("data cannot be serialized to json: %s" % type(o))

--- a/src/sas/qtgui/Utilities/GuiUtils.py
+++ b/src/sas/qtgui/Utilities/GuiUtils.py
@@ -1266,6 +1266,10 @@ def saveData(fp, data):
             content = o.__dict__.copy()
             return add_type(content, type(o))
 
+        if np.isscalar(o):
+            # scalar quantity - no default necessary
+            return None
+
         # not supported
         logging.info("data cannot be serialized to json: %s" % type(o))
         return None


### PR DESCRIPTION
When saving projects, some scalar quantities (e.g. `numpy.float32` and `numpy.float64`) were unable to set a default when saving the value, so a message was pasted into the console log saying `data cannot be serialized to json`. This fixes that issue.

No associated ticket. Originally noted in an email by @smk78 during testing of 5.0.5rc1.