### PR TITLE
Switching to PyQT 5.13 

### DIFF
--- a/.github/workflows/installers.yml
+++ b/.github/workflows/installers.yml
@@ -72,7 +72,12 @@ jobs:
         python -m pip install numpy scipy docutils "pytest<6" sphinx unittest-xml-reporting
         python -m pip install tinycc h5py sphinx pyparsing html5lib reportlab pybind11 appdirs
         python -m pip install six numba mako ipython qtconsole xhtml2pdf unittest-xml-reporting pylint
-        python -m pip install qt5reactor periodictable PyQt5 uncertainties debugpy
+        python -m pip install qt5reactor periodictable uncertainties debugpy
+
+    - name: Install PyQt (Windows + Linux)
+      if: ${{ matrix.os == 'macos-latest' }}
+      run: |
+        python -m pip install
 
     - name: Install lxml, matplotlib and PyQt (OSX)
       if: ${{ matrix.os == 'macos-latest' }}

--- a/.github/workflows/installers.yml
+++ b/.github/workflows/installers.yml
@@ -77,6 +77,7 @@ jobs:
     - name: Install lxml, matplotlib and PyQt (OSX)
       if: ${{ matrix.os == 'macos-latest' }}
       run: |
+        python -m pip install PyQt5==5.13
         python -m pip install matplotlib==3.4.3
         python -m pip install --no-binary lxml lxml
 

--- a/.github/workflows/installers.yml
+++ b/.github/workflows/installers.yml
@@ -69,7 +69,7 @@ jobs:
         python -m pip install --upgrade pip
         python -m pip install wheel setuptools
 
-        python -m pip install numpy scipy=1.7.3 docutils "pytest<6" sphinx unittest-xml-reporting
+        python -m pip install numpy scipy==1.7.3 docutils "pytest<6" sphinx unittest-xml-reporting
         python -m pip install tinycc h5py sphinx pyparsing html5lib reportlab pybind11 appdirs
         python -m pip install six numba mako ipython qtconsole xhtml2pdf unittest-xml-reporting pylint
         python -m pip install qt5reactor periodictable uncertainties debugpy

--- a/.github/workflows/installers.yml
+++ b/.github/workflows/installers.yml
@@ -75,7 +75,7 @@ jobs:
         python -m pip install qt5reactor periodictable uncertainties debugpy
 
     - name: Install PyQt (Windows + Linux)
-      if: ${{ matrix.os == 'macos-latest' }}
+      if: ${{ matrix.os != 'macos-latest' }}
       run: |
         python -m pip install PyQt5
 

--- a/.github/workflows/installers.yml
+++ b/.github/workflows/installers.yml
@@ -82,6 +82,7 @@ jobs:
     - name: Install lxml, matplotlib and PyQt (OSX)
       if: ${{ matrix.os == 'macos-latest' }}
       run: |
+        python -m pip install scipy==1.7.3
         python -m pip install PyQt5==5.13
         python -m pip install matplotlib==3.4.3
         python -m pip install --no-binary lxml lxml

--- a/.github/workflows/installers.yml
+++ b/.github/workflows/installers.yml
@@ -91,6 +91,7 @@ jobs:
       run: |
         python -m pip install pytools mako cffi
         choco install opencl-intel-cpu-runtime
+        choco install innosetup
         python -m pip install --only-binary=pyopencl --find-links http://www.silx.org/pub/wheelhouse/ --trusted-host www.silx.org pyopencl
 
     - name: Install pyopencl (Linux + macOS)

--- a/.github/workflows/installers.yml
+++ b/.github/workflows/installers.yml
@@ -72,13 +72,19 @@ jobs:
         python -m pip install numpy scipy docutils "pytest<6" sphinx unittest-xml-reporting
         python -m pip install tinycc h5py sphinx pyparsing html5lib reportlab pybind11 appdirs
         python -m pip install six numba mako ipython qtconsole xhtml2pdf unittest-xml-reporting pylint
-        python -m pip install qt5reactor periodictable PyQt5 uncertainties debugpy
+        python -m pip install qt5reactor periodictable uncertainties debugpy
 
-    - name: Install lxml and MPL (OSX)
+    - name: Install PyQt (Linux and Windows)
+      if: ${{ matrix.os != 'macos-latest' }}
+      run: |
+        python -m pip install PyQt5
+
+    - name: Install lxml, matplotlib and PyQt (OSX)
       if: ${{ matrix.os == 'macos-latest' }}
       run: |
         python -m pip install matplotlib==3.4.3
         python -m pip install --no-binary lxml lxml
+        python -m pip install PyQt5==5.14
 
     - name: Install pyopencl (Windows)
       if: ${{ matrix.os == 'windows-latest' }}

--- a/.github/workflows/installers.yml
+++ b/.github/workflows/installers.yml
@@ -70,7 +70,7 @@ jobs:
         python -m pip install wheel setuptools
 
         python -m pip install numpy scipy==1.7.3 docutils "pytest<6" sphinx unittest-xml-reporting
-        python -m pip install tinycc h5py sphinx pyparsing html5lib reportlab pybind11 appdirs
+        python -m pip install tinycc h5py sphinx pyparsing html5lib reportlab==3.6.6 pybind11 appdirs
         python -m pip install six numba mako ipython qtconsole xhtml2pdf unittest-xml-reporting pylint
         python -m pip install qt5reactor periodictable uncertainties debugpy
 

--- a/.github/workflows/installers.yml
+++ b/.github/workflows/installers.yml
@@ -77,7 +77,7 @@ jobs:
     - name: Install PyQt (Windows + Linux)
       if: ${{ matrix.os == 'macos-latest' }}
       run: |
-        python -m pip install
+        python -m pip install PyQt5
 
     - name: Install lxml, matplotlib and PyQt (OSX)
       if: ${{ matrix.os == 'macos-latest' }}

--- a/.github/workflows/installers.yml
+++ b/.github/workflows/installers.yml
@@ -72,12 +72,7 @@ jobs:
         python -m pip install numpy scipy docutils "pytest<6" sphinx unittest-xml-reporting
         python -m pip install tinycc h5py sphinx pyparsing html5lib reportlab pybind11 appdirs
         python -m pip install six numba mako ipython qtconsole xhtml2pdf unittest-xml-reporting pylint
-        python -m pip install qt5reactor periodictable uncertainties debugpy
-
-    - name: Install PyQt (Linux and Windows)
-      if: ${{ matrix.os != 'macos-latest' }}
-      run: |
-        python -m pip install PyQt5
+        python -m pip install qt5reactor periodictable PyQt5 uncertainties debugpy
 
     - name: Install lxml, matplotlib and PyQt (OSX)
       if: ${{ matrix.os == 'macos-latest' }}

--- a/.github/workflows/installers.yml
+++ b/.github/workflows/installers.yml
@@ -82,9 +82,9 @@ jobs:
     - name: Install lxml, matplotlib and PyQt (OSX)
       if: ${{ matrix.os == 'macos-latest' }}
       run: |
+        python -m pip install PyQt5==5.14
         python -m pip install matplotlib==3.4.3
         python -m pip install --no-binary lxml lxml
-        python -m pip install PyQt5==5.14
 
     - name: Install pyopencl (Windows)
       if: ${{ matrix.os == 'windows-latest' }}

--- a/.github/workflows/installers.yml
+++ b/.github/workflows/installers.yml
@@ -69,7 +69,7 @@ jobs:
         python -m pip install --upgrade pip
         python -m pip install wheel setuptools
 
-        python -m pip install numpy scipy docutils "pytest<6" sphinx unittest-xml-reporting
+        python -m pip install numpy scipy=1.7.3 docutils "pytest<6" sphinx unittest-xml-reporting
         python -m pip install tinycc h5py sphinx pyparsing html5lib reportlab pybind11 appdirs
         python -m pip install six numba mako ipython qtconsole xhtml2pdf unittest-xml-reporting pylint
         python -m pip install qt5reactor periodictable uncertainties debugpy
@@ -82,7 +82,6 @@ jobs:
     - name: Install lxml, matplotlib and PyQt (OSX)
       if: ${{ matrix.os == 'macos-latest' }}
       run: |
-        python -m pip install scipy==1.7.3
         python -m pip install PyQt5==5.13
         python -m pip install matplotlib==3.4.3
         python -m pip install --no-binary lxml lxml

--- a/.github/workflows/installers.yml
+++ b/.github/workflows/installers.yml
@@ -77,7 +77,6 @@ jobs:
     - name: Install lxml, matplotlib and PyQt (OSX)
       if: ${{ matrix.os == 'macos-latest' }}
       run: |
-        python -m pip install PyQt5==5.14
         python -m pip install matplotlib==3.4.3
         python -m pip install --no-binary lxml lxml
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,7 +72,7 @@ jobs:
         python -m pip install wheel setuptools
 
         python -m pip install numpy scipy==1.7.3 docutils "pytest<6" sphinx unittest-xml-reporting
-        python -m pip install tinycc h5py sphinx pyparsing html5lib reportlab pybind11 appdirs
+        python -m pip install tinycc h5py sphinx pyparsing html5lib reportlab==3.6.6 pybind11 appdirs
         python -m pip install six numba mako ipython qtconsole xhtml2pdf unittest-xml-reporting pylint
         python -m pip install qt5reactor periodictable uncertainties debugpy
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -92,6 +92,7 @@ jobs:
       run: |
         python -m pip install pytools mako cffi
         choco install opencl-intel-cpu-runtime
+        choco install innosetup
         python -m pip install --only-binary=pyopencl --find-links http://www.silx.org/pub/wheelhouse/ --trusted-host www.silx.org pyopencl
 
     - name: Install pyopencl (Linux + macOS)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,7 +77,7 @@ jobs:
         python -m pip install qt5reactor periodictable uncertainties debugpy
 
     - name: Install PyQt (Windows + Linux)
-      if: ${{ matrix.os == 'macos-latest' }}
+      if: ${{ matrix.os != 'macos-latest' }}
       run: |
         python -m pip install PyQt5
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,14 +74,19 @@ jobs:
         python -m pip install numpy scipy docutils "pytest<6" sphinx unittest-xml-reporting
         python -m pip install tinycc h5py sphinx pyparsing html5lib reportlab pybind11 appdirs
         python -m pip install six numba mako ipython qtconsole xhtml2pdf unittest-xml-reporting pylint
-        python -m pip install qt5reactor periodictable PyQt5 uncertainties debugpy
+        python -m pip install qt5reactor periodictable uncertainties debugpy
 
-    - name: Install lxml (OSX)
+    - name: Install PyQt (Windows + Linux)
       if: ${{ matrix.os == 'macos-latest' }}
       run: |
+        python -m pip install
+
+    - name: Install lxml, matplotlib and PyQt (OSX)
+      if: ${{ matrix.os == 'macos-latest' }}
+      run: |
+        python -m pip install PyQt5==5.13
         python -m pip install matplotlib==3.4.3
         python -m pip install --no-binary lxml lxml
-
     - name: Install pyopencl (Windows)
       if: ${{ matrix.os == 'windows-latest' }}
       run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,7 +71,7 @@ jobs:
         python -m pip install --upgrade pip
         python -m pip install wheel setuptools
 
-        python -m pip install numpy scipy docutils "pytest<6" sphinx unittest-xml-reporting
+        python -m pip install numpy scipy==1.7.3 docutils "pytest<6" sphinx unittest-xml-reporting
         python -m pip install tinycc h5py sphinx pyparsing html5lib reportlab pybind11 appdirs
         python -m pip install six numba mako ipython qtconsole xhtml2pdf unittest-xml-reporting pylint
         python -m pip install qt5reactor periodictable uncertainties debugpy
@@ -84,7 +84,6 @@ jobs:
     - name: Install lxml, matplotlib and PyQt (OSX)
       if: ${{ matrix.os == 'macos-latest' }}
       run: |
-        python -m pip install scipy==1.7.3
         python -m pip install PyQt5==5.13
         python -m pip install matplotlib==3.4.3
         python -m pip install --no-binary lxml lxml

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,6 +84,7 @@ jobs:
     - name: Install lxml, matplotlib and PyQt (OSX)
       if: ${{ matrix.os == 'macos-latest' }}
       run: |
+        python -m pip install scipy==1.7.3
         python -m pip install PyQt5==5.13
         python -m pip install matplotlib==3.4.3
         python -m pip install --no-binary lxml lxml

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,7 +79,7 @@ jobs:
     - name: Install PyQt (Windows + Linux)
       if: ${{ matrix.os == 'macos-latest' }}
       run: |
-        python -m pip install
+        python -m pip install PyQt5
 
     - name: Install lxml, matplotlib and PyQt (OSX)
       if: ${{ matrix.os == 'macos-latest' }}


### PR DESCRIPTION
The latest version of PyQt (5.15) is not statble on Mac OSX. Version 5.13 seems to be stable (tested by few users). 
As discussed at the call this PR also fixes scipy to 1.7.3 (for all platforms).