### PR TITLE
radius_effective update for smeared data

### DIFF
--- a/src/sas/qtgui/Perspectives/Fitting/FittingWidget.py
+++ b/src/sas/qtgui/Perspectives/Fitting/FittingWidget.py
@@ -3066,7 +3066,7 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
             return
         # ensure the model does not recompute when updating the value
         self._model_model.blockSignals(True)
-        self._model_model.item(ER_row, 1).setText(str(ER_value))
+        self._model_model.item(ER_row, 1).setText(GuiUtils.formatNumber(ER_value, high=True))
         self._model_model.blockSignals(False)
         # ensure the view is updated immediately
         self._model_model.layoutChanged.emit()

--- a/src/sas/qtgui/Perspectives/Fitting/ModelThread.py
+++ b/src/sas/qtgui/Perspectives/Fitting/ModelThread.py
@@ -180,7 +180,7 @@ class Calc1D(CalcThread):
             if isinstance(return_data, tuple):
                 # see sasmodels beta_approx: SasviewModel.calculate_Iq
                 # TODO: implement intermediate results in smearers
-                return_data, _ = return_data
+                return_data, intermediate_results = return_data
             unsmeared_output[first_bin:last_bin+1] = return_data
             output = self.smearer(unsmeared_output, first_bin, last_bin)
 


### PR DESCRIPTION
Bring intermediate results back when smearing is on and display radius_effective. #2009

After all this was a SasView issue, although it did look like it originated in SasModels...

This assumes SasModels returns properly smeared P(Q) and S(Q) so we don't have to do it in `ModelThread` as it is currently done. Quick test shows this is the case but more careful check should be done before merge.


`100nmPinholeSphere` file, sphere/sphere/hardsphere, fitted `radius` only.

left: existing 5.0.5rc2, right: from this PR
![smeared_intermediates](https://user-images.githubusercontent.com/8266281/155528535-cae40511-a097-41bc-91b4-f3eac1f15986.png)

