### PR TITLE
Don't show RPA in the list of models #2022

### DIFF
--- a/src/sas/qtgui/Perspectives/Fitting/FittingWidget.py
+++ b/src/sas/qtgui/Perspectives/Fitting/FittingWidget.py
@@ -1476,7 +1476,7 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         # Populate the models combobox
         self.cbModel.blockSignals(True)
         self.cbModel.addItem(MODEL_DEFAULT)
-        self.cbModel.addItems(sorted([model for (model, _) in model_list]))
+        self.cbModel.addItems(sorted([model for (model, _) in model_list if model != 'rpa']))
         self.cbModel.blockSignals(False)
 
     def onPolyModelChange(self, top, bottom):


### PR DESCRIPTION
Added a simple conditional in the list comprehension for filling the model combobox with model names.

This can be easily removed once rpa works again.

Note: this only removes RPA from the model list on the fitting widget. It is still present in the Category Manager.