### PR TITLE
Use MPFit fitter as the default fit engine

### DIFF
--- a/src/sas/qtgui/Perspectives/Fitting/FittingPerspective.py
+++ b/src/sas/qtgui/Perspectives/Fitting/FittingPerspective.py
@@ -77,7 +77,7 @@ class FittingWindow(QtWidgets.QTabWidget):
         # Fit options - uniform for all tabs
         self.fit_options = options.FIT_CONFIG
         self.fit_options_widget = FittingOptions(self, config=self.fit_options)
-        self.fit_options.selected_id = fitters.LevenbergMarquardtFit.id
+        self.fit_options.selected_id = fitters.MPFit.id
 
         # Listen to GUI Manager signal updating fit options
         self.fit_options_widget.fit_option_changed.connect(self.onFittingOptionsChange)

--- a/src/sas/sascalc/fit/BumpsFitting.py
+++ b/src/sas/sascalc/fit/BumpsFitting.py
@@ -14,7 +14,7 @@ from bumps import fitters
 try:
     from bumps.options import FIT_CONFIG
     # Default bumps to use the Levenberg-Marquardt optimizer
-    FIT_CONFIG.selected_id = fitters.LevenbergMarquardtFit.id
+    FIT_CONFIG.selected_id = fitters.MPFit.id
     def get_fitter():
         return FIT_CONFIG.selected_fitter, FIT_CONFIG.selected_values
 except ImportError:


### PR DESCRIPTION
This uses the id for the MPFit engine as the default name when generating the fitting window since this optimizer is now the default. If we want to remove the old `scipy.leastsq` option from the Fit Options combobox we could add something like the following to src/sas/sascalc/fit/BumpsFitting.py at line 17 (credit @pkienzle).

>`try:`
>`FIT_ACTIVE_IDS.remove(fitters.LevenbergMarquardtFit.id)`
>`except ValueError:`
>`pass`

refs #2036