### PR TITLE
Add id to the generated plot. #2098

### DIFF
--- a/src/sas/qtgui/Calculators/DataOperationUtilityPanel.py
+++ b/src/sas/qtgui/Calculators/DataOperationUtilityPanel.py
@@ -160,6 +160,7 @@ class DataOperationUtilityPanel(QtWidgets.QDialog, Ui_DataOperationUtility):
         """ Prepare datasets to be added to DataExplorer and DataManager """
         name = self.txtOutputData.text()
         self.output.name = name
+        self.output.id = name + str(time.time())
         new_item = GuiUtils.createModelItemWithPlot(
             self.output,
             name=name)
@@ -410,7 +411,6 @@ class DataOperationUtilityPanel(QtWidgets.QDialog, Ui_DataOperationUtility):
             # plot 2D data
             plotter2D = Plotter2DWidget(self, quickplot=True)
             plotter2D.scale = 'linear'
-
             plotter2D.ax.tick_params(axis='x', labelsize=8)
             plotter2D.ax.tick_params(axis='y', labelsize=8)
 


### PR DESCRIPTION
Plots generated by the Data Operation tool did not have the `id` attribute set. This attribute is used as a dict key when saving plots to the project json file.
Added the id attribute.

A more correct way would be to have this (and other, required) attributes defaulted in the Plotter initializer, so they are always present. This should be a part of the plot rewrite story, mentioned elsewhere