### PR TITLE
Include sas.qtgui.Utilities.Reports in build output

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -195,6 +195,13 @@ package_dir["sas.qtgui.UtilitiesUI"] = os.path.join(
     "src", "sas", "qtgui", "Utilities","UI")
 packages.append("sas.qtgui.Utilities.UI")
 
+package_dir["sas.qtgui.Utilities.Reports"] = os.path.join(
+    "src", "sas", "qtgui", "Utilities", "Reports")
+packages.append("sas.qtgui.Utilities.Reports")
+package_dir["sas.qtgui.Utilities.UI"] = os.path.join(
+    "src", "sas", "qtgui", "Utilities", "Reports", "UI")
+packages.append("sas.qtgui.Utilities.Reports.UI")
+
 package_dir["sas.qtgui.Calculators"] = os.path.join(
     "src", "sas", "qtgui", "Calculators")
 package_dir["sas.qtgui.Calculators.UI"] = os.path.join(

--- a/src/sas/qtgui/Utilities/UnitTesting/ReportDialogTest.py
+++ b/src/sas/qtgui/Utilities/UnitTesting/ReportDialogTest.py
@@ -13,7 +13,7 @@ from PyQt5.QtTest import QTest
 
 import sas.qtgui.Utilities.GuiUtils as GuiUtils
 # Local
-from qtgui.Utilities.Reports.ReportDialog import ReportDialog
+from sas.qtgui.Utilities.Reports.ReportDialog import ReportDialog
 
 if not QtWidgets.QApplication.instance():
     app = QtWidgets.QApplication(sys.argv)


### PR DESCRIPTION
During some testing, I found a couple of things missed by PR #2065. The Reports package was never included in setup.py so builds would likely not include the reports dialog (untested). Also, a unit test package was named incorrectly.