### PR TITLE
1911 - Fix issue copying custom config file

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -54,6 +54,9 @@ if os.path.isdir(sas_dir):
     f_path = os.path.join(sas_dir, 'config', "custom_config.py")
     if os.path.isfile(f_path):
         os.remove(f_path)
+    f_path = os.path.join(sas_dir, 'config', "custom_config.pyc")
+    if os.path.isfile(f_path):
+        os.remove(f_path)
     #f_path = os.path.join(sas_dir, 'plugin_models')
     # if os.path.isdir(f_path):
     #     for f in os.listdir(f_path):

--- a/src/sas/_config.py
+++ b/src/sas/_config.py
@@ -1,6 +1,7 @@
 # Setup and find Custom config dir
 from __future__ import print_function
 
+import glob
 import sys
 import os
 import traceback
@@ -90,7 +91,7 @@ def setup_custom_config(app_dir, user_dir):
         try:
             # if the custom config file does not exist, copy the default from
             # the app dir
-            shutil.copyfile(os.path.join(app_dir, "custom_config.py"), path)
+            shutil.copyfile(glob.glob(os.path.join(app_dir, "custom_config.py"))[0], path)
         except Exception:
             logger.error(traceback.format_exc())
             logger.error("Could not copy default custom config.")

--- a/src/sas/_config.py
+++ b/src/sas/_config.py
@@ -32,22 +32,22 @@ def find_app_dir():
     # Check if the path .../sas/sasview exists, and use it as the
     # app directory.  This will only be the case if the app is not frozen.
     path = joinpath(dirname(__file__), 'sasview')
-    if not exists(path):
-        path = dirname(__file__)
+    if exists(path):
+        return path
 
     # If we are running frozen, then root is a parent directory
-    # if sys.platform == 'darwin':
-    #     # Here is the path to the file on the mac:
-    #     #     .../Sasview.app/Contents/Resources/lib/python2.7/site-packages.zip/sas/__init__.pyc
-    #     # We want the path to the Resources directory.
-    #     path = dirn(__file__, 5)
-    # elif os.name == 'nt':
-    #     # Here is the path to the file on windows:
-    #     #     ../Sasview/library.zip/sas/__init__.pyc
-    #     # We want the path to the Sasview directory.
-    #     path = dirn(__file__, 1)
-    # else:
-    #     raise RuntimeError("Couldn't find the app directory")
+    if sys.platform == 'darwin':
+        # Here is the path to the file on the mac:
+        #     .../Sasview.app/Contents/Resources/lib/python2.7/site-packages.zip/sas/__init__.pyc
+        # We want the path to the Resources directory.
+        path = dirn(__file__, 4)
+    elif os.name == 'nt':
+        # Here is the path to the file on windows:
+        #     ../Sasview/library.zip/sas/__init__.pyc
+        # We want the path to the Sasview directory.
+        path = dirn(__file__, 2)
+    else:
+        raise RuntimeError("Couldn't find the app directory")
     return path
 
 def make_user_dir():

--- a/src/sas/_config.py
+++ b/src/sas/_config.py
@@ -32,22 +32,22 @@ def find_app_dir():
     # Check if the path .../sas/sasview exists, and use it as the
     # app directory.  This will only be the case if the app is not frozen.
     path = joinpath(dirname(__file__), 'sasview')
-    if exists(path):
-        return path
+    if not exists(path):
+        path = dirname(__file__)
 
     # If we are running frozen, then root is a parent directory
-    if sys.platform == 'darwin':
-        # Here is the path to the file on the mac:
-        #     .../Sasview.app/Contents/Resources/lib/python2.7/site-packages.zip/sas/__init__.pyc
-        # We want the path to the Resources directory.
-        path = dirn(__file__, 5)
-    elif os.name == 'nt':
-        # Here is the path to the file on windows:
-        #     ../Sasview/library.zip/sas/__init__.pyc
-        # We want the path to the Sasview directory.
-        path = dirn(__file__, 3)
-    else:
-        raise RuntimeError("Couldn't find the app directory")
+    # if sys.platform == 'darwin':
+    #     # Here is the path to the file on the mac:
+    #     #     .../Sasview.app/Contents/Resources/lib/python2.7/site-packages.zip/sas/__init__.pyc
+    #     # We want the path to the Resources directory.
+    #     path = dirn(__file__, 5)
+    # elif os.name == 'nt':
+    #     # Here is the path to the file on windows:
+    #     #     ../Sasview/library.zip/sas/__init__.pyc
+    #     # We want the path to the Sasview directory.
+    #     path = dirn(__file__, 1)
+    # else:
+    #     raise RuntimeError("Couldn't find the app directory")
     return path
 
 def make_user_dir():

--- a/src/sas/_config.py
+++ b/src/sas/_config.py
@@ -3,6 +3,7 @@ from __future__ import print_function
 
 import sys
 import os
+import traceback
 from os.path import exists, expanduser, dirname, realpath, join as joinpath
 import logging
 import shutil
@@ -91,6 +92,7 @@ def setup_custom_config(app_dir, user_dir):
             # the app dir
             shutil.copyfile(os.path.join(app_dir, "custom_config.py"), path)
         except Exception:
+            logger.error(traceback.format_exc())
             logger.error("Could not copy default custom config.")
 
     #Adding SAS_OPENCL if it doesn't exist in the config file


### PR DESCRIPTION
This is a test to see if the installer generated during the merge with the main branch is able to find and copy `custom_config.py` from the installation directory to the user directory.

I will test the windows installer. @celinedurniak or @wpotrzebowski, could one or both of you test the mac installer?

Steps to test:
- Delete (or move) `custom_config.py` from your `~/.sasview/config` directory
- Install the [build](https://github.com/SasView/sasview/releases/tag/untagged-a93138cafa80d1785765)

Fixes #1911 