### PR TITLE
Missed sas.sascalc.dataloader imports

### DIFF
--- a/src/sas/qtgui/MainWindow/DataExplorer.py
+++ b/src/sas/qtgui/MainWindow/DataExplorer.py
@@ -633,8 +633,8 @@ class DataExplorerWindow(DroppableDataLoadWidget):
             # add the main index
             if not value: continue
             new_data = value[0]
-            from sas.sascalc.dataloader.data_info import Data1D as old_data1d
-            from sas.sascalc.dataloader.data_info import Data2D as old_data2d
+            from sasdata.dataloader.data_info import Data1D as old_data1d
+            from sasdata.dataloader.data_info import Data2D as old_data2d
             if isinstance(new_data, (old_data1d, old_data2d)):
                 new_data = self.manager.create_gui_data(value[0], new_data.name)
             if hasattr(value[0], 'id'):

--- a/src/sas/qtgui/Perspectives/Corfunc/CorfuncCanvas.py
+++ b/src/sas/qtgui/Perspectives/Corfunc/CorfuncCanvas.py
@@ -7,7 +7,7 @@ from typing import Optional, Union, List, Iterable, TYPE_CHECKING
 from matplotlib.backends.backend_qt5agg import FigureCanvasQTAgg as FigureCanvas
 from matplotlib.figure import Figure
 
-from sas.sascalc.dataloader.data_info import Data1D
+from sasdata.dataloader.data_info import Data1D
 
 
 if TYPE_CHECKING:


### PR DESCRIPTION
A few imports were missed in #2141. The `DataExplorer` imports are only used in rare cases and the `CorfuncCanvas` was merged into main while the PR was open.

Refs #2172