### PR TITLE
2103 copy parameters from corfunc gives wrong values

### DIFF
--- a/src/sas/qtgui/MainWindow/GuiManager.py
+++ b/src/sas/qtgui/MainWindow/GuiManager.py
@@ -830,7 +830,7 @@ class GuiManager:
         can be saved to the clipboard
         """
         if self._current_perspective is not None:
-            self._current_perspective.on_copy()
+            self._current_perspective.copy()
 
     def actionPaste(self):
         """
@@ -838,7 +838,7 @@ class GuiManager:
         from the clipboard can be used to modify the fit state
         """
         if self._current_perspective is not None:
-            self._current_perspective.on_paste()
+            self._current_perspective.paste()
 
     def actionReport(self):
         """
@@ -869,7 +869,7 @@ class GuiManager:
         can be saved to the clipboard
         """
         if self._current_perspective is not None:
-            self._current_perspective.on_excel_copy()
+            self._current_perspective.excel_copy()
 
     def actionLatex(self):
         """
@@ -877,7 +877,7 @@ class GuiManager:
         can be saved to the clipboard
         """
         if self._current_perspective is not None:
-            self._current_perspective.on_latex_copy()
+            self._current_perspective.latex_copy()
 
     def actionSaveParamsAs(self):
         """

--- a/src/sas/qtgui/MainWindow/GuiManager.py
+++ b/src/sas/qtgui/MainWindow/GuiManager.py
@@ -5,7 +5,7 @@ import json
 import webbrowser
 import traceback
 
-from typing import Optional
+from typing import Optional, Dict
 
 from PyQt5.QtWidgets import *
 from PyQt5.QtGui import *
@@ -102,7 +102,7 @@ class GuiManager:
 
         # Currently displayed perspective
         self._current_perspective: Optional[Perspective] = None
-        self.loadedPerspectives = {}
+        self.loadedPerspectives: Dict[str, Perspective] = {}
 
         # Populate the main window with stuff
         self.addWidgets()
@@ -277,7 +277,6 @@ class GuiManager:
                 PlotHelper.plotById(plot).showNormal()
                 PlotHelper.plotById(plot).setFocus()
                 return
-        pass
 
     def removePlotItemsInWindowsMenu(self, plot):
         """
@@ -293,7 +292,6 @@ class GuiManager:
                 action.triggered.disconnect()
                 self._workspace.menuWindow.removeAction(action)
                 return
-        pass
 
     def updateLogContextMenus(self, visible=False):
         """
@@ -386,13 +384,10 @@ class GuiManager:
         self._workspace.actionReport.setEnabled(new_perspective.supports_reports)
 
         # Copy paste options
-
-
-
-
-
-
-
+        self._workspace.actionCopy.setEnabled(new_perspective.supports_copy)
+        self._workspace.actionLatex.setEnabled(new_perspective.supports_copy)
+        self._workspace.actionExcel.setEnabled(new_perspective.supports_copy)
+        self._workspace.actionPaste.setEnabled(new_perspective.supports_paste)
 
 
 

--- a/src/sas/qtgui/MainWindow/GuiManager.py
+++ b/src/sas/qtgui/MainWindow/GuiManager.py
@@ -385,8 +385,8 @@ class GuiManager:
 
         # Copy paste options
         self._workspace.actionCopy.setEnabled(new_perspective.supports_copy)
-        self._workspace.actionLatex.setEnabled(new_perspective.supports_copy)
-        self._workspace.actionExcel.setEnabled(new_perspective.supports_copy)
+        self._workspace.actionLatex.setEnabled(new_perspective.supports_copy_latex)
+        self._workspace.actionExcel.setEnabled(new_perspective.supports_copy_excel)
         self._workspace.actionPaste.setEnabled(new_perspective.supports_paste)
 
         # Serialisation/saving things
@@ -829,16 +829,16 @@ class GuiManager:
         Send a signal to the fitting perspective so parameters
         can be saved to the clipboard
         """
-        self.communicate.copyFitParamsSignal.emit("")
-        #self._workspace.actionPaste.setEnabled(True)
-        pass
+        if self._current_perspective is not None:
+            self._current_perspective.on_copy()
 
     def actionPaste(self):
         """
         Send a signal to the fitting perspective so parameters
         from the clipboard can be used to modify the fit state
         """
-        self.communicate.pasteFitParamsSignal.emit()
+        if self._current_perspective is not None:
+            self._current_perspective.on_paste()
 
     def actionReport(self):
         """
@@ -868,20 +868,23 @@ class GuiManager:
         Send a signal to the fitting perspective so parameters
         can be saved to the clipboard
         """
-        self.communicate.copyExcelFitParamsSignal.emit("Excel")
+        if self._current_perspective is not None:
+            self._current_perspective.on_excel_copy()
 
     def actionLatex(self):
         """
         Send a signal to the fitting perspective so parameters
         can be saved to the clipboard
         """
-        self.communicate.copyLatexFitParamsSignal.emit("Latex")
+        if self._current_perspective is not None:
+            self._current_perspective.on_latex_copy()
 
     def actionSaveParamsAs(self):
         """
         Menu Save Params
         """
-        self.communicate.SaveFitParamsSignal.emit("Save")
+        if self._current_perspective is not None:
+            self._current_perspective.save_parameters()
 
     #============ VIEW =================
     def actionShow_Grid_Window(self):

--- a/src/sas/qtgui/MainWindow/GuiManager.py
+++ b/src/sas/qtgui/MainWindow/GuiManager.py
@@ -382,7 +382,21 @@ class GuiManager:
         # but new_perspective is of type Perspective, thus call to Perspective members are safe
         new_perspective = self.loadedPerspectives[new_perspective_name]
 
+        # Report options
         self._workspace.actionReport.setEnabled(new_perspective.supports_reports)
+
+        # Copy paste options
+
+
+
+
+
+
+
+
+
+
+        # Serialisation/saving things
         self._workspace.actionOpen_Analysis.setEnabled(False)
         self._workspace.actionSave_Analysis.setEnabled(False)
 
@@ -415,6 +429,7 @@ class GuiManager:
 
         elif isinstance(new_perspective, CorfuncWindow):
             self.checkAnalysisOption(self._workspace.actionCorfunc)
+
 
 
         #

--- a/src/sas/qtgui/MainWindow/GuiManager.py
+++ b/src/sas/qtgui/MainWindow/GuiManager.py
@@ -389,8 +389,6 @@ class GuiManager:
         self._workspace.actionExcel.setEnabled(new_perspective.supports_copy)
         self._workspace.actionPaste.setEnabled(new_perspective.supports_paste)
 
-
-
         # Serialisation/saving things
         self._workspace.actionOpen_Analysis.setEnabled(False)
         self._workspace.actionSave_Analysis.setEnabled(False)

--- a/src/sas/qtgui/Perspectives/Fitting/FittingPerspective.py
+++ b/src/sas/qtgui/Perspectives/Fitting/FittingPerspective.py
@@ -591,5 +591,13 @@ class FittingWindow(QtWidgets.QTabWidget, Perspective):
         return True
 
     @property
+    def supports_copy_excel(self) -> bool:
+        return True
+
+    @property
+    def supports_copy_latex(self) -> bool:
+        return True
+
+    @property
     def supports_paste(self) -> bool:
         return True

--- a/src/sas/qtgui/Perspectives/Fitting/FittingPerspective.py
+++ b/src/sas/qtgui/Perspectives/Fitting/FittingPerspective.py
@@ -73,12 +73,6 @@ class FittingWindow(QtWidgets.QTabWidget, Perspective):
         self.fittingStartedSignal.connect(self.onFittingStarted)
         self.fittingStoppedSignal.connect(self.onFittingStopped)
 
-        self.communicate.copyFitParamsSignal.connect(self.onParamCopy)
-        self.communicate.pasteFitParamsSignal.connect(self.onParamPaste)
-        self.communicate.copyExcelFitParamsSignal.connect(self.onExcelCopy)
-        self.communicate.copyLatexFitParamsSignal.connect(self.onLatexCopy)
-        self.communicate.SaveFitParamsSignal.connect(self.onParamSave)
-
         # Perspective window not allowed to close by default
         self._allow_close = False
 
@@ -119,17 +113,25 @@ class FittingWindow(QtWidgets.QTabWidget, Perspective):
 
         self._allow_close = value
 
-    def onParamCopy(self):
-        self.currentTab.onCopyToClipboard("")
+    def copy(self):
+        if self.currentFittingWidget is not None:
+            self.currentFittingWidget.copy()
 
-    def onParamPaste(self):
-        self.currentTab.onParameterPaste()
+    def paste(self):
+        if self.currentFittingWidget is not None:
+            self.currentFittingWidget.paste()
 
-    def onExcelCopy(self):
-        self.currentTab.onCopyToClipboard("Excel")
+    def excel_copy(self):
+        if self.currentFittingWidget is not None:
+            self.currentFittingWidget.copy_excel()
 
-    def onLatexCopy(self):
-        self.currentTab.onCopyToClipboard("Latex")
+    def latex_copy(self):
+        if self.currentFittingWidget is not None:
+            self.currentFittingWidget.copy_latex()
+
+    def save_parameters(self):
+        if self.currentFittingWidget is not None:
+            self.currentFittingWidget.save_parameters()
 
     def serializeAll(self):
         return self.serializeAllFitpage()
@@ -218,9 +220,6 @@ class FittingWindow(QtWidgets.QTabWidget, Perspective):
                     tab.addConstraintToRow(constraint=constraint,
                                            row=tab.getRowFromName(
                                                constraint_param[1]))
-
-    def onParamSave(self):
-        self.currentTab.onCopyToClipboard("Save")
 
     def closeEvent(self, event):
         """

--- a/src/sas/qtgui/Perspectives/Fitting/FittingPerspective.py
+++ b/src/sas/qtgui/Perspectives/Fitting/FittingPerspective.py
@@ -586,3 +586,10 @@ class FittingWindow(QtWidgets.QTabWidget, Perspective):
     def supports_fitting_menu(self) -> bool:
         return True
 
+    @property
+    def supports_copy(self) -> bool:
+        return True
+
+    @property
+    def supports_paste(self) -> bool:
+        return True

--- a/src/sas/qtgui/Perspectives/Fitting/FittingUtilities.py
+++ b/src/sas/qtgui/Perspectives/Fitting/FittingUtilities.py
@@ -859,11 +859,11 @@ def formatParameters(parameters: list, entry_sep=',', line_sep=':'):
     Prepare the parameter string in the standard SasView layout
     """
 
-    parameter_strings = []
+    parameter_strings = ["sasview_parameter_values"]
     for parameter in parameters:
         parameters.append(entry_sep.join([str(component) for component in parameter]))
 
-    return "sasview_parameter_values:" + line_sep.join(parameter_strings)
+    return line_sep.join(parameter_strings)
 
 def formatParametersExcel(parameters: list):
     """

--- a/src/sas/qtgui/Perspectives/Fitting/FittingUtilities.py
+++ b/src/sas/qtgui/Perspectives/Fitting/FittingUtilities.py
@@ -861,7 +861,7 @@ def formatParameters(parameters: list, entry_sep=',', line_sep=':'):
 
     parameter_strings = ["sasview_parameter_values"]
     for parameter in parameters:
-        parameters.append(entry_sep.join([str(component) for component in parameter]))
+        parameter_strings.append(entry_sep.join([str(component) for component in parameter]))
 
     return line_sep.join(parameter_strings)
 

--- a/src/sas/qtgui/Perspectives/Fitting/FittingUtilities.py
+++ b/src/sas/qtgui/Perspectives/Fitting/FittingUtilities.py
@@ -854,31 +854,21 @@ def getOrientationParam(kernel_module=None):
 
     return param
 
-def formatParameters(parameters, Check=True):
+def formatParameters(parameters: list, entry_sep=',', line_sep=':'):
     """
     Prepare the parameter string in the standard SasView layout
     """
-    assert parameters is not None
-    assert isinstance(parameters, list)
-    output_string = "sasview_parameter_values:"
+
+    parameter_strings = []
     for parameter in parameters:
-        # recast tuples into strings
-        parameter = [str(p) for p in parameter]
-        output_string += ",".join([p for p in parameter if p is not None])
-        output_string += ":"
+        parameters.append(entry_sep.join([str(component) for component in parameter]))
 
-    if Check == False:
-        new_string = output_string.replace(':', '\n')
-        return new_string
-    else:
-        return output_string
+    return "sasview_parameter_values:" + line_sep.join(parameter_strings)
 
-def formatParametersExcel(parameters):
+def formatParametersExcel(parameters: list):
     """
     Prepare the parameter string in the Excel format (tab delimited)
     """
-    assert parameters is not None
-    assert isinstance(parameters, list)
     crlf = chr(13) + chr(10)
     tab = chr(9)
 
@@ -906,12 +896,11 @@ def formatParametersExcel(parameters):
     output_string = names + crlf + values + crlf + check
     return output_string
 
-def formatParametersLatex(parameters):
+def formatParametersLatex(parameters: list):
     """
     Prepare the parameter string in latex
     """
-    assert parameters is not None
-    assert isinstance(parameters, list)
+
     output_string = r'\begin{table}'
     output_string += r'\begin{tabular}[h]'
 

--- a/src/sas/qtgui/Perspectives/Fitting/FittingWidget.py
+++ b/src/sas/qtgui/Perspectives/Fitting/FittingWidget.py
@@ -3864,7 +3864,7 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         """
         Gather current fitting parameters as dict
         """
-        param_list = self.getFitParameters()
+
         param_list = self.getFitPage()
         param_list += self.getFitModel()
 
@@ -3878,60 +3878,70 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
                 line_dict[content[0]] = content[1:]
         return line_dict
 
-    def onCopyToClipboard(self, format=None):
-        """
-        Copy current fitting parameters into the clipboard
-        using requested formatting:
-        plain, excel, latex
-        """
+    def copy(self):
+        self.set_clipboard(self.full_copy_data())
+
+    def paste(self):
+        pass
+
+    def copy_excel(self):
+        self.set_clipboard(self.excel_copy_data())
+
+    def copy_latex(self):
+        self.set_clipboard(self.latex_copy_data())
+
+    def full_copy_data(self):
+        """ Data destined for the clipboard when copy clicked"""
+        param_list = self.getFitPage()
+        param_list += self.getFitModel()
+        return FittingUtilities.formatParameters(param_list)
+
+    def excel_copy_data(self):
+        """ Excel format data destined for the clipboard"""
         param_list = self.getFitParameters()
-        if format=="":
-            param_list = self.getFitPage()
-            param_list += self.getFitModel()
-            formatted_output = FittingUtilities.formatParameters(param_list)
-        elif format == "Excel":
-            formatted_output = FittingUtilities.formatParametersExcel(param_list[1:])
-        elif format == "Latex":
-            formatted_output = FittingUtilities.formatParametersLatex(param_list[1:])
-        elif format == "Save":
-            Text_output = FittingUtilities.formatParameters(param_list, False)
-            Excel_output = FittingUtilities.formatParametersExcel(param_list[1:])
-            Latex_output = FittingUtilities.formatParametersLatex(param_list[1:])
+        return FittingUtilities.formatParametersExcel(param_list[1:])
+
+    def latex_copy_data(self):
+        """ Latex format data destined for the clipboard"""
+        param_list = self.getFitParameters()
+        return FittingUtilities.formatParametersLatex(param_list[1:])
+
+    def save_parameters(self):
+        """ Save parameters to a file"""
+        param_list = self.getFitParameters()
+
+        save_dialog = QtWidgets.QFileDialog()
+        save_dialog.setAcceptMode(QtWidgets.QFileDialog.AcceptSave)
+        kwargs = {
+            'parent': self,
+            'caption': 'Save Project',
+            'filter': 'Text (*.txt);;Excel (*.xls);;Latex (*.log)',
+            'options': QtWidgets.QFileDialog.DontUseNativeDialog
+        }
+        file_path = save_dialog.getSaveFileName(**kwargs)
+        filename = file_path[0]
+
+        if not filename:
+            return
+        if file_path[1] == 'Text (*.txt)':
+            save_data = FittingUtilities.formatParameters(param_list, line_sep="\n")
+            filename = '.'.join((filename, 'txt'))
+        elif file_path[1] == 'Excel (*.xls)':
+            save_data = FittingUtilities.formatParametersExcel(param_list[1:])
+            filename = '.'.join((filename, 'xls'))
+        elif file_path[1] == 'Latex (*.log)':
+            save_data = FittingUtilities.formatParametersLatex(param_list[1:])
+            filename = '.'.join((filename, 'log'))
         else:
-            raise AttributeError("Bad parameter output format specifier.")
+            raise ValueError(f"Unknown File Format {file_path[1]}")
 
-        # Dump formatted_output to the clipboard
+        with open(filename, 'w') as file:
+            file.write(save_data)
 
-
-        if format == "Save":
-            save_dialog = QtWidgets.QFileDialog()
-            save_dialog.setAcceptMode(QtWidgets.QFileDialog.AcceptSave)
-            kwargs = {
-                'parent': self,
-                'caption': 'Save Project',
-                'filter': 'Text (*.txt);;Excel (*.xls);;Latex (*.log)',
-                'options': QtWidgets.QFileDialog.DontUseNativeDialog
-            }
-            file_path = save_dialog.getSaveFileName(**kwargs)
-            filename = file_path[0]
-            if not filename:
-                return
-            if file_path[1] == 'Text (*.txt)':
-                Type_output = Text_output
-                filename = '.'.join((filename, 'txt'))
-            elif file_path[1] == 'Excel (*.xls)':
-                Type_output = Excel_output
-                filename = '.'.join((filename, 'xls'))
-            elif file_path[1] == 'Latex (*.log)':
-                Type_output = Latex_output
-                filename = '.'.join((filename, 'log'))
-
-            file_open = open(filename, 'w')
-            with file_open:
-                file_open.write(Type_output)
-        else:
-            cb = QtWidgets.QApplication.clipboard()
-            cb.setText(formatted_output)
+    def set_clipboard(self, data: str):
+        """ Set the data in the clipboard """
+        cb = QtWidgets.QApplication.clipboard()
+        cb.setText(data)
 
 
     def getFitModel(self):

--- a/src/sas/qtgui/Perspectives/Fitting/FittingWidget.py
+++ b/src/sas/qtgui/Perspectives/Fitting/FittingWidget.py
@@ -3882,7 +3882,31 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         self.set_clipboard(self.full_copy_data())
 
     def paste(self):
-        pass
+        """
+        Use the clipboard to update fit state
+        """
+        # Check if the clipboard contains right stuff
+        cb = QtWidgets.QApplication.clipboard()
+        cb_text = cb.text()
+
+        lines = cb_text.split(':')
+        if lines[0] != 'sasview_parameter_values':
+            msg = "Clipboard content is incompatible with the Fit Page."
+            msgbox = QtWidgets.QMessageBox(self)
+            msgbox.setIcon(QtWidgets.QMessageBox.Warning)
+            msgbox.setText(msg)
+            msgbox.setWindowTitle("Clipboard")
+            msgbox.exec_()
+            return
+
+        # put the text into dictionary
+        line_dict = {}
+        for line in lines[1:]:
+            content = line.split(',')
+            if len(content) > 1 and content[0] != "tab_name":
+                line_dict[content[0]] = content[1:]
+
+        self.updatePageWithParameters(line_dict)
 
     def copy_excel(self):
         self.set_clipboard(self.excel_copy_data())
@@ -4123,33 +4147,6 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
             param_list.append(['multiplicity', str(self.kernel_module.multiplicity)])
 
         return param_list
-
-    def onParameterPaste(self):
-        """
-        Use the clipboard to update fit state
-        """
-        # Check if the clipboard contains right stuff
-        cb = QtWidgets.QApplication.clipboard()
-        cb_text = cb.text()
-
-        lines = cb_text.split(':')
-        if lines[0] != 'sasview_parameter_values':
-            msg = "Clipboard content is incompatible with the Fit Page."
-            msgbox = QtWidgets.QMessageBox(self)
-            msgbox.setIcon(QtWidgets.QMessageBox.Warning)
-            msgbox.setText(msg)
-            msgbox.setWindowTitle("Clipboard")
-            retval = msgbox.exec_()
-            return
-
-        # put the text into dictionary
-        line_dict = {}
-        for line in lines[1:]:
-            content = line.split(',')
-            if len(content) > 1 and content[0] != "tab_name":
-                line_dict[content[0]] = content[1:]
-
-        self.updatePageWithParameters(line_dict)
 
     def createPageForParameters(self, line_dict):
         """

--- a/src/sas/qtgui/Perspectives/Fitting/FittingWidget.py
+++ b/src/sas/qtgui/Perspectives/Fitting/FittingWidget.py
@@ -3879,7 +3879,8 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         return line_dict
 
     def copy(self):
-        self.set_clipboard(self.full_copy_data())
+        copy_data = self.full_copy_data()
+        self.set_clipboard(copy_data)
 
     def paste(self):
         """

--- a/src/sas/qtgui/Perspectives/perspective.py
+++ b/src/sas/qtgui/Perspectives/perspective.py
@@ -134,8 +134,13 @@ class Perspective(object, metaclass=PerspectiveMeta):
     # Copy and paste functionality
     @property
     def supports_copy(self) -> bool:
+        """ Does this perspective support copy functionality? """
         return False
 
     @property
     def supports_paste(self) -> bool:
         return False
+
+    def on_copy(self):
+        pass
+

--- a/src/sas/qtgui/Perspectives/perspective.py
+++ b/src/sas/qtgui/Perspectives/perspective.py
@@ -158,19 +158,19 @@ class Perspective(object, metaclass=PerspectiveMeta):
         """ Does this perspective allow pasting?"""
         return False
 
-    def on_copy(self):
+    def copy(self):
         """ Called by copy menu item"""
         pass
 
-    def on_paste(self):
+    def paste(self):
         """ Called by paste menu item"""
         pass
 
-    def on_excel_copy(self):
+    def excel_copy(self):
         """ Called by copy excel menu item"""
         pass
 
-    def on_latex_copy(self):
+    def latex_copy(self):
         """ Called by copy latex menu item"""
         pass
 

--- a/src/sas/qtgui/Perspectives/perspective.py
+++ b/src/sas/qtgui/Perspectives/perspective.py
@@ -131,3 +131,11 @@ class Perspective(object, metaclass=PerspectiveMeta):
     def supports_fitting_menu(self) -> bool:
         return False
 
+    # Copy and paste functionality
+    @property
+    def supports_copy(self) -> bool:
+        return False
+
+    @property
+    def supports_paste(self) -> bool:
+        return False

--- a/src/sas/qtgui/Perspectives/perspective.py
+++ b/src/sas/qtgui/Perspectives/perspective.py
@@ -99,8 +99,13 @@ class Perspective(object, metaclass=PerspectiveMeta):
 
 
     #
-    # Other shared functionality
+    # Reports
     #
+
+    @property
+    def supports_reports(self) -> bool:
+        """ Does this perspective have a report functionality (currently used by menus and toolbar)"""
+        return False
 
     def getReport(self) -> Optional[ReportData]: # TODO: Refactor to just report, or report_html
         """ A string containing the HTML to be shown in the report"""
@@ -125,25 +130,62 @@ class Perspective(object, metaclass=PerspectiveMeta):
     #
 
     @property
-    def supports_reports(self) -> bool:
-        """ Does this perspective have a report functionality (currently used by menus and toolbar)"""
-        return False
-
-    @property
     def supports_fitting_menu(self) -> bool:
         """ Should the fitting menu be shown when using this perspective (unless its Fitting, probably not)"""
         return False
 
+    #
     # Copy and paste functionality
+    #
+
     @property
     def supports_copy(self) -> bool:
         """ Does this perspective support copy functionality? """
         return False
 
     @property
+    def supports_copy_excel(self) -> bool:
+        """ Does this perspective support copy functionality? """
+        return False
+
+    @property
+    def supports_copy_latex(self) -> bool:
+        """ Does this perspective support copy functionality? """
+        return False
+
+    @property
     def supports_paste(self) -> bool:
+        """ Does this perspective allow pasting?"""
         return False
 
     def on_copy(self):
+        """ Called by copy menu item"""
         pass
+
+    def on_paste(self):
+        """ Called by paste menu item"""
+        pass
+
+    def on_excel_copy(self):
+        """ Called by copy excel menu item"""
+        pass
+
+    def on_latex_copy(self):
+        """ Called by copy latex menu item"""
+        pass
+
+    #
+    # Loading and saving of parameters
+    #
+
+    @property
+    def supports_save_parameters(self) -> bool:
+        """ Can this perspective save its parameters to a file"""
+        return False
+
+    def save_parameters(self):
+        """ Save parameters to a file"""
+        pass
+
+
 


### PR DESCRIPTION
The highlight of this pull request is that copy parameters from corfunc no longer gives "wrong" values.

I have disabled copy and paste for any perspectives that don't support it, this has required refactoring the copy and paste functionality in fitting. I have also done some tidying up of FittingUtilities but there is still plenty to do there.

As Corfunc never did, or attempted to support copy/paste, having enabled copy buttons was an oversight. 

I'm not implementing anything new in this PR. For a proper implementation I will require a clear specification of what the right values should be. I'm not sure that there is a use case for copying and pasting everything like there is in fitting (note that individual fields can be copy and pasted). This enhancement should be a new issue / discussion.