### PR TITLE
Fix compatibility with matplotlib 3.5.x

### DIFF
--- a/src/sas/qtgui/Plotting/Arrow3D.py
+++ b/src/sas/qtgui/Plotting/Arrow3D.py
@@ -2,6 +2,7 @@
 Module that draws multiple arrows in 3D coordinates
 """
 
+import numpy as np
 from matplotlib.patches import FancyArrowPatch
 from mpl_toolkits.mplot3d import proj3d
 import time
@@ -21,7 +22,7 @@ class Arrow3D(FancyArrowPatch):
         :Params colors: [[R0, G0, B0], [R1, G1, B1], ...]
         where R, G, B ranges (0,1)
         """
-        FancyArrowPatch.__init__(self, (0, 0), (0, 0), *args, **kwargs)
+        super().__init__((0, 0), (0, 0), *args, **kwargs)
         self.leftdown = False
         self.realtime = False
         self.t_click = 0
@@ -62,7 +63,7 @@ class Arrow3D(FancyArrowPatch):
         self._verts3d = xs, ys, zs
         self.base.canvas.draw()
 
-    def draw(self, renderer, rasterized=True):
+    def do_3d_projection(self):
         """
         Drawing actually happens here
         """
@@ -70,12 +71,12 @@ class Arrow3D(FancyArrowPatch):
         if self.leftdown and not self.realtime:
             return
         xs3d, ys3d, zs3d = self._verts3d
+        zmins = []
         for i in range(len(xs3d)):
-            xs, ys, _ = proj3d.proj_transform(xs3d[i], ys3d[i], zs3d[i], renderer.M)
+            xs, ys, zs = proj3d.proj_transform(xs3d[i], ys3d[i], zs3d[i], self.axes.M)
             self.set_positions((xs[0], ys[0]), (xs[1], ys[1]))
             self.set_color(self.colors[i])
-            FancyArrowPatch.draw(self, renderer)
+            zmins.append(np.min(zs))
 
         self.leftdown = False
-
-
+        return min(zmins)

--- a/src/sas/qtgui/Plotting/Plotter2D.py
+++ b/src/sas/qtgui/Plotting/Plotter2D.py
@@ -539,7 +539,7 @@ class Plotter2DWidget(PlotterBase):
             else:
                 cb = self.figure.colorbar(self.im, cax=cbax)
 
-            cb.update_bruteforce(self.im)
+            cb.update_normal(self.im)
             cb.set_label('$' + self.scale + '$')
 
             self.vmin = cb.vmin


### PR DESCRIPTION
This patch attempts to fix compatibility with matplotlib 3.5.x by updating the code to avoid functions that were deprecated (in some cases for years) and have now been removed.

Merging this patch at least allows the sasview GUI to start with matplotlib 3.5; additional places where code needs to be updated may well be uncovered by automated or manual testing.

Closes: #2170