### PR TITLE
Qt 5.15.4 compatibility

### DIFF
--- a/src/sas/qtgui/MainWindow/GuiManager.py
+++ b/src/sas/qtgui/MainWindow/GuiManager.py
@@ -466,7 +466,8 @@ class GuiManager:
         """
         Update progress bar with the required value (0-100)
         """
-        assert -1 <= value <= 100
+        if value < -1 or value > 100:
+            return
         if value == -1:
             self.progress.setVisible(False)
             return

--- a/src/sas/qtgui/Perspectives/Fitting/ViewDelegate.py
+++ b/src/sas/qtgui/Perspectives/Fitting/ViewDelegate.py
@@ -67,8 +67,8 @@ class ModelViewDelegate(QtWidgets.QStyledItemDelegate):
             rect = textRect.topLeft()
             x = rect.x()
             y = rect.y()
-            x += 3.0 # magic value for rendering nice display in the table
-            y += 2.0 # magic value for rendering nice display in the table
+            x += 3 # magic value for rendering nice display in the table
+            y += 2 # magic value for rendering nice display in the table
             rect.setX(x)
             rect.setY(y)
             painter.translate(rect)

--- a/src/sas/qtgui/Perspectives/Invariant/InvariantDetails.py
+++ b/src/sas/qtgui/Perspectives/Invariant/InvariantDetails.py
@@ -132,19 +132,19 @@ class DetailsDialog(QtWidgets.QDialog, Ui_Dialog):
         if self.progress_low_qstar == 'error':
             self.progressBarLowQ.setValue(0)
         else:
-            self.progressBarLowQ.setValue(self.progress_low_qstar)
+            self.progressBarLowQ.setValue(int(self.progress_low_qstar))
             self.progressBarLowQ.setFormat("%.2f %%" % self.progress_low_qstar)
 
         if self.progress_high_qstar == 'error':
             self.progressBarHighQ.setValue(0)
         else:
-            self.progressBarHighQ.setValue(self.progress_high_qstar)
+            self.progressBarHighQ.setValue(int(self.progress_high_qstar))
             self.progressBarHighQ.setFormat("%.2f %%" % self.progress_high_qstar)
 
         if self.progress_data_qstar == 'error':
             self.progressBarData.setValue(0)
         else:
-            self.progressBarData.setValue(self.progress_data_qstar)
+            self.progressBarData.setValue(int(self.progress_data_qstar))
             self.progressBarData.setFormat("%.2f %%" % self.progress_data_qstar)
 
         self.show()


### PR DESCRIPTION
This PR attempts to improve compatibility with newer Qt/PyQt releases. Several functions regarding progress bar values and pixel positioning that used to accept `float` now only accept `int`. The C++ Qt documentation for these functions uniformly says that the arguments should be `int`; I'm not sure whether the failures observed are due to changes in Qt or PyQt, and they may even be architecture-specific. 

I expect that there are more changes like these needed, as I found these spots just by wandering through the interface loading dialogues and hitting "fit" or "compute" buttons.

Platform: Linux (Debian)
Python: 3.10
Qt: 5.15.7
PyQt: 5.15.4