### PR TITLE
Stop making a new release on every push

### DIFF
--- a/.github/workflows/installers.yml
+++ b/.github/workflows/installers.yml
@@ -194,27 +194,3 @@ jobs:
         name: SasView-Installer-${{ matrix.os }}-${{ matrix.python-version }}-${{ github.sha }}
         path: installers/dist/SasView5.dmg
         if-no-files-found: error
-
-    - name: Declare env variables on push only
-      if: github.event_name == 'push'
-      shell: bash
-      run: echo "BRANCH_NAME=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
-
-    - name: Declare env variables on pull_request only
-      if: github.event_name == 'pull_request'
-      shell: bash
-      run: echo "BRANCH_NAME=$GITHUB_HEAD_REF" >> $GITHUB_ENV
-
-    - name: Upload installer to GitHub releases
-      #Release and main branch will be treated differently
-      if: env.BRANCH_NAME != 'main'
-      uses: ncipollo/release-action@v1
-      with:
-        draft: true
-        prerelease: true
-        allowUpdates: true
-        replacesArtifacts: true
-        token: ${{ secrets.GITHUB_TOKEN }}
-        artifacts: "installers/dist/SasView5.dmg, installers/Output/setupSasView.exe"
-        name: ${{ env.BRANCH_NAME }}
-        tag: ${{ env.BRANCH_NAME }}


### PR DESCRIPTION
As described in #2213, we are in the very strange situation of making a new release out of every single git push, and they are all published on the releases page. That is polluting the [releases page](https://github.com/SasView/sasview/releases) with lots of weird stuff ~~to which users should never be subjected~~ (Edit: not visible to not logged in users, fortunately; but still not pleasant!).

Building an installer to test can (and does!) work via the actions. They are published as artifacts of the particular action run and are visible under the "Summary" of the action once it has run. Making a release isn't needed to make those installers available For example: [https://github.com/SasView/sasview/actions/runs/3113602635](https://github.com/SasView/sasview/actions/runs/3113602635)

I don't think we really want to have releases made for every single git push so this PR removes that step from the standard GitHub Actions. I think someone also needs to do the manual work of deleting all the old ones out of the releases page... I don't know if that can be automated or even made less tedious.