### PR TITLE
Drop debugpy from installer

### DIFF
--- a/.github/workflows/installers.yml
+++ b/.github/workflows/installers.yml
@@ -72,7 +72,7 @@ jobs:
         python -m pip install numpy scipy==1.7.3 docutils "pytest<6" sphinx unittest-xml-reporting
         python -m pip install tinycc h5py sphinx pyparsing html5lib reportlab==3.6.6 pybind11 appdirs
         python -m pip install six numba mako ipython qtconsole xhtml2pdf unittest-xml-reporting pylint
-        python -m pip install qt5reactor periodictable uncertainties debugpy dominate importlib_resources
+        python -m pip install qt5reactor periodictable uncertainties dominate importlib_resources
         python -m pip install html2text
 
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,7 +74,7 @@ jobs:
         python -m pip install numpy scipy==1.7.3 docutils "pytest<6" sphinx unittest-xml-reporting
         python -m pip install tinycc h5py sphinx pyparsing html5lib reportlab==3.6.6 pybind11 appdirs
         python -m pip install six numba mako ipython qtconsole xhtml2pdf unittest-xml-reporting pylint
-        python -m pip install qt5reactor periodictable uncertainties debugpy dominate importlib_resources 
+        python -m pip install qt5reactor periodictable uncertainties dominate importlib_resources
         python -m pip install html2text
 
 

--- a/build_tools/requirements.txt
+++ b/build_tools/requirements.txt
@@ -21,7 +21,6 @@ pylint
 qt5reactor 
 periodictable 
 uncertainties 
-debugpy
 matplotlib~=3.5.2
 PyQt5
 lxml

--- a/installers/sasview.spec
+++ b/installers/sasview.spec
@@ -23,9 +23,6 @@ datas = [
 if platform.system() == 'Darwin':
     datas.append((os.path.join(PYTHON_LOC,'lib','python3.8', 'site-packages','jedi'),'jedi'))
     datas.append((os.path.join(PYTHON_LOC,'lib','python3.8', 'site-packages','zmq'),'.'))
-    datas.append((os.path.join(PYTHON_LOC,'lib','python3.8', 'site-packages','debugpy'),'debugpy'))
-else:
-    datas.append((os.path.join(PYTHON_LOC,'Lib','site-packages','debugpy'),'debugpy'))
 
 def add_data(data):
     for component in data:
@@ -63,8 +60,6 @@ hiddenimports = [
     'reportlab.graphics.barcode.fourstate',
     'xmlrpc',
     'xmlrpc.server',
-    'debugpy',
-    'debugpy._vendored',
     'uncertainties',
 ]
 


### PR DESCRIPTION
debugpy isn't used anywhere in the sasview code or in the documentation/examples; bundling it into the installer requires additional fragile workarounds, so if it's not needed, can we drop it?