### PR TITLE
Add cli option to installer to skip licence dialogue

### DIFF
--- a/installers/installer.iss
+++ b/installers/installer.iss
@@ -43,6 +43,16 @@ Name: "english"; MessagesFile: "compiler:Default.isl"
 Name: "desktopicon"; Description: "{cm:CreateDesktopIcon}"; GroupDescription: "{cm:AdditionalIcons}"; Flags: unchecked
 Name: "quicklaunchicon"; Description: "{cm:CreateQuickLaunchIcon}"; GroupDescription: "{cm:AdditionalIcons}"; OnlyBelowVersion: 6.1; Check: not IsAdminInstallMode
 
+[Code]
+{ If there is a command-line parameter "skiplicense=true", don't display license page }
+function ShouldSkipPage(PageID: Integer): Boolean;
+begin
+  Result := False
+  if PageId = wpLicense then
+    if ExpandConstant('{param:skiplicense|false}') = 'true' then
+      Result := True;
+end;
+
 [Files]
 Source: "dist\sasview\sasview.exe"; DestDir: "{app}"; Flags: ignoreversion
 Source: "dist\sasview\*"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs createallsubdirs


### PR DESCRIPTION
A tiny bit of code within the installer configuration allows the installer to be run as a completely non-interactive installer allowing for later automation:

```
./setupSasView.exe /SP- /VERYSILENT /SUPPRESSMSGBOXES /NORESTART /ALLUSERS /SKIPLICENSE=true /LANG=english /NOICONS /TASKS='' /LOG=install.log /DIR=C:/somewhere/
```

Automated testing of the Windows installer needs this to land first.