### PR TITLE
Stop making huge folder tree in user profile

### DIFF
--- a/installers/installer.iss
+++ b/installers/installer.iss
@@ -46,8 +46,8 @@ Name: "quicklaunchicon"; Description: "{cm:CreateQuickLaunchIcon}"; GroupDescrip
 [Files]
 Source: "dist\sasview\sasview.exe"; DestDir: "{app}"; Flags: ignoreversion
 Source: "dist\sasview\*"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs createallsubdirs
-Source: "dist\sasview\plugin_models\*";	DestDir: "{%USERPROFILE}\.sasview\plugin_models";	Flags: recursesubdirs createallsubdirs
-Source: "dist\sasview\custom_config.py";	DestDir: "{%USERPROFILE}\.sasview\config";	Flags: recursesubdirs createallsubdirs
+Source: "dist\sasview\plugin_models\*"; DestDir: "{%USERPROFILE}\.sasview\plugin_models"
+Source: "dist\sasview\custom_config.py"; DestDir: "{%USERPROFILE}\.sasview\config"
 
 [Icons]
 Name: "{autodesktop}\{#MyAppName}"; Filename: "{app}\{#MyAppExeName}"; Tasks: desktopicon

--- a/installers/installer.iss
+++ b/installers/installer.iss
@@ -47,7 +47,6 @@ Name: "quicklaunchicon"; Description: "{cm:CreateQuickLaunchIcon}"; GroupDescrip
 Source: "dist\sasview\sasview.exe"; DestDir: "{app}"; Flags: ignoreversion
 Source: "dist\sasview\*"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs createallsubdirs
 Source: "dist\sasview\plugin_models\*"; DestDir: "{%USERPROFILE}\.sasview\plugin_models"
-Source: "dist\sasview\custom_config.py"; DestDir: "{%USERPROFILE}\.sasview\config"
 
 [Icons]
 Name: "{autodesktop}\{#MyAppName}"; Filename: "{app}\{#MyAppExeName}"; Tasks: desktopicon


### PR DESCRIPTION
The installer accidentally creates a huge folder tree in the user's profile directory. 820 empty folders are created by the installer, which is the entire folder structure of `C:\SasView` but without any contents in it:

```
$ cd ~/.sasview
$ find config
config
config/astroid
config/astroid/brain
config/astroid/brain/__pycache__
config/backports
config/backports/zoneinfo
config/certifi
config/cryptography
config/cryptography/hazmat
config/cryptography/hazmat/bindings
config/cryptography-38.0.1.dist-info
config/debugpy
config/debugpy/adapter
config/debugpy/adapter/__pycache__
config/debugpy/common
config/debugpy/common/__pycache__
config/debugpy/launcher
config/debugpy/launcher/__pycache__
config/debugpy/server
config/debugpy/server/__pycache__
config/debugpy/_vendored
config/debugpy/_vendored/pydevd
config/debugpy/_vendored/pydevd/pydevd_attach_to_process
config/debugpy/_vendored/pydevd/pydevd_attach_to_process/common
config/debugpy/_vendored/pydevd/pydevd_attach_to_process/linux_and_mac
config/debugpy/_vendored/pydevd/pydevd_attach_to_process/linux_and_mac/__pycache__
config/debugpy/_vendored/pydevd/pydevd_attach_to_process/winappdbg
config/debugpy/_vendored/pydevd/pydevd_attach_to_process/winappdbg/win32
config/debugpy/_vendored/pydevd/pydevd_attach_to_process/winappdbg/win32/__pycache__
config/debugpy/_vendored/pydevd/pydevd_attach_to_process/winappdbg/__pycache__
config/debugpy/_vendored/pydevd/pydevd_attach_to_process/windows
config/debugpy/_vendored/pydevd/pydevd_attach_to_process/__pycache__
config/debugpy/_vendored/pydevd/pydevd_plugins
config/debugpy/_vendored/pydevd/pydevd_plugins/extensions
config/debugpy/_vendored/pydevd/pydevd_plugins/extensions/types
config/debugpy/_vendored/pydevd/pydevd_plugins/extensions/types/__pycache__
… etc …
```

The culprit is the `Flags: recursesubdirs createallsubdirs` entry in `installer.iss`. I guess that was added there assuming that it would create just the `~/.sasview/config` directory.

There's a couple of things to do here:

- the installer needs to catch up with the changes to the config class from #2164 
- the installer needs to stop making a huge pile of empty directories

I'd add a further item: the installer when run in "Install for everyone mode" (which is the default and what the installer itself recommends) should not attempt to touch *anything* in the user's profile directory. Ideally, we'd drop the entry for `plugin_models` too and allow that to be created on first run.
