### PR TITLE
Add persistent legend visibility toggle

### DIFF
--- a/src/sas/qtgui/Plotting/Plotter.py
+++ b/src/sas/qtgui/Plotting/Plotter.py
@@ -88,6 +88,8 @@ class PlotterWidget(PlotterBase):
         self.toolbar._actions['pan'].triggered.connect(self._pan)
         self.toolbar._actions['zoom'].triggered.connect(self._zoom)
 
+        self.legendVisible = True
+
         parent.geometry()
 
     @property
@@ -250,7 +252,7 @@ class PlotterWidget(PlotterBase):
         self.plot_lines[data.name] = line
 
         # Now add the legend with some customizations.
-        if self.showLegend:
+        if self.showLegend and self.legendVisible:
             width=_legendResize(self.canvas.size().width(), self.parent)
             if width is not None:
                 self.legend = ax.legend(loc='upper right', shadow=True, prop={'size':width})
@@ -303,7 +305,7 @@ class PlotterWidget(PlotterBase):
         """
         Resize the legend window/font on canvas resize
         """
-        if not self.showLegend:
+        if not self.showLegend or not self.legendVisible:
             return
         width = _legendResize(event.width, self.parent)
         # resize the legend to follow the canvas width.
@@ -799,8 +801,9 @@ class PlotterWidget(PlotterBase):
         if not self.showLegend:
             return
 
-        visible = self.legend.get_visible()
-        self.legend.set_visible(not visible)
+        #visible = self.legend.get_visible()
+        self.legendVisible = not self.legendVisible
+        self.legend.set_visible(self.legendVisible)
         self.canvas.draw_idle()
 
     def onCusotmizeLabel(self):


### PR DESCRIPTION
As discussed in #2215, adds a new instance variable to `PlotterWidget`, `self.legendVisible` which tracks the user's preference for having the legend visible/invisible (this is distinct from `self.showLegend` which tracks whether the plot has a legend at all).  The `onToggleLegend` and similar methods are updated to toggle `self.legendVisible` then trigger a redraw rather than just modifying the existing plot.  Tested and appears to work on Win10.