### PR TITLE
Add command line interface to allow scripts to be run from sasview.exe

### DIFF
--- a/installers/sasview.py
+++ b/installers/sasview.py
@@ -6,10 +6,10 @@ Run sasview from an installed bundle
 """
 
 import sys
-
-
 sys.dont_write_bytecode = True
 
-from sas.qtgui.MainWindow.MainWindow import run_sasview
-
-run_sasview()
+if __name__ == "__main__":
+    from multiprocessing import freeze_support
+    freeze_support()
+    from sas.cli import main
+    main()

--- a/run.py
+++ b/run.py
@@ -19,8 +19,7 @@ import sys
 import os
 from os.path import abspath, dirname, realpath, join as joinpath
 from contextlib import contextmanager
-
-PLUGIN_MODEL_DIR = 'plugin_models'
+from importlib import import_module
 
 def addpath(path):
     """
@@ -35,7 +34,6 @@ def addpath(path):
     os.environ['PYTHONPATH'] = PYTHONPATH
     sys.path.insert(0, path)
 
-
 @contextmanager
 def cd(path):
     """
@@ -46,62 +44,45 @@ def cd(path):
     yield
     os.chdir(old_dir)
 
-def setup_sasmodels():
-    """
-    Prepare sasmodels for running within sasview.
-    """
-    # Set SAS_MODELPATH so sasmodels can find our custom models
-
-    from sas.system.user import get_user_dir
-    plugin_dir = os.path.join(get_user_dir(), PLUGIN_MODEL_DIR)
-    os.environ['SAS_MODELPATH'] = plugin_dir
-
 def prepare():
     # Don't create *.pyc files
     sys.dont_write_bytecode = True
 
-    # find the directories for the source and build
-    from distutils.util import get_platform
+    # Turn numpy warnings into errors
+    #import numpy; numpy.seterr(all='raise')
+
+    # Find the directories for the source and build
     root = abspath(dirname(realpath(__file__)))
 
-    platform = '%s-%s' % (get_platform(), sys.version[:3])
-    build_path = joinpath(root, 'build', 'lib.' + platform)
-
-    # Notify the help menu that the Sphinx documentation is in a different
-    # place than it otherwise would be.
-    os.environ['SASVIEW_DOC_PATH'] = joinpath(build_path, "doc")
-
-    try:
-        import periodictable
-    except ImportError:
-        addpath(joinpath(root, '..', 'periodictable'))
-
-    try:
-        import bumps
-    except ImportError:
-        addpath(joinpath(root, '..', 'bumps'))
+    # TODO: Do we prioritize the sister repo or the installed package?
+    # TODO: Can we use sasview/run.py from a distributed sasview.exe?
+    # Put supporting packages on the path if they are not already available.
+    for sister in ('periodictable', 'bumps', 'sasdata', 'sasmodels'):
+        try:
+            import_module(sister)
+        except:
+            addpath(joinpath(root, '..', sister))
 
     # Put the source trees on the path
     addpath(joinpath(root, 'src'))
 
-    # sasmodels on the path
-    addpath(joinpath(root, '../sasmodels/'))
+    # == no more C sources so no need to build project to run it ==
+    # Leave this snippet around in case we add a compile step later.
+    #from distutils.util import get_platform
+    #platform = '%s-%s' % (get_platform(), sys.version[:3])
+    #build_path = joinpath(root, 'build', 'lib.' + platform)
+    ## Build project if the build directory does not already exist.
+    #if not os.path.exists(build_path):
+    #    import subprocess
+    #    with cd(root):
+    #        subprocess.call((sys.executable, "setup.py", "build"), shell=False)
 
-
+    # Notify the help menu that the Sphinx documentation is in a different
+    # place than it otherwise would be.
+    docpath = joinpath(root, 'docs', 'sphinx-docs', '_build', 'html')
+    os.environ['SASVIEW_DOC_PATH'] = docpath
 
 if __name__ == "__main__":
-    # Need to add absolute path before actual prepare call,
-    # so logging can be done during initialization process too
-    root = abspath(dirname(realpath(sys.argv[0])))
-
-    addpath(joinpath(root, 'src'))
     prepare()
-
-    # Run the UI conversion tool when executed from script.  This has to
-    # happen after prepare() so that sas.qtgui is on the path.
-    import sas.qtgui.convertUI
-    setup_sasmodels()
-
-    from sas.qtgui.MainWindow.MainWindow import run_sasview
-    run_sasview()
-    #logger.debug("Ending SASVIEW in debug mode.")
+    import sas.cli
+    sas.cli.main(logging="development")

--- a/src/sas/__init__.py
+++ b/src/sas/__init__.py
@@ -1,9 +1,9 @@
 from sas.system.version import __version__
-
-from sas.system import config, user
+from sas.system import config
 
 __all__ = ['config']
 
+# TODO: fix logger-config circular dependency
 # Load the config file
 config.load()
 

--- a/src/sas/cli.py
+++ b/src/sas/cli.py
@@ -1,0 +1,90 @@
+"""
+SasView command line interface.
+
+sasview -m module [args...]
+    Run module as main.
+sasview -c "python statements"
+    Execute python statements with sasview libraries available.
+sasview -i 
+    Start ipython interpreter.
+sasview script [args...]
+    Run script with sasview libraries available
+sasview
+    Start sasview gui
+"""
+import sys
+
+# TODO: Support dropping datafiles onto .exe?
+# TODO: Maybe use the bumps cli with project file as model?
+
+import argparse
+parser = argparse.ArgumentParser()
+parser.add_argument("-m", "--module", type=str,
+    help="Run module as main")
+parser.add_argument("-c", "--command", type=str,
+    help="Execute command")
+parser.add_argument("-i", "--interactive", action='store_true', 
+    help="Run interactive command line")
+parser.add_argument("argv", nargs="*",
+    help="script followed by argv")
+
+def exclusive_error():
+    print("Use only one of -m module args, -c command, -i, or script.py args.", sys.stderr)
+    sys.exit(1)
+
+def run_interactive():
+    """Run sasview as an interactive python interpreter"""
+    try:
+        from IPython import start_ipython
+        sys.argv = ["ipython", "--pylab"]
+        sys.exit(start_ipython())
+    except ImportError:
+        import code
+        code.interact(local={'exit': sys.exit})
+
+def main(logging="production"):
+    from sas.system import log
+    from sas.system import lib
+
+    # Eventually argument processing might affect logger or config, so do it first
+    args = parser.parse_args()
+
+    # Setup logger and sasmodels
+    if logging == "production":
+        log.production()
+    elif logging == "development":
+        log.development()
+    else:
+        raise ValueError(f"Unknown logging mode \"{logging}\"")
+    lib.setup_sasmodels()
+
+    # Parse mutually exclusive command line options
+    # mutually exclusive (-m module args, -c command, -i, script args)
+    if args.argv and not args.module: # script [arg...]
+        import runpy
+        if args.command or args.module or args.interactive:
+            exclusive_error()
+        sys.argv = args.argv
+        runpy.run_path(args.argv[0], run_name="__main__")
+    elif args.module: # -m module [arg...]
+        import runpy
+        if args.command or args.interactive:
+            exclusive_error()
+        sys.argv = [args.module, *args.argv]
+        runpy.run_module(args.module, run_name="__main__")
+    elif args.command: # -c "command"
+        if args.argv or args.module or args.interactive:
+            exclusive_error()
+        exec(args.command)
+    elif args.interactive: # -i
+        if args.argv or args.module or args.command:
+            exclusive_error()
+        run_interactive()
+    else:
+        from sas.qtgui.MainWindow.MainWindow import run_sasview as run_gui
+        run_gui()
+
+if __name__ == "__main__":
+    from multiprocessing import freeze_support
+    freeze_support()
+    main()

--- a/src/sas/qtgui/MainWindow/MainWindow.py
+++ b/src/sas/qtgui/MainWindow/MainWindow.py
@@ -1,11 +1,10 @@
 # UNLESS EXEPTIONALLY REQUIRED TRY TO AVOID IMPORTING ANY MODULES HERE
 # ESPECIALLY ANYTHING IN SAS, SASMODELS NAMESPACE
-import logging
 import os
 import sys
+import logging
 
-from sas import config
-from sas.system import env, version
+from sas.system.version import __version__
 
 from PyQt5.QtWidgets import QMainWindow
 from PyQt5.QtWidgets import QMdiArea
@@ -17,6 +16,8 @@ from PyQt5.QtCore import Qt
 # Local UI
 from .UI.MainWindowUI import Ui_SasView
 
+logger = logging.getLogger(__name__)
+
 class MainSasViewWindow(QMainWindow, Ui_SasView):
     # Main window of the application
     def __init__(self, screen_resolution, parent=None):
@@ -25,7 +26,7 @@ class MainSasViewWindow(QMainWindow, Ui_SasView):
         self.setupUi(self)
 
         # Add the version number to window title
-        self.setWindowTitle(f"SasView {version.__version__}")
+        self.setWindowTitle(f"SasView {__version__}")
         # define workspace for dialogs.
         self.workspace = QMdiArea(self)
         # some perspectives are fixed size.
@@ -45,8 +46,7 @@ class MainSasViewWindow(QMainWindow, Ui_SasView):
         try:
             self.guiManager = GuiManager(self)
         except Exception as ex:
-            import logging
-            logging.error("Application failed with: "+str(ex))
+            logger.error("Application failed with: "+str(ex))
             raise ex
 
     def closeEvent(self, event):
@@ -68,30 +68,11 @@ def SplashScreen():
     return splashScreen
 
 def run_sasview():
-    app = QApplication([])
-
-    #Initialize logger
-    from sas.system.log import SetupLogger
-    SetupLogger(__name__).config_development()
-
-    # initialize sasmodels settings
-    from sas.system.user import get_user_dir
-    if "SAS_DLL_PATH" not in os.environ:
-        os.environ["SAS_DLL_PATH"] = os.path.join(
-            get_user_dir(), "compiled_models")
-
-    # Set open cl config from environment variable, if it is set
-
-    if env.sas_opencl is not None:
-        logging.getLogger(__name__).info("Getting OpenCL settings from environment variables")
-        config.SAS_OPENCL = env.sas_opencl
-    else:
-        logging.getLogger(__name__).info("Getting OpenCL settings from config")
-        env.sas_opencl = config.SAS_OPENCL
-
     # Make the event loop interruptable quickly
     import signal
     signal.signal(signal.SIGINT, signal.SIG_DFL)
+
+    app = QApplication([])
 
     # Main must have reference to the splash screen, so making it explicit
     splash = SplashScreen()

--- a/src/sas/qtgui/Perspectives/Fitting/GPUOptions.py
+++ b/src/sas/qtgui/Perspectives/Fitting/GPUOptions.py
@@ -18,8 +18,8 @@ from PyQt5 import QtGui, QtCore, QtWidgets
 from sas.qtgui.Perspectives.Fitting.UI.GPUOptionsUI import Ui_GPUOptions
 from sas.qtgui.Perspectives.Fitting.UI.GPUTestResultsUI import Ui_GPUTestResults
 
-from sas.system import env
 from sas import config
+from sas.system import lib
 
 try:
     _fromUtf8 = QtCore.QString.fromUtf8
@@ -107,11 +107,8 @@ class GPUOptions(QtWidgets.QDialog, Ui_GPUOptions):
 
         sas_open_cl = self.cl_options[str(checked.text())]
         no_opencl_msg = sas_open_cl.lower() == "none"
-        env.sas_opencl = sas_open_cl
-        config.SAS_OPENCL = sas_open_cl
+        lib.reset_sasmodels(sas_open_cl)
 
-        # CRUFT: next version of reset_environment() will return env
-        sasmodels.sasview_model.reset_environment()
         return no_opencl_msg
 
     def testButtonClicked(self):

--- a/src/sas/system/__init__.py
+++ b/src/sas/system/__init__.py
@@ -1,3 +1,4 @@
+# TODO: Don't shadow module names; it makes debugging difficult.
 from .web import web
 from .legal import legal
 from .env import env

--- a/src/sas/system/env.py
+++ b/src/sas/system/env.py
@@ -1,3 +1,4 @@
+# ** DEPRECATED **
 """ Interface for environment variable access
 
 This is intended to handle any conversion from the environment variable string to more natural types.

--- a/src/sas/system/lib.py
+++ b/src/sas/system/lib.py
@@ -1,0 +1,41 @@
+# Setup third-party libraries (e.g., sasview, periodictable, bumps)
+import os
+
+# TODO: Add api to control sasmodels rather than using environment variables
+def setup_sasmodels():
+    """Initialize sasmodels settings"""
+    from .user import get_user_dir
+
+    # Don't need to set SAS_MODELPATH for gui because sascalc.fit uses the
+    # full paths to models, but when using the sasview package as a python
+    # distribution for running sasmodels scripts we need to set SAS_MODELPATH
+    # to the path used by SasView to store models.
+    from sas.sascalc.fit.models import find_plugins_dir
+    os.environ['SAS_MODELPATH'] = find_plugins_dir()
+
+    # TODO: Use same mechanism as OpenCL/CUDA to manage the cache file path
+    # Both scripts and gui need to know the stored DLL path.
+    if "SAS_DLL_PATH" not in os.environ:
+        os.environ["SAS_DLL_PATH"] = os.path.join(
+            get_user_dir(), "compiled_models")
+
+    # Set OpenCL config from environment variable if it is set otherwise
+    # use the value from the sas config file.
+    from sas import config
+    # Not using sas.system.env since it just adds a layer of confusion
+    SAS_OPENCL = os.environ.get("SAS_OPENCL", None)
+    if SAS_OPENCL is None:
+        # Let sasmodels know the value of the config variable
+        os.environ["SAS_OPENCL"] = config.SAS_OPENCL
+    else:
+        # Let config system know the value of the the environment variable
+        config.SAS_OPENCL = SAS_OPENCL
+
+def reset_sasmodels(sas_opencl):
+    from sasmodels.sasview_model import reset_environment
+    from sas import config
+
+    config.SAS_OPENCL = sas_opencl
+    os.environ["SAS_OPENCL"] = sas_opencl
+    # CRUFT: next version of reset_environment() will return env
+    reset_environment()

--- a/src/sas/system/log.py
+++ b/src/sas/system/log.py
@@ -84,3 +84,9 @@ class SetupLogger(object):
                 return
         print(f"'{filename}' not found.", file=sys.stderr)
         self.config_file = None
+
+def production():
+    return SetupLogger("sasview").config_production()
+
+def development():
+    return SetupLogger("sasview").config_development()


### PR DESCRIPTION
Allow scripts from the command line:
```
sasview -m module [args...]
    Run module as main.
sasview -c "python statements"
    Execute python statements with sasview libraries available.
sasview -i 
    Start ipython interpreter.
sasview script [args...]
    Run script with sasview libraries available
sasview
    Start sasview gui
```

Partially addresses #2237. Replaces #2278.

We could also add a --jupyter command line option which opens up a server on localhost with everything setup. It'll increase the size of our installed package though, especially if we include jupyterhub with a nodejs distribution.

I don't have a windows box handy so couldn't test the installed package on windows.

Do we need multiprocessing freeze support?

I don't know how modern qt apps handle console vs. gui support. Maybe need to do something like creating a separate sasviewcom.exe for the console.