### PR TITLE
Generalise pyinstaller spec paths 

### DIFF
--- a/installers/sasview.spec
+++ b/installers/sasview.spec
@@ -4,10 +4,10 @@ import sys
 from pathlib import Path
 import warnings
 import platform
-import sys
+import sysconfig
 
 block_cipher = None
-PYTHON_LOC = sys.exec_prefix
+PYTHON_PACKAGES = sysconfig.get_path('platlib')
 
 datas = [
     ('../src/sas/qtgui/images', 'images'),
@@ -21,8 +21,8 @@ datas = [
 ]
 #TODO: Hopefully we can get away from version specific packages
 if platform.system() == 'Darwin':
-    datas.append((os.path.join(PYTHON_LOC,'lib','python3.8', 'site-packages','jedi'),'jedi'))
-    datas.append((os.path.join(PYTHON_LOC,'lib','python3.8', 'site-packages','zmq'),'.'))
+    datas.append((os.path.join(PYTHON_PACKAGES, 'jedi'), 'jedi'))
+    datas.append((os.path.join(PYTHON_PACKAGES, 'zmq'), '.'))
 
 def add_data(data):
     for component in data:


### PR DESCRIPTION
The pyinstaller spec file sometimes needs to contain workarounds for packages to help pyinstaller find all the relevant imports or data files. If such introspection is still needed, we should avoid baking in platform-dependent and python-version-dependent paths. 

This PR makes use of the `sysconfig` module from the [Python stdlib](https://docs.python.org/3/library/sysconfig.html) that has information about where packages are located, so the details of `lib` vs `Lib`, `site-packages` vs `dist-packages`, `python3.8` vs `python3.10`,… all go away. This last one is very important as it means we can create installer artifacts with multiple different Python versions for testing purposes, without needing to change the spec file.

I tested an earlier version of this patch with Windows and Linux when it was still touching paths for those installers. With other changes, this code path is currently only used on macos which I can't test.

There's every chance that the actual code for `jedi` and `zmq` for Darwin can also be removed; that's a problem for a different PR and for a mac user to test. In any case, the stub of loading and using `sysconfig` may as well stay for the time being since it will be needed some time in the future, no doubt.