### PR TITLE
Fixing typo in build_tools/requirements.txt

### DIFF
--- a/build_tools/requirements.txt
+++ b/build_tools/requirements.txt
@@ -3,7 +3,7 @@ scipy==1.7.3
 docutils 
 pytest
 pytest_qt
-pyteset-mock
+pytest-mock
 unittest-xml-reporting
 tinycc 
 h5py 


### PR DESCRIPTION
Fixing typo in the pytest-mock. The bigger question is we can put this file under CI i.e. replace pip lines in ymls with `pip install -r build_tools/requirements.txt`?