### PR TITLE
Support custom data names in plot legends

### DIFF
--- a/src/sas/qtgui/Plotting/Plotter.py
+++ b/src/sas/qtgui/Plotting/Plotter.py
@@ -163,6 +163,7 @@ class PlotterWidget(PlotterBase):
         ax = self.ax
         x = data.view.x
         y = data.view.y
+        label = data.name # was self._title
 
         # Marker symbol. Passed marker is one of matplotlib.markers characters
         # Alternatively, picked up from Data1D as an int index of PlotUtilities.SHAPES dict
@@ -206,22 +207,22 @@ class PlotterWidget(PlotterBase):
         l_width = markersize * 0.4
         if marker == '-' or marker == '--':
             line = self.ax.plot(x, y, color=color, lw=l_width, marker='',
-                             linestyle=marker, label=self._title, zorder=10)[0]
+                             linestyle=marker, label=label, zorder=10)[0]
 
         elif marker == 'vline':
             y_min = min(y)*9.0/10.0 if min(y) < 0 else 0.0
             line = self.ax.vlines(x=x, ymin=y_min, ymax=y, color=color,
-                            linestyle='-', label=self._title, lw=l_width, zorder=1)
+                            linestyle='-', label=label, lw=l_width, zorder=1)
 
         elif marker == 'step':
             line = self.ax.step(x, y, color=color, marker='', linestyle='-',
-                                label=self._title, lw=l_width, zorder=1)[0]
+                                label=label, lw=l_width, zorder=1)[0]
 
         else:
             # plot data with/without errorbars
             if hide_error:
                 line = ax.plot(x, y, marker=marker, color=color, markersize=markersize,
-                        linestyle='', label=self._title, picker=True)
+                        linestyle='', label=label, picker=True)
             else:
                 dy = data.view.dy
                 # Convert tuple (lo,hi) to array [(x-lo),(hi-x)]
@@ -238,7 +239,7 @@ class PlotterWidget(PlotterBase):
                             markersize=markersize,
                             lolims=False, uplims=False,
                             xlolims=False, xuplims=False,
-                            label=self._title,
+                            label=label,
                             zorder=1,
                             picker=True)
 


### PR DESCRIPTION
Fixes #2253 by switching Plotter to use data.name as the default `label` for a plot item rather than `data._title`.  `data.name` changes with the "Change Name" option in the Data Explorer.