### PR TITLE
Nightly build artifact storage

### DIFF
--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -1,0 +1,23 @@
+name: Last Succesful Build
+on:
+  schedule:
+    - cron: '0 2 * * *' # run at 2 AM UTC
+
+jobs:
+  nightly:
+    name: Deploy nightly
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest, macOS-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+
+    - name: Find matching workflow
+      uses: SamhammerAG/last-successful-build-action@v2
+      with:
+          branch: "main"
+          workflow: "Installer"
+          verify: true
+
+

--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -1,25 +1,29 @@
-name: Last Succesful Build
+name: Nightly Build Artifacts
 on:
-  schedule:
-    - cron: '0 2 * * *' # run at 2 AM UTC
+  [push, pull_request]
+  #schedule:
+  #  - cron: '0 0 * * *' # Eventuall will run at 2 AM UTC, for testimng 
 
 jobs:
   nightly:
     name: Deploy nightly
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [windows-latest, macOS-latest]
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     steps:
 
-    - name: Find matching workflow
-      uses: SamhammerAG/last-successful-build-action@v2
-      with:
-          token: "${{ secrets.GITHUB_TOKEN }}"
-          branch: "main"
-          workflow: "Installer"
+    #- name: Find matching workflow
+    #  uses: SamhammerAG/last-successful-build-action@v2
+    #  with:
+    #      token: "${{ secrets.GITHUB_TOKEN }}"
+    #      branch: "main"
+    #      workflow: "Installer"
 
+    - name: Download artifact
+    id: download-artifact
+    uses: dawidd6/action-download-artifact@v2
+    with:
+      	github_token: ${{secrets.GITHUB_TOKEN}}
+      	workflow: installer.yml
+    	branch: main
 
     - name: Upload installer to GitHub releases
       uses: ncipollo/release-action@v1
@@ -29,7 +33,6 @@ jobs:
           allowUpdates: true
           replacesArtifacts: true
           token: ${{ secrets.GITHUB_TOKEN }}
-          #SHA of the latest succesful commit ${{ github.sha }}
-          artifacts: "installers/dist/SasView5.dmg, installers/Output/setupSasView.exe"
+          artifacts: "SasView5.dmg, setupSasView.exe"
           name: "Nightly Build"
           tag: "nightly_build"

--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -9,15 +9,27 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macOS-latest]
+        os: [windows-latest, macOS-latest]
     runs-on: ${{ matrix.os }}
     steps:
 
     - name: Find matching workflow
       uses: SamhammerAG/last-successful-build-action@v2
       with:
+          token: "${{ secrets.GITHUB_TOKEN }}"
           branch: "main"
           workflow: "Installer"
-          verify: true
 
 
+    - name: Upload installer to GitHub releases
+      uses: ncipollo/release-action@v1
+      with:
+          draft: true
+          prerelease: true
+          allowUpdates: true
+          replacesArtifacts: true
+          token: ${{ secrets.GITHUB_TOKEN }}
+          #SHA of the latest succesful commit ${{ github.sha }}
+          artifacts: "installers/dist/SasView5.dmg, installers/Output/setupSasView.exe"
+          name: "Nightly Build"
+          tag: "nightly_build"

--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -25,6 +25,10 @@ jobs:
         workflow: installers.yml
         branch: main
 
+    - name: List files in the folder
+        run: |
+          ls
+          
     - name: Upload installer to GitHub releases
       uses: ncipollo/release-action@v1
       with:

--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -26,8 +26,9 @@ jobs:
         branch: main
 
     - name: List files in the folder
-        run: |
-          ls
+      run: |
+          ls ${{ github.workspace }}
+
           
     - name: Upload installer to GitHub releases
       uses: ncipollo/release-action@v1

--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -1,8 +1,7 @@
 name: Nightly Build Artifacts
 on:
-  [push, pull_request]
-  #schedule:
-  #  - cron: '0 0 * * *' # Eventuall will run at 2 AM UTC, for testimng 
+  schedule:
+    - cron: '0 2 * * *' # will run at 2 AM UTC
 
 jobs:
   nightly:

--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -18,21 +18,21 @@ jobs:
     #      workflow: "Installer"
 
     - name: Download artifact
-    id: download-artifact
-    uses: dawidd6/action-download-artifact@v2
-    with:
-      	github_token: ${{secrets.GITHUB_TOKEN}}
-      	workflow: installer.yml
-    	branch: main
+      id: download-artifact
+      uses: dawidd6/action-download-artifact@v2
+      with:
+        github_token: ${{secrets.GITHUB_TOKEN}}
+        workflow: installer.yml
+        branch: main
 
     - name: Upload installer to GitHub releases
       uses: ncipollo/release-action@v1
       with:
-          draft: true
-          prerelease: true
-          allowUpdates: true
-          replacesArtifacts: true
-          token: ${{ secrets.GITHUB_TOKEN }}
-          artifacts: "SasView5.dmg, setupSasView.exe"
-          name: "Nightly Build"
-          tag: "nightly_build"
+        draft: true
+        prerelease: true
+        allowUpdates: true
+        replacesArtifacts: true
+        token: ${{ secrets.GITHUB_TOKEN }}
+        artifacts: "SasView5.dmg, setupSasView.exe"
+        name: "Nightly Build"
+        tag: "nightly_build"

--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -22,7 +22,7 @@ jobs:
       uses: dawidd6/action-download-artifact@v2
       with:
         github_token: ${{secrets.GITHUB_TOKEN}}
-        workflow: installer.yml
+        workflow: installers.yml
         branch: main
 
     - name: Upload installer to GitHub releases

--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -38,6 +38,6 @@ jobs:
         allowUpdates: true
         replacesArtifacts: true
         token: ${{ secrets.GITHUB_TOKEN }}
-        artifacts: "SasView5.dmg, setupSasView.exe"
+        artifacts: "SasView-Installer-macos*/SasView5.dmg, SasView-Installer-windows*/setupSasView.exe"
         name: "Nightly Build"
         tag: "nightly_build"

--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -9,14 +9,6 @@ jobs:
     name: Deploy nightly
     runs-on: ubuntu-latest
     steps:
-
-    #- name: Find matching workflow
-    #  uses: SamhammerAG/last-successful-build-action@v2
-    #  with:
-    #      token: "${{ secrets.GITHUB_TOKEN }}"
-    #      branch: "main"
-    #      workflow: "Installer"
-
     - name: Download artifact
       id: download-artifact
       uses: dawidd6/action-download-artifact@v2
@@ -24,11 +16,6 @@ jobs:
         github_token: ${{secrets.GITHUB_TOKEN}}
         workflow: installers.yml
         branch: main
-
-    - name: List files in the folder
-      run: |
-          ls ${{ github.workspace }}
-
           
     - name: Upload installer to GitHub releases
       uses: ncipollo/release-action@v1


### PR DESCRIPTION
Experimenting with nightly builds

The artifacts now upload to release page and they should be updated at 2AM (UTC). The release is currently in draft stage and is not visible for people from outside. I think however that if we remove draft flag but still keep it as a pre-release it will be accessible for people from outside and won't paper on release page as latest. 

Since this is running as cronjob I hope this won't affact extrenal PR contributions. 
Eventually the plan is to add signing and notarization for Mac as a part of this workflow (as currently we are not doing it at all). 

Keeping in a draft mode to make sure cronjob actually works 