### PR TITLE
Fit intermittent plot blanking (#2267)

### DIFF
--- a/src/sas/qtgui/Plotting/Plotter.py
+++ b/src/sas/qtgui/Plotting/Plotter.py
@@ -581,7 +581,6 @@ class PlotterWidget(PlotterBase):
         Resets the chart X and Y ranges to their original values
         """
         # Clear graph and plot everything again
-        # mpl.pyplot.cla()
         self.ax.cla()
         self.setRange = None
         for ids in self.plot_dict:
@@ -659,7 +658,6 @@ class PlotterWidget(PlotterBase):
         yl = self.ax.yaxis.label.get_text()
 
         self.ax.cla()
-        #mpl.pyplot.cla()
 
         # Recreate Artist bindings after plot clear
         self.connect = BindArtist(self.figure)
@@ -728,7 +726,6 @@ class PlotterWidget(PlotterBase):
         self.plot_dict = {}
 
         # Clean the canvas
-        # mpl.pyplot.cla()
         self.ax.cla()
 
         # Recreate the plots but reverse the error flag for the current

--- a/src/sas/qtgui/Plotting/Plotter.py
+++ b/src/sas/qtgui/Plotting/Plotter.py
@@ -581,7 +581,7 @@ class PlotterWidget(PlotterBase):
         Resets the chart X and Y ranges to their original values
         """
         # Clear graph and plot everything again
-        mpl.pyplot.cla()
+        # mpl.pyplot.cla()
         self.ax.cla()
         self.setRange = None
         for ids in self.plot_dict:
@@ -658,8 +658,8 @@ class PlotterWidget(PlotterBase):
         xl = self.ax.xaxis.label.get_text()
         yl = self.ax.yaxis.label.get_text()
 
-        mpl.pyplot.cla()
         self.ax.cla()
+        #mpl.pyplot.cla()
 
         # Recreate Artist bindings after plot clear
         self.connect = BindArtist(self.figure)
@@ -728,7 +728,7 @@ class PlotterWidget(PlotterBase):
         self.plot_dict = {}
 
         # Clean the canvas
-        mpl.pyplot.cla()
+        # mpl.pyplot.cla()
         self.ax.cla()
 
         # Recreate the plots but reverse the error flag for the current


### PR DESCRIPTION
Fixes #2267 by commenting out calls to `matplotlib.pyplot.cla()` which were already paired with the more specific alternative calls to `self.ax.cla()` (at best a duplicate, at worst it causes arbitrary plots to blank themselves as seen here.

It would be worth eyes from @rozyczko and @krzywon who wrote this originally to see if there's some reason I'm missing for the `plt.cla()` call.  It seems to now work fine on my machine.  The tell, even without a way to reproduce, is that when data is "Compute/Plot"'d on Main the plot briefly will flash to a white background with default axes from 0 to 1, linear, on both axes.  That no longer happens on this branch, at least for me.  Or see reproduction instructions in #2267.