### PR TITLE
Modify copy of config.PLUGIN_STATE_EXTENSIONS value, not config value

### DIFF
--- a/src/sas/qtgui/MainWindow/DataExplorer.py
+++ b/src/sas/qtgui/MainWindow/DataExplorer.py
@@ -1312,7 +1312,7 @@ class DataExplorerWindow(DroppableDataLoadWidget):
         for index, p_file in enumerate(path):
             basename = os.path.basename(p_file)
             _, extension = os.path.splitext(basename)
-            extension_list = config.PLUGIN_STATE_EXTENSIONS
+            extension_list = config.PLUGIN_STATE_EXTENSIONS.copy()
             if config.APPLICATION_STATE_EXTENSION is not None:
                 extension_list.append(config.APPLICATION_STATE_EXTENSION)
 


### PR DESCRIPTION
Append additional runtime extensions to a copy of config.PLUGIN_STATE_EXTENSIONS value, not config value itself.

Fixes growing config file issue noticed in @wpotrzebowski's config.json