### PR TITLE
Adding installation path to about box

### DIFF
--- a/src/sas/qtgui/MainWindow/AboutBox.py
+++ b/src/sas/qtgui/MainWindow/AboutBox.py
@@ -1,15 +1,12 @@
 import functools
+import os
+
 from PyQt5 import QtWidgets, QtCore
 
 import sas.sasview
 import sas.qtgui.Utilities.GuiUtils as GuiUtils
 import sas.system.version
-from sas.qtgui.UI import images_rc
-from sas.qtgui.UI import main_resources_rc
-
 from sas.system import web, legal
-from sas import config
-
 from .UI.AboutUI import Ui_AboutUI
 
 class AboutBox(QtWidgets.QDialog, Ui_AboutUI):
@@ -36,6 +33,9 @@ class AboutBox(QtWidgets.QDialog, Ui_AboutUI):
         lbl_font.setPointSize(24)
         self.lblVersion.setFont(lbl_font)
 
+        dir_path = os.path.split(sas.__file__)[0]
+        installation_path = os.path.split(dir_path)[0]
+
         about_text = f"""
         <html>
             <head/>
@@ -46,7 +46,11 @@ class AboutBox(QtWidgets.QDialog, Ui_AboutUI):
                 <p>
                     <a href="{web.homepage_url}">{web.homepage_url}</a>
                 </p>
-                <br/>
+                <p>
+                    Installation path: {installation_path}
+                </p>                
+                <p>A list of individual contributors can be found at: 
+                <a href="{web.homepage_url}/people">{web.homepage_url}/people</a></p>
                 <p>
                     Comments? Bugs? Requests?
                     <br/>

--- a/src/sas/qtgui/MainWindow/UI/AboutUI.ui
+++ b/src/sas/qtgui/MainWindow/UI/AboutUI.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>632</width>
+    <width>800</width>
     <height>576</height>
    </rect>
   </property>
@@ -42,6 +42,9 @@
     <widget class="QLabel" name="lblAbout">
      <property name="text">
       <string>TextLabel</string>
+     </property>
+     <property name="textInteractionFlags">
+      <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByMouse</set>
      </property>
     </widget>
    </item>
@@ -354,7 +357,7 @@
       </sizepolicy>
      </property>
      <property name="text">
-      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This work originally developed as part of the DANSE project funded by the NSF under grant DMR-0520547, and currently maintained by UTK, NIST, UMD, ORNL, ISIS, ESS, ILL, ANSTO, TU Delft, DLS, and the scattering community.&lt;/p&gt;&lt;p&gt;SasView also contains code developed with funding from the EU Horizon 2020 programme under the SINE2020 project (Grant No 654000).&lt;/p&gt;&lt;p&gt;A list of individual contributors can be found at: http://www.sasview.org/contact.html&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This work originally developed as part of the DANSE project funded by the NSF under grant DMR-0520547, and currently maintained by UTK, NIST, UMD, ORNL, ISIS, ESS, ILL, ANSTO, TU Delft, DLS, and the scattering community.&lt;/p&gt;&lt;p&gt;SasView also contains code developed with funding from the EU Horizon 2020 programme under the SINE2020 project (Grant No 654000).&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
      </property>
      <property name="wordWrap">
       <bool>true</bool>

--- a/src/sas/qtgui/MainWindow/UnitTesting/AboutBoxTest.py
+++ b/src/sas/qtgui/MainWindow/UnitTesting/AboutBoxTest.py
@@ -1,6 +1,4 @@
-import sys
 import webbrowser
-
 import pytest
 
 from PyQt5 import QtGui, QtWidgets
@@ -9,7 +7,6 @@ from PyQt5 import QtCore
 
 import sas.sasview
 import sas.system.version
-from sas import config
 from sas.system import web, legal
 
 # Local


### PR DESCRIPTION
In order to facilitate finding path for running sasview from script: #2280 it has been added to about box. 
Some minor fixes (like correcting link to contributors list) has also been introduced.