### PR TITLE
Sesans debugging

### DIFF
--- a/src/sas/qtgui/Perspectives/Fitting/FittingWidget.py
+++ b/src/sas/qtgui/Perspectives/Fitting/FittingWidget.py
@@ -1879,7 +1879,7 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
 
         # Data going in
         data = self.logic.data
-        model = copy.deepcopy(self.kernel_module)
+        model = self.kernel_module
         qmin = self.q_range_min
         qmax = self.q_range_max
 


### PR DESCRIPTION
This removes the deep copying of the model that occurs during fitting and allows the plots to update with changes after fitting. This deepcopy was done by @rozyczko so he should probably check that it is fine to remove.

This should close #1998 - This was also a problem for non-sesans data but was more apparent when working in the sesans correlation space, making it seem that the plots were not updating after fitting for sesans data only.