### PR TITLE
2319: Fix copy/paste when selecting a structure factor

### DIFF
--- a/src/sas/qtgui/Perspectives/Fitting/FittingWidget.py
+++ b/src/sas/qtgui/Perspectives/Fitting/FittingWidget.py
@@ -1300,7 +1300,7 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         cb = QtWidgets.QApplication.clipboard()
         cb_text = cb.text()
         # get the screenshot of the current param state
-        self.onCopyToClipboard("")
+        self.clipboard_copy()
 
         # Reset parameters to fit
         self.resetParametersToFit()
@@ -1309,7 +1309,7 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
 
         self.respondToModelStructure(model=model, structure_factor=structure)
         # recast the original parameters into the model
-        self.onParameterPaste()
+        self.clipboard_paste()
         # revert to the original clipboard
         cb.setText(cb_text)
 


### PR DESCRIPTION
Use the new perspective class methods that replaced the old copy/paste methods.

Fixes #2319 