### PR TITLE
2312: Restore defaults from preferences panel

### DIFF
--- a/src/sas/qtgui/Utilities/Preferences/DisplayPreferencesWidget.py
+++ b/src/sas/qtgui/Utilities/Preferences/DisplayPreferencesWidget.py
@@ -8,9 +8,15 @@ class DisplayPreferencesWidget(PreferencesWidget):
         super(DisplayPreferencesWidget, self).__init__("Display Settings")
 
     def _addAllWidgets(self):
-        self.addTextInput(title="QT Screen Scale Factor",
-                         callback=config_value_setter_generator('QT_SCALE_FACTOR', dtype=float),
-                         default_text=str(config.QT_SCALE_FACTOR))
-        self.addCheckBox(title="Automatic Screen Scale Factor",
-                         callback=config_value_setter_generator('QT_AUTO_SCREEN_SCALE_FACTOR', dtype=bool),
-                         checked=config.QT_AUTO_SCREEN_SCALE_FACTOR)
+        self.qtScaleFactor = self.addTextInput(
+            title="QT Screen Scale Factor",
+            callback=config_value_setter_generator('QT_SCALE_FACTOR', dtype=float),
+            default_text=str(config.QT_SCALE_FACTOR))
+        self.autoScaling = self.addCheckBox(
+            title="Automatic Screen Scale Factor",
+            callback=config_value_setter_generator('QT_AUTO_SCREEN_SCALE_FACTOR', dtype=bool),
+            checked=config.QT_AUTO_SCREEN_SCALE_FACTOR)
+
+    def restoreDefaults(self):
+        self.qtScaleFactor.setText(str(1.0))
+        self.autoScaling.setChecked(False)

--- a/src/sas/qtgui/Utilities/Preferences/DisplayPreferencesWidget.py
+++ b/src/sas/qtgui/Utilities/Preferences/DisplayPreferencesWidget.py
@@ -18,5 +18,5 @@ class DisplayPreferencesWidget(PreferencesWidget):
             checked=config.QT_AUTO_SCREEN_SCALE_FACTOR)
 
     def restoreDefaults(self):
-        self.qtScaleFactor.setText(str(1.0))
-        self.autoScaling.setChecked(False)
+        self.qtScaleFactor.setText(str(config.defaults.get('QT_SCALE_FACTOR')))
+        self.autoScaling.setChecked(config.defaults.get('QT_AUTO_SCREEN_SCALE_FACTOR'))

--- a/src/sas/qtgui/Utilities/Preferences/FittingOptionsWidget.py
+++ b/src/sas/qtgui/Utilities/Preferences/FittingOptionsWidget.py
@@ -373,7 +373,7 @@ class FittingOptions(PreferencesWidget):
         """Capture the default optimizer value in the and set it in the config file"""
         text = self.defaultOptimizer.currentText()
         id = dict((new_val, new_k) for new_k, new_val in FIT_CONFIG.names.items()).get(text)
-        set_config_value('DEFAULT_FITTING_OPTIMIZER', id)
+        set_config_value(id, 'DEFAULT_FITTING_OPTIMIZER')
         self.cbAlgorithm.setCurrentIndex(self.defaultOptimizer.currentIndex())
         self.setActiveOptimizer()
 

--- a/src/sas/qtgui/Utilities/Preferences/FittingOptionsWidget.py
+++ b/src/sas/qtgui/Utilities/Preferences/FittingOptionsWidget.py
@@ -59,8 +59,13 @@ class FittingOptions(PreferencesWidget):
         self.verticalLayout.addWidget(self.stackedWidget)
         self.onAlgorithmChange(self.cbAlgorithm.currentIndex())
 
+    def restoreDefaults(self):
+        name = self.config.names['lm']
+        self.defaultOptimizer.setCurrentIndex(self.defaultOptimizer.findText(name))
+        self.setActiveOptimizer()
+
     def _addFittingOptionsWidgets(self):
-        """This is a direct copy from teh python file generated from the old UI file."""
+        """This is a direct copy from the python file generated from the old UI file."""
         self.stackedWidget = QtWidgets.QStackedWidget()
         self.stackedWidget.setFrameShape(QtWidgets.QFrame.NoFrame)
         self.stackedWidget.setObjectName("stackedWidget")

--- a/src/sas/qtgui/Utilities/Preferences/FittingOptionsWidget.py
+++ b/src/sas/qtgui/Utilities/Preferences/FittingOptionsWidget.py
@@ -60,7 +60,7 @@ class FittingOptions(PreferencesWidget):
         self.onAlgorithmChange(self.cbAlgorithm.currentIndex())
 
     def restoreDefaults(self):
-        name = self.config.names['lm']
+        name = self.config.names[config.defaults.get('DEFAULT_FITTING_OPTIMIZER')]
         self.defaultOptimizer.setCurrentIndex(self.defaultOptimizer.findText(name))
         self.setActiveOptimizer()
 

--- a/src/sas/qtgui/Utilities/Preferences/PlottingPreferencesWidget.py
+++ b/src/sas/qtgui/Utilities/Preferences/PlottingPreferencesWidget.py
@@ -8,12 +8,20 @@ class PlottingPreferencesWidget(PreferencesWidget):
         super(PlottingPreferencesWidget, self).__init__("Plotting Options")
 
     def _addAllWidgets(self):
-        self.addCheckBox(title="Use full-width plot legends (most compatible)?",
-                         callback=config_value_setter_generator('FITTING_PLOT_FULL_WIDTH_LEGENDS', dtype=bool),
-                         checked=config.FITTING_PLOT_FULL_WIDTH_LEGENDS)
-        self.addCheckBox(title="Use truncated legend entries?",
-                         callback=config_value_setter_generator('FITTING_PLOT_LEGEND_TRUNCATE', dtype=bool),
-                         checked=config.FITTING_PLOT_LEGEND_TRUNCATE)
-        self.addTextInput(title="Legend entry line length",
-                          callback=config_value_setter_generator('FITTING_PLOT_LEGEND_MAX_LINE_LENGTH', dtype=int),
-                          default_text=str(config.FITTING_PLOT_LEGEND_MAX_LINE_LENGTH))
+        self.legendFullWidth = self.addCheckBox(
+            title="Use full-width plot legends (most compatible)?",
+            callback=config_value_setter_generator('FITTING_PLOT_FULL_WIDTH_LEGENDS', dtype=bool),
+            checked=config.FITTING_PLOT_FULL_WIDTH_LEGENDS)
+        self.legendTruncate = self.addCheckBox(
+            title="Use truncated legend entries?",
+            callback=config_value_setter_generator('FITTING_PLOT_LEGEND_TRUNCATE', dtype=bool),
+            checked=config.FITTING_PLOT_LEGEND_TRUNCATE)
+        self.legendLineLength = self.addTextInput(
+            title="Legend entry line length",
+            callback=config_value_setter_generator('FITTING_PLOT_LEGEND_MAX_LINE_LENGTH', dtype=int),
+            default_text=str(config.FITTING_PLOT_LEGEND_MAX_LINE_LENGTH))
+
+    def restoreDefaults(self):
+        self.legendFullWidth.setChecked(False)
+        self.legendTruncate.setChecked(False)
+        self.legendLineLength.setText('30')

--- a/src/sas/qtgui/Utilities/Preferences/PlottingPreferencesWidget.py
+++ b/src/sas/qtgui/Utilities/Preferences/PlottingPreferencesWidget.py
@@ -22,6 +22,6 @@ class PlottingPreferencesWidget(PreferencesWidget):
             default_text=str(config.FITTING_PLOT_LEGEND_MAX_LINE_LENGTH))
 
     def restoreDefaults(self):
-        self.legendFullWidth.setChecked(False)
-        self.legendTruncate.setChecked(False)
-        self.legendLineLength.setText('30')
+        self.legendFullWidth.setChecked(config.defaults.get('FITTING_PLOT_FULL_WIDTH_LEGENDS'))
+        self.legendTruncate.setChecked(config.defaults.get('FITTING_PLOT_LEGEND_TRUNCATE'))
+        self.legendLineLength.setText(str(config.defaults.get('FITTING_PLOT_LEGEND_MAX_LINE_LENGTH')))

--- a/src/sas/qtgui/Utilities/Preferences/PreferencesPanel.py
+++ b/src/sas/qtgui/Utilities/Preferences/PreferencesPanel.py
@@ -37,9 +37,6 @@ class PreferencesPanel(QDialog, Ui_preferencesUI):
         self.setupUi(self)
         self.parent = parent
         self.setWindowTitle("Preferences")
-        self.warning = None
-        # A list of callables used to restore the default values for each item in StackedWidget
-        self.restoreDefaultMethods = []
         # Add predefined widgets to window
         self.addWidgets(BASE_PANELS)
         # Set defaults values for the list and stacked widgets
@@ -84,13 +81,10 @@ class PreferencesPanel(QDialog, Ui_preferencesUI):
             self.help()
 
     def restoreDefaultPreferences(self):
-        """Reset all preferences to their default preferences"""
-        for method in self.restoreDefaultMethods:
-            if callable(method):
-                method()
-            else:
-                logger.warning(f'While restoring defaults, {str(method)} of type {type(method)}'
-                               + ' was given. A callable object was expected.')
+        """Reset preferences for the active widget to the default values."""
+        widget = self.stackedWidget.currentWidget()
+        if hasattr(widget, 'restoreDefaults') and callable(widget.restoreDefaults):
+            widget.restoreDefaults()
 
     def close(self):
         """Save the configuration values when the preferences window is closed"""
@@ -107,9 +101,6 @@ class PreferencesPanel(QDialog, Ui_preferencesUI):
         name = widget.name if hasattr(widget, 'name') and widget.name else name
         name = "Unknown" if not name else name
         self.listWidget.addItem(name)
-        # Add the widget default reset method to the global set
-        if hasattr(widget, 'resetDefaults') and callable(widget.resetDefaults):
-            self.restoreDefaultMethods.append(widget.resetDefaults)
 
     def help(self):
         """Open the help window associated with the preferences window"""

--- a/src/sas/qtgui/Utilities/Preferences/PreferencesWidget.py
+++ b/src/sas/qtgui/Utilities/Preferences/PreferencesWidget.py
@@ -74,11 +74,10 @@ class PreferencesWidget(QWidget):
     # Default name that will be used in the PreferencesPanel listWidget
     name = None  # type: str
 
-    def __init__(self, name: str, default_method: Optional[Callable] = None):
+    def __init__(self, name: str):
         super(PreferencesWidget, self).__init__()
         self.parent = None
         self.name = name
-        self.resetDefaults = default_method
         # Create generic layout
         self.verticalLayout = QVBoxLayout()
         self.setLayout(self.verticalLayout)
@@ -89,10 +88,15 @@ class PreferencesWidget(QWidget):
         self.adjustSize()
 
     def _addAllWidgets(self):
-        """A private psuedo-abstract class that children should override. All widgets should be added here to force
-        elements to the top of the window.
+        """A private pseudo-abstract class that children should override. All new widgets should be added using this
+        method to create consistency between all preference widgets.
         """
-        pass
+        raise NotImplementedError(f"{self.name} has not implemented _addAllWidgets.")
+
+    def restoreDefaults(self):
+        """A pseudo-abstract class that children should override.
+        """
+        raise NotImplementedError(f"{self.name} has not implemented restoreDefaults.")
 
     def _createLayoutAndTitle(self, title: str):
         """A private class method that creates a horizontal layout to hold the title and interactive item.

--- a/src/sas/system/config/config_meta.py
+++ b/src/sas/system/config/config_meta.py
@@ -48,6 +48,10 @@ class ConfigBase:
                                  "_deleted_attributes", "_meta_attributes",
                                  "_bad_entries"]
 
+    @property
+    def defaults(self):
+        return self._defaults
+
     def config_filename(self, create_if_nonexistent=False):
         """Filename for saving config items"""
         version_parts = sas.system.version.__version__.split(".")


### PR DESCRIPTION
When the restore defaults button is pressed in the preferences panel, the values for the active widget are restored and non-active widgets are not affected.

This is currently chained off the branch in #2306.