### PR TITLE
Add flag for experimental data and gate plotting on it

### DIFF
--- a/src/sas/qtgui/Perspectives/Fitting/FittingWidget.py
+++ b/src/sas/qtgui/Perspectives/Fitting/FittingWidget.py
@@ -2238,7 +2238,7 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         data_shown = False
         item = None
         for item, plot in plots.items():
-            if not hasattr(plot,'isExpData') and fitpage_name in plot.name:
+            if plot.plot_role != Data1D.ROLE_DATA and fitpage_name in plot.name:
                 data_shown = True
                 self.communicate.plotRequestedSignal.emit([item, plot], self.tab_id)
         # return the last data item seen, if nothing was plotted; supposed to be just data)

--- a/src/sas/qtgui/Perspectives/Fitting/FittingWidget.py
+++ b/src/sas/qtgui/Perspectives/Fitting/FittingWidget.py
@@ -2238,7 +2238,7 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         data_shown = False
         item = None
         for item, plot in plots.items():
-            if fitpage_name in plot.name:
+            if not hasattr(plot,'isExpData') and fitpage_name in plot.name:
                 data_shown = True
                 self.communicate.plotRequestedSignal.emit([item, plot], self.tab_id)
         # return the last data item seen, if nothing was plotted; supposed to be just data)

--- a/src/sas/qtgui/Perspectives/Fitting/ModelThread.py
+++ b/src/sas/qtgui/Perspectives/Fitting/ModelThread.py
@@ -253,9 +253,7 @@ class Calc1D(CalcThread):
                 intermediate_results = {}
 
         elapsed = time.time() - self.starttime
-
-        setattr(self.data,'isExpData',True)
-
+  
         res = dict(x = self.data.x[index], y = output[index],
             page_id = self.page_id, state = self.state, weight = self.weight,
             fid = self.fid, toggle_mode_on = self.toggle_mode_on,

--- a/src/sas/qtgui/Perspectives/Fitting/ModelThread.py
+++ b/src/sas/qtgui/Perspectives/Fitting/ModelThread.py
@@ -100,6 +100,8 @@ class Calc2D(CalcThread):
         output[index_model] = value
         elapsed = time.time() - self.starttime
 
+        setattr(self.data,'isExpData',True)
+
         res = dict(image = output, data = self.data, page_id = self.page_id,
             model = self.model, state = self.state,
             toggle_mode_on = self.toggle_mode_on, elapsed = elapsed,
@@ -253,6 +255,8 @@ class Calc1D(CalcThread):
                 intermediate_results = {}
 
         elapsed = time.time() - self.starttime
+
+        setattr(self.data,'isExpData',True)
 
         res = dict(x = self.data.x[index], y = output[index],
             page_id = self.page_id, state = self.state, weight = self.weight,

--- a/src/sas/qtgui/Perspectives/Fitting/ModelThread.py
+++ b/src/sas/qtgui/Perspectives/Fitting/ModelThread.py
@@ -100,8 +100,6 @@ class Calc2D(CalcThread):
         output[index_model] = value
         elapsed = time.time() - self.starttime
 
-        setattr(self.data,'isExpData',True)
-
         res = dict(image = output, data = self.data, page_id = self.page_id,
             model = self.model, state = self.state,
             toggle_mode_on = self.toggle_mode_on, elapsed = elapsed,


### PR DESCRIPTION
Fixes #2327 by adding an optional flag to Data1D objects `isExpData` marking actual, experimental data and differentiating it from models/residuals.  The plotting routines inside `Fitting` then use this flag to differentiate these two datatypes.

Edit: just uses plot role instead of new flag.