### PR TITLE
Fixes binning bug in implementation of sesans data

### DIFF
--- a/src/sas/qtgui/Perspectives/Fitting/ModelThread.py
+++ b/src/sas/qtgui/Perspectives/Fitting/ModelThread.py
@@ -172,9 +172,9 @@ class Calc1D(CalcThread):
         ##smearer the ouput of the plot
         if self.smearer is not None:
             if self.data.isSesans:
-                # For SESANS, data.x, qmin and qmax, and therefore get_bin_range are in correlation space, and
-                # the Hankel transform from q space to correlation space is set up as a resolution function, i.e.,
-                # the "unsmeared" data is in q space and the "smeared" data is in correlation space.
+                # For SESANS, data.x, qmin and qmax, and therefore get_bin_range are in real space, and
+                # the Hankel transform from q space to real space is set up as a resolution function, i.e.,
+                # the "unsmeared" data is in q space and the "smeared" data is in real space.
                 # Therefore, q_calc needs to be used here to calculate the unsmeared_out rather than data.x.
                 mask = self.smearer.resolution.q_calc
                 first_bin = 0

--- a/src/sas/qtgui/Perspectives/Fitting/ModelThread.py
+++ b/src/sas/qtgui/Perspectives/Fitting/ModelThread.py
@@ -171,10 +171,20 @@ class Calc1D(CalcThread):
         unsmeared_error = None
         ##smearer the ouput of the plot
         if self.smearer is not None:
-            first_bin, last_bin = self.smearer.get_bin_range(self.qmin,
-                                                             self.qmax)
-            mask = self.data.x[first_bin:last_bin+1]
-            unsmeared_output = numpy.zeros((len(self.data.x)))
+            if self.data.isSesans:
+                # For SESANS, data.x, qmin and qmax, and therefore get_bin_range are in correlation space, and
+                # the Hankel transform from q space to correlation space is set up as a resolution function, i.e.,
+                # the "unsmeared" data is in q space and the "smeared" data is in correlation space.
+                # Therefore, q_calc needs to be used here to calculate the unsmeared_out rather than data.x.
+                mask = self.smearer.resolution.q_calc
+                first_bin = 0
+                last_bin = len(mask)
+                unsmeared_output = numpy.zeros((len(mask)))
+            else:
+                first_bin, last_bin = self.smearer.get_bin_range(self.qmin,
+                                                                 self.qmax)
+                mask = self.data.x[first_bin:last_bin+1]
+                unsmeared_output = numpy.zeros((len(self.data.x)))
 
             return_data = self.model.calculate_Iq(mask)
             if isinstance(return_data, tuple):
@@ -183,11 +193,11 @@ class Calc1D(CalcThread):
                 return_data, intermediate_results = return_data
             unsmeared_output[first_bin:last_bin+1] = return_data
             output = self.smearer(unsmeared_output, first_bin, last_bin)
-
             # Rescale data to unsmeared model
             # Check that the arrays are compatible. If we only have a model but no data,
             # the length of data.y will be zero.
-            if isinstance(self.data.y, numpy.ndarray) and output.shape == self.data.y.shape:
+            # does not apply to SESANS where Hankel was implemented as resolution function
+            if isinstance(self.data.y, numpy.ndarray) and output.shape == self.data.y.shape and not self.data.isSesans:
                 unsmeared_data = numpy.zeros((len(self.data.x)))
                 unsmeared_error = numpy.zeros((len(self.data.x)))
                 unsmeared_data[first_bin:last_bin+1] = self.data.y[first_bin:last_bin+1]\


### PR DESCRIPTION
This fixes a binning bug for sesans data.

Sesans is in real space and the Hankel transform from q space to real space (spin echo length) was implemented as a resolution function. For other resolution functions, the qmin and qmax range is compared to data.x which are all in q space. This is then passed to the calculator to return the unsmeared Iq. However, for sesans data, qmin, qmax, and data.x are all in real space while the calculator is expecting q space data to return the unsmeared Iq (which will then get passed to the sesans "smearer" which uses the hankel transform to convert Iq to real space).

Due to the number of points in q_calc (in q space) being much greater than the number of points in q (spin echo length in real space) in the sesans transform (resolution function), this resulted in a small portion of the data being improperly calculated at the incorrect q values (spin echo length being passed as q to the calculator returning Iq) with a error on the order of 1e-10.

The q, Iq data being passed to the Hankel transform before and after the fix for a sphere form factor with scale = 0.005, background = 0, sld = 1, sld_solvent = 6, and radius = 10000:
![image](https://user-images.githubusercontent.com/17092022/198834311-c1e147d2-5d0b-41f1-86d9-a11cf8e5ff3b.png)

After the Hankel transform for both q, Iq datasets and compared to the analytical model for the same system: 
![image](https://user-images.githubusercontent.com/17092022/198834234-dff0598b-006b-4a5c-aa04-5ed02047fcb2.png)

Error between the datasets in SESANS space: 
![image](https://user-images.githubusercontent.com/17092022/198834283-1004aedd-f6bd-4465-a91b-ed802e2dadba.png)


