### PR TITLE
Fix "Use dQ Data" bug that swtiched slit length and slit width in the gui

### DIFF
--- a/src/sas/qtgui/Perspectives/Fitting/FittingWidget.py
+++ b/src/sas/qtgui/Perspectives/Fitting/FittingWidget.py
@@ -4216,12 +4216,12 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
                 pass
         if 'smearing_min' in line_dict.keys():
             try:
-                self.smearing_widget.dq_l = float(line_dict['smearing_min'][0])
+                self.smearing_widget.dq_r = float(line_dict['smearing_min'][0])
             except ValueError:
                 pass
         if 'smearing_max' in line_dict.keys():
             try:
-                self.smearing_widget.dq_r = float(line_dict['smearing_max'][0])
+                self.smearing_widget.dq_l = float(line_dict['smearing_max'][0])
             except ValueError:
                 pass
 


### PR DESCRIPTION
## Description
This fixes a bug in the SasView gui that was switching the slit length and slit width values when using a structure factor for a slit smeared dataset after switching the resolution to "Custom Slit Smear" and then back to "Use dQ Data". 
This closes #2333. Recent changes were made to the slit smearing functions and nomenclature, and so @pbeaucage and @butlerpd should take a look.

## How Has This Been Tested?
Load a slit smeared dataset that includes the slit length, select a form factor and structure factor, go to the resolution tab, switch from "Use dQ Data" back to "Custom Slit Smear" and then back again. I've also tested for other datasets with different dQ data and also using different combinations of all resolution options and form factor models with and without structure factor.

## Review Checklist (please remove items if they don't apply):

- [x] Code has been reviewed
- [x] Functionality has been tested
- [x] Windows installer (GH artifact) has been tested (installed and worked) 
- [ ] MacOSX installer (GH artifact) has been tested (installed and worked) 
- [x] User documentation is available and complete (if required)
- [x] Developers documentation is available and complete (if required)
- [x] The introduced changes comply with SasView license (BSD 3-Clause)

