### PR TITLE
fixed sesans residuals plots to show in real space rather than q space

### DIFF
--- a/src/sas/qtgui/Perspectives/Fitting/FittingUtilities.py
+++ b/src/sas/qtgui/Perspectives/Fitting/FittingUtilities.py
@@ -547,8 +547,12 @@ def residualsData1D(reference_data, current_data, weights):
     residuals.dxl = None
     residuals.dxw = None
     residuals.ytransform = 'y'
+    if reference_data.isSesans:
+        residuals.xtransform = 'x'
+        residuals.xaxis('\\rm{z} ', 'A')
     # For latter scale changes
-    residuals.xaxis('\\rm{Q} ', 'A^{-1}')
+    else:
+        residuals.xaxis('\\rm{Q} ', 'A^{-1}')
     residuals.yaxis('\\rm{Residuals} ', 'normalized')
 
     return residuals


### PR DESCRIPTION
## Description
Fixed the SESANS residuals plot so they show in real space rather than q space.
Fixes #2337 

## How Has This Been Tested?
Plotting residuals for SESANS and regular SAS data.

## Review Checklist (please remove items if they don't apply):

- [x] Code has been reviewed
- [x] Functionality has been tested
- [x] Windows installer (GH artifact) has been tested (installed and worked)  
- [x] Mac installer (GH artifact) has been tested (installed and worked) 
- [x] User documentation is available and complete (if required)
- [x] Developers documentation is available and complete (if required)
- [x] The introduced changes comply with SasView license (BSD 3-Clause)

