### PR TITLE
Back to explict blacklisting of h5py messages

### DIFF
--- a/src/sas/system/log.ini
+++ b/src/sas/system/log.ini
@@ -41,10 +41,10 @@ args=(os.path.join(os.path.expanduser("~"),'sasview.log'),"a")
 # Loggers
 
 [loggers]
-keys=root,saspr,sasgui,sascalc,sasmodels
+keys=root,saspr,sasgui,sascalc,sasmodels,h5py
 
 [logger_root]
-level=WARNING
+level=DEBUG
 formatter=default
 handlers=console,log_file
 
@@ -70,4 +70,10 @@ propagate=0
 level=INFO
 qualname=sas.sascalc
 handlers=console,log_file
+propagate=0
+
+[logger_h5py]
+level=DEBUG
+qualname=h5py
+handlers=
 propagate=0


### PR DESCRIPTION
## Description

The disable-by-default strategy of dealing with console messages turned out to be unpopular. Going with the original strategy of just dumping h5py messages into the ether.

Fixes: Paul Butler
Closes #2323

## Review Checklist (please remove items if they don't apply):

- [ ] Code has been reviewed
- [x] Functionality has been tested
- [ ] Windows installer (GH artifact) has been tested (installed and worked) 
- [ ] MacOSX installer (GH artifact) has been tested (installed and worked) 

