### PR TITLE
Fixes in invariant prespective

### DIFF
--- a/src/sas/qtgui/Perspectives/Invariant/UI/TabbedInvariantUI.ui
+++ b/src/sas/qtgui/Perspectives/Invariant/UI/TabbedInvariantUI.ui
@@ -144,7 +144,7 @@
                   <bool>true</bool>
                  </property>
                  <property name="readOnly">
-                  <bool>true</bool>
+                  <bool>false</bool>
                  </property>
                 </widget>
                </item>
@@ -161,7 +161,7 @@
                   <bool>true</bool>
                  </property>
                  <property name="readOnly">
-                  <bool>true</bool>
+                  <bool>false</bool>
                  </property>
                 </widget>
                </item>

--- a/src/sas/qtgui/Perspectives/Invariant/UI/TabbedInvariantUI.ui
+++ b/src/sas/qtgui/Perspectives/Invariant/UI/TabbedInvariantUI.ui
@@ -144,7 +144,7 @@
                   <bool>true</bool>
                  </property>
                  <property name="readOnly">
-                  <bool>false</bool>
+                  <bool>true</bool>
                  </property>
                 </widget>
                </item>
@@ -161,7 +161,7 @@
                   <bool>true</bool>
                  </property>
                  <property name="readOnly">
-                  <bool>false</bool>
+                  <bool>true</bool>
                  </property>
                 </widget>
                </item>

--- a/src/sas/qtgui/Perspectives/Invariant/UnitTesting/InvariantPerspectiveTest.py
+++ b/src/sas/qtgui/Perspectives/Invariant/UnitTesting/InvariantPerspectiveTest.py
@@ -452,6 +452,9 @@ class InvariantPerspectiveTest:
         assert not widget.txtNptsLowQ.isReadOnly()
         assert not widget.txtNptsHighQ.isReadOnly()
 
+        assert widget.txtTotalQMin.isReadOnly()
+        assert widget.txtTotalQMax.isReadOnly()
+
         # content of line edits
         assert widget.txtName.text() == 'data'
         assert widget.txtTotalQMin.text() == '0.009'

--- a/src/sas/qtgui/Perspectives/Invariant/UnitTesting/InvariantPerspectiveTest.py
+++ b/src/sas/qtgui/Perspectives/Invariant/UnitTesting/InvariantPerspectiveTest.py
@@ -452,8 +452,8 @@ class InvariantPerspectiveTest:
         assert not widget.txtNptsLowQ.isReadOnly()
         assert not widget.txtNptsHighQ.isReadOnly()
 
-        assert widget.txtTotalQMin.isReadOnly()
-        assert widget.txtTotalQMax.isReadOnly()
+        assert not widget.txtTotalQMin.isReadOnly()
+        assert not widget.txtTotalQMax.isReadOnly()
 
         # content of line edits
         assert widget.txtName.text() == 'data'

--- a/src/sas/qtgui/Perspectives/Invariant/UnitTesting/InvariantPerspectiveTest.py
+++ b/src/sas/qtgui/Perspectives/Invariant/UnitTesting/InvariantPerspectiveTest.py
@@ -452,8 +452,8 @@ class InvariantPerspectiveTest:
         assert not widget.txtNptsLowQ.isReadOnly()
         assert not widget.txtNptsHighQ.isReadOnly()
 
-        assert not widget.txtTotalQMin.isReadOnly()
-        assert not widget.txtTotalQMax.isReadOnly()
+        assert widget.txtTotalQMin.isReadOnly()
+        assert widget.txtTotalQMax.isReadOnly()
 
         # content of line edits
         assert widget.txtName.text() == 'data'

--- a/src/sas/sascalc/invariant/invariant.py
+++ b/src/sas/sascalc/invariant/invariant.py
@@ -463,7 +463,7 @@ class InvariantCalculator(object):
         if new_data.dy is None or len(new_data.x) != len(new_data.dy) or \
             (min(new_data.dy) == 0 and max(new_data.dy) == 0):
             new_data.dy = np.ones(len(new_data.x))
-        return  new_data
+        return new_data
 
     def _fit(self, model, qmin=Q_MINIMUM, qmax=Q_MAXIMUM, power=None):
         """
@@ -914,7 +914,8 @@ class InvariantCalculator(object):
         self.get_qstar(extrapolation)
 
         if self._qstar <= 0:
-            msg = "Invalid invariant: Invariant Q* must be greater than zero"
+            msg = "Invalid invariant: Invariant Q* must be greater than zero\n"
+            msg += "Please check if scale and background values are correct"
             raise RuntimeError(msg)
 
         # Compute intermediate constant


### PR DESCRIPTION
## Description

As described in #2334 two issues related to invariant perspective were identified. The firts issue with read only fields for Qmin and Qmax should be fixed now. However the other problem is more deconvoluted as it is related to the fact that we calculate invariant based on `(scale * data) - background`, which requires correct setting for scale and background. As it turned out for apoferitin example the values coming from fitting may be over/underestimated and therefore Q* may become negative. Warning has been added to the code suggesting checking backround and scale value. In the future we may consider more inteligent guidance.

I've checked documentation. It seems to be consitent but maybe we should add note about scale/background issue? 

Fixes #2334 

## How Has This Been Tested?
1) Load data set 
2) Send to Invariant
3) Check if you can modify Qmin and Qmax
4) (to check other problem) Play with scale and background (e.g. small scale, high background) and check if you get proper warning. 


## Review Checklist (please remove items if they don't apply):

- [x] Code has been reviewed
- [ ] Functionality has been tested
- [ ] Windows installer (GH artifact) has been tested (installed and worked) 
- [ ] MacOSX installer (GH artifact) has been tested (installed and worked) 
- [x] User documentation is available and complete (if required)
- [x] Developers documentation is available and complete (if required)
- [x] The introduced changes comply with SasView license (BSD 3-Clause)

