### PR TITLE
2316: Refactoring preferences

### DIFF
--- a/src/sas/qtgui/MainWindow/media/preferences_help.rst
+++ b/src/sas/qtgui/MainWindow/media/preferences_help.rst
@@ -1,11 +1,45 @@
-.. preferences_help.rst
-
+. preferences_help.rst
 .. J Krzywon wrote initial draft August 2022
-
+.. Last Updated: J Krzywon, October 2022
 .. _Preferences:
 
 Preferences
 ============
 
-SasView has a number of user-settable options available. Each heading will give more information about a
-particular group of settings. Any preferences not held within this window are planned to move here in a future release.
+SasView has a number of user-settable options available. For information on a specific preference, navigate to the
+appropriate page heading. Not all preferences are housed here, but will be eventually.
+
+A number of these preferences will only apply to the current SasView window and will reset when closing. Others,
+labelled *persistent* in this document, will be retained for the next time SasView is run.
+
+:ref:`Plot_Preferences`, :ref:`Display_Preferences`
+
+.. _Plot_Preferences:
+
+Plotting Preferences
+--------------------
+Plotting preferences only apply to new plots. Existing plots will retain existing settings.
+
+**Use full-width plot legends (most compatible)?**: With this option selected, plot legends will always be the full width
+of the plot it is on. The legend will also be partially transparent to better view the data. *persistent*
+
+**Use truncated legend entries?**: By selecting this option, legend labels are truncated to a single line of length
+*Legend entry line length* leaving only the beginning and end of the label. The central characters will be replaced with
+an ellipsis and whitespace. *persistent*
+
+**Legend entry line length**: This defines the maximum number of characters to display in a single line of a plot legend
+before wrapping to the next line. *persistent*
+
+.. _Display_Preferences:
+
+Display Preferences
+-------------------
+The display preferences modify underlying features of our GUI framework, Qt. For more information on each setting,
+please read more on the `Qt High DPI Settings <https://doc.qt.io/qt-5/highdpi.html#high-dpi-support-in-qt>`_.
+
+**QT Screen Scale Factor**: A percent scaling factor that is applied all element sizes within the GUI. A restart of
+SasView is required to take effect. *persistent*
+
+**Automatic Screen Scale Factor**: enables automatic scaling, based on the monitor's pixel density. This won't change the
+size of point-sized fonts, since point is a physical measurement unit. Multiple screens may get different scale factors.
+*persistent*

--- a/src/sas/qtgui/Utilities/Preferences/DisplayPreferencesWidget.py
+++ b/src/sas/qtgui/Utilities/Preferences/DisplayPreferencesWidget.py
@@ -19,3 +19,11 @@ class DisplayPreferencesWidget(PreferencesWidget):
             checked=config.QT_AUTO_SCREEN_SCALE_FACTOR)
         self.autoScaling.clicked.connect(
             lambda: self._stageChange('QT_AUTO_SCREEN_SCALE_FACTOR', self.autoScaling.isChecked()))
+
+    def _toggleBlockAllSignaling(self, toggle):
+        self.qtScaleFactor.blockSignals(toggle)
+        self.autoScaling.blockSignals(toggle)
+
+    def _restoreFromConfig(self):
+        self.qtScaleFactor.setText(str(config.QT_SCALE_FACTOR))
+        self.autoScaling.setChecked(config.QT_AUTO_SCREEN_SCALE_FACTOR)

--- a/src/sas/qtgui/Utilities/Preferences/DisplayPreferencesWidget.py
+++ b/src/sas/qtgui/Utilities/Preferences/DisplayPreferencesWidget.py
@@ -1,14 +1,21 @@
 from sas.system import config
 
-from .PreferencesWidget import PreferencesWidget, config_value_setter_generator
+from .PreferencesWidget import PreferencesWidget
 
 
 class DisplayPreferencesWidget(PreferencesWidget):
     def __init__(self):
         super(DisplayPreferencesWidget, self).__init__("Display Settings")
-        self.addTextInput(title="QT Screen Scale Factor",
-                         callback=config_value_setter_generator('QT_SCALE_FACTOR', dtype=float),
-                         default_text=str(config.QT_SCALE_FACTOR))
-        self.addCheckBox(title="Automatic Screen Scale Factor",
-                         callback=config_value_setter_generator('QT_AUTO_SCREEN_SCALE_FACTOR', dtype=bool),
-                         checked=config.QT_AUTO_SCREEN_SCALE_FACTOR)
+        self.config_params = ['QT_SCALE_FACTOR', 'QT_AUTO_SCREEN_SCALE_FACTOR']
+
+    def _addAllWidgets(self):
+        self.qtScaleFactor = self.addTextInput(
+            title="QT Screen Scale Factor",
+            default_text=str(config.QT_SCALE_FACTOR))
+        self.qtScaleFactor.textChanged.connect(
+            lambda: self._stageChange('QT_SCALE_FACTOR', self.qtScaleFactor.text()))
+        self.autoScaling = self.addCheckBox(
+            title="Automatic Screen Scale Factor",
+            checked=config.QT_AUTO_SCREEN_SCALE_FACTOR)
+        self.autoScaling.clicked.connect(
+            lambda: self._stageChange('QT_AUTO_SCREEN_SCALE_FACTOR', self.autoScaling.isChecked()))

--- a/src/sas/qtgui/Utilities/Preferences/DisplayPreferencesWidget.py
+++ b/src/sas/qtgui/Utilities/Preferences/DisplayPreferencesWidget.py
@@ -9,11 +9,11 @@ class DisplayPreferencesWidget(PreferencesWidget):
         self.config_params = ['QT_SCALE_FACTOR', 'QT_AUTO_SCREEN_SCALE_FACTOR']
 
     def _addAllWidgets(self):
-        self.qtScaleFactor = self.addTextInput(
+        self.qtScaleFactor = self.addFloatInput(
             title="QT Screen Scale Factor",
-            default_text=str(config.QT_SCALE_FACTOR))
+            default_number=config.QT_SCALE_FACTOR)
         self.qtScaleFactor.textChanged.connect(
-            lambda: self._stageChange('QT_SCALE_FACTOR', self.qtScaleFactor.text()))
+            lambda: self._stageChange('QT_SCALE_FACTOR', float(self.qtScaleFactor.text())))
         self.autoScaling = self.addCheckBox(
             title="Automatic Screen Scale Factor",
             checked=config.QT_AUTO_SCREEN_SCALE_FACTOR)

--- a/src/sas/qtgui/Utilities/Preferences/PlottingPreferencesWidget.py
+++ b/src/sas/qtgui/Utilities/Preferences/PlottingPreferencesWidget.py
@@ -1,17 +1,28 @@
 from sas.system import config
 
-from .PreferencesWidget import PreferencesWidget, config_value_setter_generator
+from .PreferencesWidget import PreferencesWidget
 
 
 class PlottingPreferencesWidget(PreferencesWidget):
     def __init__(self):
         super(PlottingPreferencesWidget, self).__init__("Plotting Options")
-        self.addCheckBox(title="Use full-width plot legends (most compatible)?",
-                         callback=config_value_setter_generator('FITTING_PLOT_FULL_WIDTH_LEGENDS', dtype=bool),
-                         checked=config.FITTING_PLOT_FULL_WIDTH_LEGENDS)
-        self.addCheckBox(title="Use truncated legend entries?",
-                         callback=config_value_setter_generator('FITTING_PLOT_LEGEND_TRUNCATE', dtype=bool),
-                         checked=config.FITTING_PLOT_LEGEND_TRUNCATE)
-        self.addTextInput(title="Legend entry line length",
-                          callback=config_value_setter_generator('FITTING_PLOT_LEGEND_MAX_LINE_LENGTH', dtype=int),
-                          default_text=str(config.FITTING_PLOT_LEGEND_MAX_LINE_LENGTH))
+        self.config_params = ['FITTING_PLOT_FULL_WIDTH_LEGENDS',
+                              'FITTING_PLOT_LEGEND_TRUNCATE',
+                              'FITTING_PLOT_LEGEND_MAX_LINE_LENGTH']
+
+    def _addAllWidgets(self):
+        self.legendFullWidth = self.addCheckBox(
+            title="Use full-width plot legends (most compatible)?",
+            checked=config.FITTING_PLOT_FULL_WIDTH_LEGENDS)
+        self.legendFullWidth.clicked.connect(
+            lambda: self._stageChange('FITTING_PLOT_FULL_WIDTH_LEGENDS', self.legendFullWidth.isChecked()))
+        self.legendTruncate = self.addCheckBox(
+            title="Use truncated legend entries?",
+            checked=config.FITTING_PLOT_LEGEND_TRUNCATE)
+        self.legendTruncate.clicked.connect(
+            lambda: self._stageChange('FITTING_PLOT_LEGEND_TRUNCATE', self.legendTruncate.isChecked()))
+        self.legendLineLength = self.addTextInput(
+            title="Legend entry line length",
+            default_text=str(config.FITTING_PLOT_LEGEND_MAX_LINE_LENGTH))
+        self.legendLineLength.textChanged.connect(
+            lambda: self._stageChange('FITTING_PLOT_LEGEND_MAX_LINE_LENGTH', self.legendLineLength.text()))

--- a/src/sas/qtgui/Utilities/Preferences/PlottingPreferencesWidget.py
+++ b/src/sas/qtgui/Utilities/Preferences/PlottingPreferencesWidget.py
@@ -26,3 +26,13 @@ class PlottingPreferencesWidget(PreferencesWidget):
             default_text=str(config.FITTING_PLOT_LEGEND_MAX_LINE_LENGTH))
         self.legendLineLength.textChanged.connect(
             lambda: self._stageChange('FITTING_PLOT_LEGEND_MAX_LINE_LENGTH', self.legendLineLength.text()))
+
+    def _toggleBlockAllSignaling(self, toggle):
+        self.legendFullWidth.blockSignals(toggle)
+        self.legendTruncate.blockSignals(toggle)
+        self.legendLineLength.blockSignals(toggle)
+
+    def _restoreFromConfig(self):
+        self.legendFullWidth.setChecked(config.FITTING_PLOT_FULL_WIDTH_LEGENDS)
+        self.legendTruncate.setChecked(config.FITTING_PLOT_LEGEND_TRUNCATE)
+        self.legendLineLength.setText(str(config.FITTING_PLOT_LEGEND_MAX_LINE_LENGTH))

--- a/src/sas/qtgui/Utilities/Preferences/PlottingPreferencesWidget.py
+++ b/src/sas/qtgui/Utilities/Preferences/PlottingPreferencesWidget.py
@@ -21,11 +21,11 @@ class PlottingPreferencesWidget(PreferencesWidget):
             checked=config.FITTING_PLOT_LEGEND_TRUNCATE)
         self.legendTruncate.clicked.connect(
             lambda: self._stageChange('FITTING_PLOT_LEGEND_TRUNCATE', self.legendTruncate.isChecked()))
-        self.legendLineLength = self.addTextInput(
+        self.legendLineLength = self.addIntegerInput(
             title="Legend entry line length",
-            default_text=str(config.FITTING_PLOT_LEGEND_MAX_LINE_LENGTH))
+            default_number=config.FITTING_PLOT_LEGEND_MAX_LINE_LENGTH)
         self.legendLineLength.textChanged.connect(
-            lambda: self._stageChange('FITTING_PLOT_LEGEND_MAX_LINE_LENGTH', self.legendLineLength.text()))
+            lambda: self._stageChange('FITTING_PLOT_LEGEND_MAX_LINE_LENGTH', int(self.legendLineLength.text())))
 
     def _toggleBlockAllSignaling(self, toggle):
         self.legendFullWidth.blockSignals(toggle)

--- a/src/sas/qtgui/Utilities/Preferences/PreferencesPanel.py
+++ b/src/sas/qtgui/Utilities/Preferences/PreferencesPanel.py
@@ -43,11 +43,11 @@ class PreferencesPanel(QDialog, Ui_preferencesUI):
         self.listWidget.setCurrentRow(0)
         # Add window actions
         self.listWidget.currentItemChanged.connect(self.prefMenuChanged)
-        self.buttonBox.button(QDialogButtonBox.RestoreDefaults).connect(self.restoreDefaultPreferences)
-        self.buttonBox.button(QDialogButtonBox.Ok).connect(self._okClicked())
-        self.buttonBox.button(QDialogButtonBox.Cancel).connect(self._cancelStaging)
-        self.buttonBox.button(QDialogButtonBox.Apply).connect(self._saveStagedChanges)
-        self.buttonBox.button(QDialogButtonBox.Help).connect(self.help)
+        self.buttonBox.button(QDialogButtonBox.RestoreDefaults).clicked.connect(self.restoreDefaultPreferences)
+        self.buttonBox.button(QDialogButtonBox.Ok).clicked.connect(self._okClicked)
+        self.buttonBox.button(QDialogButtonBox.Cancel).clicked.connect(self._cancelStaging)
+        self.buttonBox.button(QDialogButtonBox.Apply).clicked.connect(self._saveStagedChanges)
+        self.buttonBox.button(QDialogButtonBox.Help).clicked.connect(self.help)
 
     def addWidgets(self, widgets: Dict[str, Callable]):
         """Add a list of named widgets to the window"""

--- a/src/sas/qtgui/Utilities/Preferences/PreferencesPanel.py
+++ b/src/sas/qtgui/Utilities/Preferences/PreferencesPanel.py
@@ -114,7 +114,7 @@ class PreferencesPanel(QDialog, Ui_preferencesUI):
     def addWidget(self, widget: QWidget, name: Optional[str] = None):
         """Add a single widget to the panel"""
         # Set the parent of the new widget to the parent of this window
-        widget.parent = self.parent
+        widget.parent = self
         self.stackedWidget.addWidget(widget)
         # Set display name in the listWidget with the priority of
         #  name passed to method > widget.name > "Generic Preferences"

--- a/src/sas/qtgui/Utilities/Preferences/PreferencesPanel.py
+++ b/src/sas/qtgui/Utilities/Preferences/PreferencesPanel.py
@@ -98,6 +98,8 @@ class PreferencesPanel(QDialog, Ui_preferencesUI):
 
     def _cancelStaging(self):
         """ When the Cancel button is clicked, throw away any staged changes and hide the window"""
+        for i in range(self.stackedWidget.count()):
+            self.stackedWidget.widget(i).restoreGUIValuesFromConfig()
         self._staged_changes = {}
         self.close()
 

--- a/src/sas/qtgui/Utilities/Preferences/PreferencesPanel.py
+++ b/src/sas/qtgui/Utilities/Preferences/PreferencesPanel.py
@@ -1,6 +1,6 @@
 import logging
 
-from PyQt5.QtWidgets import QDialog, QPushButton, QWidget
+from PyQt5.QtWidgets import QDialog, QPushButton, QWidget, QDialogButtonBox
 from PyQt5.QtCore import Qt
 from typing import Optional, Callable, Dict, Any
 
@@ -43,7 +43,11 @@ class PreferencesPanel(QDialog, Ui_preferencesUI):
         self.listWidget.setCurrentRow(0)
         # Add window actions
         self.listWidget.currentItemChanged.connect(self.prefMenuChanged)
-        self.buttonBox.clicked.connect(self.onClick)
+        self.buttonBox.button(QDialogButtonBox.RestoreDefaults).connect(self.restoreDefaultPreferences)
+        self.buttonBox.button(QDialogButtonBox.Ok).connect(self._okClicked())
+        self.buttonBox.button(QDialogButtonBox.Cancel).connect(self._cancelStaging)
+        self.buttonBox.button(QDialogButtonBox.Apply).connect(self._saveStagedChanges)
+        self.buttonBox.button(QDialogButtonBox.Help).connect(self.help)
 
     def addWidgets(self, widgets: Dict[str, Callable]):
         """Add a list of named widgets to the window"""
@@ -69,16 +73,6 @@ class PreferencesPanel(QDialog, Ui_preferencesUI):
         """Set the menu and options stack to a given index"""
         self.listWidget.setCurrentRow(row)
         self.stackedWidget.setCurrentIndex(row)
-
-    def onClick(self, btn: QPushButton):
-        """Handle button click events in one area"""
-        # Reset to the default preferences
-        if btn.text() == 'Restore Defaults':
-            self.restoreDefaultPreferences()
-        elif btn.text() == 'OK':
-            self._okClicked()
-        elif btn.text() == 'Help':
-            self.help()
 
     def restoreDefaultPreferences(self):
         """Reset preferences for the active widget to the default values."""

--- a/src/sas/qtgui/Utilities/Preferences/PreferencesWidget.py
+++ b/src/sas/qtgui/Utilities/Preferences/PreferencesWidget.py
@@ -1,39 +1,11 @@
-import functools
 import logging
 
-from PyQt5.QtWidgets import QComboBox, QWidget, QLabel, QHBoxLayout, QVBoxLayout, QLineEdit, QCheckBox
-from typing import Optional, List, Union, Callable, Any
+from PyQt5.QtWidgets import QComboBox, QWidget, QLabel, QHBoxLayout, QVBoxLayout, QLineEdit, QCheckBox, QFrame
+from typing import Optional, List, Union
 
 from sas.system import config
 
 logger = logging.getLogger(__name__)
-
-
-def set_config_value(value: Any, attr: str, dtype: Optional[Callable] = None):
-    """Helper method to set any config value
-    :param attr: The configuration attribute that will be set
-    :param value: The value the attribute will be set to. This could be a str, int, bool, a class instance, or any other
-    :param dtype: The datatype to cast the input value to if casting is desired
-    """
-    if hasattr(config, attr):
-        # Attempt to coerce value to a specific type. Useful for numeric values from text boxes, etc.
-        if dtype is not None:
-            value = dtype(value)
-        # Another sanity check - the config system would also raise on data type mismatch, so potentially redundant
-        if type(getattr(config,attr)) == type(value):
-            setattr(config, attr, value)
-        else:
-            raise TypeError(f"Data type mismatch: {value} has type {type(value)}, expected {type(getattr(config,attr))}")
-    else:
-        # The only way to get here **should** be during development, thus the debug log.
-        logger.debug(f"Please add {attr} to the configuration and give it a sensible default value.")
-
-def get_config_value(attr: str, default: Optional[Any] = None) -> Any:
-    """Helper method to get any config value, regardless if it exists or not
-    :param attr: The configuration attribute that will be returned
-    :param default: The assumed value, if the attribute cannot be found
-    """
-    return getattr(config, attr, default) if hasattr(config, attr) else default
 
 
 def cb_replace_all_items_with_new(cb: QComboBox, new_items: List[str], default_item: Optional[str] = None):
@@ -48,32 +20,47 @@ def cb_replace_all_items_with_new(cb: QComboBox, new_items: List[str], default_i
     cb.setCurrentIndex(index)
 
 
-def config_value_setter_generator(attr: str, dtype: Optional[Callable] = None):
-    """Helper method that generates a callback to set a config value.
-
-    :param attr: name of the attribute to set
-    :param dtype: The datatype to cast the input value to if casting is desired
-    :return: a function that takes a single argument, which will be cast to dtype
-            and set in config as attr
-    """
-    
-    return functools.partial(set_config_value, attr=attr, dtype=dtype)
-
+class QHLine(QFrame):
+    """::CRUFT:: This creates a horizontal line in PyQt5. PyQt6 QFrame has finer shape control"""
+    def __init__(self):
+        super(QHLine, self).__init__()
+        self.setFrameShape(QFrame.HLine)
+        self.setFrameShadow(QFrame.Sunken)
 
 
 class PreferencesWidget(QWidget):
     """A helper class that bundles all values needed to add a new widget to the preferences panel
     """
-    # Name that will be added to the PreferencesPanel listWidget
-    name = None  # type: str
 
-    def __init__(self, name: str, default_method: Optional[Callable] = None):
+    def __init__(self, name: str):
         super(PreferencesWidget, self).__init__()
-        self.name = name
-        self.resetDefaults = default_method
+        # Keep parent as None until widget is added to preferences panel, then this will become th
+        self.parent = None
+        self.name: str = name
+        # All parameter names used in this panel
+        self.config_params: List[str] = []
+        # Create generic layout
         self.verticalLayout = QVBoxLayout()
         self.setLayout(self.verticalLayout)
+        # Child class generates GUI elements
+        self._addAllWidgets()
+        # Push all elements to the top of the window
+        self.verticalLayout.addStretch()
         self.adjustSize()
+
+    def restoreDefaults(self):
+        """Generic method to restore all default values for the widget. """
+        for param in self.config_params:
+            default = config.defaults.get(param)
+            setattr(config, param, default)
+
+    #############################################################
+    # GUI Helper methods for widgets that don't have a UI element
+
+    def _addAllWidgets(self):
+        """A private pseudo-abstract class that children should override. Widgets with their own UI file should pass.
+        """
+        raise NotImplementedError(f"{self.name} has not implemented _addAllWidgets.")
 
     def _createLayoutAndTitle(self, title: str):
         """A private class method that creates a horizontal layout to hold the title and interactive item.
@@ -85,44 +72,53 @@ class PreferencesWidget(QWidget):
         layout.addWidget(label)
         return layout
 
-    def addComboBox(self, title: str, params: List[Union[str, int, float]], callback: Callable,
-                    default: Optional[str] = None):
+    def addComboBox(self, title: str, params: List[Union[str, int, float]], default: Optional[str] = None) -> QComboBox:
         """Add a title and combo box within the widget.
         :param title: The title of the combo box to be added to the preferences panel.
         :param params: A list of options to be added to the combo box.
-        :param callback: A callback method called when the combobox value is changed.
         :param default: The default option to be selected in the combo box. The first item is selected if None.
+        :return: QComboBox instance to allow subclasses to assign instance name
         """
         layout = self._createLayoutAndTitle(title)
         box = QComboBox(self)
         cb_replace_all_items_with_new(box, params, default)
-        box.currentIndexChanged.connect(callback)
         layout.addWidget(box)
         self.verticalLayout.addLayout(layout)
+        return box
 
-    def addTextInput(self, title: str, callback: Callable, default_text: Optional[str] = ""):
+    def addTextInput(self, title: str, default_text: Optional[str] = "") -> QLineEdit:
         """Add a title and text box within the widget.
         :param title: The title of the text box to be added to the preferences panel.
-        :param callback: A callback method called when the combobox value is changed.
         :param default_text: An optional value to be put within the text box as a default. Defaults to an empty string.
+        :return: QLineEdit instance to allow subclasses to assign instance name
         """
         layout = self._createLayoutAndTitle(title)
         text_box = QLineEdit(self)
-        if default_text:
-            text_box.setText(default_text)
-        text_box.textChanged.connect(callback)
         layout.addWidget(text_box)
         self.verticalLayout.addLayout(layout)
+        return text_box
 
-    def addCheckBox(self, title: str, callback: Callable, checked: Optional[bool] = False):
+    def addCheckBox(self, title: str, checked: Optional[bool] = False) -> QCheckBox:
         """Add a title and check box within the widget.
         :param title: The title of the check box to be added to the preferences panel.
-        :param callback: A callback method called when the combobox value is changed.
         :param checked: An optional boolean value to specify if the check box is checked. Defaults to unchecked.
+        :return: QCheckBox instance to allow subclasses to assign instance name
         """
         layout = self._createLayoutAndTitle(title)
         check_box = QCheckBox(self)
         check_box.setChecked(checked)
-        check_box.toggled.connect(callback)
         layout.addWidget(check_box)
         self.verticalLayout.addLayout(layout)
+        return check_box
+
+    def addHorizontalLine(self):
+        """Add a horizontal line as a divider."""
+        self.verticalLayout.addWidget(QHLine())
+
+    def addHeaderText(self, text: str):
+        """Add a static text box to the widget, likely as a heading to separate options
+        :param text: The title of the check box to be added to the preferences panel.
+        """
+        label = QLabel()
+        label.setText(text)
+        self.verticalLayout.addWidget(label)

--- a/src/sas/qtgui/Utilities/Preferences/PreferencesWidget.py
+++ b/src/sas/qtgui/Utilities/Preferences/PreferencesWidget.py
@@ -54,6 +54,11 @@ class PreferencesWidget(QWidget):
             default = config.defaults.get(param)
             setattr(config, param, default)
 
+    def _stageChange(self, key, value):
+        """ All inputs should call this method when attempting to change config values. """
+        if self.parent is not None and hasattr(self.parent, 'stageSingleChange'):
+            self.parent.stageSingleChange(key, value)
+
     #############################################################
     # GUI Helper methods for widgets that don't have a UI element
 

--- a/src/sas/qtgui/Utilities/Preferences/PreferencesWidget.py
+++ b/src/sas/qtgui/Utilities/Preferences/PreferencesWidget.py
@@ -53,11 +53,27 @@ class PreferencesWidget(QWidget):
         for param in self.config_params:
             default = config.defaults.get(param)
             setattr(config, param, default)
+        self.restoreGUIValuesFromConfig()
 
-    def _stageChange(self, key, value):
+    def _stageChange(self, key: str, value: Union[str, bool, float, int, List]):
         """ All inputs should call this method when attempting to change config values. """
         if self.parent is not None and hasattr(self.parent, 'stageSingleChange'):
             self.parent.stageSingleChange(key, value)
+
+    def restoreGUIValuesFromConfig(self):
+        """A generic method that blocks all signalling, and restores the GUI values from the config file.
+        Called when staging is cancelled or defaults should be restored."""
+        self._toggleBlockAllSignaling(True)
+        self._restoreFromConfig()
+        self._toggleBlockAllSignaling(False)
+
+    def _restoreFromConfig(self):
+        """A pseudo-abstract class that children should override. Recalls all config values and restores the GUI. """
+        raise NotImplementedError(f"{self.name} has not implemented revertChanges.")
+
+    def _toggleBlockAllSignaling(self, toggle: bool):
+        """A pseudo-abstract class that children should override. Toggles signalling for all elements. """
+        raise NotImplementedError(f"{self.name} has not implemented _toggleBlockAllSignalling.")
 
     #############################################################
     # GUI Helper methods for widgets that don't have a UI element

--- a/src/sas/qtgui/Utilities/Preferences/PreferencesWidget.py
+++ b/src/sas/qtgui/Utilities/Preferences/PreferencesWidget.py
@@ -1,5 +1,6 @@
 import logging
 
+from PyQt5.QtGui import QIntValidator, QDoubleValidator
 from PyQt5.QtWidgets import QComboBox, QWidget, QLabel, QHBoxLayout, QVBoxLayout, QLineEdit, QCheckBox, QFrame
 from typing import Optional, List, Union
 
@@ -116,10 +117,30 @@ class PreferencesWidget(QWidget):
         layout = self._createLayoutAndTitle(title)
         text_box = QLineEdit(self)
         if default_text:
-            text_box.setText(default_text)
+            text_box.setText(str(default_text))
         layout.addWidget(text_box)
         self.verticalLayout.addLayout(layout)
         return text_box
+
+    def addIntegerInput(self, title: str, default_number: Optional[int] = 0) -> QLineEdit:
+        """Similar to the text input creator, this creates a text input with an integer validator assigned to it.
+        :param title: The title of the text box to be added to the preferences panel.
+        :param default_number: An optional value to be put within the text box as a default. Defaults to an empty string.
+        :return: QLineEdit instance to allow subclasses to assign instance name
+        """
+        int_box = self.addTextInput(title, str(default_number))
+        int_box.setValidator(QIntValidator())
+        return int_box
+
+    def addFloatInput(self, title: str, default_number: Optional[int] = 0) -> QLineEdit:
+        """Similar to the text input creator, this creates a text input with an float validator assigned to it.
+        :param title: The title of the text box to be added to the preferences panel.
+        :param default_number: An optional value to be put within the text box as a default. Defaults to an empty string.
+        :return: QLineEdit instance to allow subclasses to assign instance name
+        """
+        float_box = self.addTextInput(title, str(default_number))
+        float_box.setValidator(QDoubleValidator())
+        return float_box
 
     def addCheckBox(self, title: str, checked: Optional[bool] = False) -> QCheckBox:
         """Add a title and check box within the widget.

--- a/src/sas/qtgui/Utilities/Preferences/PreferencesWidget.py
+++ b/src/sas/qtgui/Utilities/Preferences/PreferencesWidget.py
@@ -99,6 +99,8 @@ class PreferencesWidget(QWidget):
         """
         layout = self._createLayoutAndTitle(title)
         text_box = QLineEdit(self)
+        if default_text:
+            text_box.setText(default_text)
         layout.addWidget(text_box)
         self.verticalLayout.addLayout(layout)
         return text_box

--- a/src/sas/qtgui/Utilities/Preferences/UI/PreferencesUI.ui
+++ b/src/sas/qtgui/Utilities/Preferences/UI/PreferencesUI.ui
@@ -47,7 +47,7 @@
         </size>
        </property>
        <property name="currentRow">
-        <number>0</number>
+        <number>-1</number>
        </property>
       </widget>
      </item>
@@ -74,7 +74,7 @@
           <number>1</number>
          </property>
          <property name="currentIndex">
-          <number>0</number>
+          <number>-1</number>
          </property>
         </widget>
        </item>
@@ -88,7 +88,7 @@
       <enum>Qt::Horizontal</enum>
      </property>
      <property name="standardButtons">
-      <set>QDialogButtonBox::Help|QDialogButtonBox::Ok|QDialogButtonBox::RestoreDefaults</set>
+      <set>QDialogButtonBox::Apply|QDialogButtonBox::Cancel|QDialogButtonBox::Help|QDialogButtonBox::Ok|QDialogButtonBox::RestoreDefaults</set>
      </property>
     </widget>
    </item>

--- a/src/sas/qtgui/Utilities/Preferences/UnitTesting/PreferencesPanelTest.py
+++ b/src/sas/qtgui/Utilities/Preferences/UnitTesting/PreferencesPanelTest.py
@@ -1,10 +1,23 @@
-import os
 import pytest
 from PyQt5.QtWidgets import QWidget, QLineEdit, QComboBox, QCheckBox
 
 from sas.qtgui.Plotting.PlotterData import Data1D
 from sas.qtgui.Utilities.Preferences.PreferencesPanel import PreferencesPanel
 from sas.qtgui.Utilities.Preferences.PreferencesWidget import PreferencesWidget
+
+
+class DummyPrefWidget(PreferencesWidget):
+    def __init__(self, name):
+        super(DummyPrefWidget, self).__init__(name)
+
+    def _restoreFromConfig(self):
+        pass
+
+    def _toggleBlockAllSignaling(self):
+        pass
+
+    def _addAllWidgets(self):
+        pass
 
 
 class PreferencesPanelTest:
@@ -46,7 +59,7 @@ class PreferencesPanelTest:
     def testPreferencesExtensibility(self, widget):
         """Test ability to add and remove items from the listWidget and stackedWidget"""
         # Create fake PreferencesWidget, add to stacked widget, and add item to list widget
-        new_widget = PreferencesWidget("Fake Widget")
+        new_widget = DummyPrefWidget("Fake Widget")
         starting_size = widget.stackedWidget.count()
         widget.addWidget(new_widget)
         # Ensure stacked widget and list widget have the same number of elements
@@ -57,9 +70,9 @@ class PreferencesPanelTest:
         assert widget.stackedWidget.currentIndex() == widget.listWidget.currentRow()
 
     def testHelp(self, widget, mocker):
-        mocker.patch.object(widget, 'onClick')
+        mocker.patch.object(widget, 'close')
         widget.buttonBox.buttons()[0].click()
-        assert widget.onClick.called_once()
+        assert widget.close.called_once()
 
     def testPreferencesWidget(self, widget, mocker):
         mocker.patch.object(widget, 'checked', create=True)
@@ -67,10 +80,10 @@ class PreferencesPanelTest:
         mocker.patch.object(widget, 'textified', create=True)
         mocker.patch.object(widget, 'resetPref', create=True)
 
-        pref = PreferencesWidget("Dummy Widget", widget.resetPref)
-        pref.addTextInput("blah", widget.textified)
-        pref.addCheckBox("ho hum", widget.checked)
-        pref.addComboBox("combo", ["a", "b", "c"], widget.combo, "a")
+        pref = DummyPrefWidget("Dummy Widget")
+        pref.addTextInput("blah")
+        pref.addCheckBox("ho hum")
+        pref.addComboBox("combo", ["a", "b", "c"], "a")
 
         widget.addWidget(pref)
 
@@ -88,4 +101,3 @@ class PreferencesPanelTest:
         assert widget.textified.called_once()
         assert widget.combo.called_once()
         assert widget.checked.called_once()
-

--- a/src/sas/system/config/config_meta.py
+++ b/src/sas/system/config/config_meta.py
@@ -192,6 +192,7 @@ class ConfigBase:
             if key not in self.__dict__:
                 raise ConfigLocked("New attribute attempt")
 
-        super().__setattr__(key, value)
-
-
+        if self._schema[key].validate(key):
+            super().__setattr__(key, value)
+        else:
+            raise TypeError(f"Tried to set bad value '{value}' to config entry of type '{self._schema[key]}'")

--- a/src/sas/system/config/config_meta.py
+++ b/src/sas/system/config/config_meta.py
@@ -48,6 +48,11 @@ class ConfigBase:
                                  "_deleted_attributes", "_meta_attributes",
                                  "_bad_entries"]
 
+    @property
+    def defaults(self):
+        """ Expose the default values to allow resetting of defaults. No setter should ever be created for this! """
+        return self._defaults
+
     def config_filename(self, create_if_nonexistent=False):
         """Filename for saving config items"""
         version_parts = sas.system.version.__version__.split(".")

--- a/src/sas/system/config/schema_elements.py
+++ b/src/sas/system/config/schema_elements.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from typing import Optional, List
+from typing import Optional, List, Any
 import logging
 
 
@@ -25,6 +25,15 @@ class SchemaElement(ABC):
     def coerce(self, value):
         """ Force a variable to conform to the schema, if possible"""
         pass
+
+    def validate(self, value: Any) -> bool:
+        """ Return true if value is valid according to the schema"""
+        try:
+            self.coerce(value)
+            return True
+
+        except CoercionError:
+            return False
 
     def __eq__(self, value):
         return False

--- a/src/sas/system/config/schema_elements.py
+++ b/src/sas/system/config/schema_elements.py
@@ -83,7 +83,7 @@ class SchemaFloat(SchemaVariable):
         if isinstance(value, (int, float)):
             return float(value)
         else:
-            raise CoercionError(f"Cannot coerce {type(value)} to bool")
+            raise CoercionError(f"Cannot coerce {type(value)} to float")
 
 
 class SchemaStr(SchemaVariable):


### PR DESCRIPTION
## Description

This hopes to combine parts of what was done in #2306 and #2321, specifically related to formalizing the preferences panel and widget class structures.

As asked for in #2316, the following has been added to this PR:
- Settings are staged in the preferences panel until they are accepted and only then is the config updated (using the OK or Apply buttons)
- All staged changes are discarded if they are rejected (using the Close button or X)
- Restore defaults resets the active widget to the default values as read in from the configuration
- Added 'Cancel' and 'Apply' buttons
- Updated the help documentation to include expected behaviors and information on specific

Fixes #2312
Fixes #2313

## How Has This Been Tested?

- Unit tests that are in this PR
- From `run.py`:
  - Open preferences, modify settings, click Cancel, open preferences, and be sure previous changes are gone
  - Open preferences, modify settings, click X, open preferences, and be sure previous changes are gone
  - Open preferences, modify settings, click Ok, open preferences, and be sure previous changes are persistent
  - Open preferences, modify settings, click Apply, click Close and/or X, open preferences, and be sure previous changes are persistent
  - Open preferences, modify settings, click Apply, click Close and/or X, open preferences, click Restore Defaults, and be sure values reset to defaults

## Review Checklist (please remove items if they don't apply):

- [x] Code has been reviewed
- [x] Functionality has been tested
- [ ] Windows installer (GH artifact) has been tested (installed and worked) 
- [x] MacOSX installer (GH artifact) has been tested (installed and worked) 
- [ ] User documentation is available and complete (if required)
- [x] Developers documentation is available and complete (if required)
- [x] The introduced changes comply with SasView license (BSD 3-Clause)

