### PR TITLE
Re-add rc file to MainWindow.py

### DIFF
--- a/src/sas/qtgui/MainWindow/MainWindow.py
+++ b/src/sas/qtgui/MainWindow/MainWindow.py
@@ -15,6 +15,7 @@ from PyQt5.QtGui import QPixmap
 from PyQt5.QtCore import Qt, QTimer
 
 # Local UI
+from sas.qtgui.UI import main_resources_rc
 from .UI.MainWindowUI import Ui_SasView
 
 class MainSasViewWindow(QMainWindow, Ui_SasView):


### PR DESCRIPTION
## Description

Re-add the resources (rc) for the MainWindow which was incorrectly removed in 11a1ef2fb231d6b1c0b456bb998b63616f806dff. Without it, there are no icons in the main toolbar, the main window icon or the sub-window icons. 

Closes: #2363

## Review Checklist 

- [X] Code has been reviewed
- [X] Functionality has been tested
- [X] Windows installer (GH artifact) has been tested (installed and worked) 
- [x] MacOSX installer (GH artifact) has been tested (installed and worked) 
- [X] The introduced changes comply with SasView license (BSD 3-Clause)

