### PR TITLE
2350: Close the BUMPS/DREAM results panel when data is deleted

### DIFF
--- a/src/sas/qtgui/MainWindow/DataExplorer.py
+++ b/src/sas/qtgui/MainWindow/DataExplorer.py
@@ -696,6 +696,11 @@ class DataExplorerWindow(DroppableDataLoadWidget):
 
                 # Delete corresponding open plots
                 self.closePlotsForItem(item)
+                # Close result panel if results represent the deleted data item
+                # Results panel only stores Data1D/Data2D object
+                #   => QStandardItems must still exist for direct comparison
+                self.closeResultPanelOnDelete(item)
+
 
                 self.model.removeRow(ind)
                 # Decrement index since we just deleted it
@@ -1904,6 +1909,13 @@ class DataExplorerWindow(DroppableDataLoadWidget):
                         logging.error("Closing of %s failed:\n %s" % (plot_name, str(ex)))
 
         pass  # debugger anchor
+
+    def closeResultPanelOnDelete(self, items):
+        """
+        Given a standard item, close the fitting results panel if currently populated with item
+        """
+        # items - List[HashableStandardItem] of deleted data items
+        self.parent.results_panel.dataDeleted(items)
 
     def onAnalysisUpdate(self, new_perspective_name: str):
         """

--- a/src/sas/qtgui/MainWindow/DataExplorer.py
+++ b/src/sas/qtgui/MainWindow/DataExplorer.py
@@ -699,8 +699,7 @@ class DataExplorerWindow(DroppableDataLoadWidget):
                 # Close result panel if results represent the deleted data item
                 # Results panel only stores Data1D/Data2D object
                 #   => QStandardItems must still exist for direct comparison
-                self.closeResultPanelOnDelete(item)
-
+                self.closeResultPanelOnDelete(GuiUtils.dataFromItem(item))
 
                 self.model.removeRow(ind)
                 # Decrement index since we just deleted it
@@ -1910,12 +1909,12 @@ class DataExplorerWindow(DroppableDataLoadWidget):
 
         pass  # debugger anchor
 
-    def closeResultPanelOnDelete(self, items):
+    def closeResultPanelOnDelete(self, data):
         """
         Given a standard item, close the fitting results panel if currently populated with item
         """
         # items - List[HashableStandardItem] of deleted data items
-        self.parent.results_panel.dataDeleted(items)
+        self.parent.results_panel.dataDeleted(data)
 
     def onAnalysisUpdate(self, new_perspective_name: str):
         """

--- a/src/sas/qtgui/MainWindow/DataExplorer.py
+++ b/src/sas/qtgui/MainWindow/DataExplorer.py
@@ -1911,10 +1911,10 @@ class DataExplorerWindow(DroppableDataLoadWidget):
 
     def closeResultPanelOnDelete(self, data):
         """
-        Given a standard item, close the fitting results panel if currently populated with item
+        Given a data1d/2d object, close the fitting results panel if currently populated with the data
         """
-        # items - List[HashableStandardItem] of deleted data items
-        self.parent.results_panel.dataDeleted(data)
+        # data - Single data1d/2d object to be deleted
+        self.parent.results_panel.onDataDeleted(data)
 
     def onAnalysisUpdate(self, new_perspective_name: str):
         """

--- a/src/sas/qtgui/Utilities/ResultPanel.py
+++ b/src/sas/qtgui/Utilities/ResultPanel.py
@@ -56,13 +56,7 @@ class ResultPanel(QtWidgets.QTabWidget):
     def onPlotResults(self, results, optimizer="Unknown"):
         # import moved here due to its cost
         from bumps.dream.stats import var_stats, format_vars
-        # Clear up previous results
-        for view in (self.convergenceView, self.correlationView,
-                     self.uncertaintyView, self.traceView):
-            view.close()
-        # close all tabs. REMEMBER TO USE REVERSED RANGE!!!
-        for index in reversed(range(self.count())):
-            self.removeTab(index)
+        self.clearAnyData()
 
         result = results[0][0]
         name = result.data.sas_data.name
@@ -97,11 +91,25 @@ class ResultPanel(QtWidgets.QTabWidget):
         if self.count()==0:
             self.close()
 
-    def dataDeleted(self, data):
+    def onDataDeleted(self, data):
+        """ Check if the data set is shown in the window and close tabs as needed. """
         if not data or not self.isVisible():
             return
         if data.id == self.data_id:
+            self.setWindowTitle(self.window_name)
+            self.clearAnyData()
             self.close()
+
+    def clearAnyData(self):
+        """ Clear any previous results and reset window to its base state. """
+        self.data_id = None
+        # Clear up previous results
+        for view in (self.convergenceView, self.correlationView,
+                     self.uncertaintyView, self.traceView):
+            view.close()
+        # close all tabs. REMEMBER TO USE REVERSED RANGE!!!
+        for index in reversed(range(self.count())):
+            self.removeTab(index)
 
     def closeEvent(self, event):
         """

--- a/src/sas/qtgui/Utilities/ResultPanel.py
+++ b/src/sas/qtgui/Utilities/ResultPanel.py
@@ -9,6 +9,9 @@ from PyQt5 import QtCore
 from PyQt5 import QtGui
 from PyQt5 import QtWidgets
 
+from .GuiUtils import dataFromItem
+
+
 class ResultPanel(QtWidgets.QTabWidget):
     """
     FitPanel class contains fields allowing to fit  models and  data
@@ -28,6 +31,7 @@ class ResultPanel(QtWidgets.QTabWidget):
         self.manager = manager
         self.communicator = self.manager.communicator()
         self.setMinimumSize(400, 400)
+        self.data_id = None
 
         self.updateBumps() # patch bumps ## TEMPORARY ##
 
@@ -63,9 +67,10 @@ class ResultPanel(QtWidgets.QTabWidget):
             self.removeTab(index)
 
         result = results[0][0]
-        filename = result.data.sas_data.filename
+        name = result.data.sas_data.name
         current_optimizer = optimizer
-        self.setWindowTitle(self.window_name + " - " + filename + " - " + current_optimizer)
+        self.data_id = result.data.sas_data.id
+        self.setWindowTitle(self.window_name + " - " + name + " - " + current_optimizer)
         if hasattr(result, 'convergence') and len(result.convergence) > 0:
             best, pop = result.convergence[:, 0], result.convergence[:, 1:]
             self.convergenceView.update(best, pop)
@@ -92,6 +97,13 @@ class ResultPanel(QtWidgets.QTabWidget):
                 view.close()
         # no tabs in the widget - possibly LM optimizer. Mark "closed"
         if self.count()==0:
+            self.close()
+
+    def dataDeleted(self, item):
+        if not item or not self.isVisible():
+            return
+        data = dataFromItem(item)
+        if data.id == self.data_id:
             self.close()
 
     def closeEvent(self, event):

--- a/src/sas/qtgui/Utilities/ResultPanel.py
+++ b/src/sas/qtgui/Utilities/ResultPanel.py
@@ -9,8 +9,6 @@ from PyQt5 import QtCore
 from PyQt5 import QtGui
 from PyQt5 import QtWidgets
 
-from .GuiUtils import dataFromItem
-
 
 class ResultPanel(QtWidgets.QTabWidget):
     """
@@ -99,10 +97,9 @@ class ResultPanel(QtWidgets.QTabWidget):
         if self.count()==0:
             self.close()
 
-    def dataDeleted(self, item):
-        if not item or not self.isVisible():
+    def dataDeleted(self, data):
+        if not data or not self.isVisible():
             return
-        data = dataFromItem(item)
         if data.id == self.data_id:
             self.close()
 


### PR DESCRIPTION
## Description

The Bumps convergence window now closes when the data it shows is deleted. This also updates the results panel title to show the same name as the data explorer and fit panel.

Fixes #2350

## How Has This Been Tested?

Steps I followed:

- Loaded a data set
- Sent to fit and ran fit using LM
- Verified convergence window is displayed
- Deleted data set and verified convergence window no longer shown
- Loaded three data sets (data1, data2, and data3)
- Sent data1 and data2 to fitting
- Fit data1 using LM and verified convergence window is displayed for data1
- Fit data2 using LM and verified convergence window is displayed for data2
- Delete data1 and verified the convergence window still displays data2
- Delete data3 and verified the convergence window still displays data2
- Delete data2 and verified convergence window no longer shown

## Review Checklist (please remove items if they don't apply):

- [x] Code has been reviewed
- [x] Functionality has been tested
- [x] Windows installer (GH artifact) has been tested (installed and worked) 
- [ ] MacOSX installer (GH artifact) has been tested (installed and worked)
- [ ] Developers documentation is available and complete (if required)
- [x] The introduced changes comply with SasView license (BSD 3-Clause)

