### PR TITLE
Replaced requirements list with install -r requirements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,12 +84,12 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install wheel setuptools
-
-          python -m pip install numpy scipy==1.7.3 pytest pytest-mock pytest_qt
-          python -m pip install tinycc h5py pyparsing html5lib reportlab==3.6.6 pybind11 appdirs
-          python -m pip install six numba mako ipython qtconsole xhtml2pdf pylint debugpy
-          python -m pip install qt5reactor periodictable uncertainties dominate importlib_resources
-          python -m pip install html2text superqt
+#          python -m pip install numpy scipy==1.7.3 pytest pytest-mock pytest_qt
+#          python -m pip install tinycc h5py pyparsing html5lib reportlab==3.6.6 pybind11 appdirs
+#          python -m pip install six numba mako ipython qtconsole xhtml2pdf pylint debugpy
+#          python -m pip install qt5reactor periodictable uncertainties dominate importlib_resources
+#          python -m pip install html2text superqt
+          python -m pip install -r build_tools/requirements.txt
 
       - name: Install PyQt (Windows + Linux)
         if: ${{ !startsWith(matrix.os, 'macos') }}


### PR DESCRIPTION
Just read requirements.txt instead of having a separate list of requirements in `ci.yml`.