### PR TITLE
2385 incosistent tabbing order across the widgets

### DIFF
--- a/src/sas/qtgui/Calculators/KiessigPanel.py
+++ b/src/sas/qtgui/Calculators/KiessigPanel.py
@@ -27,13 +27,9 @@ class KiessigPanel(QtWidgets.QDialog, Ui_KiessigPanel):
 
         # signals
         self.helpButton.clicked.connect(self.onHelp)
-        # self.computeButton.setVisible(False)
         self.closeButton.clicked.connect(self.onClose)
         self.deltaq_in.textChanged.connect(self.onCompute)
         self.deltaq_in.setText("0.05")
-
-        # Set focus away from Close
-        # self.computeButton.setFocus()
 
         # no reason to have this widget resizable
         self.setFixedSize(self.minimumSizeHint())

--- a/src/sas/qtgui/Calculators/KiessigPanel.py
+++ b/src/sas/qtgui/Calculators/KiessigPanel.py
@@ -27,13 +27,13 @@ class KiessigPanel(QtWidgets.QDialog, Ui_KiessigPanel):
 
         # signals
         self.helpButton.clicked.connect(self.onHelp)
-        self.computeButton.setVisible(False)
+        # self.computeButton.setVisible(False)
         self.closeButton.clicked.connect(self.onClose)
         self.deltaq_in.textChanged.connect(self.onCompute)
         self.deltaq_in.setText("0.05")
 
         # Set focus away from Close
-        self.computeButton.setFocus()
+        # self.computeButton.setFocus()
 
         # no reason to have this widget resizable
         self.setFixedSize(self.minimumSizeHint())

--- a/src/sas/qtgui/Calculators/UI/DataOperationUtilityUI.ui
+++ b/src/sas/qtgui/Calculators/UI/DataOperationUtilityUI.ui
@@ -477,6 +477,20 @@ Append(Combine): |</string>
    </item>
   </layout>
  </widget>
+ <tabstops>
+  <tabstop>txtOutputData</tabstop>
+  <tabstop>cbData1</tabstop>
+  <tabstop>cbOperator</tabstop>
+  <tabstop>cbData2</tabstop>
+  <tabstop>txtNumber</tabstop>
+  <tabstop>graphOutput</tabstop>
+  <tabstop>graphData1</tabstop>
+  <tabstop>graphData2</tabstop>
+  <tabstop>cmdReset</tabstop>
+  <tabstop>cmdCompute</tabstop>
+  <tabstop>cmdClose</tabstop>
+  <tabstop>cmdHelp</tabstop>
+ </tabstops>
  <resources/>
  <connections/>
 </ui>

--- a/src/sas/qtgui/Calculators/UI/DataOperationUtilityUI.ui
+++ b/src/sas/qtgui/Calculators/UI/DataOperationUtilityUI.ui
@@ -119,6 +119,9 @@
             <height>300</height>
            </size>
           </property>
+          <property name="focusPolicy">
+           <enum>Qt::NoFocus</enum>
+          </property>
          </widget>
         </item>
         <item row="1" column="4">
@@ -216,6 +219,9 @@
             <width>300</width>
             <height>300</height>
            </size>
+          </property>
+          <property name="focusPolicy">
+           <enum>Qt::NoFocus</enum>
           </property>
          </widget>
         </item>
@@ -377,6 +383,9 @@ Append(Combine): |</string>
             <width>300</width>
             <height>300</height>
            </size>
+          </property>
+          <property name="focusPolicy">
+           <enum>Qt::NoFocus</enum>
           </property>
          </widget>
         </item>

--- a/src/sas/qtgui/Calculators/UI/DensityPanel.ui
+++ b/src/sas/qtgui/Calculators/UI/DensityPanel.ui
@@ -47,6 +47,9 @@
          <height>21</height>
         </size>
        </property>
+       <property name="focusPolicy">
+        <enum>Qt::StrongFocus</enum>
+       </property>
       </widget>
      </item>
      <item row="0" column="2">
@@ -76,6 +79,9 @@
          <width>61</width>
          <height>21</height>
         </size>
+       </property>
+       <property name="focusPolicy">
+        <enum>Qt::StrongFocus</enum>
        </property>
        <property name="styleSheet">
         <string notr="true"/>
@@ -135,6 +141,9 @@
          <height>21</height>
         </size>
        </property>
+       <property name="focusPolicy">
+        <enum>Qt::StrongFocus</enum>
+       </property>
       </widget>
      </item>
      <item row="3" column="2">
@@ -164,6 +173,9 @@
          <width>61</width>
          <height>21</height>
         </size>
+       </property>
+       <property name="focusPolicy">
+        <enum>Qt::StrongFocus</enum>
        </property>
       </widget>
      </item>
@@ -200,6 +212,9 @@
        <verstretch>0</verstretch>
       </sizepolicy>
      </property>
+     <property name="focusPolicy">
+      <enum>Qt::StrongFocus</enum>
+     </property>
      <property name="orientation">
       <enum>Qt::Horizontal</enum>
      </property>
@@ -218,6 +233,7 @@
   <tabstop>editMolarMass</tabstop>
   <tabstop>editMolarVolume</tabstop>
   <tabstop>editMassDensity</tabstop>
+  <tabstop>buttonBox</tabstop>
  </tabstops>
  <resources/>
  <connections>

--- a/src/sas/qtgui/Calculators/UI/DensityPanel.ui
+++ b/src/sas/qtgui/Calculators/UI/DensityPanel.ui
@@ -218,7 +218,6 @@
   <tabstop>editMolarMass</tabstop>
   <tabstop>editMolarVolume</tabstop>
   <tabstop>editMassDensity</tabstop>
-  <tabstop>buttonBox</tabstop>
  </tabstops>
  <resources/>
  <connections>

--- a/src/sas/qtgui/Calculators/UI/GenericScatteringCalculator.ui
+++ b/src/sas/qtgui/Calculators/UI/GenericScatteringCalculator.ui
@@ -36,7 +36,7 @@
     <normaloff>:/res/ball.ico</normaloff>:/res/ball.ico</iconset>
   </property>
   <layout class="QGridLayout" name="gridLayout_12">
-   <item row="0" column="0" rowspan="1" colspan="2">
+   <item row="0" column="0" colspan="2">
     <widget class="QGroupBox" name="groupBox_Datafile">
      <property name="font">
       <font>
@@ -69,7 +69,7 @@
         <item row="0" column="1">
          <widget class="QCheckBox" name="checkboxNucData">
           <property name="text">
-           <string></string>
+           <string/>
           </property>
          </widget>
         </item>
@@ -151,7 +151,7 @@
         <item row="1" column="1">
          <widget class="QCheckBox" name="checkboxMagData">
           <property name="text">
-           <string></string>
+           <string/>
           </property>
          </widget>
         </item>
@@ -920,7 +920,6 @@ Not editable.</string>
      <zorder>groupBox_5</zorder>
      <zorder>groupBox_6</zorder>
      <zorder>groupBox_Stepsize</zorder>
-     <zorder>verticalSpacer_2</zorder>
     </widget>
    </item>
    <item row="1" column="2">
@@ -962,7 +961,7 @@ Not editable.</string>
      </property>
      <layout class="QGridLayout" name="gridLayout_6">
       <item row="0" column="0">
-       <layout class="QGridLayout" name="gridLayout_InputParam" rowstretch="0,0,0,0,0,0,0,0" rowminimumheight="0,0,0,0,0,0,0,0">
+       <layout class="QGridLayout" name="gridLayout_InputParam" rowstretch="0,0,0,0,0,0,0,0,0" rowminimumheight="0,0,0,0,0,0,0,0,0">
         <property name="sizeConstraint">
          <enum>QLayout::SetMinimumSize</enum>
         </property>
@@ -1522,159 +1521,159 @@ Number of Qbins &amp;isin; [2, 1000].</string>
          <string>Environment Coordinates (uvw)</string>
         </property>
         <layout class="QGridLayout" name="gridLayout_14">
-          <item row="0" column="0">
-           <widget class="QLabel" name="lblEnvYaw">
-            <property name="font">
-             <font>
-              <weight>50</weight>
-              <bold>false</bold>
-             </font>
-            </property>
-            <property name="toolTip">
-             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The yaw angle of the environment coordinates from the beamline coordinates.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-            </property>
-            <property name="text">
-             <string>Yaw</string>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="1">
-           <widget class="QLineEdit" name="txtEnvYaw">
-            <property name="minimumSize">
-             <size>
-              <width>0</width>
-              <height>18</height>
-             </size>
-            </property>
-            <property name="font">
-             <font>
-              <weight>50</weight>
-              <bold>false</bold>
-             </font>
-            </property>
-            <property name="toolTip">
-             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The yaw angle of the environment coordinates from the beamline coordinates.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-            </property>
-            <property name="text">
-             <string>0.0</string>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="2">
-           <widget class="QLabel" name="lblEnvYawUnit">
-            <property name="font">
-             <font>
-              <weight>50</weight>
-              <bold>false</bold>
-             </font>
-            </property>
-            <property name="text">
-             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; vertical-align:super;&quot;&gt;o&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="0">
-           <widget class="QLabel" name="lblEnvPitch">
-            <property name="font">
-             <font>
-              <weight>50</weight>
-              <bold>false</bold>
-             </font>
-            </property>
-            <property name="toolTip">
-             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The pitch angle of the environment coordinates from the beamline coordinates.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-            </property>
-            <property name="text">
-             <string>Pitch</string>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="1">
-           <widget class="QLineEdit" name="txtEnvPitch">
-            <property name="minimumSize">
-             <size>
-              <width>0</width>
-              <height>18</height>
-             </size>
-            </property>
-            <property name="font">
-             <font>
-              <weight>50</weight>
-              <bold>false</bold>
-             </font>
-            </property>
-            <property name="toolTip">
-             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The pitch angle of the environment coordinates from the beamline coordinates.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-            </property>
-            <property name="text">
-             <string>0.0</string>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="2">
-           <widget class="QLabel" name="lblEnvPitchUnit">
-            <property name="font">
-             <font>
-              <weight>50</weight>
-              <bold>false</bold>
-             </font>
-            </property>
-            <property name="text">
-             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; vertical-align:super;&quot;&gt;o&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-            </property>
-           </widget>
-          </item>
-          <item row="2" column="0">
-           <widget class="QLabel" name="lblEnvRoll">
-            <property name="font">
-             <font>
-              <weight>50</weight>
-              <bold>false</bold>
-             </font>
-            </property>
-            <property name="toolTip">
-             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The roll angle of the environment coordinates from the beamline coordinates.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-            </property>
-            <property name="text">
-             <string>Roll</string>
-            </property>
-           </widget>
-          </item>
-          <item row="2" column="1">
-           <widget class="QLineEdit" name="txtEnvRoll">
-            <property name="minimumSize">
-             <size>
-              <width>0</width>
-              <height>18</height>
-             </size>
-            </property>
-            <property name="font">
-             <font>
-              <weight>50</weight>
-              <bold>false</bold>
-             </font>
-            </property>
-            <property name="toolTip">
-             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The roll angle of the environment coordinates from the beamline coordinates.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-            </property>
-            <property name="text">
-             <string>0.0</string>
-            </property>
-           </widget>
-          </item>
-          <item row="2" column="2">
-           <widget class="QLabel" name="lblEnvRollUnit">
-            <property name="font">
-             <font>
-              <weight>50</weight>
-              <bold>false</bold>
-             </font>
-            </property>
-            <property name="text">
-             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; vertical-align:super;&quot;&gt;o&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-            </property>
-           </widget>
-          </item>
+         <item row="0" column="0">
+          <widget class="QLabel" name="lblEnvYaw">
+           <property name="font">
+            <font>
+             <weight>50</weight>
+             <bold>false</bold>
+            </font>
+           </property>
+           <property name="toolTip">
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The yaw angle of the environment coordinates from the beamline coordinates.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+           </property>
+           <property name="text">
+            <string>Yaw</string>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="1">
+          <widget class="QLineEdit" name="txtEnvYaw">
+           <property name="minimumSize">
+            <size>
+             <width>0</width>
+             <height>18</height>
+            </size>
+           </property>
+           <property name="font">
+            <font>
+             <weight>50</weight>
+             <bold>false</bold>
+            </font>
+           </property>
+           <property name="toolTip">
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The yaw angle of the environment coordinates from the beamline coordinates.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+           </property>
+           <property name="text">
+            <string>0.0</string>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="2">
+          <widget class="QLabel" name="lblEnvYawUnit">
+           <property name="font">
+            <font>
+             <weight>50</weight>
+             <bold>false</bold>
+            </font>
+           </property>
+           <property name="text">
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; vertical-align:super;&quot;&gt;o&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="0">
+          <widget class="QLabel" name="lblEnvPitch">
+           <property name="font">
+            <font>
+             <weight>50</weight>
+             <bold>false</bold>
+            </font>
+           </property>
+           <property name="toolTip">
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The pitch angle of the environment coordinates from the beamline coordinates.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+           </property>
+           <property name="text">
+            <string>Pitch</string>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="1">
+          <widget class="QLineEdit" name="txtEnvPitch">
+           <property name="minimumSize">
+            <size>
+             <width>0</width>
+             <height>18</height>
+            </size>
+           </property>
+           <property name="font">
+            <font>
+             <weight>50</weight>
+             <bold>false</bold>
+            </font>
+           </property>
+           <property name="toolTip">
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The pitch angle of the environment coordinates from the beamline coordinates.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+           </property>
+           <property name="text">
+            <string>0.0</string>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="2">
+          <widget class="QLabel" name="lblEnvPitchUnit">
+           <property name="font">
+            <font>
+             <weight>50</weight>
+             <bold>false</bold>
+            </font>
+           </property>
+           <property name="text">
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; vertical-align:super;&quot;&gt;o&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="0">
+          <widget class="QLabel" name="lblEnvRoll">
+           <property name="font">
+            <font>
+             <weight>50</weight>
+             <bold>false</bold>
+            </font>
+           </property>
+           <property name="toolTip">
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The roll angle of the environment coordinates from the beamline coordinates.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+           </property>
+           <property name="text">
+            <string>Roll</string>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="1">
+          <widget class="QLineEdit" name="txtEnvRoll">
+           <property name="minimumSize">
+            <size>
+             <width>0</width>
+             <height>18</height>
+            </size>
+           </property>
+           <property name="font">
+            <font>
+             <weight>50</weight>
+             <bold>false</bold>
+            </font>
+           </property>
+           <property name="toolTip">
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The roll angle of the environment coordinates from the beamline coordinates.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+           </property>
+           <property name="text">
+            <string>0.0</string>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="2">
+          <widget class="QLabel" name="lblEnvRollUnit">
+           <property name="font">
+            <font>
+             <weight>50</weight>
+             <bold>false</bold>
+            </font>
+           </property>
+           <property name="text">
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; vertical-align:super;&quot;&gt;o&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+           </property>
+          </widget>
+         </item>
         </layout>
        </widget>
       </item>
@@ -1690,159 +1689,159 @@ Number of Qbins &amp;isin; [2, 1000].</string>
          <string>Sample Coordinates (xyz)</string>
         </property>
         <layout class="QGridLayout" name="gridLayout_14">
-          <item row="0" column="0">
-           <widget class="QLabel" name="lblSampleYaw">
-            <property name="font">
-             <font>
-              <weight>50</weight>
-              <bold>false</bold>
-             </font>
-            </property>
-            <property name="toolTip">
-             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The yaw angle of the sample coordinates from the environment coordinates.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-            </property>
-            <property name="text">
-             <string>Yaw</string>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="1">
-           <widget class="QLineEdit" name="txtSampleYaw">
-            <property name="minimumSize">
-             <size>
-              <width>0</width>
-              <height>18</height>
-             </size>
-            </property>
-            <property name="font">
-             <font>
-              <weight>50</weight>
-              <bold>false</bold>
-             </font>
-            </property>
-            <property name="toolTip">
-             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The yaw angle of the sample coordinates from the environment coordinates.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-            </property>
-            <property name="text">
-             <string>0.0</string>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="2">
-           <widget class="QLabel" name="lblSampleYawUnit">
-            <property name="font">
-             <font>
-              <weight>50</weight>
-              <bold>false</bold>
-             </font>
-            </property>
-            <property name="text">
-             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; vertical-align:super;&quot;&gt;o&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="0">
-           <widget class="QLabel" name="lblSamplePitch">
-            <property name="font">
-             <font>
-              <weight>50</weight>
-              <bold>false</bold>
-             </font>
-            </property>
-            <property name="toolTip">
-             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The pitch angle of the sample coordinates from the environment coordinates.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-            </property>
-            <property name="text">
-             <string>Pitch</string>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="1">
-           <widget class="QLineEdit" name="txtSamplePitch">
-            <property name="minimumSize">
-             <size>
-              <width>0</width>
-              <height>18</height>
-             </size>
-            </property>
-            <property name="font">
-             <font>
-              <weight>50</weight>
-              <bold>false</bold>
-             </font>
-            </property>
-            <property name="toolTip">
-             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The pitch angle of the sample coordinates from the environment coordinates.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-            </property>
-            <property name="text">
-             <string>0.0</string>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="2">
-           <widget class="QLabel" name="lblSamplePitchUnit">
-            <property name="font">
-             <font>
-              <weight>50</weight>
-              <bold>false</bold>
-             </font>
-            </property>
-            <property name="text">
-             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; vertical-align:super;&quot;&gt;o&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-            </property>
-           </widget>
-          </item>
-          <item row="2" column="0">
-           <widget class="QLabel" name="lblSampleRoll">
-            <property name="font">
-             <font>
-              <weight>50</weight>
-              <bold>false</bold>
-             </font>
-            </property>
-            <property name="toolTip">
-             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The roll angle of the sample coordinates from the environment coordinates.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-            </property>
-            <property name="text">
-             <string>Roll</string>
-            </property>
-           </widget>
-          </item>
-          <item row="2" column="1">
-           <widget class="QLineEdit" name="txtSampleRoll">
-            <property name="minimumSize">
-             <size>
-              <width>0</width>
-              <height>18</height>
-             </size>
-            </property>
-            <property name="font">
-             <font>
-              <weight>50</weight>
-              <bold>false</bold>
-             </font>
-            </property>
-            <property name="toolTip">
-             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The roll angle of the sample coordinates from the enivronment coordinates.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-            </property>
-            <property name="text">
-             <string>0.0</string>
-            </property>
-           </widget>
-          </item>
-          <item row="2" column="2">
-           <widget class="QLabel" name="lblSampleRollUnit">
-            <property name="font">
-             <font>
-              <weight>50</weight>
-              <bold>false</bold>
-             </font>
-            </property>
-            <property name="text">
-             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; vertical-align:super;&quot;&gt;o&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-            </property>
-           </widget>
-          </item>
+         <item row="0" column="0">
+          <widget class="QLabel" name="lblSampleYaw">
+           <property name="font">
+            <font>
+             <weight>50</weight>
+             <bold>false</bold>
+            </font>
+           </property>
+           <property name="toolTip">
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The yaw angle of the sample coordinates from the environment coordinates.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+           </property>
+           <property name="text">
+            <string>Yaw</string>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="1">
+          <widget class="QLineEdit" name="txtSampleYaw">
+           <property name="minimumSize">
+            <size>
+             <width>0</width>
+             <height>18</height>
+            </size>
+           </property>
+           <property name="font">
+            <font>
+             <weight>50</weight>
+             <bold>false</bold>
+            </font>
+           </property>
+           <property name="toolTip">
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The yaw angle of the sample coordinates from the environment coordinates.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+           </property>
+           <property name="text">
+            <string>0.0</string>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="2">
+          <widget class="QLabel" name="lblSampleYawUnit">
+           <property name="font">
+            <font>
+             <weight>50</weight>
+             <bold>false</bold>
+            </font>
+           </property>
+           <property name="text">
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; vertical-align:super;&quot;&gt;o&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="0">
+          <widget class="QLabel" name="lblSamplePitch">
+           <property name="font">
+            <font>
+             <weight>50</weight>
+             <bold>false</bold>
+            </font>
+           </property>
+           <property name="toolTip">
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The pitch angle of the sample coordinates from the environment coordinates.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+           </property>
+           <property name="text">
+            <string>Pitch</string>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="1">
+          <widget class="QLineEdit" name="txtSamplePitch">
+           <property name="minimumSize">
+            <size>
+             <width>0</width>
+             <height>18</height>
+            </size>
+           </property>
+           <property name="font">
+            <font>
+             <weight>50</weight>
+             <bold>false</bold>
+            </font>
+           </property>
+           <property name="toolTip">
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The pitch angle of the sample coordinates from the environment coordinates.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+           </property>
+           <property name="text">
+            <string>0.0</string>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="2">
+          <widget class="QLabel" name="lblSamplePitchUnit">
+           <property name="font">
+            <font>
+             <weight>50</weight>
+             <bold>false</bold>
+            </font>
+           </property>
+           <property name="text">
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; vertical-align:super;&quot;&gt;o&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="0">
+          <widget class="QLabel" name="lblSampleRoll">
+           <property name="font">
+            <font>
+             <weight>50</weight>
+             <bold>false</bold>
+            </font>
+           </property>
+           <property name="toolTip">
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The roll angle of the sample coordinates from the environment coordinates.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+           </property>
+           <property name="text">
+            <string>Roll</string>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="1">
+          <widget class="QLineEdit" name="txtSampleRoll">
+           <property name="minimumSize">
+            <size>
+             <width>0</width>
+             <height>18</height>
+            </size>
+           </property>
+           <property name="font">
+            <font>
+             <weight>50</weight>
+             <bold>false</bold>
+            </font>
+           </property>
+           <property name="toolTip">
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The roll angle of the sample coordinates from the enivronment coordinates.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+           </property>
+           <property name="text">
+            <string>0.0</string>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="2">
+          <widget class="QLabel" name="lblSampleRollUnit">
+           <property name="font">
+            <font>
+             <weight>50</weight>
+             <bold>false</bold>
+            </font>
+           </property>
+           <property name="text">
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; vertical-align:super;&quot;&gt;o&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+           </property>
+          </widget>
+         </item>
         </layout>
        </widget>
       </item>
@@ -1850,8 +1849,7 @@ Number of Qbins &amp;isin; [2, 1000].</string>
     </widget>
    </item>
    <item row="2" column="5" rowspan="5" colspan="8">
-    <layout class="QHBoxLayout" name="coordDisplay">
-    </layout>
+    <layout class="QHBoxLayout" name="coordDisplay"/>
    </item>
    <item row="3" column="6">
     <spacer name="horizontalSpacer_4">
@@ -2046,34 +2044,78 @@ Number of Qbins &amp;isin; [2, 1000].</string>
    </item>
    <item row="7" column="5">
     <widget class="QLabel" name="lblVerifyError">
-      <property name="font">
-        <font>
-        <weight>50</weight>
-        <bold>false</bold>
-        </font>
-      </property>
-      <property name="toolTip">
-        <string>Verification Error</string>
-      </property>
-      <property name="text">
-        <string></string>
-      </property>
-      <property name="wordWrap">
-        <bool>true</bool>
-      </property>
-      <property name="alignment">
-        <enum>Qt::AlignHCenter</enum>
-      </property>
-      <property name="minimumSize">
-        <size>
-        <width>0</width>
-        <height>30</height>
-        </size>
-      </property>
+     <property name="minimumSize">
+      <size>
+       <width>0</width>
+       <height>30</height>
+      </size>
+     </property>
+     <property name="font">
+      <font>
+       <weight>50</weight>
+       <bold>false</bold>
+      </font>
+     </property>
+     <property name="toolTip">
+      <string>Verification Error</string>
+     </property>
+     <property name="text">
+      <string/>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignHCenter</set>
+     </property>
+     <property name="wordWrap">
+      <bool>true</bool>
+     </property>
     </widget>
    </item>
   </layout>
  </widget>
+ <tabstops>
+  <tabstop>checkboxNucData</tabstop>
+  <tabstop>txtNucData</tabstop>
+  <tabstop>checkboxMagData</tabstop>
+  <tabstop>txtMagData</tabstop>
+  <tabstop>cbShape</tabstop>
+  <tabstop>cmdNucLoad</tabstop>
+  <tabstop>cmdMagLoad</tabstop>
+  <tabstop>cmdDraw</tabstop>
+  <tabstop>txtUpFracIn</tabstop>
+  <tabstop>txtUpFracOut</tabstop>
+  <tabstop>txtUpTheta</tabstop>
+  <tabstop>txtUpPhi</tabstop>
+  <tabstop>txtBackground</tabstop>
+  <tabstop>txtScale</tabstop>
+  <tabstop>txtSolventSLD</tabstop>
+  <tabstop>txtTotalVolume</tabstop>
+  <tabstop>txtNoQBins</tabstop>
+  <tabstop>txtQxMax</tabstop>
+  <tabstop>cbOptionsCalc</tabstop>
+  <tabstop>txtNoPixels</tabstop>
+  <tabstop>txtMx</tabstop>
+  <tabstop>txtMy</tabstop>
+  <tabstop>txtMz</tabstop>
+  <tabstop>txtNucl</tabstop>
+  <tabstop>cmdDrawpoints</tabstop>
+  <tabstop>cmdSave</tabstop>
+  <tabstop>txtXnodes</tabstop>
+  <tabstop>txtYnodes</tabstop>
+  <tabstop>txtZnodes</tabstop>
+  <tabstop>txtXstepsize</tabstop>
+  <tabstop>txtYstepsize</tabstop>
+  <tabstop>txtZstepsize</tabstop>
+  <tabstop>txtEnvYaw</tabstop>
+  <tabstop>txtEnvPitch</tabstop>
+  <tabstop>txtEnvRoll</tabstop>
+  <tabstop>txtSampleYaw</tabstop>
+  <tabstop>txtSamplePitch</tabstop>
+  <tabstop>txtSampleRoll</tabstop>
+  <tabstop>cmdCompute</tabstop>
+  <tabstop>cmdReset</tabstop>
+  <tabstop>cmdClose</tabstop>
+  <tabstop>cmdHelp</tabstop>
+ </tabstops>
  <resources/>
  <connections/>
 </ui>

--- a/src/sas/qtgui/Calculators/UI/KiessigPanel.ui
+++ b/src/sas/qtgui/Calculators/UI/KiessigPanel.ui
@@ -158,6 +158,13 @@
    </item>
   </layout>
  </widget>
+ <tabstops>
+  <tabstop>deltaq_in</tabstop>
+  <tabstop>lengthscale_out</tabstop>
+  <tabstop>computeButton</tabstop>
+  <tabstop>closeButton</tabstop>
+  <tabstop>helpButton</tabstop>
+ </tabstops>
  <resources/>
  <connections/>
 </ui>

--- a/src/sas/qtgui/Calculators/UI/KiessigPanel.ui
+++ b/src/sas/qtgui/Calculators/UI/KiessigPanel.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>365</width>
-    <height>197</height>
+    <width>392</width>
+    <height>209</height>
    </rect>
   </property>
   <property name="focusPolicy">
@@ -146,22 +146,11 @@
      </property>
     </widget>
    </item>
-   <item row="3" column="0">
-    <widget class="QPushButton" name="computeButton">
-     <property name="toolTip">
-      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Compute the thickness or diameter.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-     </property>
-     <property name="text">
-      <string>Compute</string>
-     </property>
-    </widget>
-   </item>
   </layout>
  </widget>
  <tabstops>
   <tabstop>deltaq_in</tabstop>
   <tabstop>lengthscale_out</tabstop>
-  <tabstop>computeButton</tabstop>
   <tabstop>closeButton</tabstop>
   <tabstop>helpButton</tabstop>
  </tabstops>

--- a/src/sas/qtgui/Calculators/UI/ResolutionCalculatorPanelUI.ui
+++ b/src/sas/qtgui/Calculators/UI/ResolutionCalculatorPanelUI.ui
@@ -708,6 +708,9 @@
        <height>415</height>
       </size>
      </property>
+     <property name="focusPolicy">
+      <enum>Qt::NoFocus</enum>
+     </property>
     </widget>
    </item>
    <item row="1" column="0">

--- a/src/sas/qtgui/Calculators/UI/ResolutionCalculatorPanelUI.ui
+++ b/src/sas/qtgui/Calculators/UI/ResolutionCalculatorPanelUI.ui
@@ -57,7 +57,16 @@
       <string>Instrumental Parameters</string>
      </property>
      <layout class="QGridLayout" name="gridLayout_6">
-      <property name="margin">
+      <property name="leftMargin">
+       <number>6</number>
+      </property>
+      <property name="topMargin">
+       <number>6</number>
+      </property>
+      <property name="rightMargin">
+       <number>6</number>
+      </property>
+      <property name="bottomMargin">
        <number>6</number>
       </property>
       <item row="0" column="0">
@@ -726,7 +735,16 @@
       <string>Q Location of the Estimation</string>
      </property>
      <layout class="QGridLayout" name="gridLayout_9">
-      <property name="margin">
+      <property name="leftMargin">
+       <number>6</number>
+      </property>
+      <property name="topMargin">
+       <number>6</number>
+      </property>
+      <property name="rightMargin">
+       <number>6</number>
+      </property>
+      <property name="bottomMargin">
        <number>6</number>
       </property>
       <item row="0" column="0">
@@ -851,7 +869,16 @@
       <string>Standard Deviation of the Resolution Distribution</string>
      </property>
      <layout class="QGridLayout" name="gridLayout_4">
-      <property name="margin">
+      <property name="leftMargin">
+       <number>6</number>
+      </property>
+      <property name="topMargin">
+       <number>6</number>
+      </property>
+      <property name="rightMargin">
+       <number>6</number>
+      </property>
+      <property name="bottomMargin">
        <number>6</number>
       </property>
       <item row="0" column="0">
@@ -1231,17 +1258,17 @@
   <tabstop>txtSampleOffset</tabstop>
   <tabstop>txtDetectorSize</tabstop>
   <tabstop>txtDetectorPixSize</tabstop>
+  <tabstop>graphicsView</tabstop>
   <tabstop>txtQx</tabstop>
   <tabstop>txtQy</tabstop>
-  <tabstop>cmdCompute</tabstop>
-  <tabstop>cmdHelp</tabstop>
-  <tabstop>cmdReset</tabstop>
-  <tabstop>cmdClose</tabstop>
-  <tabstop>txtSigma_lamd</tabstop>
-  <tabstop>txtSigma_y</tabstop>
-  <tabstop>txt1DSigma</tabstop>
-  <tabstop>graphicsView</tabstop>
   <tabstop>txtSigma_x</tabstop>
+  <tabstop>txtSigma_y</tabstop>
+  <tabstop>txtSigma_lamd</tabstop>
+  <tabstop>txt1DSigma</tabstop>
+  <tabstop>cmdReset</tabstop>
+  <tabstop>cmdCompute</tabstop>
+  <tabstop>cmdClose</tabstop>
+  <tabstop>cmdHelp</tabstop>
  </tabstops>
  <resources/>
  <connections/>

--- a/src/sas/qtgui/Calculators/UI/SldPanel.ui
+++ b/src/sas/qtgui/Calculators/UI/SldPanel.ui
@@ -385,11 +385,17 @@
   <tabstop>editMolecularFormula</tabstop>
   <tabstop>editMassDensity</tabstop>
   <tabstop>editNeutronWavelength</tabstop>
+  <tabstop>editXrayWavelength</tabstop>
   <tabstop>editNeutronSldReal</tabstop>
   <tabstop>editNeutronSldImag</tabstop>
+  <tabstop>editXraySldReal</tabstop>
+  <tabstop>editXraySldImag</tabstop>
   <tabstop>editNeutronIncXs</tabstop>
   <tabstop>editNeutronAbsXs</tabstop>
   <tabstop>editNeutronLength</tabstop>
+  <tabstop>closeButton</tabstop>
+  <tabstop>helpButton</tabstop>
+  <tabstop>recalculateButton</tabstop>
  </tabstops>
  <resources/>
  <connections/>

--- a/src/sas/qtgui/Calculators/UI/SldPanel.ui
+++ b/src/sas/qtgui/Calculators/UI/SldPanel.ui
@@ -332,6 +332,9 @@
           <height>28</height>
          </size>
         </property>
+        <property name="focusPolicy">
+         <enum>Qt::NoFocus</enum>
+        </property>
         <property name="text">
          <string>Recalculate</string>
         </property>

--- a/src/sas/qtgui/Calculators/UI/SlitSizeCalculator.ui
+++ b/src/sas/qtgui/Calculators/UI/SlitSizeCalculator.ui
@@ -182,6 +182,14 @@
    </item>
   </layout>
  </widget>
+ <tabstops>
+  <tabstop>data_file</tabstop>
+  <tabstop>browseButton</tabstop>
+  <tabstop>slit_length_out</tabstop>
+  <tabstop>unit_out</tabstop>
+  <tabstop>closeButton</tabstop>
+  <tabstop>helpButton</tabstop>
+ </tabstops>
  <resources/>
  <connections/>
 </ui>

--- a/src/sas/qtgui/MainWindow/UI/AboutUI.ui
+++ b/src/sas/qtgui/MainWindow/UI/AboutUI.ui
@@ -366,6 +366,20 @@
    </item>
   </layout>
  </widget>
+ <tabstops>
+  <tabstop>cmdLinkUT</tabstop>
+  <tabstop>cmdLinkUMD</tabstop>
+  <tabstop>cmdLinkNIST</tabstop>
+  <tabstop>cmdLinkESS</tabstop>
+  <tabstop>cmdLinkISIS</tabstop>
+  <tabstop>cmdLinkDELFT</tabstop>
+  <tabstop>cmdLinkILL</tabstop>
+  <tabstop>cmdLinkANSTO</tabstop>
+  <tabstop>cmdLinkDIAMOND</tabstop>
+  <tabstop>cmdLinkBAM</tabstop>
+  <tabstop>cmdLinkSNS</tabstop>
+  <tabstop>cmdOK</tabstop>
+ </tabstops>
  <resources/>
  <connections/>
 </ui>

--- a/src/sas/qtgui/MainWindow/UI/CategoryManagerUI.ui
+++ b/src/sas/qtgui/MainWindow/UI/CategoryManagerUI.ui
@@ -164,6 +164,15 @@
    </item>
   </layout>
  </widget>
+ <tabstops>
+  <tabstop>chkEnable</tabstop>
+  <tabstop>txtSearch</tabstop>
+  <tabstop>lstCategory</tabstop>
+  <tabstop>cmdModify</tabstop>
+  <tabstop>cmdReset</tabstop>
+  <tabstop>cmdOK</tabstop>
+  <tabstop>cmdHelp</tabstop>
+ </tabstops>
  <resources/>
  <connections/>
 </ui>

--- a/src/sas/qtgui/MainWindow/UI/ChangeCategoryUI.ui
+++ b/src/sas/qtgui/MainWindow/UI/ChangeCategoryUI.ui
@@ -126,6 +126,17 @@
    </item>
   </layout>
  </widget>
+ <tabstops>
+  <tabstop>lstCategories</tabstop>
+  <tabstop>rbExisting</tabstop>
+  <tabstop>cbCategories</tabstop>
+  <tabstop>rbNew</tabstop>
+  <tabstop>txtNewCategory</tabstop>
+  <tabstop>cmdAdd</tabstop>
+  <tabstop>cmdRemove</tabstop>
+  <tabstop>cmdOK</tabstop>
+  <tabstop>cmdCancel</tabstop>
+ </tabstops>
  <resources/>
  <connections/>
 </ui>

--- a/src/sas/qtgui/MainWindow/UI/ChangeNameUI.ui
+++ b/src/sas/qtgui/MainWindow/UI/ChangeNameUI.ui
@@ -122,6 +122,18 @@
    </layout>
   </widget>
  </widget>
+ <tabstops>
+  <tabstop>rbExisting</tabstop>
+  <tabstop>txtCurrentName</tabstop>
+  <tabstop>rbDataName</tabstop>
+  <tabstop>txtDataName</tabstop>
+  <tabstop>rbFileName</tabstop>
+  <tabstop>txtFileName</tabstop>
+  <tabstop>rbNew</tabstop>
+  <tabstop>txtNewCategory</tabstop>
+  <tabstop>cmdOK</tabstop>
+  <tabstop>cmdCancel</tabstop>
+ </tabstops>
  <resources/>
  <connections/>
 </ui>

--- a/src/sas/qtgui/Perspectives/Corfunc/UI/CorfuncPanel.ui
+++ b/src/sas/qtgui/Perspectives/Corfunc/UI/CorfuncPanel.ui
@@ -985,6 +985,35 @@
    </item>
   </layout>
  </widget>
+ <tabstops>
+  <tabstop>scrollArea</tabstop>
+  <tabstop>txtFilename</tabstop>
+  <tabstop>txtLowerQMin</tabstop>
+  <tabstop>txtLowerQMax</tabstop>
+  <tabstop>txtUpperQMin</tabstop>
+  <tabstop>txtUpperQMax</tabstop>
+  <tabstop>cmdCalculateBg</tabstop>
+  <tabstop>txtBackground</tabstop>
+  <tabstop>txtGuinierA</tabstop>
+  <tabstop>txtGuinierB</tabstop>
+  <tabstop>txtPorodK</tabstop>
+  <tabstop>txtPorodSigma</tabstop>
+  <tabstop>cmdExtrapolate</tabstop>
+  <tabstop>cmdSaveExtrapolation</tabstop>
+  <tabstop>cmdTransform</tabstop>
+  <tabstop>cmdSave</tabstop>
+  <tabstop>txtAvgHardBlock</tabstop>
+  <tabstop>txtAvgSoftBlock</tabstop>
+  <tabstop>txtAvgIntThick</tabstop>
+  <tabstop>txtAvgCoreThick</tabstop>
+  <tabstop>txtPolyRyan</tabstop>
+  <tabstop>txtPolyStribeck</tabstop>
+  <tabstop>txtLongPeriod</tabstop>
+  <tabstop>txtLocalCrystal</tabstop>
+  <tabstop>cmdExtract</tabstop>
+  <tabstop>cmdHelp</tabstop>
+  <tabstop>tabWidget</tabstop>
+ </tabstops>
  <resources/>
  <connections/>
 </ui>

--- a/src/sas/qtgui/Perspectives/Fitting/FittingWidget.py
+++ b/src/sas/qtgui/Perspectives/Fitting/FittingWidget.py
@@ -1474,6 +1474,9 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         if self.page_parameters:
             self.updatePageWithParameters(self.page_parameters, warn_user=False)
 
+        # set focus so it doesn't move up
+        self.cbModel.setFocus()
+
     def onSelectBatchFilename(self, data_index):
         """
         Update the logic based on the selected file in batch fitting

--- a/src/sas/qtgui/Perspectives/Fitting/UI/ConstraintWidgetUI.ui
+++ b/src/sas/qtgui/Perspectives/Fitting/UI/ConstraintWidgetUI.ui
@@ -211,6 +211,17 @@
    </item>
   </layout>
  </widget>
+ <tabstops>
+  <tabstop>btnSingle</tabstop>
+  <tabstop>btnBatch</tabstop>
+  <tabstop>chkWeight</tabstop>
+  <tabstop>chkChain</tabstop>
+  <tabstop>cbCases</tabstop>
+  <tabstop>cmdAdd</tabstop>
+  <tabstop>tblConstraints</tabstop>
+  <tabstop>cmdFit</tabstop>
+  <tabstop>cmdHelp</tabstop>
+ </tabstops>
  <resources/>
  <connections/>
 </ui>

--- a/src/sas/qtgui/Perspectives/Fitting/UI/FittingWidgetUI.ui
+++ b/src/sas/qtgui/Perspectives/Fitting/UI/FittingWidgetUI.ui
@@ -511,6 +511,24 @@ angles</string>
    </item>
   </layout>
  </widget>
+ <tabstops>
+  <tabstop>cbFileNames</tabstop>
+  <tabstop>tabFitting</tabstop>
+  <tabstop>cbCategory</tabstop>
+  <tabstop>cbModel</tabstop>
+  <tabstop>cbStructureFactor</tabstop>
+  <tabstop>lstParams</tabstop>
+  <tabstop>chkPolydispersity</tabstop>
+  <tabstop>chk2DView</tabstop>
+  <tabstop>chkMagnetism</tabstop>
+  <tabstop>chkChainFit</tabstop>
+  <tabstop>lstPoly</tabstop>
+  <tabstop>lstMagnetic</tabstop>
+  <tabstop>cmdMagneticDisplay</tabstop>
+  <tabstop>cmdPlot</tabstop>
+  <tabstop>cmdFit</tabstop>
+  <tabstop>cmdHelp</tabstop>
+ </tabstops>
  <resources/>
  <connections/>
 </ui>

--- a/src/sas/qtgui/Perspectives/Fitting/UI/OptionsWidgetUI.ui
+++ b/src/sas/qtgui/Perspectives/Fitting/UI/OptionsWidgetUI.ui
@@ -240,6 +240,19 @@
    </item>
   </layout>
  </widget>
+ <tabstops>
+  <tabstop>txtMinRange</tabstop>
+  <tabstop>txtMaxRange</tabstop>
+  <tabstop>txtNpts</tabstop>
+  <tabstop>chkLogData</tabstop>
+  <tabstop>txtNptsFit</tabstop>
+  <tabstop>rbWeighting1</tabstop>
+  <tabstop>rbWeighting2</tabstop>
+  <tabstop>rbWeighting3</tabstop>
+  <tabstop>rbWeighting4</tabstop>
+  <tabstop>cmdReset</tabstop>
+  <tabstop>cmdMaskEdit</tabstop>
+ </tabstops>
  <resources/>
  <connections/>
 </ui>

--- a/src/sas/qtgui/Perspectives/Invariant/UI/TabbedInvariantUI.ui
+++ b/src/sas/qtgui/Perspectives/Invariant/UI/TabbedInvariantUI.ui
@@ -720,6 +720,39 @@ while extrapolating the low-Q region</string>
    </item>
   </layout>
  </widget>
+ <tabstops>
+  <tabstop>tabWidget</tabstop>
+  <tabstop>txtName</tabstop>
+  <tabstop>txtTotalQMin</tabstop>
+  <tabstop>txtTotalQMax</tabstop>
+  <tabstop>txtVolFract</tabstop>
+  <tabstop>txtVolFractErr</tabstop>
+  <tabstop>txtSpecSurf</tabstop>
+  <tabstop>txtSpecSurfErr</tabstop>
+  <tabstop>txtInvariantTot</tabstop>
+  <tabstop>txtInvariantTotErr</tabstop>
+  <tabstop>cmdCalculate</tabstop>
+  <tabstop>cmdStatus</tabstop>
+  <tabstop>cmdHelp</tabstop>
+  <tabstop>txtBackgd</tabstop>
+  <tabstop>txtScale</tabstop>
+  <tabstop>txtContrast</tabstop>
+  <tabstop>txtPorodCst</tabstop>
+  <tabstop>txtExtrapolQMin</tabstop>
+  <tabstop>txtExtrapolQMax</tabstop>
+  <tabstop>chkLowQ</tabstop>
+  <tabstop>txtNptsLowQ</tabstop>
+  <tabstop>chkHighQ</tabstop>
+  <tabstop>txtNptsHighQ</tabstop>
+  <tabstop>rbGuinier</tabstop>
+  <tabstop>rbFitLowQ</tabstop>
+  <tabstop>rbFitHighQ</tabstop>
+  <tabstop>rbPowerLawLowQ</tabstop>
+  <tabstop>rbFixLowQ</tabstop>
+  <tabstop>rbFixHighQ</tabstop>
+  <tabstop>txtPowerLowQ</tabstop>
+  <tabstop>txtPowerHighQ</tabstop>
+ </tabstops>
  <resources/>
  <connections/>
 </ui>

--- a/src/sas/qtgui/Perspectives/Invariant/UI/TabbedInvariantUI.ui
+++ b/src/sas/qtgui/Perspectives/Invariant/UI/TabbedInvariantUI.ui
@@ -198,6 +198,9 @@
             <property name="enabled">
              <bool>true</bool>
             </property>
+            <property name="focusPolicy">
+             <enum>Qt::ClickFocus</enum>
+            </property>
             <property name="autoFillBackground">
              <bool>true</bool>
             </property>
@@ -227,6 +230,9 @@
             <property name="enabled">
              <bool>true</bool>
             </property>
+            <property name="focusPolicy">
+             <enum>Qt::ClickFocus</enum>
+            </property>
             <property name="frame">
              <bool>true</bool>
             </property>
@@ -250,6 +256,9 @@
             <property name="enabled">
              <bool>true</bool>
             </property>
+            <property name="focusPolicy">
+             <enum>Qt::ClickFocus</enum>
+            </property>
             <property name="frame">
              <bool>true</bool>
             </property>
@@ -272,6 +281,9 @@
            <widget class="QLineEdit" name="txtSpecSurfErr">
             <property name="enabled">
              <bool>true</bool>
+            </property>
+            <property name="focusPolicy">
+             <enum>Qt::ClickFocus</enum>
             </property>
             <property name="frame">
              <bool>true</bool>
@@ -310,6 +322,9 @@
             <property name="enabled">
              <bool>true</bool>
             </property>
+            <property name="focusPolicy">
+             <enum>Qt::ClickFocus</enum>
+            </property>
             <property name="toolTip">
              <string>Total invariant [Q*], including extrapolated regions.</string>
             </property>
@@ -335,6 +350,9 @@
            <widget class="QLineEdit" name="txtInvariantTotErr">
             <property name="enabled">
              <bool>true</bool>
+            </property>
+            <property name="focusPolicy">
+             <enum>Qt::ClickFocus</enum>
             </property>
             <property name="frame">
              <bool>true</bool>

--- a/src/sas/qtgui/Perspectives/Inversion/UI/TabbedInversionUI.ui
+++ b/src/sas/qtgui/Perspectives/Inversion/UI/TabbedInversionUI.ui
@@ -299,6 +299,9 @@ p, li { white-space: pre-wrap; }
               <verstretch>0</verstretch>
              </sizepolicy>
             </property>
+            <property name="focusPolicy">
+             <enum>Qt::ClickFocus</enum>
+            </property>
             <property name="readOnly">
              <bool>true</bool>
             </property>
@@ -336,6 +339,9 @@ p, li { white-space: pre-wrap; }
               <verstretch>0</verstretch>
              </sizepolicy>
             </property>
+            <property name="focusPolicy">
+             <enum>Qt::ClickFocus</enum>
+            </property>
             <property name="readOnly">
              <bool>true</bool>
             </property>
@@ -358,6 +364,9 @@ p, li { white-space: pre-wrap; }
               <horstretch>0</horstretch>
               <verstretch>0</verstretch>
              </sizepolicy>
+            </property>
+            <property name="focusPolicy">
+             <enum>Qt::ClickFocus</enum>
             </property>
             <property name="readOnly">
              <bool>true</bool>
@@ -389,6 +398,9 @@ p, li { white-space: pre-wrap; }
               <verstretch>0</verstretch>
              </sizepolicy>
             </property>
+            <property name="focusPolicy">
+             <enum>Qt::ClickFocus</enum>
+            </property>
             <property name="readOnly">
              <bool>true</bool>
             </property>
@@ -411,6 +423,9 @@ p, li { white-space: pre-wrap; }
               <horstretch>0</horstretch>
               <verstretch>0</verstretch>
              </sizepolicy>
+            </property>
+            <property name="focusPolicy">
+             <enum>Qt::ClickFocus</enum>
             </property>
             <property name="readOnly">
              <bool>true</bool>
@@ -442,6 +457,9 @@ p, li { white-space: pre-wrap; }
               <verstretch>0</verstretch>
              </sizepolicy>
             </property>
+            <property name="focusPolicy">
+             <enum>Qt::ClickFocus</enum>
+            </property>
             <property name="readOnly">
              <bool>true</bool>
             </property>
@@ -464,6 +482,9 @@ p, li { white-space: pre-wrap; }
               <horstretch>0</horstretch>
               <verstretch>0</verstretch>
              </sizepolicy>
+            </property>
+            <property name="focusPolicy">
+             <enum>Qt::ClickFocus</enum>
             </property>
             <property name="readOnly">
              <bool>true</bool>
@@ -494,6 +515,9 @@ p, li { white-space: pre-wrap; }
               <horstretch>0</horstretch>
               <verstretch>0</verstretch>
              </sizepolicy>
+            </property>
+            <property name="focusPolicy">
+             <enum>Qt::ClickFocus</enum>
             </property>
             <property name="readOnly">
              <bool>true</bool>
@@ -784,7 +808,6 @@ p, li { white-space: pre-wrap; }
   </layout>
  </widget>
  <tabstops>
-  <tabstop>PrTabWidget</tabstop>
   <tabstop>dataList</tabstop>
   <tabstop>removeButton</tabstop>
   <tabstop>noOfTermsInput</tabstop>
@@ -805,6 +828,7 @@ p, li { white-space: pre-wrap; }
   <tabstop>calculateAllButton</tabstop>
   <tabstop>stopButton</tabstop>
   <tabstop>helpButton</tabstop>
+  <tabstop>PrTabWidget</tabstop>
   <tabstop>backgroundInput</tabstop>
   <tabstop>estimateBgd</tabstop>
   <tabstop>manualBgd</tabstop>

--- a/src/sas/qtgui/Perspectives/Inversion/UI/TabbedInversionUI.ui
+++ b/src/sas/qtgui/Perspectives/Inversion/UI/TabbedInversionUI.ui
@@ -783,6 +783,36 @@ p, li { white-space: pre-wrap; }
    </item>
   </layout>
  </widget>
+ <tabstops>
+  <tabstop>PrTabWidget</tabstop>
+  <tabstop>dataList</tabstop>
+  <tabstop>removeButton</tabstop>
+  <tabstop>noOfTermsInput</tabstop>
+  <tabstop>noOfTermsSuggestionButton</tabstop>
+  <tabstop>regularizationConstantInput</tabstop>
+  <tabstop>regConstantSuggestionButton</tabstop>
+  <tabstop>maxDistanceInput</tabstop>
+  <tabstop>explorerButton</tabstop>
+  <tabstop>rgValue</tabstop>
+  <tabstop>chiDofValue</tabstop>
+  <tabstop>iQ0Value</tabstop>
+  <tabstop>oscillationValue</tabstop>
+  <tabstop>backgroundValue</tabstop>
+  <tabstop>posFractionValue</tabstop>
+  <tabstop>computationTimeValue</tabstop>
+  <tabstop>sigmaPosFractionValue</tabstop>
+  <tabstop>calculateThisButton</tabstop>
+  <tabstop>calculateAllButton</tabstop>
+  <tabstop>stopButton</tabstop>
+  <tabstop>helpButton</tabstop>
+  <tabstop>backgroundInput</tabstop>
+  <tabstop>estimateBgd</tabstop>
+  <tabstop>manualBgd</tabstop>
+  <tabstop>minQInput</tabstop>
+  <tabstop>maxQInput</tabstop>
+  <tabstop>slitHeightInput</tabstop>
+  <tabstop>slitWidthInput</tabstop>
+ </tabstops>
  <resources/>
  <connections/>
 </ui>

--- a/src/sas/qtgui/Plotting/UI/ColorMapUI.ui
+++ b/src/sas/qtgui/Plotting/UI/ColorMapUI.ui
@@ -233,6 +233,12 @@
   <zorder>groupBox_2</zorder>
   <zorder>verticalSpacer</zorder>
  </widget>
+ <tabstops>
+  <tabstop>cbColorMap</tabstop>
+  <tabstop>txtMinAmplitude</tabstop>
+  <tabstop>txtMaxAmplitude</tabstop>
+  <tabstop>chkReverse</tabstop>
+ </tabstops>
  <resources/>
  <connections>
   <connection>

--- a/src/sas/qtgui/Plotting/UI/MaskEditorUI.ui
+++ b/src/sas/qtgui/Plotting/UI/MaskEditorUI.ui
@@ -142,6 +142,17 @@
    </item>
   </layout>
  </widget>
+ <tabstops>
+  <tabstop>rbWings</tabstop>
+  <tabstop>rbCircularDisk</tabstop>
+  <tabstop>rbRectangularDisk</tabstop>
+  <tabstop>rbDoubleWingWindow</tabstop>
+  <tabstop>rbCircularWindow</tabstop>
+  <tabstop>rbRectangularWindow</tabstop>
+  <tabstop>cmdAdd</tabstop>
+  <tabstop>cmdReset</tabstop>
+  <tabstop>cmdClear</tabstop>
+ </tabstops>
  <resources/>
  <connections/>
 </ui>

--- a/src/sas/qtgui/Plotting/UI/PlotLabelPropertiesUI.ui
+++ b/src/sas/qtgui/Plotting/UI/PlotLabelPropertiesUI.ui
@@ -217,6 +217,22 @@
    </item>
   </layout>
  </widget>
+ <tabstops>
+  <tabstop>cbFont</tabstop>
+  <tabstop>cbWeight</tabstop>
+  <tabstop>cbColor</tabstop>
+  <tabstop>cmdCustom</tabstop>
+  <tabstop>cbSize</tabstop>
+  <tabstop>txtLegend</tabstop>
+  <tabstop>chkTicks</tabstop>
+  <tabstop>cbFont_y</tabstop>
+  <tabstop>cbWeight_y</tabstop>
+  <tabstop>cbColor_y</tabstop>
+  <tabstop>cmdCustom_y</tabstop>
+  <tabstop>cbSize_y</tabstop>
+  <tabstop>txtLegend_y</tabstop>
+  <tabstop>chkTicks_y</tabstop>
+ </tabstops>
  <resources/>
  <connections>
   <connection>

--- a/src/sas/qtgui/Plotting/UI/SlicerParametersUI.ui
+++ b/src/sas/qtgui/Plotting/UI/SlicerParametersUI.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>362</width>
-    <height>427</height>
+    <width>395</width>
+    <height>458</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -331,6 +331,21 @@
    </item>
   </layout>
  </widget>
+ <tabstops>
+  <tabstop>tabWidget</tabstop>
+  <tabstop>lstParams</tabstop>
+  <tabstop>cbSlicer</tabstop>
+  <tabstop>cmdApply</tabstop>
+  <tabstop>cmdClose</tabstop>
+  <tabstop>cmdHelp</tabstop>
+  <tabstop>lstPlots</tabstop>
+  <tabstop>cbSave1DPlots</tabstop>
+  <tabstop>txtLocation</tabstop>
+  <tabstop>cmdFiles</tabstop>
+  <tabstop>cbSaveExt</tabstop>
+  <tabstop>txtExtension</tabstop>
+  <tabstop>cbFitOptions</tabstop>
+ </tabstops>
  <resources/>
  <connections/>
 </ui>

--- a/src/sas/qtgui/Utilities/UI/AddMultEditorUI.ui
+++ b/src/sas/qtgui/Utilities/UI/AddMultEditorUI.ui
@@ -174,6 +174,14 @@ Multiply: *</string>
    </item>
   </layout>
  </widget>
+ <tabstops>
+  <tabstop>txtName</tabstop>
+  <tabstop>chkOverwrite</tabstop>
+  <tabstop>txtDescription</tabstop>
+  <tabstop>cbModel1</tabstop>
+  <tabstop>cbOperator</tabstop>
+  <tabstop>cbModel2</tabstop>
+ </tabstops>
  <resources/>
  <connections/>
 </ui>

--- a/src/sas/qtgui/Utilities/UI/PluginDefinitionUI.ui
+++ b/src/sas/qtgui/Utilities/UI/PluginDefinitionUI.ui
@@ -135,8 +135,8 @@ value</string>
          <string>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
-&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'MS Shell Dlg 2'; font-size:7.8pt; font-weight:400; font-style:normal;&quot;&gt;
-&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;br /&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'MS Shell Dlg 2'; font-size:6.6pt; font-weight:400; font-style:normal;&quot;&gt;
+&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-size:7.8pt;&quot;&gt;&lt;br /&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
         </property>
        </widget>
       </item>
@@ -145,6 +145,14 @@ p, li { white-space: pre-wrap; }
    </item>
   </layout>
  </widget>
+ <tabstops>
+  <tabstop>txtName</tabstop>
+  <tabstop>chkOverwrite</tabstop>
+  <tabstop>txtDescription</tabstop>
+  <tabstop>tblParams</tabstop>
+  <tabstop>tblParamsPD</tabstop>
+  <tabstop>txtFunction</tabstop>
+ </tabstops>
  <resources/>
  <connections/>
 </ui>


### PR DESCRIPTION
## Description

This PR addresses one of the issues brought up in https://github.com/orgs/SasView/discussions/2342 and spun off into https://github.com/SasView/sasview/issues/2385.

Now, tab order for all widgets in SasView is consistent and goes in standard direction (left->right, up->down)

Fixes #2385

## Review Checklist (please remove items if they don't apply):

- [x] Code has been reviewed
- [x] Functionality has been tested
- [ ] Windows installer (GH artifact) has been tested (installed and worked) 
- [ ] MacOSX installer (GH artifact) has been tested (installed and worked) 
- [x] The introduced changes comply with SasView license (BSD 3-Clause)

