### PR TITLE
Updated release gh actions

### DIFF
--- a/.github/workflows/installers.yml
+++ b/.github/workflows/installers.yml
@@ -182,27 +182,3 @@ jobs:
         name: SasView-Installer-${{ matrix.os }}-${{ matrix.python-version }}-${{ github.sha }}
         path: installers/dist/SasView5.dmg
         if-no-files-found: error
-
-    - name: Declare env variables on push only
-      if: github.event_name == 'push'
-      shell: bash
-      run: echo "BRANCH_NAME=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
-
-    - name: Declare env variables on pull_request only
-      if: github.event_name == 'pull_request'
-      shell: bash
-      run: echo "BRANCH_NAME=$GITHUB_HEAD_REF" >> $GITHUB_ENV
-
-    - name: Upload installer to GitHub releases
-      #Release and main branch will be treated differently
-      if: env.BRANCH_NAME != 'main'
-      uses: ncipollo/release-action@v1
-      with:
-        draft: true
-        prerelease: true
-        allowUpdates: true
-        replacesArtifacts: true
-        token: ${{ secrets.GITHUB_TOKEN }}
-        artifacts: "installers/dist/SasView5.dmg, installers/Output/setupSasView.exe"
-        name: ${{ env.BRANCH_NAME }}
-        tag: ${{ env.BRANCH_NAME }}

--- a/.github/workflows/installers.yml
+++ b/.github/workflows/installers.yml
@@ -105,8 +105,8 @@ jobs:
 
     - name: Fetch sources for sibling projects
       run: |
-        git clone --depth=50 --branch=master https://github.com/SasView/sasmodels.git ../sasmodels
-        git clone --depth=50 --branch=master https://github.com/bumps/bumps.git ../bumps
+        git clone --depth=1 --branch==release_1.0.7 https://github.com/SasView/sasmodels.git ../sasmodels
+        git clone --depth=1 --branch=v0.9.0 https://github.com/bumps/bumps.git ../bumps
 
     - name: Build and install sasmodels
       run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -215,25 +215,3 @@ jobs:
       uses: devbotsxyz/xcode-staple@v1
       with:
         product-path: "installers/dist/SasView5.dmg"
-
-    - name: Declare env variables on push only
-      if: github.event_name == 'push'
-      shell: bash
-      run: echo "BRANCH_NAME=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
-
-    - name: Declare env variables on pull_request only
-      if: github.event_name == 'pull_request'
-      shell: bash
-      run: echo "BRANCH_NAME=$GITHUB_HEAD_REF" >> $GITHUB_ENV
-
-    - name: Upload installer to GitHub releases
-      uses: ncipollo/release-action@v1
-      with:
-          draft: true
-          prerelease: true
-          allowUpdates: true
-          replacesArtifacts: true
-          token: ${{ secrets.GITHUB_TOKEN }}
-          artifacts: "installers/dist/SasView5.dmg, installers/Output/setupSasView.exe"
-          name: ${{ env.BRANCH_NAME }}
-          tag: ${{ env.BRANCH_NAME }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,6 @@
 name: Create release
 
 on:
-  push:
-    branches:
-      - release*
   pull_request:
     branches:
       - release*
@@ -107,7 +104,7 @@ jobs:
     ### TODO: Bumps and sasmodels branches needs to be setup manually until we find better mechanism
     - name: Fetch sources for sibling projects
       run: |
-        git clone --depth=1 --branch=v1.0.6 https://github.com/SasView/sasmodels.git ../sasmodels
+        git clone --depth=1 --branch=release_1.0.7 https://github.com/SasView/sasmodels.git ../sasmodels
         git clone --depth=1 --branch=v0.9.0 https://github.com/bumps/bumps.git ../bumps
 
     - name: Build and install sasmodels
@@ -205,20 +202,20 @@ jobs:
         path: installers/dist/SasView5.dmg
         if-no-files-found: error
           
-#     - name: Notarize Release Build (OSX)
-#       if: ${{ matrix.os == 'macos-latest' }}
-#       uses: devbotsxyz/xcode-notarize@v1
-#       with:
-#           product-path: "installers/dist/SasView5.dmg"
-#           primary-bundle-id: "org.sasview.SasView5"
-#           appstore-connect-username: ${{ secrets.NOTARIZATION_USERNAME }}
-#           appstore-connect-password: ${{ secrets.NOTARIZATION_PASSWORD }}
+     - name: Notarize Release Build (OSX)
+       if: ${{ matrix.os == 'macos-latest' }}
+       uses: devbotsxyz/xcode-notarize@v1
+       with:
+           product-path: "installers/dist/SasView5.dmg"
+           primary-bundle-id: "org.sasview.SasView5"
+           appstore-connect-username: ${{ secrets.NOTARIZATION_USERNAME }}
+           appstore-connect-password: ${{ secrets.NOTARIZATION_PASSWORD }}
 
-#     - name: Staple Release Build (OSX)
-#       if: ${{ matrix.os == 'macos-latest' }}
-#       uses: devbotsxyz/xcode-staple@v1
-#       with:
-#           product-path: "installers/dist/SasView5.dmg"
+     - name: Staple Release Build (OSX)
+       if: ${{ matrix.os == 'macos-latest' }}
+       uses: devbotsxyz/xcode-staple@v1
+       with:
+           product-path: "installers/dist/SasView5.dmg"
 
     - name: Declare env variables on push only
       if: github.event_name == 'push'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -203,7 +203,7 @@ jobs:
           
     - name: Notarize Release Build (OSX)
       if: ${{ matrix.os == 'macos-latest' }}
-      uses: devbotsxyz/xcode-notarize@v1
+      uses: GuillaumeFalourd/xcode-notarize@v1
       with:
         product-path: "installers/dist/SasView5.dmg"
         primary-bundle-id: "org.sasview.SasView5"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -202,19 +202,19 @@ jobs:
         if-no-files-found: error
           
     - name: Notarize Release Build (OSX)
-       if: ${{ matrix.os == 'macos-latest' }}
-       uses: devbotsxyz/xcode-notarize@v1
-       with:
-           product-path: "installers/dist/SasView5.dmg"
-           primary-bundle-id: "org.sasview.SasView5"
-           appstore-connect-username: ${{ secrets.NOTARIZATION_USERNAME }}
-           appstore-connect-password: ${{ secrets.NOTARIZATION_PASSWORD }}
+      if: ${{ matrix.os == 'macos-latest' }}
+      uses: devbotsxyz/xcode-notarize@v1
+      with:
+        product-path: "installers/dist/SasView5.dmg"
+        primary-bundle-id: "org.sasview.SasView5"
+        appstore-connect-username: ${{ secrets.NOTARIZATION_USERNAME }}
+        appstore-connect-password: ${{ secrets.NOTARIZATION_PASSWORD }}
 
     - name: Staple Release Build (OSX)
-       if: ${{ matrix.os == 'macos-latest' }}
-       uses: devbotsxyz/xcode-staple@v1
-       with:
-           product-path: "installers/dist/SasView5.dmg"
+      if: ${{ matrix.os == 'macos-latest' }}
+      uses: devbotsxyz/xcode-staple@v1
+      with:
+        product-path: "installers/dist/SasView5.dmg"
 
     - name: Declare env variables on push only
       if: github.event_name == 'push'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,6 @@ defaults:
 
 jobs:
   installer:
-
     timeout-minutes: 40
 
     runs-on: ${{ matrix.os }}
@@ -202,7 +201,7 @@ jobs:
         path: installers/dist/SasView5.dmg
         if-no-files-found: error
           
-     - name: Notarize Release Build (OSX)
+    - name: Notarize Release Build (OSX)
        if: ${{ matrix.os == 'macos-latest' }}
        uses: devbotsxyz/xcode-notarize@v1
        with:
@@ -211,7 +210,7 @@ jobs:
            appstore-connect-username: ${{ secrets.NOTARIZATION_USERNAME }}
            appstore-connect-password: ${{ secrets.NOTARIZATION_PASSWORD }}
 
-     - name: Staple Release Build (OSX)
+    - name: Staple Release Build (OSX)
        if: ${{ matrix.os == 'macos-latest' }}
        uses: devbotsxyz/xcode-staple@v1
        with:


### PR DESCRIPTION
## Description

Updated GH actions for release. It is set so it only triggers build when PR is created and updated. It should be sufficient with Installer workflow doing essentially the same job. 

This PR uses old approach to GH actions, which we decided to run for 5.0.6. Main branch has different mechanism (merged at the last code camp).

Fixes # (issue/issues)

## How Has This Been Tested?

It can only be tested from installers and logs. 

## Review Checklist (please remove items if they don't apply):

- [ ] Code has been reviewed
- [ ] Functionality has been tested
- [ ] Windows installer (GH artifact) has been tested (installed and worked) 
- [ ] MacOSX installer (GH artifact) has been tested (installed and worked) 
- [ ] User documentation is available and complete (if required)
- [ ] Developers documentation is available and complete (if required)
- [ ] The introduced changes comply with SasView license (BSD 3-Clause)

