### PR TITLE
Installer 5.0.6 GitHub actions

### DIFF
--- a/.github/workflows/installers.yml
+++ b/.github/workflows/installers.yml
@@ -105,7 +105,7 @@ jobs:
 
     - name: Fetch sources for sibling projects
       run: |
-        git clone --depth=1 --branch==release_1.0.7 https://github.com/SasView/sasmodels.git ../sasmodels
+        git clone --depth=1 --branch=release_1.0.7 https://github.com/SasView/sasmodels.git ../sasmodels
         git clone --depth=1 --branch=v0.9.0 https://github.com/bumps/bumps.git ../bumps
 
     - name: Build and install sasmodels


### PR DESCRIPTION
## Description

Fixing typo in installer yml. The branch name starts with "installer" not "release" to trigger installer.yml workflow. 

