### PR TITLE
1999: Clip fitting values set outside the fit range

### DIFF
--- a/src/sas/qtgui/Perspectives/Fitting/FittingWidget.py
+++ b/src/sas/qtgui/Perspectives/Fitting/FittingWidget.py
@@ -2008,6 +2008,9 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
             logger.error(msg)
             return
 
+        if results.mesg:
+            logger.warning(results.mesg)
+
         param_list = results.param_list # ['radius', 'radius.width']
         param_values = results.pvec     # array([ 0.36221662,  0.0146783 ])
         param_stderr = results.stderr   # array([ 1.71293015,  1.71294233])


### PR DESCRIPTION
## Description

As described in [bumps/bumps#58](https://github.com/bumps/bumps/issues/58) and #1999, when the initial fit values are set outside the fitting bounds, the MPFit (L-M) and Quasi-Newton fitters fail to converge and may throw errors. This utilizes the bumps `FitDriver.clip()` feature to coerce the initial values within the bounds prior to fitting. A warning is logged when any values are coerced.

Fixes #1999

This fix should also be added to v5.0.6 once it's reviewed.

## How Has This Been Tested?

Run SasView, select the L-M (MPFit) optimizer, load a data set, send it to fitting, and select a model. From there, I tried 2 different things
1. Set the fit range of one of the parameters to not include the initial value. This was done by changing both the upper a lower limits.
2. Set the initial value of one of the parameters so it is outside the initial bounds of the fit.

Select the modified fit parameter to be fit and run the fit.

Previously, the fit would fail with an assertion error. Now the fit succeeds and a warning message is given.

I did not test the Quasi-Newton optimizer.

## Review Checklist (please remove items if they don't apply):

- [ ] Code has been reviewed
- [ ] Functionality has been tested
- [ ] Windows installer (GH artifact) has been tested (installed and worked) 
- [ ] MacOSX installer (GH artifact) has been tested (installed and worked) 
- [ ] User documentation is available and complete (if required)
- [ ] Developers documentation is available and complete (if required)
- [ ] The introduced changes comply with SasView license (BSD 3-Clause)

