### PR TITLE
Remove ubuntu 18.04 from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -309,7 +309,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [ windows-latest, ubuntu-18.04 ]
+        os: [ windows-latest, ubuntu-20.04 ]
         python-version: [ 3.8 ]
       fail-fast: false
 

--- a/.github/workflows/matrix.py
+++ b/.github/workflows/matrix.py
@@ -26,7 +26,7 @@ jobs = []
 #   dynamically linked by pyinstaller.
 #   https://pyinstaller.readthedocs.io/en/stable/usage.html#making-gnu-linux-apps-forward-compatible
 os_release_list = [
-    'ubuntu-18.04',
+    'ubuntu-20.04',
     'windows-latest',
     'macos-latest',
 ]


### PR DESCRIPTION
## Description

Ubuntu v18.04 was removed from the CI.

Fixes #2398 

## How Has This Been Tested?

CI ran successfully

## Review Checklist (please remove items if they don't apply):

- [ ] Code has been reviewed
- [ ] Functionality has been tested
- [ ] Windows installer (GH artifact) has been tested (installed and worked) 
- [ ] MacOSX installer (GH artifact) has been tested (installed and worked) 
- [ ] User documentation is available and complete (if required)
- [ ] Developers documentation is available and complete (if required)
- [ ] The introduced changes comply with SasView license (BSD 3-Clause)

