### PR TITLE
Add +/- 1 and 3 sigma lines on residual plots

### DIFF
--- a/src/sas/qtgui/Plotting/Plotter.py
+++ b/src/sas/qtgui/Plotting/Plotter.py
@@ -227,6 +227,12 @@ class PlotterWidget(PlotterBase):
         if data.show_yzero:
             ax.axhline(color='black', linewidth=1)
 
+        # Display +/- 3 sigma and +/- 1 sigma lines for residual plots
+        if data.plot_role == data.ROLE_RESIDUAL:
+            ax.axhline(y=3, color='red', linestyle='-')
+            ax.axhline(y=-3, color='red', linestyle='-')
+            ax.axhline(y=1, color='gray', linestyle='--')
+            ax.axhline(y=-1, color='gray', linestyle='--')
         # Update the list of data sets (plots) in chart
         self.plot_dict[data.name] = data
 


### PR DESCRIPTION
## Description
Residual plots should now have 2 red lines at +/- 3 sigma and 2 dashed gray lines at +/-1 sigma.  There does not seem to be any documentation that needs updating.

The only change necessary for this was to use the `data1D_plot_role` already established. This allows the fix to require only a small 5 line block of code in the `PlotterWidget` in `plotter.py`.  Basically if `data.plot_role==data1D.ROLE_RESIDUAL` then add 4 horizontal lines (`ax.axhline()`). 

Fixes #1329

## How Has This Been Tested?
by running in developer environment

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.
Load a data set (AOT microemulsion for example), send to fitting, choose a model (e.g. sphere/core_shell_sphere), hit compute/plot and/or fit (after choosing some parameters to fit).  The residual plots should have the extra 4 lines.

## Review Checklist (please remove items if they don't apply):

- [ ] Code has been reviewed
- [ ] Functionality has been tested
- [ ] Windows installer (GH artifact) has been tested (installed and worked) 
- [ ] MacOSX installer (GH artifact) has been tested (installed and worked) 
- [x] The introduced changes comply with SasView license (BSD 3-Clause)

