### PR TITLE
2447 plot roles

### DIFF
--- a/src/sas/qtgui/MainWindow/DataExplorer.py
+++ b/src/sas/qtgui/MainWindow/DataExplorer.py
@@ -1044,8 +1044,11 @@ class DataExplorerWindow(DroppableDataLoadWidget):
                     or name in plot.name
                     or name == plot.filename):
                 # Residuals get their own plot
-                if plot.plot_role == DataRole.ROLE_RESIDUAL:
+                if plot.plot_role in [DataRole.ROLE_RESIDUAL, DataRole.ROLE_STAND_ALONE_LINEAR]:
                     plot.yscale = 'linear'
+                    self.plotData([(item, plot)])
+                elif plot.plot_role in [DataRole.ROLE_STAND_ALONE_LOG]:
+                    plot.yscale = 'log'
                     self.plotData([(item, plot)])
                 else:
                     new_plots.append((item, plot))
@@ -1091,13 +1094,20 @@ class DataExplorerWindow(DroppableDataLoadWidget):
 
             plot_name = plot_to_show.name
             role = plot_to_show.plot_role
+            stand_alone_types = [DataRole.ROLE_RESIDUAL, DataRole.ROLE_STAND_ALONE_LINEAR, DataRole.ROLE_STAND_ALONE_LOG]
+            stand_alone_linear_types = [DataRole.ROLE_RESIDUAL, DataRole.ROLE_STAND_ALONE_LINEAR]
+            stand_alone_log_types = [DataRole.ROLE_STAND_ALONE_LOG]
 
-            if (role == DataRole.ROLE_RESIDUAL and shown) or role == DataRole.ROLE_DELETABLE:
+            if (role in stand_alone_types and shown) or role == DataRole.ROLE_DELETABLE:
                 # Nothing to do if separate plot already shown or to be deleted
                 continue
-            elif role == DataRole.ROLE_RESIDUAL:
-                # Residual plots should always be separate
-                plot_to_show.yscale='linear'
+            elif role in stand_alone_linear_types:
+                # Stand-alone linear and residual plots should always be separate
+                plot_to_show.yscale = 'linear'
+                self.plotData([(plot_item, plot_to_show)])
+            elif role in stand_alone_log_types:
+                # Stand-alone log plots should always be separate
+                plot_to_show.yscale = 'log'
                 self.plotData([(plot_item, plot_to_show)])
             elif append:
                 # Assume all other plots sent together should be on the same chart if a previous plot exists

--- a/src/sas/qtgui/MainWindow/DataExplorer.py
+++ b/src/sas/qtgui/MainWindow/DataExplorer.py
@@ -21,6 +21,7 @@ import sas.qtgui.Plotting.PlotHelper as PlotHelper
 
 from sas.qtgui.Plotting.PlotterData import Data1D
 from sas.qtgui.Plotting.PlotterData import Data2D
+from sas.qtgui.Plotting.PlotterData import DataRole
 from sas.qtgui.Plotting.Plotter import Plotter
 from sas.qtgui.Plotting.Plotter2D import Plotter2D
 from sas.qtgui.Plotting.MaskEditor import MaskEditor
@@ -1043,7 +1044,7 @@ class DataExplorerWindow(DroppableDataLoadWidget):
                     or name in plot.name
                     or name == plot.filename):
                 # Residuals get their own plot
-                if plot.plot_role == Data1D.ROLE_RESIDUAL:
+                if plot.plot_role == DataRole.ROLE_RESIDUAL:
                     plot.yscale = 'linear'
                     self.plotData([(item, plot)])
                 else:
@@ -1091,10 +1092,10 @@ class DataExplorerWindow(DroppableDataLoadWidget):
             plot_name = plot_to_show.name
             role = plot_to_show.plot_role
 
-            if (role == Data1D.ROLE_RESIDUAL and shown) or role == Data1D.ROLE_DELETABLE:
+            if (role == DataRole.ROLE_RESIDUAL and shown) or role == DataRole.ROLE_DELETABLE:
                 # Nothing to do if separate plot already shown or to be deleted
                 continue
-            elif role == Data1D.ROLE_RESIDUAL:
+            elif role == DataRole.ROLE_RESIDUAL:
                 # Residual plots should always be separate
                 plot_to_show.yscale='linear'
                 self.plotData([(plot_item, plot_to_show)])
@@ -1128,7 +1129,7 @@ class DataExplorerWindow(DroppableDataLoadWidget):
         if not hasattr(plot, 'name'):
             return False
         ids_vals = [val.data[0].name for val in self.active_plots.values()]
-                    #if val.data[0].plot_role != Data1D.ROLE_DATA]
+                    #if val.data[0].plot_role != DataRole.ROLE_DATA]
 
         return plot.name in ids_vals
 
@@ -1271,13 +1272,13 @@ class DataExplorerWindow(DroppableDataLoadWidget):
         data_id = data.name
         if data_id in ids_keys:
             # We have data, let's replace data that needs replacing
-            if data.plot_role != Data1D.ROLE_DATA:
+            if data.plot_role != DataRole.ROLE_DATA:
                 self.active_plots[data_id].replacePlot(data_id, data)
                 # restore minimized window, if applicable
                 self.active_plots[data_id].showNormal()
             return True
         #elif data_id in ids_vals:
-        #    if data.plot_role != Data1D.ROLE_DATA:
+        #    if data.plot_role != DataRole.ROLE_DATA:
         #        list(self.active_plots.values())[ids_vals.index(data_id)].replacePlot(data_id, data)
         #        self.active_plots[data_id].showNormal()
         #    return True

--- a/src/sas/qtgui/MainWindow/DataManager.py
+++ b/src/sas/qtgui/MainWindow/DataManager.py
@@ -27,7 +27,7 @@ import re
 from io import BytesIO
 import numpy as np
 
-from sas.qtgui.Plotting.PlotterData import Data1D
+from sas.qtgui.Plotting.PlotterData import Data1D, DataRole
 from sas.qtgui.Plotting.PlotterData import Data2D
 from sas.qtgui.Plotting.Plottables import PlottableTheory1D
 from sas.qtgui.Plotting.Plottables import PlottableFit1D
@@ -128,7 +128,7 @@ class DataManager(object):
         new_plot.path = path
         new_plot.list_group_id = []
         # Assign the plot role to data
-        new_plot.plot_role = Data1D.ROLE_DATA
+        new_plot.plot_role = DataRole.ROLE_DATA
         ##post data to plot
         # plot data
         return new_plot

--- a/src/sas/qtgui/MainWindow/UnitTesting/DataExplorerTest.py
+++ b/src/sas/qtgui/MainWindow/UnitTesting/DataExplorerTest.py
@@ -11,7 +11,7 @@ from PyQt5.QtCore import *
 from mpl_toolkits.mplot3d import Axes3D
 
 # Local
-from sas.qtgui.Plotting.PlotterData import Data1D, Data2D
+from sas.qtgui.Plotting.PlotterData import Data1D, Data2D, DataRole
 from sasdata.dataloader.loader import Loader
 from sas.qtgui.MainWindow.DataManager import DataManager
 
@@ -1143,19 +1143,19 @@ class DataExplorerTest:
         plot1 = Plotter(parent=form)
         data1 = Data1D()
         data1.name = 'p1'
-        data1.plot_role = Data1D.ROLE_DATA
+        data1.plot_role = DataRole.ROLE_DATA
         plot1.data = data1
 
         plot2 = Plotter(parent=form)
         data2 = Data1D()
         data2.name = 'M2 [p1]'
-        data2.plot_role = Data1D.ROLE_DEFAULT
+        data2.plot_role = DataRole.ROLE_DEFAULT
         plot2.data = data2
 
         plot3 = Plotter(parent=form)
         data3 = Data1D()
         data3.name = 'Residuals for M2[p1]'
-        data3.plot_role = Data1D.ROLE_RESIDUAL
+        data3.plot_role = DataRole.ROLE_RESIDUAL
         plot3.data = data3
 
         # pretend we're displaying three plots
@@ -1175,7 +1175,7 @@ class DataExplorerTest:
         plot4 = Plotter(parent=form)
         data4 = Data1D()
         data4.name = 'M1 [p1]'
-        data4.plot_role = Data1D.ROLE_DEFAULT
+        data4.plot_role = DataRole.ROLE_DEFAULT
         plot4.data = data1
         # same data but must show, since different model
         assert not form.isPlotShown(data4)
@@ -1190,19 +1190,19 @@ class DataExplorerTest:
         plot1 = Plotter(parent=form)
         data1 = Data2D()
         data1.name = 'p1'
-        data1.plot_role = Data1D.ROLE_DATA
+        data1.plot_role = DataRole.ROLE_DATA
         plot1.data = data1
 
         plot2 = Plotter(parent=form)
         data2 = Data2D()
         data2.name = 'M2 [p1]'
-        data2.plot_role = Data1D.ROLE_DEFAULT
+        data2.plot_role = DataRole.ROLE_DEFAULT
         plot2.data = data2
 
         plot3 = Plotter(parent=form)
         data3 = Data2D()
         data3.name = 'Residuals for M2[p1]'
-        data3.plot_role = Data1D.ROLE_RESIDUAL
+        data3.plot_role = DataRole.ROLE_RESIDUAL
         plot3.data = data3
 
         # pretend we're displaying three plots

--- a/src/sas/qtgui/MainWindow/UnitTesting/DataExplorerTest.py
+++ b/src/sas/qtgui/MainWindow/UnitTesting/DataExplorerTest.py
@@ -1132,7 +1132,6 @@ class DataExplorerTest:
         assert len(PlotHelper.currentPlotIds()) == 0
         assert len(form.plot_widgets) == 0
 
-    @pytest.mark.xfail(reason="2022-09 already broken")
     def testPlotsFromMultipleData1D(self, form):
         """
         Tests interplay between plotting 1D datasets and plotting
@@ -1165,7 +1164,7 @@ class DataExplorerTest:
 
         # redoing plots from the same tab
         # data -> must be shown
-        assert not form.isPlotShown(data1)
+        assert form.isPlotShown(data1)
 
         # model and residuals are already shown
         assert form.isPlotShown(data2)

--- a/src/sas/qtgui/Perspectives/Fitting/FittingLogic.py
+++ b/src/sas/qtgui/Perspectives/Fitting/FittingLogic.py
@@ -1,7 +1,6 @@
 import numpy as np
 
-from sas.qtgui.Plotting.PlotterData import Data1D
-from sas.qtgui.Plotting.PlotterData import Data2D
+from sas.qtgui.Plotting.PlotterData import Data1D, Data2D, DataRole
 
 from sasdata.dataloader.data_info import Detector
 from sasdata.dataloader.data_info import Source
@@ -155,7 +154,7 @@ class FittingLogic:
         new_plot.yaxis(_yaxis, _yunit)
 
         if component is not None:
-            new_plot.plot_role = Data1D.ROLE_DELETABLE #deletable
+            new_plot.plot_role = DataRole.ROLE_DELETABLE #deletable
 
         return new_plot
 

--- a/src/sas/qtgui/Perspectives/Fitting/FittingUtilities.py
+++ b/src/sas/qtgui/Perspectives/Fitting/FittingUtilities.py
@@ -643,7 +643,7 @@ def plotPolydispersities(model):
         data1d.symbol = 'Line'
         data1d.name = "{} polydispersity".format(name)
         data1d.id = data1d.name # placeholder, has to be completed later
-        data1d.plot_role = DataRole.ROLE_RESIDUAL
+        data1d.plot_role = DataRole.ROLE_STAND_ALONE_LINEAR
         plots.append(data1d)
     return plots
 

--- a/src/sas/qtgui/Perspectives/Fitting/FittingUtilities.py
+++ b/src/sas/qtgui/Perspectives/Fitting/FittingUtilities.py
@@ -5,8 +5,7 @@ from PyQt5 import QtGui
 
 import numpy
 
-from sas.qtgui.Plotting.PlotterData import Data1D
-from sas.qtgui.Plotting.PlotterData import Data2D
+from sas.qtgui.Plotting.PlotterData import Data1D, DataRole, Data2D
 
 from sas.qtgui.Perspectives.Fitting.AssociatedComboBox import AssociatedComboBox
 
@@ -644,7 +643,7 @@ def plotPolydispersities(model):
         data1d.symbol = 'Line'
         data1d.name = "{} polydispersity".format(name)
         data1d.id = data1d.name # placeholder, has to be completed later
-        data1d.plot_role = Data1D.ROLE_RESIDUAL
+        data1d.plot_role = DataRole.ROLE_RESIDUAL
         plots.append(data1d)
     return plots
 

--- a/src/sas/qtgui/Perspectives/Fitting/FittingWidget.py
+++ b/src/sas/qtgui/Perspectives/Fitting/FittingWidget.py
@@ -28,8 +28,7 @@ from sas.sascalc.fit import models
 
 import sas.qtgui.Utilities.GuiUtils as GuiUtils
 from sas.qtgui.Utilities.CategoryInstaller import CategoryInstaller
-from sas.qtgui.Plotting.PlotterData import Data1D
-from sas.qtgui.Plotting.PlotterData import Data2D
+from sas.qtgui.Plotting.PlotterData import Data1D, Data2D, DataRole
 from sas.qtgui.Plotting.Plotter import PlotterWidget
 
 from sas.qtgui.Perspectives.Fitting.UI.FittingWidgetUI import Ui_FittingWidgetUI
@@ -2451,7 +2450,7 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         data_shown = False
         item = None
         for item, plot in plots.items():
-            if plot.plot_role != Data1D.ROLE_DATA and fitpage_name in plot.name:
+            if plot.plot_role != DataRole.ROLE_DATA and fitpage_name in plot.name:
                 data_shown = True
                 self.communicate.plotRequestedSignal.emit([item, plot], self.tab_id)
         # return the last data item seen, if nothing was plotted; supposed to be just data)
@@ -3333,7 +3332,7 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         if residuals_plot is None:
             return
         residuals_plot.id = "Residual " + residuals_plot.id
-        residuals_plot.plot_role = Data1D.ROLE_RESIDUAL
+        residuals_plot.plot_role = DataRole.ROLE_RESIDUAL
         self.createNewIndex(residuals_plot)
         return residuals_plot
 

--- a/src/sas/qtgui/Perspectives/Invariant/InvariantPerspective.py
+++ b/src/sas/qtgui/Perspectives/Invariant/InvariantPerspective.py
@@ -11,7 +11,7 @@ from twisted.internet import reactor
 
 # sas-global
 from sas.sascalc.invariant import invariant
-from sas.qtgui.Plotting.PlotterData import Data1D
+from sas.qtgui.Plotting.PlotterData import Data1D, DataRole
 import sas.qtgui.Utilities.GuiUtils as GuiUtils
 
 # local
@@ -266,7 +266,7 @@ class InvariantWindow(QtWidgets.QDialog, Ui_tabbedInvariantUI, Perspective):
         # Send the modified model item to DE for keeping in the model
         plots = [self._model_item]
         if self.high_extrapolation_plot:
-            self.high_extrapolation_plot.plot_role = Data1D.ROLE_DEFAULT
+            self.high_extrapolation_plot.plot_role = DataRole.ROLE_DEFAULT
             self.high_extrapolation_plot.symbol = "Line"
             self.high_extrapolation_plot.show_errors = False
             self.high_extrapolation_plot.show_q_range_sliders = True
@@ -280,7 +280,7 @@ class InvariantWindow(QtWidgets.QDialog, Ui_tabbedInvariantUI, Perspective):
                                              self.high_extrapolation_plot.title)
             plots.append(self.high_extrapolation_plot)
         if self.low_extrapolation_plot:
-            self.low_extrapolation_plot.plot_role = Data1D.ROLE_DEFAULT
+            self.low_extrapolation_plot.plot_role = DataRole.ROLE_DEFAULT
             self.low_extrapolation_plot.symbol = "Line"
             self.low_extrapolation_plot.show_errors = False
             self.low_extrapolation_plot.show_q_range_sliders = True

--- a/src/sas/qtgui/Perspectives/Inversion/InversionPerspective.py
+++ b/src/sas/qtgui/Perspectives/Inversion/InversionPerspective.py
@@ -654,7 +654,7 @@ class InversionWindow(QtWidgets.QDialog, Ui_PrInversion, Perspective):
                                            pr.get_pos_err(out, cov))))
         if self.prPlot is not None:
             title = self.prPlot.name
-            self.prPlot.plot_role = DataRole.ROLE_RESIDUAL
+            self.prPlot.plot_role = DataRole.ROLE_STAND_ALONE_LINEAR
             GuiUtils.updateModelItemWithPlot(self._data, self.prPlot, title)
             self.communicate.plotRequestedSignal.emit([self._data,self.prPlot], None)
         if self.dataPlot is not None:

--- a/src/sas/qtgui/Perspectives/Inversion/InversionPerspective.py
+++ b/src/sas/qtgui/Perspectives/Inversion/InversionPerspective.py
@@ -13,7 +13,7 @@ from .InversionLogic import InversionLogic
 
 # pr inversion calculation elements
 from sas.sascalc.pr.invertor import Invertor
-from sas.qtgui.Plotting.PlotterData import Data1D
+from sas.qtgui.Plotting.PlotterData import Data1D, DataRole
 # Batch calculation display
 from sas.qtgui.Utilities.GridPanel import BatchInversionOutputPanel
 from sas.qtgui.Perspectives.perspective import Perspective
@@ -654,12 +654,12 @@ class InversionWindow(QtWidgets.QDialog, Ui_PrInversion, Perspective):
                                            pr.get_pos_err(out, cov))))
         if self.prPlot is not None:
             title = self.prPlot.name
-            self.prPlot.plot_role = Data1D.ROLE_RESIDUAL
+            self.prPlot.plot_role = DataRole.ROLE_RESIDUAL
             GuiUtils.updateModelItemWithPlot(self._data, self.prPlot, title)
             self.communicate.plotRequestedSignal.emit([self._data,self.prPlot], None)
         if self.dataPlot is not None:
             title = self.dataPlot.name
-            self.dataPlot.plot_role = Data1D.ROLE_DEFAULT
+            self.dataPlot.plot_role = DataRole.ROLE_DEFAULT
             self.dataPlot.symbol = "Line"
             self.dataPlot.show_errors = False
             GuiUtils.updateModelItemWithPlot(self._data, self.dataPlot, title)

--- a/src/sas/qtgui/Plotting/Plotter.py
+++ b/src/sas/qtgui/Plotting/Plotter.py
@@ -11,7 +11,7 @@ import textwrap
 from matplotlib.font_manager import FontProperties
 from packaging import version
 
-from sas.qtgui.Plotting.PlotterData import Data1D
+from sas.qtgui.Plotting.PlotterData import Data1D, DataRole
 from sas.qtgui.Plotting.PlotterBase import PlotterBase
 from sas.qtgui.Plotting.AddText import AddText
 from sas.qtgui.Plotting.Binder import BindArtist
@@ -228,7 +228,7 @@ class PlotterWidget(PlotterBase):
             ax.axhline(color='black', linewidth=1)
 
         # Display +/- 3 sigma and +/- 1 sigma lines for residual plots
-        if data.plot_role == data.ROLE_RESIDUAL:
+        if data.plot_role == DataRole.ROLE_RESIDUAL:
             ax.axhline(y=3, color='red', linestyle='-')
             ax.axhline(y=-3, color='red', linestyle='-')
             ax.axhline(y=1, color='gray', linestyle='--')

--- a/src/sas/qtgui/Plotting/PlotterData.py
+++ b/src/sas/qtgui/Plotting/PlotterData.py
@@ -55,7 +55,7 @@ class Data1D(PlottableData1D, LoadData1D):
         # 1: normal lifecycle (fit)
         # 2: deletable on model change (Q(I), S(I)...)
         # 3: separate chart on Show Plot (residuals)
-        self.plot_role = Data1D.ROLE_DEFAULT
+        self.plot_role = DataRole.ROLE_DEFAULT
         # Q-range slider definitions
         self.show_q_range_sliders = False  # Should sliders be shown?
         self.slider_update_on_move = True  # Should the gui update during the move?
@@ -221,7 +221,7 @@ class Data2D(PlottableData2D, LoadData2D):
         self.title = ""
         self.scale = None
         # Always default
-        self.plot_role = Data1D.ROLE_DEFAULT
+        self.plot_role = DataRole.ROLE_DEFAULT
         
     def copy_from_datainfo(self, data2d):
         """

--- a/src/sas/qtgui/Plotting/PlotterData.py
+++ b/src/sas/qtgui/Plotting/PlotterData.py
@@ -25,8 +25,10 @@ class DataRole(Enum):
     ROLE_DELETABLE = 2
     # Residual is for stand-alone residual plots
     ROLE_RESIDUAL = 3
-    # Stand alone is for plots that should be plotted alone, but wth no specific application
-    ROLE_STAND_ALONE = 4
+    # Stand alone linear is for plots that should be plotted separately on a linear scale
+    ROLE_STAND_ALONE_LINEAR = 4
+    # Stand alone log is for plots that should be plotted separately on a logarithmic scale
+    ROLE_STAND_ALONE_LOG = 5
 
 
 class Data1D(PlottableData1D, LoadData1D):

--- a/src/sas/qtgui/Plotting/PlotterData.py
+++ b/src/sas/qtgui/Plotting/PlotterData.py
@@ -4,6 +4,8 @@ Adapters for fitting module
 import copy
 import numpy
 import math
+from enum import Enum
+
 from sasdata.data_util.uncertainty import Uncertainty
 
 from sas.qtgui.Plotting.Plottables import PlottableData1D
@@ -13,13 +15,23 @@ from sasdata.dataloader.data_info import Data1D as LoadData1D
 from sasdata.dataloader.data_info import Data2D as LoadData2D
 
 
+class DataRole(Enum):
+    """Labels to apply to different plot types."""
+    # Data is for imported data
+    ROLE_DATA = 0
+    # Default is for fits of the imported data
+    ROLE_DEFAULT = 1
+    # Deletable is for orphaned plots
+    ROLE_DELETABLE = 2
+    # Residual is for stand-alone residual plots
+    ROLE_RESIDUAL = 3
+    # Stand alone is for plots that should be plotted alone, but wth no specific application
+    ROLE_STAND_ALONE = 4
+
+
 class Data1D(PlottableData1D, LoadData1D):
     """
     """
-    ROLE_DATA=0
-    ROLE_DEFAULT=1
-    ROLE_DELETABLE=2
-    ROLE_RESIDUAL=3
     def __init__(self, x=None, y=None, dx=None, dy=None):
         """
         """

--- a/src/sas/qtgui/Utilities/GuiUtils.py
+++ b/src/sas/qtgui/Utilities/GuiUtils.py
@@ -27,8 +27,7 @@ from PyQt5 import QtWidgets
 from periodictable import formula as Formula
 from sas.qtgui.Plotting import DataTransform
 from sas.qtgui.Plotting.ConvertUnits import convertUnit
-from sas.qtgui.Plotting.PlotterData import Data1D
-from sas.qtgui.Plotting.PlotterData import Data2D
+from sas.qtgui.Plotting.PlotterData import Data1D, Data2D, DataRole
 from sas.qtgui.Plotting.Plottables import Plottable
 from sasdata.dataloader.data_info import Sample, Source, Vector
 from sasdata.dataloader.data_info import Detector, Process, TransmissionSpectrum
@@ -240,7 +239,7 @@ def deleteRedundantPlots(item, new_plots):
         if (plot_data.id is not None) and \
             (plot_data.id not in ids) and \
             (plot_data.name not in names) and \
-            (plot_data.plot_role == Data1D.ROLE_DELETABLE):
+            (plot_data.plot_role == DataRole.ROLE_DELETABLE):
             items_to_delete.append(plot_item)
 
     for plot_item in items_to_delete:


### PR DESCRIPTION
## Description

Two new plotting roles are introduced here - stand-alone linear and stand-alone log. These are in addition to the residual role which has unique characteristics. These roles allow a plot to be displayed on its own without the parent data set. These new roles have been applied to the P(r) and polydispersity plots so the residual lines added in #2443 are not shown.

Fixes #2447

## How Has This Been Tested?

Run sasview. Run a fit with polydispersity. Residual plots have the +/- 1 and 3 lines, dispersity plots do not. Run a P(r) inversion. P(r) plots do not have the +/- lines.

## Review Checklist (please remove items if they don't apply):

- [ ] Code has been reviewed
- [ ] Functionality has been tested
- [ ] Windows installer (GH artifact) has been tested (installed and worked) 
- [ ] MacOSX installer (GH artifact) has been tested (installed and worked) 
- [x] Developers documentation is available and complete (if required)
- [x] The introduced changes comply with SasView license (BSD 3-Clause)

