### PR TITLE
Fix for 1D operations on 2D residual plots

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -106,7 +106,7 @@ jobs:
         git clone --depth=1 --branch=release_1.0.7 https://github.com/SasView/sasmodels.git ../sasmodels
         git clone --branch=master https://github.com/bumps/bumps.git ../bumps
         cd ../bumps
-        git checkout ccc150c60d5cf5f4e16a45a8dfd67c3db1f8c581
+        git checkout b339e9e1e7e01047816a6f6d6dd67cb97c7227b5
         cd ../sasview
 
     - name: Build and install sasmodels

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -105,6 +105,9 @@ jobs:
       run: |
         git clone --depth=1 --branch=release_1.0.7 https://github.com/SasView/sasmodels.git ../sasmodels
         git clone --depth=1 --branch=master https://github.com/bumps/bumps.git ../bumps
+        cd ../bumps
+        git checkout ccc150c60d5cf5f4e16a45a8dfd67c3db1f8c581
+        cd ../sasview
 
     - name: Build and install sasmodels
       run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -104,10 +104,7 @@ jobs:
     - name: Fetch sources for sibling projects
       run: |
         git clone --depth=1 --branch=release_1.0.7 https://github.com/SasView/sasmodels.git ../sasmodels
-        git clone --branch=master https://github.com/bumps/bumps.git ../bumps
-        cd ../bumps
-        git checkout b339e9e1e7e01047816a6f6d6dd67cb97c7227b5
-        cd ../sasview
+        git clone --depth=1 --branch=master https://github.com/bumps/bumps.git ../bumps
 
     - name: Build and install sasmodels
       run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -104,7 +104,7 @@ jobs:
     - name: Fetch sources for sibling projects
       run: |
         git clone --depth=1 --branch=release_1.0.7 https://github.com/SasView/sasmodels.git ../sasmodels
-        git clone --depth=1 --branch=master https://github.com/bumps/bumps.git ../bumps
+        git clone --branch=master https://github.com/bumps/bumps.git ../bumps
         cd ../bumps
         git checkout ccc150c60d5cf5f4e16a45a8dfd67c3db1f8c581
         cd ../sasview

--- a/src/sas/sascalc/dataloader/manipulations.py
+++ b/src/sas/sascalc/dataloader/manipulations.py
@@ -344,7 +344,8 @@ class _Slab(object):
 
         # Get data
         data = data2D.data[np.isfinite(data2D.data)]
-        err_data = data2D.err_data[np.isfinite(data2D.data)]
+        if data2D.err_data is not None:
+            err_data = data2D.err_data[np.isfinite(data2D.data)]
         qx_data = data2D.qx_data[np.isfinite(data2D.data)]
         qy_data = data2D.qy_data[np.isfinite(data2D.data)]
         mask_data = data2D.mask[np.isfinite(data2D.data)]
@@ -507,7 +508,8 @@ class Boxsum(object):
             raise RuntimeError(msg)
         # Get data
         data = data2D.data[np.isfinite(data2D.data)]
-        err_data = data2D.err_data[np.isfinite(data2D.data)]
+        if data2D.err_data is not None:
+            err_data = data2D.err_data[np.isfinite(data2D.data)]
         qx_data = data2D.qx_data[np.isfinite(data2D.data)]
         qy_data = data2D.qy_data[np.isfinite(data2D.data)]
         mask_data = data2D.mask[np.isfinite(data2D.data)]
@@ -602,7 +604,9 @@ class CircularAverage(object):
         # Get data W/ finite values
         data = data2D.data[np.isfinite(data2D.data)]
         q_data = data2D.q_data[np.isfinite(data2D.data)]
-        err_data = data2D.err_data[np.isfinite(data2D.data)]
+        err_data = None
+        if data2D.err_data is not None:
+            err_data = data2D.err_data[np.isfinite(data2D.data)]
         mask_data = data2D.mask[np.isfinite(data2D.data)]
 
         dq_data = None
@@ -735,7 +739,8 @@ class Ring(object):
         # Get data
         data = data2D.data[np.isfinite(data2D.data)]
         q_data = data2D.q_data[np.isfinite(data2D.data)]
-        err_data = data2D.err_data[np.isfinite(data2D.data)]
+        if data2D.err_data is not None:
+            err_data = data2D.err_data[np.isfinite(data2D.data)]
         qx_data = data2D.qx_data[np.isfinite(data2D.data)]
         qy_data = data2D.qy_data[np.isfinite(data2D.data)]
         mask_data = data2D.mask[np.isfinite(data2D.data)]
@@ -840,7 +845,8 @@ class _Sector(object):
         # Get the all data & info
         data = data2D.data[np.isfinite(data2D.data)]
         q_data = data2D.q_data[np.isfinite(data2D.data)]
-        err_data = data2D.err_data[np.isfinite(data2D.data)]
+        if data2D.err_data is not None:
+            err_data = data2D.err_data[np.isfinite(data2D.data)]
         qx_data = data2D.qx_data[np.isfinite(data2D.data)]
         qy_data = data2D.qy_data[np.isfinite(data2D.data)]
         mask_data = data2D.mask[np.isfinite(data2D.data)]

--- a/src/sas/sascalc/dataloader/manipulations.py
+++ b/src/sas/sascalc/dataloader/manipulations.py
@@ -935,7 +935,7 @@ class _Sector(object):
             # Get the total y
             y[i_bin] += data_n
             x[i_bin] += q_value
-            if err_data[n] is None or err_data[n] == 0.0:
+            if err_data is None or err_data[n] == 0.0:
                 if data_n < 0:
                     data_n = -data_n
                 y_err[i_bin] += data_n

--- a/src/sas/sascalc/dataloader/manipulations.py
+++ b/src/sas/sascalc/dataloader/manipulations.py
@@ -344,6 +344,7 @@ class _Slab(object):
 
         # Get data
         data = data2D.data[np.isfinite(data2D.data)]
+        err_data = None
         if data2D.err_data is not None:
             err_data = data2D.err_data[np.isfinite(data2D.data)]
         qx_data = data2D.qx_data[np.isfinite(data2D.data)]
@@ -508,6 +509,7 @@ class Boxsum(object):
             raise RuntimeError(msg)
         # Get data
         data = data2D.data[np.isfinite(data2D.data)]
+        err_data = None
         if data2D.err_data is not None:
             err_data = data2D.err_data[np.isfinite(data2D.data)]
         qx_data = data2D.qx_data[np.isfinite(data2D.data)]
@@ -739,6 +741,7 @@ class Ring(object):
         # Get data
         data = data2D.data[np.isfinite(data2D.data)]
         q_data = data2D.q_data[np.isfinite(data2D.data)]
+        err_data = None
         if data2D.err_data is not None:
             err_data = data2D.err_data[np.isfinite(data2D.data)]
         qx_data = data2D.qx_data[np.isfinite(data2D.data)]
@@ -845,6 +848,7 @@ class _Sector(object):
         # Get the all data & info
         data = data2D.data[np.isfinite(data2D.data)]
         q_data = data2D.q_data[np.isfinite(data2D.data)]
+        err_data = None
         if data2D.err_data is not None:
             err_data = data2D.err_data[np.isfinite(data2D.data)]
         qx_data = data2D.qx_data[np.isfinite(data2D.data)]


### PR DESCRIPTION
## Description

`data.err` can be None for certain plots, like residuals.
This should be checked when data.err is being subscripted.
Note - correct handlers for `None` are present in subsequent code.

Fixes #2436

## How Has This Been Tested?

Tested locally

## Review Checklist (please remove items if they don't apply):

- [x] Code has been reviewed
- [x] Functionality has been tested
- [x] Windows installer (GH artifact) has been tested (installed and worked) 
- [ ] MacOSX installer (GH artifact) has been tested (installed and worked) 
- [x] User documentation is available and complete (if required)
- [x] Developers documentation is available and complete (if required)
- [X] The introduced changes comply with SasView license (BSD 3-Clause)

