### PR TITLE
Console fix 5.0.6

### DIFF
--- a/.github/workflows/installers.yml
+++ b/.github/workflows/installers.yml
@@ -69,9 +69,9 @@ jobs:
         python -m pip install --upgrade pip
         python -m pip install wheel setuptools
 
-        python -m pip install numpy scipy==1.7.3 docutils "pytest<6" sphinx unittest-xml-reporting
+        python -m pip install numpy==1.21.6 scipy==1.7.3 docutils "pytest<6" sphinx unittest-xml-reporting
         python -m pip install tinycc h5py sphinx pyparsing html5lib reportlab==3.6.6 pybind11 appdirs
-        python -m pip install six numba mako ipython==8.5.0 qtconsole==5.3.2 xhtml2pdf unittest-xml-reporting pylint
+        python -m pip install six==1.16.0 numba==0.55.1 mako ipython==8.3.0 qtconsole==5.3.0 xhtml2pdf unittest-xml-reporting pylint
         python -m pip install qt5reactor periodictable uncertainties debugpy
 
 

--- a/.github/workflows/installers.yml
+++ b/.github/workflows/installers.yml
@@ -71,10 +71,9 @@ jobs:
 
         python -m pip install numpy scipy==1.7.3 docutils "pytest<6" sphinx unittest-xml-reporting
         python -m pip install tinycc h5py sphinx pyparsing html5lib reportlab==3.6.6 pybind11 appdirs
-        python -m pip install six numba mako ipython qtconsole xhtml2pdf unittest-xml-reporting pylint
+        python -m pip install six numba mako ipython==8.5.0 qtconsole==5.3.2 xhtml2pdf unittest-xml-reporting pylint
         python -m pip install qt5reactor periodictable uncertainties debugpy
-        python -m pip install qtconsole==5.3.2
-        python -m pip install ipython==8.5.0
+
 
     - name: Install PyQt (Windows + Linux)
       if: ${{ matrix.os != 'macos-latest' }}

--- a/.github/workflows/installers.yml
+++ b/.github/workflows/installers.yml
@@ -69,9 +69,9 @@ jobs:
         python -m pip install --upgrade pip
         python -m pip install wheel setuptools
 
-        python -m pip install numpy==1.21.6 scipy==1.7.3 matplotlib==2.2.5 docutils "pytest<6" sphinx unittest-xml-reporting
+        python -m pip install numpy scipy==1.7.3 docutils "pytest<6" sphinx unittest-xml-reporting
         python -m pip install tinycc h5py sphinx pyparsing html5lib reportlab==3.6.6 pybind11 appdirs
-        python -m pip install six==1.16.0 numba==0.55.1 mako ipython==8.3.0 qtconsole==5.3.0 xhtml2pdf unittest-xml-reporting pylint
+        python -m pip install six numba mako ipython qtconsole==5.3.0 xhtml2pdf unittest-xml-reporting pylint
         python -m pip install qt5reactor periodictable uncertainties debugpy "ipykernel<6"
 
 

--- a/.github/workflows/installers.yml
+++ b/.github/workflows/installers.yml
@@ -69,7 +69,7 @@ jobs:
         python -m pip install --upgrade pip
         python -m pip install wheel setuptools
 
-        python -m pip install numpy==1.21.6 scipy==1.7.3 docutils "pytest<6" sphinx unittest-xml-reporting
+        python -m pip install numpy==1.21.6 scipy==1.7.3 matplotlib==2.2.5 docutils "pytest<6" sphinx unittest-xml-reporting
         python -m pip install tinycc h5py sphinx pyparsing html5lib reportlab==3.6.6 pybind11 appdirs
         python -m pip install six==1.16.0 numba==0.55.1 mako ipython==8.3.0 qtconsole==5.3.0 xhtml2pdf unittest-xml-reporting pylint
         python -m pip install qt5reactor periodictable uncertainties debugpy

--- a/.github/workflows/installers.yml
+++ b/.github/workflows/installers.yml
@@ -72,7 +72,7 @@ jobs:
         python -m pip install numpy==1.21.6 scipy==1.7.3 matplotlib==2.2.5 docutils "pytest<6" sphinx unittest-xml-reporting
         python -m pip install tinycc h5py sphinx pyparsing html5lib reportlab==3.6.6 pybind11 appdirs
         python -m pip install six==1.16.0 numba==0.55.1 mako ipython==8.3.0 qtconsole==5.3.0 xhtml2pdf unittest-xml-reporting pylint
-        python -m pip install qt5reactor periodictable uncertainties debugpy
+        python -m pip install qt5reactor periodictable uncertainties debugpy "ipykernel<6"
 
 
     - name: Install PyQt (Windows + Linux)

--- a/.github/workflows/installers.yml
+++ b/.github/workflows/installers.yml
@@ -73,6 +73,8 @@ jobs:
         python -m pip install tinycc h5py sphinx pyparsing html5lib reportlab==3.6.6 pybind11 appdirs
         python -m pip install six numba mako ipython qtconsole xhtml2pdf unittest-xml-reporting pylint
         python -m pip install qt5reactor periodictable uncertainties debugpy
+        python -m pip install qtconsole==5.3.2
+        python -m pip install ipython==8.5.0
 
     - name: Install PyQt (Windows + Linux)
       if: ${{ matrix.os != 'macos-latest' }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,8 +69,8 @@ jobs:
 
         python -m pip install numpy scipy==1.7.3 docutils "pytest<6" sphinx unittest-xml-reporting
         python -m pip install tinycc h5py sphinx pyparsing html5lib reportlab==3.6.6 pybind11 appdirs
-        python -m pip install six numba mako ipython qtconsole xhtml2pdf unittest-xml-reporting pylint
-        python -m pip install qt5reactor periodictable uncertainties debugpy
+        python -m pip install six numba mako ipython qtconsole==5.3.0 xhtml2pdf unittest-xml-reporting pylint
+        python -m pip install qt5reactor periodictable uncertainties debugpy "ipykernel<6"
 
     - name: Install PyQt (Windows + Linux)
       if: ${{ matrix.os != 'macos-latest' }}

--- a/src/sas/qtgui/MainWindow/GuiManager.py
+++ b/src/sas/qtgui/MainWindow/GuiManager.py
@@ -923,7 +923,7 @@ class GuiManager(object):
         if sys.stdout is None:
             logging.warning(f"sys.stdout is None")
             logging.warning(str(sys.__stdout__))
-            logging.warning(str(sys.__stderr__)
+            logging.warning(str(sys.__stderr__))
             sys.stdout = sys.__stdout__
             sys.stderr = sys.__stderr__
 

--- a/src/sas/qtgui/MainWindow/GuiManager.py
+++ b/src/sas/qtgui/MainWindow/GuiManager.py
@@ -921,6 +921,9 @@ class GuiManager(object):
         """
         # reset stdout/stderr
         if sys.stdout is None:
+            logging.warning(f"sys.stdout is None")
+            logging.warning(str(sys.__stdout__))
+            logging.warning(str(sys.__stderr__)
             sys.stdout = sys.__stdout__
             sys.stderr = sys.__stderr__
 

--- a/src/sas/qtgui/MainWindow/GuiManager.py
+++ b/src/sas/qtgui/MainWindow/GuiManager.py
@@ -919,10 +919,11 @@ class GuiManager(object):
         """
         Display the Jupyter console as a docked widget.
         """
-        # show stdout 
-        std_out = str(sys.stdout)
-        logging.warning(f" *** actionPython_Shell_Editor  sys.stdout = {std_out} *******")
-        sys.stdout = self._workspace.console
+        # reset stdout/stderr
+        if sys.stdout is None:
+            sys.stdout = sys.__stdout__
+            sys.stderr = sys.__stderr__
+
         # Import moved here for startup performance reasons
         from sas.qtgui.Utilities.IPythonWidget import IPythonWidget
         terminal = IPythonWidget()

--- a/src/sas/qtgui/MainWindow/GuiManager.py
+++ b/src/sas/qtgui/MainWindow/GuiManager.py
@@ -919,6 +919,10 @@ class GuiManager(object):
         """
         Display the Jupyter console as a docked widget.
         """
+        # show stdout 
+        std_out = str(sys.stdout)
+        logging.warning(f" *** actionPython_Shell_Editor  sys.stdout = {std_out} *******")
+        sys.stdout = self._workspace.console
         # Import moved here for startup performance reasons
         from sas.qtgui.Utilities.IPythonWidget import IPythonWidget
         terminal = IPythonWidget()

--- a/src/sas/qtgui/MainWindow/GuiManager.py
+++ b/src/sas/qtgui/MainWindow/GuiManager.py
@@ -919,14 +919,6 @@ class GuiManager(object):
         """
         Display the Jupyter console as a docked widget.
         """
-        # reset stdout/stderr
-        if sys.stdout is None:
-            logging.warning(f"sys.stdout is None")
-            logging.warning(str(sys.__stdout__))
-            logging.warning(str(sys.__stderr__))
-            sys.stdout = sys.__stdout__
-            sys.stderr = sys.__stderr__
-
         # Import moved here for startup performance reasons
         from sas.qtgui.Utilities.IPythonWidget import IPythonWidget
         terminal = IPythonWidget()


### PR DESCRIPTION
## Description

Pinning ipykernel and qtconsole version

Fixes #2452

## How Has This Been Tested?

Locally, with the installer from https://github.com/SasView/sasview/actions/runs/4426851089

## Review Checklist (please remove items if they don't apply):

- [ ] Code has been reviewed
- [ ] Functionality has been tested
- [ ] Windows installer (GH artifact) has been tested (installed and worked) 
- [ ] MacOSX installer (GH artifact) has been tested (installed and worked) 
- [ ] User documentation is available and complete (if required)
- [ ] Developers documentation is available and complete (if required)
- [ ] The introduced changes comply with SasView license (BSD 3-Clause)

