### PR TITLE
Add requests to requriements.txt

### DIFF
--- a/build_tools/requirements.txt
+++ b/build_tools/requirements.txt
@@ -39,3 +39,4 @@ pywin32; platform_system == "Windows"
 superqt
 pyopengl
 pyopengl_accelerate
+requests


### PR DESCRIPTION
## Description

This adds the `requests` module to requirements.txt. This will be needed for sasview/sasdata#31 in order to load remote data by URL. The work I'm doing in https://github.com/SasView/sasdata/tree/31-load-data-from-url isn't finished yet, but thought I should get this in before I break the build here.

## Review Checklist (please remove items if they don't apply):

- [ ] Code has been reviewed
- [ ] Functionality has been tested
- [ ] Windows installer (GH artifact) has been tested (installed and worked) 
- [ ] MacOSX installer (GH artifact) has been tested (installed and worked)
- [ ] The introduced changes comply with SasView license (BSD 3-Clause)

