### PR TITLE
Add argument to convertUI that forces full UI rebuild

### DIFF
--- a/run.py
+++ b/run.py
@@ -83,6 +83,11 @@ def prepare():
     os.environ['SASVIEW_DOC_PATH'] = docpath
 
 if __name__ == "__main__":
+
+    from sas.qtgui.convertUI import rebuild_new_ui
+    rebuild_new_ui()
+
     prepare()
+
     import sas.cli
     sys.exit(sas.cli.main(logging="development"))

--- a/setup.py
+++ b/setup.py
@@ -82,9 +82,12 @@ build_commands = [
 ]
 # determine if this run requires building of Qt GUI ui->py
 build_qt = any(c in sys.argv for c in build_commands)
+force_rebuild = "-f" if 'rebuildUI' in sys.argv else ""
+if force_rebuild:
+    sys.argv.remove('rebuildUI')
 
 if build_qt:
-    _ = subprocess.call([sys.executable, "src/sas/qtgui/convertUI.py"])
+    _ = subprocess.call([sys.executable, "src/sas/qtgui/convertUI.py", force_rebuild])
 
 
 # Required packages

--- a/setup.py
+++ b/setup.py
@@ -82,9 +82,9 @@ build_commands = [
 ]
 # determine if this run requires building of Qt GUI ui->py
 build_qt = any(c in sys.argv for c in build_commands)
-force_rebuild = "-f" if 'rebuildUI' in sys.argv else ""
-if force_rebuild:
-    sys.argv.remove('rebuildUI')
+force_rebuild = "-f" if 'rebuild_ui' in sys.argv or 'clean' in sys.argv else ""
+if 'rebuild_ui' in sys.argv:
+    sys.argv.remove('rebuild_ui')
 
 if build_qt:
     _ = subprocess.call([sys.executable, "src/sas/qtgui/convertUI.py", force_rebuild])

--- a/src/sas/qtgui/convertUI.py
+++ b/src/sas/qtgui/convertUI.py
@@ -52,19 +52,15 @@ def file_in_newer(file_in, file_out):
     # simple comparison of modification time
     return in_stat.st_mtime >= out_stat.st_mtime
 
-def main():
-    """ Entry point for running as a script """
 
-    args = sys.argv
-    force_recreate = '-f' in args
-
+def rebuild_new_ui(force=False):
     # look for .ui files
     for root, dirs, files in os.walk("."):
         for file in files:
             if file.endswith(".ui"):
                 file_in = os.path.join(root, file)
-                file_out = os.path.splitext(file_in)[0]+'.py'
-                if force_recreate or file_in_newer(file_in, file_out):
+                file_out = os.path.splitext(file_in)[0] + '.py'
+                if force or file_in_newer(file_in, file_out):
                     print("Generating " + file_out + " ...")
                     pyuic(file_in, file_out)
 
@@ -77,7 +73,7 @@ def main():
     in_file = os.path.join(ui_root, rc_file)
     out_file = os.path.join(ui_root, out_file)
 
-    if force_recreate or file_in_newer(in_file, out_file):
+    if force or file_in_newer(in_file, out_file):
         print("Generating " + out_file + " ...")
         pyrrc(in_file, out_file)
 
@@ -90,9 +86,18 @@ def main():
     in_file = os.path.join(images_root, rc_file)
     out_file = os.path.join(ui_root, out_file)
 
-    if force_recreate or file_in_newer(in_file, out_file):
+    if force or file_in_newer(in_file, out_file):
         print("Generating " + out_file + " ...")
         pyrrc(in_file, out_file)
+
+
+def main():
+    """ Entry point for running as a script """
+
+    args = sys.argv
+    force_recreate = '-f' in args
+
+    rebuild_new_ui(force_recreate)
 
 
 if __name__ == "__main__":

--- a/src/sas/qtgui/convertUI.py
+++ b/src/sas/qtgui/convertUI.py
@@ -51,43 +51,47 @@ def file_in_newer(file_in, file_out):
     # simple comparison of modification time
     return in_stat.st_mtime >= out_stat.st_mtime
 
+def main():
 
-args = sys.argv
-force_recreate = '-f' in args
+    args = sys.argv
+    force_recreate = '-f' in args
 
-# look for .ui files
-for root, dirs, files in os.walk("."):
-    for file in files:
-        if file.endswith(".ui"):
-            file_in = os.path.join(root, file)
-            file_out = os.path.splitext(file_in)[0]+'.py'
-            if force_recreate or file_in_newer(file_in, file_out):
-                print("Generating " + file_out + " ...")
-                pyuic(file_in, file_out)
+    # look for .ui files
+    for root, dirs, files in os.walk("."):
+        for file in files:
+            if file.endswith(".ui"):
+                file_in = os.path.join(root, file)
+                file_out = os.path.splitext(file_in)[0]+'.py'
+                if force_recreate or file_in_newer(file_in, file_out):
+                    print("Generating " + file_out + " ...")
+                    pyuic(file_in, file_out)
 
-# RC file in UI directory
-execute_root = os.path.split(sys.modules[__name__].__file__)[0]
-ui_root = os.path.join(execute_root, 'UI')
-rc_file = 'main_resources.qrc'
-out_file = 'main_resources_rc.py'
+    # RC file in UI directory
+    execute_root = os.path.split(sys.modules[__name__].__file__)[0]
+    ui_root = os.path.join(execute_root, 'UI')
+    rc_file = 'main_resources.qrc'
+    out_file = 'main_resources_rc.py'
 
-in_file = os.path.join(ui_root, rc_file)
-out_file = os.path.join(ui_root, out_file)
+    in_file = os.path.join(ui_root, rc_file)
+    out_file = os.path.join(ui_root, out_file)
 
-if force_recreate or file_in_newer(in_file, out_file):
-    print("Generating " + out_file + " ...")
-    pyrrc(in_file, out_file)
+    if force_recreate or file_in_newer(in_file, out_file):
+        print("Generating " + out_file + " ...")
+        pyrrc(in_file, out_file)
 
-# Images
-images_root = os.path.join(execute_root, 'images')
-out_root = os.path.join(execute_root, 'UI')
-rc_file = 'images.qrc'
-out_file = 'images_rc.py'
+    # Images
+    images_root = os.path.join(execute_root, 'images')
+    out_root = os.path.join(execute_root, 'UI')
+    rc_file = 'images.qrc'
+    out_file = 'images_rc.py'
 
-in_file = os.path.join(images_root, rc_file)
-out_file = os.path.join(ui_root, out_file)
+    in_file = os.path.join(images_root, rc_file)
+    out_file = os.path.join(ui_root, out_file)
 
-if force_recreate or file_in_newer(in_file, out_file):
-    print("Generating " + out_file + " ...")
-    pyrrc(in_file, out_file)
+    if force_recreate or file_in_newer(in_file, out_file):
+        print("Generating " + out_file + " ...")
+        pyrrc(in_file, out_file)
 
+
+if __name__ == "__main__":
+    main()

--- a/src/sas/qtgui/convertUI.py
+++ b/src/sas/qtgui/convertUI.py
@@ -1,4 +1,7 @@
 # Convert all .ui files in all subdirectories of the current script
+
+# Usage: python convert.py [-f]
+#  Arguments: -f -> Force the UI elements to be rebuilt, even if they exist
 import os
 import sys
 
@@ -48,13 +51,17 @@ def file_in_newer(file_in, file_out):
     # simple comparison of modification time
     return in_stat.st_mtime >= out_stat.st_mtime
 
+
+args = sys.argv
+force_recreate = '-f' in args
+
 # look for .ui files
 for root, dirs, files in os.walk("."):
     for file in files:
         if file.endswith(".ui"):
             file_in = os.path.join(root, file)
             file_out = os.path.splitext(file_in)[0]+'.py'
-            if file_in_newer(file_in, file_out):
+            if force_recreate or file_in_newer(file_in, file_out):
                 print("Generating " + file_out + " ...")
                 pyuic(file_in, file_out)
 
@@ -67,7 +74,7 @@ out_file = 'main_resources_rc.py'
 in_file = os.path.join(ui_root, rc_file)
 out_file = os.path.join(ui_root, out_file)
 
-if file_in_newer(in_file, out_file):
+if force_recreate or file_in_newer(in_file, out_file):
     print("Generating " + out_file + " ...")
     pyrrc(in_file, out_file)
 
@@ -80,7 +87,7 @@ out_file = 'images_rc.py'
 in_file = os.path.join(images_root, rc_file)
 out_file = os.path.join(ui_root, out_file)
 
-if file_in_newer(in_file, out_file):
+if force_recreate or file_in_newer(in_file, out_file):
     print("Generating " + out_file + " ...")
     pyrrc(in_file, out_file)
 

--- a/src/sas/qtgui/convertUI.py
+++ b/src/sas/qtgui/convertUI.py
@@ -5,6 +5,7 @@
 import os
 import sys
 
+
 def run(main, name, *args):
     saved_argv = sys.argv
     sys.argv = [name, *args]
@@ -19,6 +20,7 @@ def run(main, name, *args):
         pass
     return 0
 
+
 def pyrrc(in_file, out_file):
     """
     Run the qt resource compiler
@@ -26,12 +28,14 @@ def pyrrc(in_file, out_file):
     from PyQt5.pyrcc_main import main
     run(main, "pyrcc", in_file, "-o", out_file)
 
+
 def pyuic(in_file, out_file):
     """
     Run the qt UI compiler
     """
     from PyQt5.uic.pyuic import main
     run(main, "pyuic", "-o", out_file, in_file)
+
 
 def file_in_newer(file_in, file_out):
     """
@@ -55,39 +59,31 @@ def file_in_newer(file_in, file_out):
 args = sys.argv
 force_recreate = '-f' in args
 
-# look for .ui files
+# Files that don't meet the default behavior of generating a python file with the same base name in the same directory
+#  - /same/path/to/<filename>.ui -> /same/path/to/<filename>.py using the pyuic() method
+oddity_dict = {
+    # Format: {'filename': {'f_name': 'new_filename', 'root': '/new/path/to/<f_name>.py', 'method': callable}}
+    'main_resources.qrc':
+        {
+            'f_name': 'main_resources_rc',
+            'root': '.\\UI\\',
+            'method': pyrrc,
+        },
+    'images.qrc':
+        {
+            'f_name': 'images_rc',
+            'root': '.\\UI\\',
+            'method': pyrrc,
+        },
+}
+
+# look for .ui and .qrc files and generate .py files in their required location
 for root, dirs, files in os.walk("."):
     for file in files:
-        if file.endswith(".ui"):
+        if file.endswith(".ui") or file.endswith('.qrc'):
+            file_dict = oddity_dict.get(file, {'f_name': file, 'root': root, 'method': pyuic})
             file_in = os.path.join(root, file)
-            file_out = os.path.splitext(file_in)[0]+'.py'
+            file_out = os.path.join(file_dict['root'], os.path.splitext(file_dict['f_name'])[0]+'.py')
             if force_recreate or file_in_newer(file_in, file_out):
                 print("Generating " + file_out + " ...")
-                pyuic(file_in, file_out)
-
-# RC file in UI directory
-execute_root = os.path.split(sys.modules[__name__].__file__)[0]
-ui_root = os.path.join(execute_root, 'UI')
-rc_file = 'main_resources.qrc'
-out_file = 'main_resources_rc.py'
-
-in_file = os.path.join(ui_root, rc_file)
-out_file = os.path.join(ui_root, out_file)
-
-if force_recreate or file_in_newer(in_file, out_file):
-    print("Generating " + out_file + " ...")
-    pyrrc(in_file, out_file)
-
-# Images
-images_root = os.path.join(execute_root, 'images')
-out_root = os.path.join(execute_root, 'UI')
-rc_file = 'images.qrc'
-out_file = 'images_rc.py'
-
-in_file = os.path.join(images_root, rc_file)
-out_file = os.path.join(ui_root, out_file)
-
-if force_recreate or file_in_newer(in_file, out_file):
-    print("Generating " + out_file + " ...")
-    pyrrc(in_file, out_file)
-
+                file_dict['method'](file_in, file_out)

--- a/src/sas/qtgui/convertUI.py
+++ b/src/sas/qtgui/convertUI.py
@@ -5,11 +5,12 @@
 import os
 import sys
 
-def run(main, name, *args):
+def run_compiler(compiler_main, name, *args):
+    """ Wrapper to run a compiler, either pyrrc or pyuic"""
     saved_argv = sys.argv
     sys.argv = [name, *args]
     try:
-        main()
+        compiler_main()
     except SystemExit as exc:
         if exc.code != 0:
             raise RuntimeError(f"\"{name} {' '.join(args)}\" exited with {exc.code}")
@@ -24,14 +25,14 @@ def pyrrc(in_file, out_file):
     Run the qt resource compiler
     """
     from PyQt5.pyrcc_main import main
-    run(main, "pyrcc", in_file, "-o", out_file)
+    run_compiler(main, "pyrcc", in_file, "-o", out_file)
 
 def pyuic(in_file, out_file):
     """
     Run the qt UI compiler
     """
     from PyQt5.uic.pyuic import main
-    run(main, "pyuic", "-o", out_file, in_file)
+    run_compiler(main, "pyuic", "-o", out_file, in_file)
 
 def file_in_newer(file_in, file_out):
     """
@@ -52,6 +53,7 @@ def file_in_newer(file_in, file_out):
     return in_stat.st_mtime >= out_stat.st_mtime
 
 def main():
+    """ Entry point for running as a script """
 
     args = sys.argv
     force_recreate = '-f' in args


### PR DESCRIPTION
## Description

This adds new arguments to convertUI.py and setup.py to force all UI elements to be rebuilt, regardless if they exist or not. This is partly in response to the cleanup needed to test #2478 but could also have utility for future dependency changes.

## How Has This Been Tested?

Ran `python convertUI.py -f`, `python setup.py rebuild_ui`, and `python setup.py clean`, and all 3 rebuilt the UI elements regardless if they existed or not.

## Review Checklist (please remove items if they don't apply):

- [ ] Code has been reviewed
- [ ] Functionality has been tested
- [ ] Windows installer (GH artifact) has been tested (installed and worked) 
- [ ] MacOSX installer (GH artifact) has been tested (installed and worked) 
- [ ] User documentation is available and complete (if required)
- [ ] Developers documentation is available and complete (if required)
- [ ] The introduced changes comply with SasView license (BSD 3-Clause)

