### PR TITLE
Remove UI conversion from run.py

### DIFF
--- a/run.py
+++ b/run.py
@@ -82,10 +82,8 @@ def prepare():
     docpath = joinpath(root, 'docs', 'sphinx-docs', '_build', 'html')
     os.environ['SASVIEW_DOC_PATH'] = docpath
 
-if __name__ == "__main__":
 
-    from sas.qtgui.convertUI import rebuild_new_ui
-    rebuild_new_ui()
+if __name__ == "__main__":
 
     prepare()
 

--- a/run.py
+++ b/run.py
@@ -87,5 +87,8 @@ if __name__ == "__main__":
 
     prepare()
 
+    from sas.qtgui.convertUI import rebuild_new_ui
+    rebuild_new_ui()
+
     import sas.cli
     sys.exit(sas.cli.main(logging="development"))


### PR DESCRIPTION
## Description

This removes the UI generation step to ensure all environments are able to start the SasView application using `run.py`.

Fixes #2510

## How Has This Been Tested?

Ran `python run.py` from the base sasview directory and the application launched.

## Review Checklist (please remove items if they don't apply):

- [x] Code has been reviewed
- [ ] Functionality has been tested

