### PR TITLE
2482 problem with dragging slicer elements on plot

### DIFF
--- a/src/sas/qtgui/Plotting/Slicers/AnnulusSlicer.py
+++ b/src/sas/qtgui/Plotting/Slicers/AnnulusSlicer.py
@@ -48,6 +48,7 @@ class AnnulusInteractor(BaseInteractor, SlicerModel):
         self.outer_circle.qmax = self.qmax * 1.2
         self.update()
         self._post_data()
+        self.draw()
 
         self.setModelFromParams()
 
@@ -148,7 +149,6 @@ class AnnulusInteractor(BaseInteractor, SlicerModel):
 
         if self.update_model:
             self.setModelFromParams()
-        self.draw()
 
     def validate(self, param_name, param_value):
         """
@@ -188,6 +188,7 @@ class AnnulusInteractor(BaseInteractor, SlicerModel):
         Redraw the plot with new parameters.
         """
         self._post_data(self.nbins)
+        self.draw()
 
     def restore(self, ev):
         """
@@ -232,6 +233,7 @@ class AnnulusInteractor(BaseInteractor, SlicerModel):
         self.outer_circle.set_cursor(outer, self.outer_circle._inner_mouse_y)
         # Post the data given the nbins entered by the user
         self._post_data(self.nbins)
+        self.draw()
 
     def draw(self):
         """
@@ -353,7 +355,8 @@ class RingInteractor(BaseInteractor):
         """
         self._inner_mouse_x = x
         self._inner_mouse_y = y
-        self.base.base.update()
+        self.base.update()
+        self.base.draw()
 
     def set_cursor(self, x, y):
         """

--- a/src/sas/qtgui/Plotting/Slicers/AnnulusSlicer.py
+++ b/src/sas/qtgui/Plotting/Slicers/AnnulusSlicer.py
@@ -8,10 +8,13 @@ from sas.qtgui.Plotting.SlicerModel import SlicerModel
 
 class AnnulusInteractor(BaseInteractor, SlicerModel):
     """
-    Select an annulus through a 2D plot.
-    This interactor is used to average 2D data  with the region
-    defined by 2 radius.
-    this class is defined by 2 Ringinterators.
+    AnnulusInteractor plots a data1D average of an annulus area defined in a
+    Data2D object. The data1D averaging itself is performed in sasdata by
+    manipulations.py
+
+    This class uses the RingInteractor classe to define two rings of radius
+    r1 and r2 (Q1 and Q2). All Q points at a constant angle phi from the x-axis
+    are averaged together to provide a 1D array in phi from 0 to 180 degrees.
     """
     def __init__(self, base, axes, item=None, color='black', zorder=3):
 
@@ -243,13 +246,13 @@ class AnnulusInteractor(BaseInteractor, SlicerModel):
 
 class RingInteractor(BaseInteractor):
     """
-     Draw a ring Given a radius
+     Draw a ring on a data2D plot centered at (0,0) given a radius
     """
     def __init__(self, base, axes, color='black', zorder=5, r=1.0, sign=1):
         """
         :param: the color of the line that defined the ring
         :param r: the radius of the ring
-        :param sign: the direction of motion the the marker
+        :param sign: the direction of motion the marker
 
         """
         BaseInteractor.__init__(self, base, axes, color=color)

--- a/src/sas/qtgui/Plotting/Slicers/Arc.py
+++ b/src/sas/qtgui/Plotting/Slicers/Arc.py
@@ -1,13 +1,15 @@
-"""
-    Arc slicer for 2D data
-"""
 import numpy as np
 
 from sas.qtgui.Plotting.Slicers.BaseInteractor import BaseInteractor
 
 class ArcInteractor(BaseInteractor):
     """
-    Select an annulus through a 2D plot
+     Draw an arc on a data2D plot between radial points (centered at [0,0]) at
+     angles theta1 and theta2.
+
+     param r: radius from (0,0) of the arc on a data2D plot
+     param theta1: angle from x-axis of right end of arc
+     param theta2: angle from x-axis of left end of arc
     """
     def __init__(self, base, axes, color='black', zorder=5, r=1.0,
                  theta1=np.pi / 8, theta2=np.pi / 4):

--- a/src/sas/qtgui/Plotting/Slicers/Arc.py
+++ b/src/sas/qtgui/Plotting/Slicers/Arc.py
@@ -108,7 +108,6 @@ class ArcInteractor(BaseInteractor):
         :param ev: event
         """
         self.has_move = False
-
         self.base.moveend(ev)
 
     def restore(self, ev):
@@ -125,7 +124,8 @@ class ArcInteractor(BaseInteractor):
         self._mouse_x = x
         self._mouse_y = y
         self.has_move = True
-        self.base.base.update()
+        self.base.update()
+        self.base.draw()
 
     def set_cursor(self, radius, phi_min, phi_max, nbins):
         """

--- a/src/sas/qtgui/Plotting/Slicers/AzimutSlicer.py
+++ b/src/sas/qtgui/Plotting/Slicers/AzimutSlicer.py
@@ -10,7 +10,20 @@ from sas.qtgui.Plotting.Slicers.BaseInteractor import BaseInteractor
 
 class SectorInteractor(BaseInteractor):
     """
-    Select an annulus through a 2D plot
+    This SectorInteractor is a cross between the SectorInteractor defined in
+    SectorSicer.py and the AnnulusInteractor. It plots a data1D average of a
+    wedge area defined in a Data2D object. The data1D averaging itself is
+    performed in sasdata by manipulations.py.
+
+    This class uses two other classes, ArcInteractor (in Arc.py) and
+    RadiusInteractor (in RadiusInteractor.py), to define a wedge area contained
+    between two radial lines running through (0,0) defining the left and right
+    edges of the wedge (similar to the sector), and two rings at Q1 and Q2
+    (similar to the annulus). This class is itself subclassed by
+    SectorInteractorPhi and SectorInteractorQ which define the direction of the
+    averaging. SectorInteractorPhi averages all Q points at constant Phi ( as
+    for the AnnulusSlicer) and SectorInteractorQ averages all phi points at
+    constant Q (as for the SectorSlicer).
     """
     def __init__(self, base, axes, color='black', zorder=3):
         """
@@ -234,6 +247,9 @@ class SectorInteractor(BaseInteractor):
 
 class SectorInteractorQ(SectorInteractor):
     """
+    Average in Q direction. The data for all phi at a constant Q are
+    averaged together to provide a 1D array in Q (to be plotted as a function
+     of Q)
     """
     def __init__(self, base, axes, color='black', zorder=3):
         """
@@ -251,6 +267,9 @@ class SectorInteractorQ(SectorInteractor):
 
 class SectorInteractorPhi(SectorInteractor):
     """
+    Average in phi direction. The data for all Q at a constant phi are
+    averaged together to provide a 1D array in phi (to be plotted as a function
+     of phi)
     """
     def __init__(self, base, axes, color='black', zorder=3):
         """

--- a/src/sas/qtgui/Plotting/Slicers/AzimutSlicer.py
+++ b/src/sas/qtgui/Plotting/Slicers/AzimutSlicer.py
@@ -51,6 +51,7 @@ class SectorInteractor(BaseInteractor):
                                           arc2=self.outer_circle,
                                           theta=theta2)
         self.update()
+        self.draw()
         self._post_data()
 
     def set_layer(self, n):

--- a/src/sas/qtgui/Plotting/Slicers/BaseInteractor.py
+++ b/src/sas/qtgui/Plotting/Slicers/BaseInteractor.py
@@ -140,7 +140,6 @@ class BaseInteractor(object):
             self.move(ev.xdata, ev.ydata, ev)
         else:
             self.restore(ev)
-        self.base.update()
         return True
 
     def onKey(self, ev):

--- a/src/sas/qtgui/Plotting/Slicers/BoxSlicer.py
+++ b/src/sas/qtgui/Plotting/Slicers/BoxSlicer.py
@@ -8,8 +8,16 @@ from sas.qtgui.Plotting.SlicerModel import SlicerModel
 
 class BoxInteractor(BaseInteractor, SlicerModel):
     """
-    BoxInteractor define a rectangle that return data1D average of Data2D
-    in a rectangle area defined by -x, x ,y, -y
+    BoxInteractor plots a data1D average of a rectangular area defined in
+    a Data2D object. The data1D averaging itself is performed in sasdata
+    by manipulations.py
+
+    This class uses two other classes, HorizontalLines and VerticalLines,
+    to define the rectangle area: -x, x ,y, -y. It is subclassed by
+    BoxInteractorX and BoxInteracgtorY which define the direction of the
+    average. BoxInteractorX averages all the points from -y to +y as a
+    function of Q_x and BoxInteractorY averages all the points from
+    -x to +x as a function of Q_y
     """
     def __init__(self, base, axes, item=None, color='black', zorder=3):
         BaseInteractor.__init__(self, base, axes, color=color)
@@ -115,7 +123,7 @@ class BoxInteractor(BaseInteractor, SlicerModel):
 
     def post_data(self, new_slab=None, nbins=None, direction=None):
         """
-        post data averaging in Qx or Qy given new_slab type
+        post 1D data averaging in Qx or Qy given new_slab type
 
         :param new_slab: slicer that determine with direction to average
         :param nbins: the number of points plotted when averaging
@@ -256,6 +264,8 @@ class BoxInteractor(BaseInteractor, SlicerModel):
 
     def draw(self):
         """
+        Draws the Canvas using the canvas.draw from the calling class
+        that instatiated this object.
         """
         self.base.draw()
 
@@ -263,7 +273,8 @@ class BoxInteractor(BaseInteractor, SlicerModel):
 class HorizontalLines(BaseInteractor):
     """
     Draw 2 Horizontal lines centered on (0,0) that can move
-    on the x- direction and in opposite direction
+    on the x direction. The two lines move symmetrically (in opposite
+    directions). It also defines the x and -x position of a box.
     """
     def __init__(self, base, axes, color='black', zorder=5, x=0.5, y=0.5):
         """
@@ -371,7 +382,9 @@ class HorizontalLines(BaseInteractor):
 
 class VerticalLines(BaseInteractor):
     """
-    Select an annulus through a 2D plot
+    Draw 2 vertical lines centered on (0,0) that can move
+    on the y direction. The two lines move symmetrically (in opposite
+    directions). It also defines the y and -y position of a box.
     """
     def __init__(self, base, axes, color='black', zorder=5, x=0.5, y=0.5):
         """
@@ -479,7 +492,9 @@ class VerticalLines(BaseInteractor):
 
 class BoxInteractorX(BoxInteractor):
     """
-    Average in Qx direction
+    Average in Qx direction. The data for all Qy at a constant Qx are
+    averaged together to provide a 1D array in Qx (to be plotted as a function
+     of Qx)
     """
     def __init__(self, base, axes, item=None, color='black', zorder=3):
         BoxInteractor.__init__(self, base, axes, item=item, color=color)
@@ -510,7 +525,9 @@ class BoxInteractorX(BoxInteractor):
 
 class BoxInteractorY(BoxInteractor):
     """
-    Average in Qy direction
+    Average in Qy direction. The data for all Qx at a constant Qy are
+    averaged together to provide a 1D array in Qy (to be plotted as a function
+     of Qy)
     """
     def __init__(self, base, axes, item=None, color='black', zorder=3):
         BoxInteractor.__init__(self, base, axes, item=item, color=color)

--- a/src/sas/qtgui/Plotting/Slicers/BoxSlicer.py
+++ b/src/sas/qtgui/Plotting/Slicers/BoxSlicer.py
@@ -57,6 +57,7 @@ class BoxInteractor(BaseInteractor, SlicerModel):
         # of averaging data2D
         self.update()
         self._post_data()
+        self.draw()
         self.setModelFromParams()
 
     def update_and_post(self):
@@ -65,6 +66,7 @@ class BoxInteractor(BaseInteractor, SlicerModel):
         """
         self.update()
         self._post_data()
+        self.draw()
 
     def set_layer(self, n):
         """
@@ -195,7 +197,6 @@ class BoxInteractor(BaseInteractor, SlicerModel):
 
         if self.update_model:
             self.setModelFromParams()
-        self.draw()
 
     def moveend(self, ev):
         """
@@ -251,6 +252,7 @@ class BoxInteractor(BaseInteractor, SlicerModel):
         self.horizontal_lines.update(x=self.x, y=self.y)
         self.vertical_lines.update(x=self.x, y=self.y)
         self.post_data(nbins=None)
+        self.draw()
 
     def draw(self):
         """
@@ -363,7 +365,8 @@ class HorizontalLines(BaseInteractor):
         """
         self.y = y
         self.has_move = True
-        self.base.base.update()
+        self.base.update()
+        self.base.draw()
 
 
 class VerticalLines(BaseInteractor):
@@ -470,7 +473,8 @@ class VerticalLines(BaseInteractor):
         """
         self.has_move = True
         self.x = x
-        self.base.base.update()
+        self.base.update()
+        self.base.draw()
 
 
 class BoxInteractorX(BoxInteractor):

--- a/src/sas/qtgui/Plotting/Slicers/BoxSum.py
+++ b/src/sas/qtgui/Plotting/Slicers/BoxSum.py
@@ -226,7 +226,6 @@ class BoxSumCalculator(BaseInteractor):
         self.total, self.totalerror, self.points = boxtotal(self.data)
         if self.update_model:
             self.setModelFromParams()
-        self.draw()
 
     def moveend(self, ev):
         """
@@ -391,7 +390,8 @@ class PointInteractor(BaseInteractor):
         self.x = x
         self.y = y
         self.has_move = True
-        self.base.base.update()
+        self.base.update()
+        self.base.draw()
 
     def setCursor(self, x, y):
         """
@@ -558,7 +558,8 @@ class VerticalDoubleLine(BaseInteractor):
         self.x2 = self.center_x - delta
         self.half_width = numpy.fabs(self.x1 - self.x2) / 2
         self.has_move = True
-        self.base.base.update()
+        self.base.update()
+        self.base.draw()
 
     def setCursor(self, x, y):
         """
@@ -720,7 +721,8 @@ class HorizontalDoubleLine(BaseInteractor):
         self.y2 = self.center_y - delta
         self.half_height = numpy.fabs(self.y1) - self.center_y
         self.has_move = True
-        self.base.base.update()
+        self.base.update()
+        self.base.draw()
 
     def setCursor(self, x, y):
         """

--- a/src/sas/qtgui/Plotting/Slicers/BoxSum.py
+++ b/src/sas/qtgui/Plotting/Slicers/BoxSum.py
@@ -1,7 +1,3 @@
-"""
-Boxsum Class: determine 2 rectangular area to compute
-the sum of pixel of a Data.
-"""
 import numpy
 from PyQt5 import QtGui
 
@@ -15,9 +11,17 @@ from sas.qtgui.Plotting.SlicerModel import SlicerModel
 
 class BoxSumCalculator(BaseInteractor):
     """
-    Boxsum Class: determine 2 rectangular area to compute
-    the sum of pixel of a Data.
-    Uses PointerInteractor , VerticalDoubleLine,HorizontalDoubleLine.
+    BoxSumCalculator Class computes properties (such as sum and average of
+    intensities) from a rectangular area defined in a data2D object. The actual
+    calculations are done by manipulations.py
+
+    This class uses three other classes, PointerInteractor to define the center
+    of the rectangle, and VerticalDoubleLine and HorizontalDoubleLine to define
+    the rectangle x1,x2,y1,y2.
+
+    ..TODO: the 3 classes here are the same as used by the BoxSlicer. These
+            should probably be abstracted out.
+
     @param zorder:  Artists with lower zorder values are drawn first.
     @param x_min: the minimum value of the x coordinate
     @param x_max: the maximum value of the x coordinate
@@ -570,7 +574,8 @@ class VerticalDoubleLine(BaseInteractor):
 
 class HorizontalDoubleLine(BaseInteractor):
     """
-    Select an annulus through a 2D plot
+    Draw 2 horizontal lines moving in opposite direction and centered on
+    a point (PointInteractor)
     """
     def __init__(self, base, axes, color='black', zorder=5, x=0.5, y=0.5,
                  center_x=0.0, center_y=0.0):

--- a/src/sas/qtgui/Plotting/Slicers/RadiusInteractor.py
+++ b/src/sas/qtgui/Plotting/Slicers/RadiusInteractor.py
@@ -4,7 +4,15 @@ from sas.qtgui.Plotting.Slicers.BaseInteractor import BaseInteractor
 
 class RadiusInteractor(BaseInteractor):
     """
-    Select an annulus through a 2D plot
+     Draw a radial line (centered at [0,0]) at an angle theta from the x-axis
+     on a data2D plot from r1 to r2 defined by two arcs (arc1 and arc2). Used
+     for example to define a wedge area on the plot.
+
+     param theta: angle of the radial line from the x-axis
+     param arc1: inner arc of radius r1 used to define the starting point of
+                the radial line
+     param arc2: outer arc of radius r2 used to define the ending point of
+                the radial line
     """
     def __init__(self, base, axes, color='black', zorder=5, arc1=None,
                  arc2=None, theta=np.pi / 8):

--- a/src/sas/qtgui/Plotting/Slicers/RadiusInteractor.py
+++ b/src/sas/qtgui/Plotting/Slicers/RadiusInteractor.py
@@ -100,7 +100,8 @@ class RadiusInteractor(BaseInteractor):
         """
         self.theta = np.arctan2(y, x)
         self.has_move = True
-        self.base.base.update()
+        self.base.update()
+        self.base.draw()
 
     def set_cursor(self, r_min, r_max, theta):
         """

--- a/src/sas/qtgui/Plotting/Slicers/SectorSlicer.py
+++ b/src/sas/qtgui/Plotting/Slicers/SectorSlicer.py
@@ -1,6 +1,3 @@
-"""
-    Sector interactor
-"""
 import numpy
 import logging
 
@@ -13,7 +10,21 @@ MIN_PHI = 0.05
 
 class SectorInteractor(BaseInteractor, SlicerModel):
     """
-    Draw a sector slicer.Allow to performQ averaging on data 2D
+    SectorInteractor plots a data1D average of a sector area defined in a
+    Data2D object. The data1D averaging itself is performed in sasdata by
+    manipulations.py. Sectors all go through a single point as (0,0).
+
+    This class uses two other classes, LineInteractor and SideInteractor, to
+    define a sector centered around a main line defined by LineInteractor
+    which goes through 0,0 at some user settable angle theta from 0. The
+    sector itself is defined by the right and left sidelines, both of which
+    also go through (0,0), and set by SideInteractor from -phi to +phi around
+    the center line defined by the main line. All points at a constant Q from
+    -phi to +phi are averaged together to provide a 1D array in Q (to be
+    plotted as a function of Q).
+
+        ..TODO: the 2 subclasses here are the same as used by the BoxSum. These
+            should probably be abstracted out.
     """
     def __init__(self, base, axes, item=None, color='black', zorder=3):
 
@@ -277,7 +288,10 @@ class SectorInteractor(BaseInteractor, SlicerModel):
 
 class SideInteractor(BaseInteractor):
     """
-    Draw an oblique line
+    Draws a line though 0,0 on a data2D plot with reference to a center line.
+    This is used to define both a left and right line which are always updated
+    together as they must remain symmetric at some phi value around the main
+    line (at -phi and +phi).
 
     :param phi: the phase between the middle line and one side line
     :param theta2: the angle between the middle line and x- axis
@@ -466,7 +480,11 @@ class SideInteractor(BaseInteractor):
 
 class LineInteractor(BaseInteractor):
     """
-    Select an annulus through a 2D plot
+    Draws a line though 0,0 on a data2D plot. This is used to define the
+    centerline around with other lines can be drawn to define a region of
+    interest (such as a sector).
+
+    :param theta: the angle between the middle line and x- axis
     """
     def __init__(self, base, axes, color='black',
                  zorder=5, r=1.0, theta=numpy.pi / 4):

--- a/src/sas/qtgui/Plotting/Slicers/SectorSlicer.py
+++ b/src/sas/qtgui/Plotting/Slicers/SectorSlicer.py
@@ -57,6 +57,7 @@ class SectorInteractor(BaseInteractor, SlicerModel):
         # draw the sector
         self.update()
         self._post_data()
+        self.draw()
         self.setModelFromParams()
 
     def set_layer(self, n):
@@ -178,7 +179,6 @@ class SectorInteractor(BaseInteractor, SlicerModel):
 
         if self.update_model:
             self.setModelFromParams()
-        self.draw()
 
     def validate(self, param_name, param_value):
         """
@@ -266,6 +266,7 @@ class SectorInteractor(BaseInteractor, SlicerModel):
                               mline=self.main_line, side=True)
         # Post the new corresponding data
         self._post_data(nbins=self.nbins)
+        self.draw()
 
     def draw(self):
         """
@@ -445,7 +446,8 @@ class SideInteractor(BaseInteractor):
         self.phi = numpy.fabs(self.theta2 - self.theta)
         if self.phi > numpy.pi:
             self.phi = 2 * numpy.pi - numpy.fabs(self.theta2 - self.theta)
-        self.base.base.update()
+        self.base.update()
+        self.base.draw()
 
     def set_cursor(self, x, y):
         self.move(x, y, None)
@@ -549,7 +551,8 @@ class LineInteractor(BaseInteractor):
         """
         self.theta = numpy.arctan2(y, x)
         self.has_move = True
-        self.base.base.update()
+        self.base.update()
+        self.base.draw()
 
     def set_cursor(self, x, y):
         self.move(x, y, None)

--- a/src/sas/qtgui/Plotting/Slicers/WedgeSlicer.py
+++ b/src/sas/qtgui/Plotting/Slicers/WedgeSlicer.py
@@ -8,9 +8,9 @@ from sas.qtgui.Plotting.Slicers.Arc import ArcInteractor
 from sas.qtgui.Plotting.Slicers.RadiusInteractor import RadiusInteractor
 from sas.qtgui.Plotting.Slicers.BaseInteractor import BaseInteractor
 
-class SectorInteractor(BaseInteractor):
+class WedgeInteractor(BaseInteractor):
     """
-    This SectorInteractor is a cross between the SectorInteractor defined in
+    This WedgeInteractor is a cross between the SectorInteractor defined in
     SectorSicer.py and the AnnulusInteractor. It plots a data1D average of a
     wedge area defined in a Data2D object. The data1D averaging itself is
     performed in sasdata by manipulations.py.
@@ -245,7 +245,7 @@ class SectorInteractor(BaseInteractor):
         """
         self.base.draw()
 
-class SectorInteractorQ(SectorInteractor):
+class SectorInteractorQ(WedgeInteractor):
     """
     Average in Q direction. The data for all phi at a constant Q are
     averaged together to provide a 1D array in Q (to be plotted as a function
@@ -254,7 +254,7 @@ class SectorInteractorQ(SectorInteractor):
     def __init__(self, base, axes, color='black', zorder=3):
         """
         """
-        SectorInteractor.__init__(self, base, axes, color=color)
+        WedgeInteractor.__init__(self, base, axes, color=color)
         self.base = base
         self._post_data()
 
@@ -265,7 +265,7 @@ class SectorInteractorQ(SectorInteractor):
         self.post_data(SectorQ)
 
 
-class SectorInteractorPhi(SectorInteractor):
+class SectorInteractorPhi(WedgeInteractor):
     """
     Average in phi direction. The data for all Q at a constant phi are
     averaged together to provide a 1D array in phi (to be plotted as a function
@@ -274,7 +274,7 @@ class SectorInteractorPhi(SectorInteractor):
     def __init__(self, base, axes, color='black', zorder=3):
         """
         """
-        SectorInteractor.__init__(self, base, axes, color=color)
+        WedgeInteractor.__init__(self, base, axes, color=color)
         self.base = base
         self._post_data()
 


### PR DESCRIPTION
## Description

The main thing this does is to Fix #2482 by making sure the plot is updated first and then drawn on drag operations for all slicere.  In the process 2 other commits were made to
 1. Make a first pass at cleaning up the class level docstrings of the slicers
 2. Fix the duplicate class nomenclature 

Fixes #2482

## How Has This Been Tested?

the functional changes were tested by following the steps described in the issue this fixes and verifying that the behavior is now as expected. 

## Review Checklist (please remove items if they don't apply):

- [ ] Code has been reviewed
- [x] Functionality has been tested
- [ ] Windows installer (GH artifact) has been tested (installed and worked) 
- [ ] MacOSX installer (GH artifact) has been tested (installed and worked) 
- [x] User documentation is available and complete (if required)
- [x] Developers documentation is available and complete (if required)
- [x] The introduced changes comply with SasView license (BSD 3-Clause)

