### PR TITLE
Reinstate math import to Plotter.py

### DIFF
--- a/src/sas/qtgui/Plotting/Plotter.py
+++ b/src/sas/qtgui/Plotting/Plotter.py
@@ -3,6 +3,7 @@ from PySide6 import QtWidgets
 
 import functools
 import copy
+import math
 import matplotlib as mpl
 import numpy as np
 import textwrap


### PR DESCRIPTION
## Description

The math import was reinstated to Plotter.py.

Fixes #2516

## How Has This Been Tested?

Run SasView and plot data -> no more errors in the console!

## Review Checklist (please remove items if they don't apply):

- [ ] Code has been reviewed
- [ ] Functionality has been tested
- [ ] Windows installer (GH artifact) has been tested (installed and worked) 
- [ ] MacOSX installer (GH artifact) has been tested (installed and worked) 

