### PR TITLE
Import pytest in density calculator GUI tests

### DIFF
--- a/src/sas/qtgui/Calculators/UnitTesting/DensityCalculatorTest.py
+++ b/src/sas/qtgui/Calculators/UnitTesting/DensityCalculatorTest.py
@@ -1,5 +1,6 @@
 import sys
 import webbrowser
+import pytest
 
 from PySide6 import QtGui, QtWidgets
 from PySide6.QtTest import QTest


### PR DESCRIPTION
## Description

Recently, while attempting to run the GUI tests locally, `pytest` fails with an `no module 'pytest' on line 36 of DensityCalculatorTest.py` error. This fixes the error.

There is no associated issue.

## How Has This Been Tested?

Run `python -m pytest -v -s src/sas/qtgui` from the base sasview directory and the tests run again.

## Review Checklist (please remove items if they don't apply):

- [ ] Code has been reviewed
- [ ] Functionality has been tested
- [X] The introduced changes comply with SasView license (BSD 3-Clause)

