### PR TITLE
[5.0.6] PyPi requirements in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -281,7 +281,7 @@ packages.append("sas.qtgui")
 required = [
     'bumps>=0.7.5.9', 'periodictable>=1.5.0', 'pyparsing>=2.0.0',
     'lxml', 'h5py', 'sasmodels==1.0.7', 'qt5reactor', 'twisted', 'typing-extensions>=4.5.0',
-    'pyopenssl', 'cryptography<39.0'
+    'pyopenssl', 'cryptography<39.0', 'PyQt5', 'service-identity'
 ]
 
 if os.name == 'nt':

--- a/setup.py
+++ b/setup.py
@@ -280,7 +280,8 @@ packages.append("sas.qtgui")
 
 required = [
     'bumps>=0.7.5.9', 'periodictable>=1.5.0', 'pyparsing>=2.0.0',
-    'lxml', 'h5py',
+    'lxml', 'h5py', 'sasmodels==1.0.7', 'qt5reactor', 'twisted', 'typing-extensions>=4.5.0',
+    'pyopenssl', 'cryptography<39.0'
 ]
 
 if os.name == 'nt':


### PR DESCRIPTION
## Description

This updates setup.py to create a Windows package available for PyPi. This has not been tested on Mac or Ubuntu (yet).

Files: https://pypi.org/project/sasview/5.0.6b3/#files

Work left to be done:
- Test on Mac and various Linux distros
- Create specific Mac and Linux distros (as needed)
- Port to `main`: Will require (at minimum) PySide instead of PyQt
- Integrate into the build process (`.github/workflows`) for both the releases (PyPi bot account, GitHub secret for ssh, and add build and twine upload to yml files) and nightly builds (Append latest git hash to end of version number to ensure unique name)

I should probably document these issues more thoroughly in a separate issue.

## How Has This Been Tested?

On Windows:
```
> pip install sasview==5.0.6b3
> sasview
```
The SasView GUI launches!

## Review Checklist (please remove items if they don't apply):

- [ ] Code has been reviewed
- [ ] Functionality has been tested
- [ ] Windows installer (GH artifact) has been tested (installed and worked) 
- [ ] MacOSX installer (GH artifact) has been tested (installed and worked) 
- [ ] User documentation is available and complete (if required)
- [ ] Developers documentation is available and complete (if required)
- [ ] The introduced changes comply with SasView license (BSD 3-Clause)

