### PR TITLE
Reparent QAction from QtWidget to QtGui (PySide6)

### DIFF
--- a/src/sas/qtgui/Perspectives/Fitting/ConstraintWidget.py
+++ b/src/sas/qtgui/Perspectives/Fitting/ConstraintWidget.py
@@ -790,19 +790,19 @@ class ConstraintWidget(QtWidgets.QWidget, Ui_ConstraintWidgetUI):
         # Select for fitting
         param_string = "Fit Page " if num_rows==1 else "Fit Pages "
 
-        self.actionSelect = QtWidgets.QAction(self)
+        self.actionSelect = QtGui.QAction(self)
         self.actionSelect.setObjectName("actionSelect")
         self.actionSelect.setText(QtCore.QCoreApplication.translate("self", "Select "+param_string+" for fitting"))
         # Unselect from fitting
-        self.actionDeselect = QtWidgets.QAction(self)
+        self.actionDeselect = QtGui.QAction(self)
         self.actionDeselect.setObjectName("actionDeselect")
         self.actionDeselect.setText(QtCore.QCoreApplication.translate("self", "De-select "+param_string+" from fitting"))
 
-        self.actionRemoveConstraint = QtWidgets.QAction(self)
+        self.actionRemoveConstraint = QtGui.QAction(self)
         self.actionRemoveConstraint.setObjectName("actionRemoveConstrain")
         self.actionRemoveConstraint.setText(QtCore.QCoreApplication.translate("self", "Remove all constraints on selected models"))
 
-        self.actionMutualMultiConstrain = QtWidgets.QAction(self)
+        self.actionMutualMultiConstrain = QtGui.QAction(self)
         self.actionMutualMultiConstrain.setObjectName("actionMutualMultiConstrain")
         self.actionMutualMultiConstrain.setText(QtCore.QCoreApplication.translate("self", "Mutual constrain of parameters in selected models..."))
 
@@ -835,15 +835,15 @@ class ConstraintWidget(QtWidgets.QWidget, Ui_ConstraintWidgetUI):
         # Select for fitting
         param_string = "constraint " if num_rows==1 else "constraints "
 
-        self.actionSelect = QtWidgets.QAction(self)
+        self.actionSelect = QtGui.QAction(self)
         self.actionSelect.setObjectName("actionSelect")
         self.actionSelect.setText(QtCore.QCoreApplication.translate("self", "Select "+param_string+" for fitting"))
         # Unselect from fitting
-        self.actionDeselect = QtWidgets.QAction(self)
+        self.actionDeselect = QtGui.QAction(self)
         self.actionDeselect.setObjectName("actionDeselect")
         self.actionDeselect.setText(QtCore.QCoreApplication.translate("self", "De-select "+param_string+" from fitting"))
 
-        self.actionRemoveConstraint = QtWidgets.QAction(self)
+        self.actionRemoveConstraint = QtGui.QAction(self)
         self.actionRemoveConstraint.setObjectName("actionRemoveConstrain")
         self.actionRemoveConstraint.setText(QtCore.QCoreApplication.translate("self", "Remove "+param_string))
 

--- a/src/sas/qtgui/Perspectives/Fitting/FittingWidget.py
+++ b/src/sas/qtgui/Perspectives/Fitting/FittingWidget.py
@@ -711,31 +711,31 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         has_constraints = any([self.rowHasConstraint(i, model_key=model_key) for i in rows])
         has_real_constraints = any([self.rowHasActiveConstraint(i, model_key=model_key) for i in rows])
 
-        self.actionSelect = QtWidgets.QAction(self)
+        self.actionSelect = QtGui.QAction(self)
         self.actionSelect.setObjectName("actionSelect")
         self.actionSelect.setText(QtCore.QCoreApplication.translate("self", "Select "+param_string+" for fitting"))
         # Unselect from fitting
-        self.actionDeselect = QtWidgets.QAction(self)
+        self.actionDeselect = QtGui.QAction(self)
         self.actionDeselect.setObjectName("actionDeselect")
         self.actionDeselect.setText(QtCore.QCoreApplication.translate("self", "De-select "+param_string+" from fitting"))
 
-        self.actionConstrain = QtWidgets.QAction(self)
+        self.actionConstrain = QtGui.QAction(self)
         self.actionConstrain.setObjectName("actionConstrain")
         self.actionConstrain.setText(QtCore.QCoreApplication.translate("self", "Constrain "+param_string + to_string))
 
-        self.actionRemoveConstraint = QtWidgets.QAction(self)
+        self.actionRemoveConstraint = QtGui.QAction(self)
         self.actionRemoveConstraint.setObjectName("actionRemoveConstrain")
         self.actionRemoveConstraint.setText(QtCore.QCoreApplication.translate("self", "Remove constraint"))
 
-        self.actionEditConstraint = QtWidgets.QAction(self)
+        self.actionEditConstraint = QtGui.QAction(self)
         self.actionEditConstraint.setObjectName("actionEditConstrain")
         self.actionEditConstraint.setText(QtCore.QCoreApplication.translate("self", "Edit constraint"))
 
-        self.actionMultiConstrain = QtWidgets.QAction(self)
+        self.actionMultiConstrain = QtGui.QAction(self)
         self.actionMultiConstrain.setObjectName("actionMultiConstrain")
         self.actionMultiConstrain.setText(QtCore.QCoreApplication.translate("self", "Constrain selected parameters to their current values"))
 
-        self.actionMutualMultiConstrain = QtWidgets.QAction(self)
+        self.actionMutualMultiConstrain = QtGui.QAction(self)
         self.actionMutualMultiConstrain.setObjectName("actionMutualMultiConstrain")
         self.actionMutualMultiConstrain.setText(QtCore.QCoreApplication.translate("self", "Mutual constrain of selected parameters..."))
 

--- a/src/sas/qtgui/Utilities/GridPanel.py
+++ b/src/sas/qtgui/Utilities/GridPanel.py
@@ -114,7 +114,7 @@ class BatchOutputPanel(QtWidgets.QMainWindow, Ui_GridPanelUI):
         # Find out which items got selected and in which row
         # Select for fitting
 
-        self.actionPlotResults = QtWidgets.QAction(self)
+        self.actionPlotResults = QtGui.QAction(self)
         self.actionPlotResults.setObjectName("actionPlot")
         self.actionPlotResults.setText(QtCore.QCoreApplication.translate("self", "Plot selected fits."))
 


### PR DESCRIPTION
## Description

Simple change to point to the proper location of QAction

Fixes #2530

## How Has This Been Tested?

Locally Win10

## Review Checklist (please remove items if they don't apply):

- [x] Code has been reviewed
- [x] Functionality has been tested
- [ ] Windows installer (GH artifact) has been tested (installed and worked) 
- [ ] MacOSX installer (GH artifact) has been tested (installed and worked) 
- [ ] User documentation is available and complete (if required)
- [ ] Developers documentation is available and complete (if required)
- [X] The introduced changes comply with SasView license (BSD 3-Clause)

