### PR TITLE
Fix for save dataset error #2533

### DIFF
--- a/src/sas/qtgui/Utilities/GuiUtils.py
+++ b/src/sas/qtgui/Utilities/GuiUtils.py
@@ -713,6 +713,7 @@ def saveAnyData(data, wildcard_dict=None):
     # Query user for filename.
     filename_tuple = QtWidgets.QFileDialog.getSaveFileName(parent,
                                                            caption,
+                                                           "",
                                                            filter,
                                                            "",
                                                            options)


### PR DESCRIPTION
## Description

a `getSaveFileName` call managed to squeak by unchanged from the Qt5 version.
In Qt6, there is one more positional argument needed.

Additionally, checked all the other occurrences of this call to make sure we're done here.

Fixes #2533 

## How Has This Been Tested?

Local tests on Win10

## Review Checklist (please remove items if they don't apply):

- [x] Code has been reviewed
- [x] Functionality has been tested
- [ ] Windows installer (GH artifact) has been tested (installed and worked) 
- [ ] MacOSX installer (GH artifact) has been tested (installed and worked) 
- [x] User documentation is available and complete (if required)
- [x] Developers documentation is available and complete (if required)
- [x] The introduced changes comply with SasView license (BSD 3-Clause)

