### PR TITLE
Lowercase PySide6 executables for Linux compatability #2542

### DIFF
--- a/src/sas/qtgui/convertUI.py
+++ b/src/sas/qtgui/convertUI.py
@@ -24,7 +24,7 @@ def pyrrc(in_file, out_file):
     """
     Run the qt resource compiler
     """
-    run_line = f"PySide6-rcc {in_file} -o {out_file}"
+    run_line = f"pyside6-rcc {in_file} -o {out_file}"
     os.system(run_line)
 
 
@@ -34,7 +34,7 @@ def pyuic(in_file, out_file):
     """
     in_file2 = os.path.abspath(in_file)
     out_file2 = os.path.abspath(out_file)
-    run_line = "PySide6-uic " + in_file2 + " -o " + out_file2
+    run_line = "pyside6-uic " + in_file2 + " -o " + out_file2
     os.system(run_line)
 
 def file_in_newer(file_in, file_out):


### PR DESCRIPTION
## Description

This RP makes the PySide6 script names in converUI.py all lowercase, as their respective script names on Linux systems are all lowercase. Without this change, 'command not found' errors are produced when SasView is installed or run by following the dev environment setup instructions given in the wiki.

Fixes #2542 

## How Has This Been Tested?

The changes were made and found to get rid of the errors, allowing SasView to install and run correctly on both Arch Linux and Ubuntu. I have not personally tested the effect of these changes on Windows or MacOS, but wpotrzebowski and piotr have informed me via Slack that both upper and lower case work for both of these operating systems, so this change should not cause any problems.

## Review Checklist (please remove items if they don't apply):

- [ ] Code has been reviewed
- [ ] Functionality has been tested
- [ ] Windows installer (GH artifact) has been tested (installed and worked) 
- [ ] MacOSX installer (GH artifact) has been tested (installed and worked) 