### PR TITLE
2541 nightly build artifact doesnt start on mac

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: 3.8
+          python-version: 3.9
 
       - uses: actions/checkout@v3
       - id: set-matrix

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -283,7 +283,7 @@ jobs:
     strategy:
       matrix:
         os: [ windows-latest, ubuntu-20.04 ]
-        python-version: [ 3.9 ]
+        python-version: [ 3.8 ]
       fail-fast: false
 
     name: Test installer

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -195,7 +195,7 @@ jobs:
       - name: Install utilities to build installer
         if: ${{ matrix.installer }}
         run: |
-          python -m pip install pyinstaller
+          python -m pip install pyinstaller==5.7.0
 
       - name: Build sasview with pyinstaller
         if: ${{ matrix.installer }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -283,7 +283,7 @@ jobs:
     strategy:
       matrix:
         os: [ windows-latest, ubuntu-20.04 ]
-        python-version: [ 3.8 ]
+        python-version: [ 3.9 ]
       fail-fast: false
 
     name: Test installer

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -195,7 +195,7 @@ jobs:
       - name: Install utilities to build installer
         if: ${{ matrix.installer }}
         run: |
-          python -m pip install pyinstaller==5.7.0
+          python -m pip install pyinstaller
 
       - name: Build sasview with pyinstaller
         if: ${{ matrix.installer }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: 3.9
+          python-version: 3.8
 
       - uses: actions/checkout@v3
       - id: set-matrix

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,7 +72,7 @@ jobs:
       - name: Install X11 libraries (Linux)
         if: ${{ startsWith(matrix.os, 'ubuntu') }}
         run: |
-          sudo apt install libxkbcommon-x11-0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 libxcb-xinerama0 libxcb-xfixes0 x11-utils xvfb
+          sudo apt install libxkbcommon-x11-0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 libxcb-xinerama0 libxcb-xfixes0 x11-utils xvfb libegl-mesa0
 
       - name: Install Python dependencies
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,7 +72,7 @@ jobs:
       - name: Install X11 libraries (Linux)
         if: ${{ startsWith(matrix.os, 'ubuntu') }}
         run: |
-          sudo apt install libxkbcommon-x11-0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 libxcb-xinerama0 libxcb-xfixes0 x11-utils xvfb libegl-mesa0
+          sudo apt install libxkbcommon-x11-0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 libxcb-xinerama0 libxcb-xfixes0 x11-utils xvfb libegl-dev
 
       - name: Install Python dependencies
         run: |

--- a/.github/workflows/matrix.py
+++ b/.github/workflows/matrix.py
@@ -38,7 +38,7 @@ os_test_list = os_release_list + [
 
 # List of python versions to use for release builds
 python_release_list = [
-    '3.8',
+    '3.9',
 ]
 
 # List of python versions to use for tests

--- a/.github/workflows/matrix.py
+++ b/.github/workflows/matrix.py
@@ -38,7 +38,7 @@ os_test_list = os_release_list + [
 
 # List of python versions to use for release builds
 python_release_list = [
-    '3.9',
+    '3.8',
 ]
 
 # List of python versions to use for tests

--- a/build_tools/requirements.txt
+++ b/build_tools/requirements.txt
@@ -1,6 +1,5 @@
 numpy 
 scipy==1.7.3 
-pyside2
 docutils 
 pytest
 pytest_qt

--- a/pytest.ini
+++ b/pytest.ini
@@ -3,4 +3,4 @@ norecursedirs=test/sasrealspace test/calculatorview UnitTesting/SquishTestSuites
 addopts=--ignore test/utest_sasview.py
 python_files='u*py' '*Test*py'
 python_classes = *Test Test*
-qt_api=pyside2
+qt_api=pyside6


### PR DESCRIPTION
## Description
Fixing OSX build from the main branch. It is pyside2 that is problematic and therefore it was removed from requirements (keeping only PySide6). 
It also updates the version of Python and the installer. These were probably not required, but it will be a useful update if it works on all platforms.

Fixes # (issue/issues)
#2541 

## How Has This Been Tested?
Installer downloaded and tested. 
## Review Checklist (please remove items if they don't apply):

- [x] Code has been reviewed
- [ ] Functionality has been tested
- [ ] Windows installer (GH artifact) has been tested (installed and worked) 
- [x] MacOSX installer (GH artifact) has been tested (installed and worked) 
- [x] The introduced changes comply with SasView license (BSD 3-Clause)

