### PR TITLE
Log explorer fix

### DIFF
--- a/src/sas/qtgui/MainWindow/GuiManager.py
+++ b/src/sas/qtgui/MainWindow/GuiManager.py
@@ -116,7 +116,7 @@ class GuiManager:
 
         # Fork off logging messages to the Log Window
         handler = setup_qt_logging()
-        handler.messageWritten.connect(self.appendLog)
+        handler.postman.messageWritten.connect(self.appendLog)
 
         # Log the start of the session
         logging.info(f" --- SasView session started, version {SASVIEW_VERSION}, {SASVIEW_RELEASE_DATE} ---")

--- a/src/sas/qtgui/Utilities/SasviewLogger.py
+++ b/src/sas/qtgui/Utilities/SasviewLogger.py
@@ -2,32 +2,32 @@ import os
 import sys
 import logging
 
-from PySide6.QtCore import *
+from PySide6.QtCore import QObject, Signal
 
-
-class QtHandler(QObject, logging.Handler):
-    """
-    Version of logging handler "emitting" the message to custom stdout()
-    """
+class QtPostman(QObject):
     messageWritten = Signal(str)
 
+class QtLogger(logging.Handler):
+    """
+    Emit python log messages through a Qt signal. Receivers can connect
+    to *handler.postman.messageWritten* with a method accepting the
+    formatted log entry produced by the logger.
+    """
     def __init__(self):
-        QObject.__init__(self)
         logging.Handler.__init__(self)
+        self.postman = QtPostman()
 
     def emit(self, record):
-        record = self.format(record)
-        if record:
-            # self.messageWritten.emit('%s\n'%record)
-            pass
-
+        message = self.format(record)
+        if message:
+            self.postman.messageWritten .emit(message)
 
 def setup_qt_logging():
     # Define the default logger
     logger = logging.getLogger()
 
     # Add the qt-signal logger
-    handler = QtHandler()
+    handler = QtLogger()
     handler.setFormatter(logging.Formatter(
         fmt="%(asctime)s - %(levelname)s: %(message)s",
         datefmt="%H:%M:%S"
@@ -35,3 +35,4 @@ def setup_qt_logging():
     logger.addHandler(handler)
 
     return handler
+        

--- a/src/sas/qtgui/Utilities/SasviewLogger.py
+++ b/src/sas/qtgui/Utilities/SasviewLogger.py
@@ -20,7 +20,7 @@ class QtHandler(logging.Handler):
     def emit(self, record):
         message = self.format(record)
         if message:
-            self.postman.messageWritten .emit(message)
+            self.postman.messageWritten.emit(message)
 
 def setup_qt_logging():
     # Define the default logger

--- a/src/sas/qtgui/Utilities/SasviewLogger.py
+++ b/src/sas/qtgui/Utilities/SasviewLogger.py
@@ -7,7 +7,7 @@ from PySide6.QtCore import QObject, Signal
 class QtPostman(QObject):
     messageWritten = Signal(str)
 
-class QtLogger(logging.Handler):
+class QtHandler(logging.Handler):
     """
     Emit python log messages through a Qt signal. Receivers can connect
     to *handler.postman.messageWritten* with a method accepting the
@@ -27,7 +27,7 @@ def setup_qt_logging():
     logger = logging.getLogger()
 
     # Add the qt-signal logger
-    handler = QtLogger()
+    handler = QtHandler()
     handler.setFormatter(logging.Formatter(
         fmt="%(asctime)s - %(levelname)s: %(message)s",
         datefmt="%H:%M:%S"


### PR DESCRIPTION
## Description

Fix found by @pkienzle. Fixes issue stemming from move to Pyside6 from pyqt5, where the Log Explorer stopped working after the switch. Previously, there were two instances of the function `emit()` that were inherited into the handler- one from logging.handler, and one from QObject.

Fixes #2538 

## How Has This Been Tested?

Run Sasview. Log messages should now show up in the Log Explorer.

## Review Checklist (please remove items if they don't apply):

- [ ] Code has been reviewed
- [ ] Functionality has been tested
- [ ] Windows installer (GH artifact) has been tested (installed and worked) 
- [ ] MacOSX installer (GH artifact) has been tested (installed and worked) 
- [ ] User documentation is available and complete (if required)
- [ ] Developers documentation is available and complete (if required)
- [ ] The introduced changes comply with SasView license (BSD 3-Clause)

