### PR TITLE
Polydisperse parameter check on model load

### DIFF
--- a/src/sas/qtgui/Perspectives/Fitting/FittingWidget.py
+++ b/src/sas/qtgui/Perspectives/Fitting/FittingWidget.py
@@ -1473,6 +1473,11 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         if self.page_parameters:
             self.updatePageWithParameters(self.page_parameters, warn_user=False)
 
+        # disable polydispersity if the model does not support it
+        has_poly = self._poly_model.rowCount() != 0
+        self.chkPolydispersity.setEnabled(has_poly)
+        self.tabFitting.setTabEnabled(TAB_POLY, has_poly)
+
         # set focus so it doesn't move up
         self.cbModel.setFocus()
 

--- a/src/sas/qtgui/Perspectives/Fitting/FittingWidget.py
+++ b/src/sas/qtgui/Perspectives/Fitting/FittingWidget.py
@@ -582,7 +582,7 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         self.cbFileNames.setVisible(False)
         self.cmdFit.setEnabled(False)
         self.cmdPlot.setEnabled(False)
-        self.chkPolydispersity.setEnabled(True)
+        self.chkPolydispersity.setEnabled(False)
         self.chkPolydispersity.setChecked(False)
         self.chk2DView.setEnabled(True)
         self.chk2DView.setChecked(False)


### PR DESCRIPTION
This adds a simple check for polydisperse parameters for the chosen model.
If there are such parameters, the polydisp checkbox and the polydisp tab are enabled.

Fixes #2551 

## How Has This Been Tested?

Local tests on windows

## Review Checklist (please remove items if they don't apply):

- [ ] Code has been reviewed
- [ ] Functionality has been tested
- [ ] Windows installer (GH artifact) has been tested (installed and worked) 
- [ ] MacOSX installer (GH artifact) has been tested (installed and worked) 


