### PR TITLE
Strip debug messages from production version of Qt console

### DIFF
--- a/src/sas/cli.py
+++ b/src/sas/cli.py
@@ -68,6 +68,8 @@ def parse_cli(argv):
         help="Open console to display output (windows only)")
     parser.add_argument("-q", "--quiet", action='store_true',
         help="Don't print banner when entering interactive mode")
+    parser.add_argument("-l", "--loglevel", type=str,
+        help="Logging level (production or development for now)")
     parser.add_argument("args", nargs="*",
         help="script followed by args")
 
@@ -118,12 +120,18 @@ def main(logging="production"):
     cli = parse_cli(sys.argv)
 
     # Setup logger and sasmodels
-    if logging == "production":
+    if cli.loglevel:
+        logging = cli.loglevel
+    logging = logging.upper()
+    if logging == "PRODUCTION":
         log.production()
-    elif logging == "development":
+    elif logging == "DEVELOPMENT":
         log.development()
+    elif logging.upper() in {'DEBUG', 'INFO', 'WARN', 'ERROR', 'CRITICAL'}:
+        log.setup_logging(logging)
     else:
         raise ValueError(f"Unknown logging mode \"{logging}\"")
+
     lib.setup_sasmodels()
     lib.setup_qt_env() # Note: does not import any gui libraries
 

--- a/src/sas/qtgui/MainWindow/GuiManager.py
+++ b/src/sas/qtgui/MainWindow/GuiManager.py
@@ -122,6 +122,9 @@ class GuiManager:
         logging.info(f" --- SasView session started, version {SASVIEW_VERSION}, {SASVIEW_RELEASE_DATE} ---")
         # Log the python version
         logging.info("Python: %s" % sys.version)
+        #logging.debug("Debug messages are shown.")
+        #logging.warn("Warnings are shown.")
+        #logging.error("Errors are shown.")
 
         # Set up the status bar
         self.statusBarSetup()

--- a/src/sas/qtgui/Utilities/SasviewLogger.py
+++ b/src/sas/qtgui/Utilities/SasviewLogger.py
@@ -4,6 +4,9 @@ import logging
 
 from PySide6.QtCore import QObject, Signal
 
+LOG_FORMAT = "%(asctime)s - %(levelname)s: %(message)s"
+DATE_FORMAT = "%H:%M:%S"
+
 class QtPostman(QObject):
     messageWritten = Signal(str)
 
@@ -23,16 +26,18 @@ class QtHandler(logging.Handler):
             self.postman.messageWritten.emit(message)
 
 def setup_qt_logging():
-    # Define the default logger
-    logger = logging.getLogger()
-
     # Add the qt-signal logger
-    handler = QtHandler()
-    handler.setFormatter(logging.Formatter(
-        fmt="%(asctime)s - %(levelname)s: %(message)s",
-        datefmt="%H:%M:%S"
-    ))
-    logger.addHandler(handler)
+    logger = logging.root
 
+    # If a QtHandler is already defined in log.ini then use it. This allows
+    # config to override the default message formatting. We don't do this
+    # by default because we may be using sasview as a library and don't
+    # want to load Qt.
+    for handler in logger.handlers:
+        if isinstance(handler, QtHandler):
+            return handler
+
+    handler = QtHandler()
+    handler.setFormatter(logging.Formatter(fmt=LOG_FORMAT, datefmt=DATE_FORMAT))
+    logger.addHandler(handler)
     return handler
-        

--- a/src/sas/sascalc/calculator/geni.py
+++ b/src/sas/sascalc/calculator/geni.py
@@ -9,10 +9,6 @@ import numpy as np
 try:
     if os.environ.get('SAS_NUMBA', '1').lower() in ('1', 'yes', 'true', 't'):
         from numba import njit, prange
-        # Suppress numba debug info
-        import logging
-        numba_logger = logging.getLogger('numba')
-        numba_logger.setLevel(logging.WARNING)
         USE_NUMBA = True
     else:
         raise ImportError("fail")

--- a/src/sas/system/log.ini
+++ b/src/sas/system/log.ini
@@ -28,58 +28,18 @@ keys=console,log_file
 [handler_console]
 class=logging.StreamHandler
 formatter=simple
-level=WARNING
-args=tuple()
 
 [handler_log_file]
 class=logging.FileHandler
-level=WARNING
 formatter=detailed
 args=(os.path.join(os.path.expanduser("~"),'sasview.log'),"a")
+
 
 ###############################################################################
 # Loggers
 
 [loggers]
-keys=root,saspr,sasgui,sascalc,sasmodels,h5py,glshaders
+keys=root
 
 [logger_root]
-level=DEBUG
-formatter=default
 handlers=console,log_file
-
-[logger_sasmodels]
-level=INFO
-qualname=sas.models
-handlers=console,log_file
-propagate=0
-
-[logger_saspr]
-level=INFO
-qualname=sas.pr
-handlers=console,log_file
-propagate=0
-
-[logger_sasgui]
-level=DEBUG
-qualname=sas.sasgui
-handlers=console,log_file
-propagate=0
-
-[logger_sascalc]
-level=INFO
-qualname=sas.sascalc
-handlers=console,log_file
-propagate=0
-
-[logger_h5py]
-level=DEBUG
-qualname=h5py
-handlers=
-propagate=0
-
-[logger_glshaders]
-level=DEBUG
-qualname=OpenGL.GL.shaders
-handlers=
-propagate=0

--- a/src/sas/system/log.py
+++ b/src/sas/system/log.py
@@ -16,7 +16,7 @@ Module that manages the global logging
 TRACED_PACKAGES = ('sas', 'sasmodels', 'sasdata', 'bumps', 'periodictable')
 IGNORED_PACKAGES = {
     'matplotlib': 'ERROR',
-    'numba': 'ERROR',
+    'numba': 'WARN',
     'h5py': 'ERROR',
     'ipykernel': 'CRITICAL',
 }
@@ -26,7 +26,7 @@ def setup_logging(level=logging.INFO):
     logging.captureWarnings(True)
     for package in TRACED_PACKAGES:
         logging.getLogger(package).setLevel(level)
-    for package, package_level in IGNORED_PACKAGES:
+    for package, package_level in IGNORED_PACKAGES.items():
         logging.getLogger(package).setLevel(package_level)
 
     # SasView is often using the root logger to emit error messages. Until
@@ -38,7 +38,6 @@ def setup_logging(level=logging.INFO):
     # the culprits:
     #    grep -R "logg\(ing\|er\)" src | grep -v .pyc | less
     # TODO: use __name__ as the logger for all sasview log messages
-    # TODO: remove numba logger setting from sas.sascalc.calculator.geni
     logging.root.setLevel(level)
 
     # Apply the logging config after setting the defaults

--- a/src/sas/system/log.py
+++ b/src/sas/system/log.py
@@ -12,70 +12,60 @@ import importlib.resources
 Module that manages the global logging
 '''
 
+#BASE_LOGGER = 'sasview'
+TRACED_PACKAGES = ('sas', 'sasmodels', 'sasdata', 'bumps', 'periodictable')
+IGNORED_PACKAGES = {
+    'matplotlib': 'ERROR',
+    'numba': 'ERROR',
+    'h5py': 'ERROR',
+    'ipykernel': 'CRITICAL',
+}
 
-class SetupLogger(object):
-    '''
-    Called at the beginning of run.py or sasview.py
-    '''
+def setup_logging(level=logging.INFO):
+    # Setup the defaults
+    logging.captureWarnings(True)
+    for package in TRACED_PACKAGES:
+        logging.getLogger(package).setLevel(level)
+    for package, package_level in IGNORED_PACKAGES:
+        logging.getLogger(package).setLevel(package_level)
 
-    def __init__(self, logger_name):
-        self._config_file = None
-        self._find_config_file()
-        self.name = logger_name
+    # SasView is often using the root logger to emit error messages. Until
+    # that is fixed we need to set the level of the root logger to the target
+    # level. Unfortunately that means that all broken third party packages
+    # (i.e., those that use the root logger rather than __name__) will also
+    # be set to that level, which is why we have to explicitly override them
+    # with the 'IGNORED_PACKAGES' list. The following regex will find most of
+    # the culprits:
+    #    grep -R "logg\(ing\|er\)" src | grep -v .pyc | less
+    # TODO: use __name__ as the logger for all sasview log messages
+    # TODO: remove numba logger setting from sas.sascalc.calculator.geni
+    logging.root.setLevel(level)
 
-    def config_production(self):
-        logger = logging.getLogger(self.name)
-        if not logger.root.handlers:
-            self._read_config_file()
-            logging.captureWarnings(True)
-            logger = logging.getLogger(self.name)
-        logging.getLogger('matplotlib').setLevel(logging.WARN)
-        logging.getLogger('numba').setLevel(logging.WARN)
-        return logger
+    # Apply the logging config after setting the defaults
+    try:
+        fd = importlib.resources.open_text('sas.system', 'log.ini')
+        logging.config.fileConfig(fd)
+    except FileNotFoundError:
+        print(f"ERROR: Log config '{filename}' not found...", file=sys.stderr)
 
-    def config_development(self):
-        '''
-        '''
-        self._read_config_file()
-        logger = logging.getLogger(self.name)
-        self._update_all_logs_to_debug(logger)
-        logging.captureWarnings(True)
-        logging.getLogger('matplotlib').setLevel(logging.WARN)
-        logging.getLogger('numba').setLevel(logging.WARN)
-        return logger
-
-    def _read_config_file(self):
-        if self._config_file is not None:
-            logging.config.fileConfig(self._config_file)
-
-    def _update_all_logs_to_debug(self, logger):
-        '''
-        This updates all loggers and respective handlers to DEBUG
-        '''
-        for handler in logger.handlers or logger.parent.handlers:
-            handler.setLevel(logging.DEBUG)
-        for name, _ in logging.Logger.manager.loggerDict.items():
-            logging.getLogger(name).setLevel(logging.DEBUG)
-
-    def _find_config_file(self, filename="log.ini"):
-        '''
-        The config file is in:
-        Debug ./sasview/
-        Packaging: sas/sasview/
-        Packaging / production does not work well with absolute paths
-        thus importlib is used to find a filehandle to the resource
-        wherever it is actually located.
-
-        Returns a TextIO instance that is open for reading the resource.
-        '''
-        self._config_file = None
-        try:
-            self._config_file = importlib.resources.open_text('sas.system', filename)
-        except FileNotFoundError:
-            print(f"ERROR: '{filename}' not found...", file=sys.stderr)
+    #print_config()
 
 def production():
-    return SetupLogger("sasview").config_production()
+    setup_logging('INFO')
 
 def development():
-    return SetupLogger("sasview").config_development()
+    setup_logging('DEBUG')
+
+def print_config(msg="Logger config:"):
+    """
+    When debugging the logging configuration it is handy to see exactly how
+    it is configured. To do so you will need to pip install the logging_tree
+    package and add *log.print_config()* at choice points in the code.
+    """
+    try:
+        from logging_tree import printout
+    except ImportError:
+        print("log.print_config requires the logging_tree package from PyPI")
+        return
+    print(msg)
+    printout()


### PR DESCRIPTION
## Description

Suggested changes to logging controls.

Note that the Qt linkage is via the QtPostman signal. This is currently owned by QtHandler, but it could instead be owned by the console window and passed to the handler on creation. This would be consistent with the file handler which takes a log file name as input. With this change the set_qt_logger code would not have to check if there is an existing handler before creating its own.

Moving the QtHandler creation to log.ini causes a different problem: it requires the GUI in order to bind the QtPostman signal to the handler. An alternative is to create a QtPostman signal instance as a global so it is available for binding independently by logging handler and gui (e.g., as a class attribute of QtHandler).

As currently implemented the logging config is called even when we are using sasview to run a script file, so setting up QtHandler as part of logging config would force a Qt dependence on sascalc. Maybe it would be better if logging were only set up when the QtGui is about run?

## How Has This Been Tested?

A `--level` option was added to `cli.py` so that you can specify production or development when running sasview from the development branch. You can instead specify the message level that will be displayed. The `GuiManager.py` file includes some commented out logging lines at various severity levels. Or you can trace through the code to find a message at the right level and try to trigger it. For example, `matplotlib._afm._parse_header` will produce errors if you give it an almost usable header string.

## Review Checklist (please remove items if they don't apply):

- [ ] Code has been reviewed
- [ ] Functionality has been tested
- [ ] Windows installer (GH artifact) has been tested (installed and worked) 
- [ ] MacOSX installer (GH artifact) has been tested (installed and worked) 
- [ ] User documentation is available and complete (if required)
- [ ] Developers documentation is available and complete (if required)
- [ ] The introduced changes comply with SasView license (BSD 3-Clause)

