### PR TITLE
unit conversion for gui is missing

### DIFF
--- a/src/sas/qtgui/Utilities/GuiUtils.py
+++ b/src/sas/qtgui/Utilities/GuiUtils.py
@@ -1007,6 +1007,7 @@ RST_PROLOG_DICT["1e-6/Ang^2"] = "10<sup>-6</sup>/Å<sup>2</sup>"
 RST_PROLOG_DICT["1e15/cm^3"] = "10<sup>15</sup>/cm<sup>3</sup>"
 RST_PROLOG_DICT["inf"] = "∞"
 RST_PROLOG_DICT["-inf"] = "-∞"
+RST_PROLOG_DICT["degrees"] = "°"
 
 
 def convertUnitToHTML(unit):

--- a/src/sas/qtgui/Utilities/GuiUtils.py
+++ b/src/sas/qtgui/Utilities/GuiUtils.py
@@ -968,22 +968,25 @@ def rst_to_html(s):
     unit = None
     replacement = None
 
-    if  match_replace:
-        # replace the 'replace' section
-
-        unit, replacement = match_replace.groups()
-
-        # Convert the unit into a valid Python string condition
-        unit = unit.replace("Ang", "Å").replace("\\", "").replace(" ", "")
-
-        # Convert the replacement into the desired HTML format
-        replacement = replacement.replace("|Ang|", "Å").replace("\\ :sup:`", "<sup>").replace("`", "</sup>").replace("\\", "")
 
     if match_unit:
         # replace the 'unicode' section
         unit, unicode_val = match_unit.groups()
         # Convert the unicode value to actual character representation
         replacement = chr(int(unicode_val[2:], 16))
+
+    if  match_replace:
+        # replace the 'replace' section
+
+        unit, replacement = match_replace.groups()
+
+        # Convert the unit into a valid Python string condition
+        unit = unit.replace("\\", "").replace(" ", "")
+
+        # Convert the replacement into the desired HTML format
+        replacement = replacement.replace("|Ang|", "Å").replace("\\ :sup:`", "<sup>").replace("`", "</sup>").replace("\\", "")
+        replacement = replacement.replace("|cdot|", "·").replace("|deg|", "°").replace("|pm|", "±")
+
 
     return unit, replacement
 
@@ -995,49 +998,26 @@ for line in input_rst_strings:
     if line.startswith(".. |"):
         key, value = rst_to_html(line)
         RST_PROLOG_DICT[key] = value
+# add units not in RST_PROLOG
+# This section will be removed once all these units are added to sasmodels
+RST_PROLOG_DICT["1/A"] = "Å<sup>-1</sup>"
+RST_PROLOG_DICT["1/Ang"] = "Å<sup>-1</sup>"
+RST_PROLOG_DICT["1/cm"] = "cm<sup>-1</sup>"
+RST_PROLOG_DICT["1e-6/Ang^2"] = "10<sup>-6</sup>/Å<sup>2</sup>"
+RST_PROLOG_DICT["1e15/cm^3"] = "10<sup>15</sup>/cm<sup>3</sup>"
+RST_PROLOG_DICT["inf"] = "∞"
+RST_PROLOG_DICT["-inf"] = "-∞"
+
 
 def convertUnitToHTML(unit):
+    """
+    Convert ASCII unit display into HTML symbol
+    """
     if unit in RST_PROLOG_DICT:
         return RST_PROLOG_DICT[unit]
     else:
-        return unit
-
-def convertUnitToUTF8_old(unit):
-    """
-    Convert ASCII unit display into UTF-8 symbol
-    """
-    if unit == "1/A":
-        return "Å<sup>-1</sup>"
-    elif unit == "1/cm":
-        return "cm<sup>-1</sup>"
-    elif unit == "Ang":
-        return "Å"
-    elif unit == "1e-6/Ang^2":
-        return "10<sup>-6</sup>/Å<sup>2</sup>"
-    elif unit == "inf":
-        return "∞"
-    elif unit == "-inf":
-        return "-∞"
-    else:
-        return unit
-
-def convertUnitToHTML(unit):
-    """
-    Convert ASCII unit display into well rendering HTML
-    """
-    if unit == "1/A":
-        return "&#x212B;<sup>-1</sup>"
-    elif unit == "1/cm":
-        return "cm<sup>-1</sup>"
-    elif unit == "Ang":
-        return "&#x212B;"
-    elif unit == "1e-6/Ang^2":
-        return "10<sup>-6</sup>/&#x212B;<sup>2</sup>"
-    elif unit == "inf":
-        return "&#x221e;"
-    elif unit == "-inf":
-        return "-&#x221e;"
-    else:
+        if "None" in unit:
+            return ""
         return unit
 
 def parseName(name, expression):

--- a/src/sas/qtgui/Utilities/GuiUtils.py
+++ b/src/sas/qtgui/Utilities/GuiUtils.py
@@ -991,7 +991,10 @@ def rst_to_html(s):
     return unit, replacement
 
 # RST_PROLOG conversion table
-from sasmodels.generate import RST_PROLOG
+try:
+    from sasmodels.generate import RST_PROLOG
+except ImportError:
+    RST_PROLOG = ""
 RST_PROLOG_DICT = {}
 input_rst_strings = RST_PROLOG.splitlines()
 for line in input_rst_strings:

--- a/src/sas/qtgui/Utilities/GuiUtils.py
+++ b/src/sas/qtgui/Utilities/GuiUtils.py
@@ -961,7 +961,48 @@ def replaceHTMLwithASCII(html):
 
     return html
 
+def rst_to_latex(s):
+    # Extract the unit and replacement parts
+    match_replace = re.match(r'(?:\.\. )?\|(.+?)\| replace:: (.+)', s)
+    match_unit = re.match(r'(?:\.\. )?\|(.+?)\| unicode:: (U\+\w+)', s)
+    unit = None
+    replacement = None
+
+    if  match_replace:
+        # replace the 'replace' section
+
+        unit, replacement = match_replace.groups()
+
+        # Convert the unit into a valid Python string condition
+        unit = unit.replace("Ang", "Å").replace("\\", "").replace(" ", "")
+
+        # Convert the replacement into the desired HTML format
+        replacement = replacement.replace("|Ang|", "Å").replace("\\ :sup:`", "<sup>").replace("`", "</sup>").replace("\\", "")
+
+    if match_unit:
+        # replace the 'unicode' section
+        unit, unicode_val = match_unit.groups()
+        # Convert the unicode value to actual character representation
+        replacement = chr(int(unicode_val[2:], 16))
+
+    return unit, replacement
+
+# RST_PROLOG conversion table
+from sasmodels.generate import RST_PROLOG
+RST_PROLOG_DICT = {}
+input_rst_strings = RST_PROLOG.splitlines()
+for line in input_rst_strings:
+    if line.startswith(".. |"):
+        key, value = rst_to_latex(line)
+        RST_PROLOG_DICT[key] = value
+
 def convertUnitToUTF8(unit):
+    if unit in RST_PROLOG_DICT:
+        return RST_PROLOG_DICT[unit]
+    else:
+        return ""
+
+def convertUnitToUTF8_old(unit):
     """
     Convert ASCII unit display into UTF-8 symbol
     """

--- a/src/sas/qtgui/Utilities/GuiUtils.py
+++ b/src/sas/qtgui/Utilities/GuiUtils.py
@@ -961,7 +961,7 @@ def replaceHTMLwithASCII(html):
 
     return html
 
-def rst_to_latex(s):
+def rst_to_html(s):
     # Extract the unit and replacement parts
     match_replace = re.match(r'(?:\.\. )?\|(.+?)\| replace:: (.+)', s)
     match_unit = re.match(r'(?:\.\. )?\|(.+?)\| unicode:: (U\+\w+)', s)
@@ -993,14 +993,14 @@ RST_PROLOG_DICT = {}
 input_rst_strings = RST_PROLOG.splitlines()
 for line in input_rst_strings:
     if line.startswith(".. |"):
-        key, value = rst_to_latex(line)
+        key, value = rst_to_html(line)
         RST_PROLOG_DICT[key] = value
 
-def convertUnitToUTF8(unit):
+def convertUnitToHTML(unit):
     if unit in RST_PROLOG_DICT:
         return RST_PROLOG_DICT[unit]
     else:
-        return ""
+        return unit
 
 def convertUnitToUTF8_old(unit):
     """

--- a/src/sas/qtgui/Utilities/GuiUtils.py
+++ b/src/sas/qtgui/Utilities/GuiUtils.py
@@ -961,7 +961,7 @@ def replaceHTMLwithASCII(html):
 
     return html
 
-def rst_to_html(s):
+def rstToHtml(s):
     # Extract the unit and replacement parts
     match_replace = re.match(r'(?:\.\. )?\|(.+?)\| replace:: (.+)', s)
     match_unit = re.match(r'(?:\.\. )?\|(.+?)\| unicode:: (U\+\w+)', s)
@@ -999,7 +999,7 @@ RST_PROLOG_DICT = {}
 input_rst_strings = RST_PROLOG.splitlines()
 for line in input_rst_strings:
     if line.startswith(".. |"):
-        key, value = rst_to_html(line)
+        key, value = rstToHtml(line)
         RST_PROLOG_DICT[key] = value
 # add units not in RST_PROLOG
 # This section will be removed once all these units are added to sasmodels
@@ -1020,7 +1020,7 @@ def convertUnitToHTML(unit):
     if unit in RST_PROLOG_DICT:
         return RST_PROLOG_DICT[unit]
     else:
-        if "None" in unit:
+        if unit is None or "None" in unit:
             return ""
         return unit
 

--- a/src/sas/qtgui/Utilities/Reports/ReportDialog.py
+++ b/src/sas/qtgui/Utilities/Reports/ReportDialog.py
@@ -127,8 +127,9 @@ class ReportDialog(QtWidgets.QDialog, Ui_ReportDialogUI):
         """
         Write string to file
         """
-        with open(filename, 'w') as f:
-            f.write(string)
+        with open(filename, 'wb') as f:
+            # weird unit symbols need to be saved as UTF-8
+            f.write(bytes(string, 'utf-8'))
 
     @staticmethod
     def save_pdf(data, filename):

--- a/src/sas/qtgui/Utilities/UnitTesting/GuiUtilsTest.py
+++ b/src/sas/qtgui/Utilities/UnitTesting/GuiUtilsTest.py
@@ -507,32 +507,6 @@ class GuiUtilsTest:
         s = "&#x212B; &#x221e;      &#177;"
         assert replaceHTMLwithASCII(s) == "Ang inf      +/-"
 
-    def testConvertUnitToUTF8(self):
-        ''' test unit string replacement'''
-        s = None
-        assert convertUnitToUTF8(s) is None
-
-        s = ""
-        assert convertUnitToUTF8(s) == s
-
-        s = "aaaa"
-        assert convertUnitToUTF8(s) == s
-
-        s = "1/A"
-        assert convertUnitToUTF8(s) == "Å<sup>-1</sup>"
-
-        s = "Ang"
-        assert convertUnitToUTF8(s) == "Å"
-
-        s = "1e-6/Ang^2"
-        assert convertUnitToUTF8(s) == "10<sup>-6</sup>/Å<sup>2</sup>"
-
-        s = "inf"
-        assert convertUnitToUTF8(s) == "∞"
-
-        s = "1/cm"
-        assert convertUnitToUTF8(s) == "cm<sup>-1</sup>"
-
     def testConvertUnitToHTML(self):
         ''' test unit string replacement'''
         s = None

--- a/src/sas/qtgui/Utilities/UnitTesting/GuiUtilsTest.py
+++ b/src/sas/qtgui/Utilities/UnitTesting/GuiUtilsTest.py
@@ -507,10 +507,32 @@ class GuiUtilsTest:
         s = "&#x212B; &#x221e;      &#177;"
         assert replaceHTMLwithASCII(s) == "Ang inf      +/-"
 
+    def testrstToHtml(self):
+        ''' test rst to html conversion'''
+        s = None
+        with pytest.raises(TypeError):
+            result = rstToHtml(s)
+
+        s = ".. |Ang| unicode:: U+212B"
+        assert rstToHtml(s) == ('Ang', 'Å')
+        s = ".. |Ang^-1| replace:: |Ang|\ :sup:`-1`"
+        assert rstToHtml(s) == ('Ang^-1', 'Å<sup>-1</sup>')
+        s = ".. |1e-6Ang^-2| replace:: 10\ :sup:`-6`\ |Ang|\ :sup:`-2`"
+        assert rstToHtml(s) == ('1e-6Ang^-2', '10<sup>-6</sup> Å<sup>-2</sup>')
+        s = ".. |cm^-1| replace:: cm\ :sup:`-1`"
+        assert rstToHtml(s) == ('cm^-1', 'cm<sup>-1</sup>')
+        s = ".. |deg| unicode:: U+00B0"
+        assert rstToHtml(s) == ('deg', '°')
+        s = ".. |cdot| unicode:: U+00B7"
+        assert rstToHtml(s) == ('cdot', '·')
+        s = "bad string"
+        assert rstToHtml(s) == (None, None)
+
+
     def testConvertUnitToHTML(self):
         ''' test unit string replacement'''
         s = None
-        assert convertUnitToHTML(s) is None
+        assert convertUnitToHTML(s) is ""
 
         s = ""
         assert convertUnitToHTML(s) == s
@@ -519,22 +541,25 @@ class GuiUtilsTest:
         assert convertUnitToHTML(s) == s
 
         s = "1/A"
-        assert convertUnitToHTML(s) == "&#x212B;<sup>-1</sup>"
+        assert convertUnitToHTML(s) == "Å<sup>-1</sup>"
 
         s = "Ang"
-        assert convertUnitToHTML(s) == "&#x212B;"
+        assert convertUnitToHTML(s) == "Å"
 
         s = "1e-6/Ang^2"
-        assert convertUnitToHTML(s) == "10<sup>-6</sup>/&#x212B;<sup>2</sup>"
+        assert convertUnitToHTML(s) == "10<sup>-6</sup>/Å<sup>2</sup>"
 
         s = "inf"
-        assert convertUnitToHTML(s) == "&#x221e;"
+        assert convertUnitToHTML(s) == "∞"
         s = "-inf"
 
-        assert convertUnitToHTML(s) == "-&#x221e;"
+        assert convertUnitToHTML(s) == "-∞"
 
         s = "1/cm"
         assert convertUnitToHTML(s) == "cm<sup>-1</sup>"
+
+        s = "degrees"
+        assert convertUnitToHTML(s) == "°"
 
     def testParseName(self):
         '''test parse out a string from the beinning of a string'''


### PR DESCRIPTION
## Description

Unit coversion for GUI widgets is now based on sasmodels RST_PROLOG struct.
This struct is read in and parsed in GuiUtils to create a dictionary which is then used to convert ASCII units into HTML for display in the parameters table, report document and its serialized versions.

Several units, missing from rst_prolog were explicitly added and can/will be removed when sasmodels is updated.

Fixes #2561 

## How Has This Been Tested?

Local tests on win10.

## Review Checklist (please remove items if they don't apply):

- [ ] Code has been reviewed
- [ ] Functionality has been tested
- [ ] Windows installer (GH artifact) has been tested (installed and worked) 
- [ ] MacOSX installer (GH artifact) has been tested (installed and worked) 

