### PR TITLE
Adjusts scale and angular range in 1D plots from WedgeSlicer

### DIFF
--- a/src/sas/qtgui/Plotting/Slicers/WedgeSlicer.py
+++ b/src/sas/qtgui/Plotting/Slicers/WedgeSlicer.py
@@ -138,6 +138,12 @@ class WedgeInteractor(BaseInteractor, SlicerModel):
 
         :param new_sector: slicer used for directional averaging in Q or Phi
         :param nbins: the number of point plotted when averaging
+        :TODO - Unlike other slicers, the two sector types are sufficiently
+        different that this method contains three instances of If (check class name) do x.
+        The point of post_data vs _post_data I think was to avoid this kind of thing and
+        suggests that in this case we may need a new method in the WedgeInteracgtorPhi
+        and WedgeInteracgtorQ to handle these specifics. Probably by creating the 1D plot
+        object in those top level classes along with the specifc attributes.
         """
         # Data to average
         data = self.data
@@ -176,10 +182,12 @@ class WedgeInteractor(BaseInteractor, SlicerModel):
             dxw = sector.dxw
         else:
             dxw = None
-        # And here subtract pi when getting angular data back from sector averaging in
-        # manipulations to get back in the -pi,pi range. Also convert from radians to
-        # degrees for nicer display.
-        new_plot = Data1D(x=(sector.x - np.pi) * 180 / np.pi, y=sector.y, dy=sector.dy, dx=sector.dx)
+        if self.averager.__name__ == 'SectorPhi':
+            # And here subtract pi when getting angular data back from wedge averaging in
+            # phi in manipulations to get back in the -pi,pi range. Also convert from
+            # radians to degrees for nicer display.
+            sector.x = (sector.x - np.pi) * 180 / np.pi
+        new_plot = Data1D(x=sector.x, y=sector.y, dy=sector.dy, dx=sector.dx)
         new_plot.dxl = dxl
         new_plot.dxw = dxw
         new_plot.name = str(self.averager.__name__) + \


### PR DESCRIPTION
## Description

The 1D plots created by the new `WedgeSlicer` now returns:
* Properly converted radians to degrees for the x scale
* The default scale for both x (phi) and y (intensity) are linear.
* The Angular range is pi to pi (with 0 pointing along the positive x axis) as per the normal python and sasview convention

NOTE: this was tested and works well with uncommitted changes to manipulation.py in sasdata needed to fix the actual averaging. This can still be tested with sasdata/master I think as long as one does not allow the wedge to straddle the negative x axis. This should not affect merging since that problem exists in the current main of sasview.

NOTE2:  The caveat to the angular range is that when the wedge straddles the negative x axis the phi max will be greater than 2pi but the data will be in proper consecutive order. This is mostly coming from sasdata. While this may seem a bit odd it is the only rational way to display such data.

Fixes #2578

## How Has This Been Tested?

run on windows 10 developer and checked the wedge slicer (moving the different interactors around), and compared to the annular and sector interactors

## Review Checklist (please remove items if they don't apply):

- [ ] Code has been reviewed
- [ ] Functionality has been tested
- [ ] Windows installer (GH artifact) has been tested (installed and worked) 
- [ ] MacOSX installer (GH artifact) has been tested (installed and worked) 
- [ ] User documentation is available and complete (if required)
- [ ] Developers documentation is available and complete (if required)
- [ ] The introduced changes comply with SasView license (BSD 3-Clause)

