### PR TITLE
fix dialog sizes for some calculators. #2437

### DIFF
--- a/src/sas/qtgui/Calculators/DensityPanel.py
+++ b/src/sas/qtgui/Calculators/DensityPanel.py
@@ -57,8 +57,7 @@ class DensityPanel(QtWidgets.QDialog):
         self.ui = Ui_DensityPanel()
         self.ui.setupUi(self)
 
-        #self.setFixedSize(self.minimumSizeHint())
-        self.resize(self.minimumSizeHint())
+        self.setFixedSize(self.minimumSizeHint())
 
         # set validators
         #self.ui.editMolecularFormula.setValidator(FormulaValidator(self.ui.editMolecularFormula))

--- a/src/sas/qtgui/Calculators/GenericScatteringCalculator.py
+++ b/src/sas/qtgui/Calculators/GenericScatteringCalculator.py
@@ -54,6 +54,7 @@ class GenericScatteringCalculator(QtWidgets.QDialog, Ui_GenericScatteringCalcula
         self.setupUi(self)
         # disable the context help icon
         self.setWindowFlags(self.windowFlags() & ~QtCore.Qt.WindowContextHelpButtonHint)
+        self.setFixedSize(self.minimumSizeHint())
 
         self.manager = parent
         self.communicator = self.manager.communicator()

--- a/src/sas/qtgui/Calculators/ResolutionCalculatorPanel.py
+++ b/src/sas/qtgui/Calculators/ResolutionCalculatorPanel.py
@@ -42,6 +42,7 @@ class ResolutionCalculatorPanel(QtWidgets.QDialog, Ui_ResolutionCalculatorPanel)
         self.setupUi(self)
         # disable the context help icon
         self.setWindowFlags(self.windowFlags() & ~QtCore.Qt.WindowContextHelpButtonHint)
+        self.setFixedSize(self.minimumSizeHint())
 
         self.manager = parent
 

--- a/src/sas/qtgui/Calculators/SldPanel.py
+++ b/src/sas/qtgui/Calculators/SldPanel.py
@@ -97,6 +97,7 @@ class SldPanel(QtWidgets.QDialog):
         self.setupUi()
         # disable the context help icon
         self.setWindowFlags(self.windowFlags() & ~QtCore.Qt.WindowContextHelpButtonHint)
+        self.setFixedSize(self.minimumSizeHint())
 
         self.setupModel()
         self.setupMapper()


### PR DESCRIPTION
## Description

Several calculators didn't limit the max size of the dialog, making it possible to resize them silly.
This fixes it.

Fixes #2437

## How Has This Been Tested?

Local win10 build
## Review Checklist (please remove items if they don't apply):

- [ ] Code has been reviewed
- [ ] Functionality has been tested
- [ ] Windows installer (GH artifact) has been tested (installed and worked) 
- [ ] MacOSX installer (GH artifact) has been tested (installed and worked) 


