### PR TITLE
Remove Unused Dependency: h5py

### DIFF
--- a/build_tools/requirements.txt
+++ b/build_tools/requirements.txt
@@ -6,6 +6,7 @@ pytest_qt
 pytest-mock
 unittest-xml-reporting
 tinycc 
+h5py
 sphinx
 pyparsing 
 html5lib 

--- a/build_tools/requirements.txt
+++ b/build_tools/requirements.txt
@@ -6,7 +6,6 @@ pytest_qt
 pytest-mock
 unittest-xml-reporting
 tinycc 
-h5py 
 sphinx
 pyparsing 
 html5lib 

--- a/setup.py
+++ b/setup.py
@@ -93,7 +93,7 @@ if build_qt:
 # Required packages
 required = [
     'bumps>=0.7.5.9', 'periodictable>=1.5.0', 'pyparsing>=2.0.0',
-    'lxml', 'h5py',
+    'lxml',
 ]
 
 if os.name == 'nt':

--- a/src/sas/system/log.py
+++ b/src/sas/system/log.py
@@ -17,7 +17,6 @@ TRACED_PACKAGES = ('sas', 'sasmodels', 'sasdata', 'bumps', 'periodictable')
 IGNORED_PACKAGES = {
     'matplotlib': 'ERROR',
     'numba': 'WARN',
-    'h5py': 'ERROR',
     'ipykernel': 'CRITICAL',
 }
 

--- a/src/sas/system/log.py
+++ b/src/sas/system/log.py
@@ -17,6 +17,7 @@ TRACED_PACKAGES = ('sas', 'sasmodels', 'sasdata', 'bumps', 'periodictable')
 IGNORED_PACKAGES = {
     'matplotlib': 'ERROR',
     'numba': 'WARN',
+    'h5py': 'ERROR',
     'ipykernel': 'CRITICAL',
 }
 


### PR DESCRIPTION
## Description

This pull request removes the unused dependency `h5py` from the `requirements.txt` and  `setup.py` configuration files. Moreover, the`log.py` is updated to ensure there are no references to `h5py`. The removal of this dependency is a finding from ongoing research aimed at identifying and eliminating code bloat within software projects.

## Rationale

Initially, the project incorporated the `h5py` library. However, over time, the codebase evolved, and currently the library is unused. Still, the package continues to be listed in the project's dependency files. Removing this unused dependency reduces the overall footprint of the application, mitigating potential security risks, and simplifying the dependency management process.


## Review Checklist (please remove items if they don't apply):

- [x] Code has been reviewed
- [x] Functionality has been tested
- [x] Windows installer (GH artifact) has been tested (installed and worked) 
- [ ] MacOSX installer (GH artifact) has been tested (installed) 
- [x] The introduced changes comply with SasView license (BSD 3-Clause)

