### PR TITLE
Plot2D instances are now of `Plotter2DWidget` type. Fixes #2586

### DIFF
--- a/src/sas/qtgui/MainWindow/DataExplorer.py
+++ b/src/sas/qtgui/MainWindow/DataExplorer.py
@@ -1251,7 +1251,7 @@ class DataExplorerWindow(DroppableDataLoadWidget):
     @staticmethod
     def appendOrUpdatePlot(self, data, plot):
         name = data.name
-        if isinstance(plot, Plotter2D) or name in plot.plot_dict.keys():
+        if isinstance(plot, Plotter2DWidget) or name in plot.plot_dict.keys():
             plot.replacePlot(name, data)
         else:
             plot.plot(data)


### PR DESCRIPTION
## Description

When fixing #2527, I failed to spot a conditional checking the 2D plotter class. This is now fixed. I found no other direct comparison of Plotter[1,2]D in the relevant code.

Fixes #2586

## How Has This Been Tested?

Locally, dev version on Win10

## Review Checklist (please remove items if they don't apply):

- [ ] Code has been reviewed
- [ ] Functionality has been tested
- [ ] Windows installer (GH artifact) has been tested (installed and worked) 
- [ ] MacOSX installer (GH artifact) has been tested (installed and worked) 


