### PR TITLE
Fixed unmatched method signatures in Box&Wedge Interactor child classes

### DIFF
--- a/src/sas/qtgui/Plotting/Slicers/BoxSlicer.py
+++ b/src/sas/qtgui/Plotting/Slicers/BoxSlicer.py
@@ -19,6 +19,7 @@ class BoxInteractor(BaseInteractor, SlicerModel):
     function of Q_x and BoxInteractorY averages all the points from
     -x to +x as a function of Q_y
     """
+
     def __init__(self, base, axes, item=None, color='black', zorder=3):
         BaseInteractor.__init__(self, base, axes, color=color)
         SlicerModel.__init__(self)
@@ -256,7 +257,7 @@ class BoxInteractor(BaseInteractor, SlicerModel):
 
         self.horizontal_lines.update(x=self.x, y=self.y)
         self.vertical_lines.update(x=self.x, y=self.y)
-        self._post_data(nbins=None)
+        self._post_data()
         self.draw()
 
     def draw(self):
@@ -273,6 +274,7 @@ class HorizontalLines(BaseInteractor):
     on the x direction. The two lines move symmetrically (in opposite
     directions). It also defines the x and -x position of a box.
     """
+
     def __init__(self, base, axes, color='black', zorder=5, x=0.5, y=0.5):
         """
         """
@@ -383,6 +385,7 @@ class VerticalLines(BaseInteractor):
     on the y direction. The two lines move symmetrically (in opposite
     directions). It also defines the y and -y position of a box.
     """
+
     def __init__(self, base, axes, color='black', zorder=5, x=0.5, y=0.5):
         """
         """
@@ -493,12 +496,13 @@ class BoxInteractorX(BoxInteractor):
     averaged together to provide a 1D array in Qx (to be plotted as a function
      of Qx)
     """
+
     def __init__(self, base, axes, item=None, color='black', zorder=3):
         BoxInteractor.__init__(self, base, axes, item=item, color=color)
         self.base = base
-        self._post_data()
+        super()._post_data()
 
-    def _post_data(self):
+    def _post_data(self, new_slab=None, nbins=None, direction=None):
         """
         Post data creating by averaging in Qx direction
         """
@@ -526,12 +530,13 @@ class BoxInteractorY(BoxInteractor):
     averaged together to provide a 1D array in Qy (to be plotted as a function
      of Qy)
     """
+
     def __init__(self, base, axes, item=None, color='black', zorder=3):
         BoxInteractor.__init__(self, base, axes, item=item, color=color)
         self.base = base
-        self._post_data()
+        super()._post_data()
 
-    def _post_data(self):
+    def _post_data(self, new_slab=None, nbins=None, direction=None):
         """
         Post data creating by averaging in Qy direction
         """

--- a/src/sas/qtgui/Plotting/Slicers/WedgeSlicer.py
+++ b/src/sas/qtgui/Plotting/Slicers/WedgeSlicer.py
@@ -9,6 +9,7 @@ from sas.qtgui.Plotting.Slicers.ArcInteractor import ArcInteractor
 from sas.qtgui.Plotting.Slicers.RadiusInteractor import RadiusInteractor
 from sas.qtgui.Plotting.Slicers.SectorSlicer import LineInteractor
 
+
 class WedgeInteractor(BaseInteractor, SlicerModel):
     """
     This WedgeInteractor is a cross between the SectorInteractor and the
@@ -29,6 +30,7 @@ class WedgeInteractor(BaseInteractor, SlicerModel):
     AnnulusSlicer) and SectorInteractorQ averages all phi points at constant Q
     (as for the SectorSlicer).
     """
+
     def __init__(self, base, axes, item=None, color='black', zorder=3):
 
         BaseInteractor.__init__(self, base, axes, color=color)
@@ -115,7 +117,7 @@ class WedgeInteractor(BaseInteractor, SlicerModel):
             self.phi = self.radial_lines.phi
             self.inner_arc.update(phi=self.phi)
             self.outer_arc.update(phi=self.phi)
-        if  self.central_line.has_move:
+        if self.central_line.has_move:
             self.central_line.update()
             self.theta = self.central_line.theta
             self.inner_arc.update(theta=self.theta)
@@ -205,7 +207,6 @@ class WedgeInteractor(BaseInteractor, SlicerModel):
         else:
             new_plot.xaxis("\\rm{Q}", 'A^{-1}')
         new_plot.yaxis("\\rm{Intensity} ", "cm^{-1}")
-
 
         new_plot.id = str(self.averager.__name__) + self.data.name
         new_plot.group_id = new_plot.id
@@ -327,18 +328,20 @@ class WedgeInteractor(BaseInteractor, SlicerModel):
         """
         self.base.draw()
 
+
 class WedgeInteractorQ(WedgeInteractor):
     """
     Average in Q direction. The data for all phi at a constant Q are
     averaged together to provide a 1D array in Q (to be plotted as a function
      of Q)
     """
+
     def __init__(self, base, axes, item=None, color='black', zorder=3):
         WedgeInteractor.__init__(self, base, axes, item=item, color=color)
         self.base = base
-        self._post_data()
+        super()._post_data()
 
-    def _post_data(self):
+    def _post_data(self, new_sector=None, nbins=None):
         from sasdata.data_util.manipulations import SectorQ
         super()._post_data(SectorQ)
 
@@ -349,12 +352,13 @@ class WedgeInteractorPhi(WedgeInteractor):
     averaged together to provide a 1D array in phi (to be plotted as a function
      of phi)
     """
+
     def __init__(self, base, axes, item=None, color='black', zorder=3):
         WedgeInteractor.__init__(self, base, axes, item=item, color=color)
         self.base = base
-        self._post_data()
+        super()._post_data()
 
-    def _post_data(self):
+    def _post_data(self, new_sector=None, nbins=None):
         from sasdata.data_util.manipulations import SectorPhi
         super()._post_data(SectorPhi)
 


### PR DESCRIPTION
## Description

This commit fixes the mismatch between the `_post_data` method signatures in BoxInteractor and WedgeInteractor and their child classes. It also removes an unnecessary argument from one `_post_data` call, as it only sets a parameter to its default value. This fixes an error that occurs when the 'fold' setting is changed in Box Interactor X and Box Interactor Y's Slicer Parameters menu.

Fixes #2588

## How Has This Been Tested?

The check-box can now be checked and un-checked without causing the error, and the plot updates accordingly.

## Review Checklist (please remove items if they don't apply):

- [ ] Code has been reviewed
- [ ] Functionality has been tested
- [ ] Windows installer (GH artifact) has been tested (installed and worked) 
- [ ] MacOSX installer (GH artifact) has been tested (installed and worked) 

