### PR TITLE
Pass the Data1D/2D object, not its `data` attribute

### DIFF
--- a/src/sas/qtgui/Calculators/DataOperationUtilityPanel.py
+++ b/src/sas/qtgui/Calculators/DataOperationUtilityPanel.py
@@ -369,14 +369,7 @@ class DataOperationUtilityPanel(QtWidgets.QDialog, Ui_DataOperationUtility):
     def _extractData(self, key_id):
         """ Extract data from file with id contained in list of filenames """
         data_complete = self.filenames[key_id]
-        dimension = data_complete.data.__class__.__name__
-
-        if dimension in ('Data1D', 'Data2D'):
-            return copy.deepcopy(data_complete.data)
-
-        else:
-            logging.error('Error with data format')
-            return
+        return copy.deepcopy(data_complete)
 
     # ########
     # PLOTS


### PR DESCRIPTION
## Description

This fixes a (post-5.0.6) bug in the Data Operation Panel, where datasets would not load properly. 

Fixes #2591 

## How Has This Been Tested?

Local dev version on Win10

## Review Checklist (please remove items if they don't apply):

- [ ] Code has been reviewed
- [ ] Functionality has been tested
- [ ] Windows installer (GH artifact) has been tested (installed and worked) 
- [ ] MacOSX installer (GH artifact) has been tested (installed and worked) 


