### PR TITLE
2593 wedge slicer fold negative q workaround

### DIFF
--- a/src/sas/qtgui/Plotting/Slicers/WedgeSlicer.py
+++ b/src/sas/qtgui/Plotting/Slicers/WedgeSlicer.py
@@ -187,6 +187,18 @@ class WedgeInteractor(BaseInteractor, SlicerModel):
             # phi in manipulations to get back in the -pi,pi range. Also convert from
             # radians to degrees for nicer display.
             sector.x = (sector.x - np.pi) * 180 / np.pi
+        else:
+            # When using SectorQ, fold = False results in data with negative Q
+            # values also being plotted. This data is from the opposite side of
+            # the origin to the main ROI, and is unwanted. Here we discard it.
+            # If at some later point this is handled on the sasdata side, then
+            # this code can be deleted.
+            pos_q = [sector.x >= 0]
+            sector.x = sector.x[pos_q]
+            sector.y = sector.y[pos_q]
+            sector.dy = sector.dy[pos_q]
+            sector.dx = sector.dx[pos_q] if sector.dx is not None else None
+
         new_plot = Data1D(x=sector.x, y=sector.y, dy=sector.dy, dx=sector.dx)
         new_plot.dxl = dxl
         new_plot.dxw = dxw


### PR DESCRIPTION
## Description

Added an `else` clause to a pre-existing `if self.averager.__name__ == 'SectorPhi':` check, which removes any data points associated with negative Q values from the data returned by `SectorQ`.

Fixes #2593

## How Has This Been Tested?

The steps from the associated issue (detailing how to reproduce the bug) were followed, and the expected behaviour was observed with this fix present.

## Review Checklist (please remove items if they don't apply):

- [ ] Code has been reviewed
- [ ] Functionality has been tested
- [ ] Windows installer (GH artifact) has been tested (installed and worked) 
- [ ] MacOSX installer (GH artifact) has been tested (installed and worked) 
- [X] Developers documentation is available and complete (if required)

