### PR TITLE
Fix for getting directory name

### DIFF
--- a/src/sas/qtgui/MainWindow/DataExplorer.py
+++ b/src/sas/qtgui/MainWindow/DataExplorer.py
@@ -232,7 +232,7 @@ class DataExplorerWindow(DroppableDataLoadWidget):
         caption = 'Choose a directory'
         options = QtWidgets.QFileDialog.ShowDirsOnly | QtWidgets.QFileDialog.DontUseNativeDialog
         directory = self.default_load_location
-        folder = QtWidgets.QFileDialog.getExistingDirectory(parent, caption, directory, "", options)
+        folder = QtWidgets.QFileDialog.getExistingDirectory(parent, caption, directory, options)
 
         if folder is None:
             return

--- a/src/sas/qtgui/Plotting/SlicerParameters.py
+++ b/src/sas/qtgui/Plotting/SlicerParameters.py
@@ -220,7 +220,7 @@ class SlicerParameters(QtWidgets.QDialog, Ui_SlicerParametersUI):
         caption = 'Save files to:'
         options = QtWidgets.QFileDialog.ShowDirsOnly | QtWidgets.QFileDialog.DontUseNativeDialog
         directory = self.save_location
-        folder = QtWidgets.QFileDialog.getExistingDirectory(parent, caption, directory, "", options)
+        folder = QtWidgets.QFileDialog.getExistingDirectory(parent, caption, directory, options)
 
         if folder is None:
             return


### PR DESCRIPTION
## Description

Corrected the signature of a method responsible for selecting a directory in Qt6.

Fixes #2595

## How Has This Been Tested?

Locally on Win10

## Review Checklist (please remove items if they don't apply):

- [ ] Code has been reviewed
- [ ] Functionality has been tested
- [ ] Windows installer (GH artifact) has been tested (installed and worked) 
- [ ] MacOSX installer (GH artifact) has been tested (installed and worked) 

