### PR TITLE
2603: Numeric coercion in preferences

### DIFF
--- a/src/sas/qtgui/Utilities/Preferences/PreferencesWidget.py
+++ b/src/sas/qtgui/Utilities/Preferences/PreferencesWidget.py
@@ -149,12 +149,17 @@ class PreferencesWidget(QWidget):
 
     def addIntegerInput(self, title: str, default_number: Optional[int] = 0) -> QLineEdit:
         """Similar to the text input creator, this creates a text input with an integer validator assigned to it.
+        This adds a method called `coerce` to the QLineEdit instance that is called before sending the value to the
+        config to ensure the value type matches the expected schema type.
         :param title: The title of the text box to be added to the preferences panel.
         :param default_number: An optional value to be put within the text box as a default. Defaults to an empty string.
         :return: QLineEdit instance to allow subclasses to assign instance name
         """
+        def coerce(box: QLineEdit):
+            return int(box.text())
         int_box = self.addTextInput(title, str(default_number))
         int_box.setValidator(QIntValidator())
+        int_box.coerce = coerce
         return int_box
 
     def _validate_input_and_stage(self, edit: QLineEdit, key: str):
@@ -169,6 +174,8 @@ class PreferencesWidget(QWidget):
         validator = edit.validator()
         text = edit.text()
         (state, val, pos) = validator.validate(text, 0) if validator else (0, 0, 0)
+        # Certain inputs, added using class methods, will have a coerce method to coerce the value to the expected type
+        text = edit.coerce(edit) if hasattr(edit, 'coerce') else text
         if state == QValidator.Acceptable or not validator:
             self._stageChange(key, text)
         else:
@@ -178,12 +185,17 @@ class PreferencesWidget(QWidget):
 
     def addFloatInput(self, title: str, default_number: Optional[int] = 0) -> QLineEdit:
         """Similar to the text input creator, this creates a text input with an float validator assigned to it.
+        This adds a method called `coerce` to the QLineEdit instance that is called before sending the value to the
+        config to ensure the value type matches the expected schema type.
         :param title: The title of the text box to be added to the preferences panel.
         :param default_number: An optional value to be put within the text box as a default. Defaults to an empty string.
         :return: QLineEdit instance to allow subclasses to assign instance name
         """
+        def coerce(box: QLineEdit):
+            return float(box.text())
         float_box = self.addTextInput(title, str(default_number))
         float_box.setValidator(QDoubleValidator())
+        float_box.coerce = coerce
         return float_box
 
     def addCheckBox(self, title: str, checked: Optional[bool] = False) -> QCheckBox:

--- a/src/sas/qtgui/Utilities/Preferences/UnitTesting/PreferencesPanelTest.py
+++ b/src/sas/qtgui/Utilities/Preferences/UnitTesting/PreferencesPanelTest.py
@@ -1,5 +1,7 @@
 import pytest
 from PySide6.QtWidgets import QWidget, QLineEdit, QComboBox, QCheckBox
+from PySide6.QtGui import QIntValidator, QDoubleValidator
+
 
 from sas.qtgui.Plotting.PlotterData import Data1D
 from sas.qtgui.Utilities.Preferences.PreferencesPanel import PreferencesPanel
@@ -85,21 +87,26 @@ class PreferencesPanelTest:
         text_input = pref.addTextInput("blah")
         text_input.textChanged.connect(
             lambda: pref._validate_input_and_stage(text_input, "blah"))
-        pref.addCheckBox("ho hum")
-        pref.addComboBox("combo", ["a", "b", "c"], "a")
+        int_input = pref.addIntegerInput("blah_int")
+        int_input.textChanged.connect(
+            lambda: pref._validate_input_and_stage(int_input, "blah_int"))
+        float_input = pref.addFloatInput("blah_float")
+        float_input.textChanged.connect(
+            lambda: pref._validate_input_and_stage(float_input, "blah_float"))
+        check_box = pref.addCheckBox("ho hum")
+        combo_box = pref.addComboBox("combo", ["a", "b", "c"], "a")
 
         widget.addWidget(pref)
 
         widget.restoreDefaultPreferences()
         assert widget.resetPref.called_once()
 
-        for child in pref.layout().children():
-            if isinstance(child, QLineEdit):
-                child.setText("new text")
-            elif isinstance(child, QComboBox):
-                child.setCurrentIndex(1)
-            elif isinstance(child, QCheckBox):
-                child.setChecked(not child.checkState())
+        # Explicitly modify each input type
+        text_input.setText("new text")
+        int_input.setText('35')
+        float_input.setText('35.6')
+        check_box.setChecked(not check_box.checkState())
+        combo_box.setCurrentIndex(1)
 
         assert widget.textified.called_once()
         assert widget._validate_input_and_stage.called_once()

--- a/src/sas/qtgui/Utilities/Preferences/UnitTesting/PreferencesPanelTest.py
+++ b/src/sas/qtgui/Utilities/Preferences/UnitTesting/PreferencesPanelTest.py
@@ -13,7 +13,7 @@ class DummyPrefWidget(PreferencesWidget):
     def _restoreFromConfig(self):
         pass
 
-    def _toggleBlockAllSignaling(self):
+    def _toggleBlockAllSignaling(self, toggle: bool):
         pass
 
     def _addAllWidgets(self):


### PR DESCRIPTION
## Description
Numerical inputs are now coerced into their respective types before hitting the config system.

Fixes #2603

## How Has This Been Tested?

Run SasView and modify both a float input and an integer input. Hit the `Apply` button. No error! Also, GUI unit tests were added that I ran locally.

## Review Checklist (please remove items if they don't apply):

- [ ] Code has been reviewed
- [ ] Functionality has been tested
- [ ] Windows installer (GH artifact) has been tested (installed and worked) 
- [ ] MacOSX installer (GH artifact) has been tested (installed and worked) 
- [ ] Developers documentation is available and complete (if required)
- [ ] The introduced changes comply with SasView license (BSD 3-Clause)

