### PR TITLE
created submenu for slicers being part of #2604

### DIFF
--- a/src/sas/qtgui/Plotting/Plotter2D.py
+++ b/src/sas/qtgui/Plotting/Plotter2D.py
@@ -165,7 +165,35 @@ class Plotter2DWidget(PlotterBase):
         """
         Define common context menu and associated actions for the MPL widget
         """
+                
         self.defaultContextMenu()
+        
+        plot_slicer_menu=self.contextMenu.addMenu('Slicers')
+        plot_slicer_menu.actionCircularAverage = plot_slicer_menu.addAction("&Perform Circular Average")
+        plot_slicer_menu.actionCircularAverage.triggered.connect(self.onCircularAverage)
+        plot_slicer_menu.actionSectorView = plot_slicer_menu.addAction("&Sector [Q View]")
+        plot_slicer_menu.actionSectorView.triggered.connect(self.onSectorView)
+        plot_slicer_menu.actionAnnulusView = plot_slicer_menu.addAction("&Annulus [Phi View]")
+        plot_slicer_menu.actionAnnulusView.triggered.connect(self.onAnnulusView)
+        plot_slicer_menu.actionBoxSum = plot_slicer_menu.addAction("&Box Sum")
+        plot_slicer_menu.actionBoxSum.triggered.connect(self.onBoxSum)
+        plot_slicer_menu.actionBoxAveragingX = plot_slicer_menu.addAction("&Box Averaging in Qx")
+        plot_slicer_menu.actionBoxAveragingX.triggered.connect(self.onBoxAveragingX)
+        plot_slicer_menu.actionBoxAveragingY = plot_slicer_menu.addAction("&Box Averaging in Qy")
+        plot_slicer_menu.actionBoxAveragingY.triggered.connect(self.onBoxAveragingY)
+        plot_slicer_menu.actionWedgeAveragingQ = plot_slicer_menu.addAction("&Wedge Averaging in Q")
+        plot_slicer_menu.actionWedgeAveragingQ.triggered.connect(self.onWedgeAveragingQ)
+        plot_slicer_menu.actionWedgeAveragingPhi = plot_slicer_menu.addAction("&Wedge Averaging in Phi")
+        plot_slicer_menu.actionWedgeAveragingPhi.triggered.connect(self.onWedgeAveragingPhi)
+
+        plot_slicer_menu.addSeparator()
+
+        # Additional items for slicer interaction
+        if self.slicer:
+            plot_slicer_menu.actionClearSlicer = plot_slicer_menu.addAction("&Clear Slicer")
+            plot_slicer_menu.actionClearSlicer.triggered.connect(self.onClearSlicer)
+        plot_slicer_menu.actionEditSlicer = plot_slicer_menu.addAction("&Edit Slicer Parameters")
+        plot_slicer_menu.actionEditSlicer.triggered.connect(self.onEditSlicer)
 
         self.contextMenu.addSeparator()
         self.actionDataInfo = self.contextMenu.addAction("&DataInfo")
@@ -177,29 +205,29 @@ class Plotter2DWidget(PlotterBase):
              functools.partial(self.onSavePoints, self.data0))
         self.contextMenu.addSeparator()
 
-        self.actionCircularAverage = self.contextMenu.addAction("&Perform Circular Average")
-        self.actionCircularAverage.triggered.connect(self.onCircularAverage)
+        #self.actionCircularAverage = self.contextMenu.addAction("&Perform Circular Average")
+        #self.actionCircularAverage.triggered.connect(self.onCircularAverage)
+        #self.actionSectorView = self.contextMenu.addAction("&Sector [Q View]")
+        #self.actionSectorView.triggered.connect(self.onSectorView)
+        #self.actionAnnulusView = self.contextMenu.addAction("&Annulus [Phi View]")
+        #self.actionAnnulusView.triggered.connect(self.onAnnulusView)
+        #self.actionBoxSum = self.contextMenu.addAction("&Box Sum")
+        #self.actionBoxSum.triggered.connect(self.onBoxSum)
+        #self.actionBoxAveragingX = self.contextMenu.addAction("&Box Averaging in Qx")
+        #self.actionBoxAveragingX.triggered.connect(self.onBoxAveragingX)
+        #self.actionBoxAveragingY = self.contextMenu.addAction("&Box Averaging in Qy")
+        #self.actionBoxAveragingY.triggered.connect(self.onBoxAveragingY)
+        #self.actionWedgeAveragingQ = self.contextMenu.addAction("&Wedge Averaging in Q")
+        #self.actionWedgeAveragingQ.triggered.connect(self.onWedgeAveragingQ)
+        #self.actionWedgeAveragingPhi = self.contextMenu.addAction("&Wedge Averaging in Phi")
+        #self.actionWedgeAveragingPhi.triggered.connect(self.onWedgeAveragingPhi)
 
-        self.actionSectorView = self.contextMenu.addAction("&Sector [Q View]")
-        self.actionSectorView.triggered.connect(self.onSectorView)
-        self.actionAnnulusView = self.contextMenu.addAction("&Annulus [Phi View]")
-        self.actionAnnulusView.triggered.connect(self.onAnnulusView)
-        self.actionBoxSum = self.contextMenu.addAction("&Box Sum")
-        self.actionBoxSum.triggered.connect(self.onBoxSum)
-        self.actionBoxAveragingX = self.contextMenu.addAction("&Box Averaging in Qx")
-        self.actionBoxAveragingX.triggered.connect(self.onBoxAveragingX)
-        self.actionBoxAveragingY = self.contextMenu.addAction("&Box Averaging in Qy")
-        self.actionBoxAveragingY.triggered.connect(self.onBoxAveragingY)
-        self.actionWedgeAveragingQ = self.contextMenu.addAction("&Wedge Averaging in Q")
-        self.actionWedgeAveragingQ.triggered.connect(self.onWedgeAveragingQ)
-        self.actionWedgeAveragingPhi = self.contextMenu.addAction("&Wedge Averaging in Phi")
-        self.actionWedgeAveragingPhi.triggered.connect(self.onWedgeAveragingPhi)
         # Additional items for slicer interaction
-        if self.slicer:
-            self.actionClearSlicer = self.contextMenu.addAction("&Clear Slicer")
-            self.actionClearSlicer.triggered.connect(self.onClearSlicer)
-        self.actionEditSlicer = self.contextMenu.addAction("&Edit Slicer Parameters")
-        self.actionEditSlicer.triggered.connect(self.onEditSlicer)
+        #if self.slicer:
+           # self.actionClearSlicer = self.contextMenu.addAction("&Clear Slicer")
+           # self.actionClearSlicer.triggered.connect(self.onClearSlicer)
+        #self.actionEditSlicer = self.contextMenu.addAction("&Edit Slicer Parameters")
+        #self.actionEditSlicer.triggered.connect(self.onEditSlicer)
         self.contextMenu.addSeparator()
         self.actionColorMap = self.contextMenu.addAction("&2D Color Map")
         self.actionColorMap.triggered.connect(self.onColorMap)


### PR DESCRIPTION
## Description

From the issue #2604 I have started implementing a dropdown menu for slicers in the 2Dplot context menu, and shifted all slicers, as well as "Edit slicer parameters" and "Clear slicer" to this dropdown menu. 
Following issue #2604 now first the multiplication of one type of slicer would need to be allowed for every slicer inside the slicer-dropdown_menu, and afterwards the option to add multiple different slicers at the same time.

Fixes #2604

## How Has This Been Tested?

I have tested it locally in the created branch of #2604.

## Review Checklist (please remove items if they don't apply):

- [ ] Code has been reviewed
- [ ] Functionality has been tested
- [ ] Windows installer (GH artifact) has been tested (installed and worked) 
- [ ] MacOSX installer (GH artifact) has been tested (installed and worked) 
- [ ] User documentation is available and complete (if required)
- [ ] Developers documentation is available and complete (if required)
- [ ] The introduced changes comply with SasView license (BSD 3-Clause)

