### PR TITLE
2618: Fix GPU and Optimizer Preferences

### DIFF
--- a/src/sas/qtgui/Perspectives/Fitting/GPUOptions.py
+++ b/src/sas/qtgui/Perspectives/Fitting/GPUOptions.py
@@ -77,6 +77,10 @@ class GPUOptions(PreferencesWidget, Ui_GPUOptions):
     def _addAllWidgets(self):
         pass
 
+    def applyNonConfigValues(self):
+        """Applies values that aren't stored in config. Only widgets that require this need to override this method."""
+        self.set_sas_open_cl()
+
     def add_options(self):
         """
         Populate the window with a list of OpenCL options
@@ -85,7 +89,6 @@ class GPUOptions(PreferencesWidget, Ui_GPUOptions):
         cl_tuple = _get_clinfo()
 
         self.cl_options = {}
-
 
         for title, descr in cl_tuple:
 
@@ -96,13 +99,22 @@ class GPUOptions(PreferencesWidget, Ui_GPUOptions):
             self.optionsLayout.addWidget(radio_button)
 
             if title.lower() == config.SAS_OPENCL.lower():
-
                 radio_button.setChecked(True)
 
+            radio_button.toggled.connect(self._stage_sas_open_cl)
             self.cl_options[descr] = title
             self.radio_buttons.append(radio_button)
 
         self.openCLCheckBoxGroup.setMinimumWidth(self.optionsLayout.sizeHint().width()+10)
+
+    def _stage_sas_open_cl(self, checked):
+        checked = None
+        for box in self.radio_buttons:
+            if box.isChecked():
+                checked = box
+        if checked:
+            sas_open_cl = self.cl_options[str(checked.text())]
+            self._stageChange('SAS_OPENCL', sas_open_cl)
 
     def set_sas_open_cl(self):
         """

--- a/src/sas/qtgui/Utilities/Preferences/DisplayPreferencesWidget.py
+++ b/src/sas/qtgui/Utilities/Preferences/DisplayPreferencesWidget.py
@@ -7,9 +7,7 @@ class DisplayPreferencesWidget(PreferencesWidget):
     def __init__(self):
         super(DisplayPreferencesWidget, self).__init__("Display Settings")
         self.config_params = ['QT_SCALE_FACTOR',
-                              'QT_AUTO_SCREEN_SCALE_FACTOR',
-                              'DISABLE_RESIDUAL_PLOT',
-                              'DISABLE_POLYDISPERSITY_PLOT']
+                              'QT_AUTO_SCREEN_SCALE_FACTOR']
         self.restart_params = {'QT_SCALE_FACTOR': 'QT Screen Scale Factor',
                                'QT_AUTO_SCREEN_SCALE_FACTOR': "Enable Automatic Scaling"}
 
@@ -24,26 +22,12 @@ class DisplayPreferencesWidget(PreferencesWidget):
             checked=config.QT_AUTO_SCREEN_SCALE_FACTOR)
         self.autoScaling.clicked.connect(
             lambda: self._stageChange('QT_AUTO_SCREEN_SCALE_FACTOR', self.autoScaling.isChecked()))
-        self.disableResidualPlot = self.addCheckBox(
-            title="Disable Residuals Display",
-            checked=config.DISABLE_RESIDUAL_PLOT)
-        self.disableResidualPlot.clicked.connect(
-            lambda: self._stageChange('DISABLE_RESIDUAL_PLOT', self.disableResidualPlot.isChecked()))
-        self.disablePolydispersityPlot = self.addCheckBox(
-            title="Disable Polydispersity Plot Display",
-            checked=config.DISABLE_POLYDISPERSITY_PLOT)
-        self.disablePolydispersityPlot.clicked.connect(
-            lambda: self._stageChange('DISABLE_POLYDISPERSITY_PLOT', self.disablePolydispersityPlot.isChecked()))
 
     def _toggleBlockAllSignaling(self, toggle):
         self.qtScaleFactor.blockSignals(toggle)
         self.autoScaling.blockSignals(toggle)
-        self.disableResidualPlot.blockSignals(toggle)
-        self.disablePolydispersityPlot.blockSignals(toggle)
 
     def _restoreFromConfig(self):
         self.qtScaleFactor.setText(str(config.QT_SCALE_FACTOR))
         self.qtScaleFactor.setStyleSheet("background-color: white")
         self.autoScaling.setChecked(bool(config.QT_AUTO_SCREEN_SCALE_FACTOR))
-        self.disableResidualPlot.setChecked(config.DISABLE_RESIDUAL_PLOT)
-        self.disablePolydispersityPlot.setChecked(config.DISABLE_POLYDISPERSITY_PLOT)

--- a/src/sas/qtgui/Utilities/Preferences/PlottingPreferencesWidget.py
+++ b/src/sas/qtgui/Utilities/Preferences/PlottingPreferencesWidget.py
@@ -8,7 +8,9 @@ class PlottingPreferencesWidget(PreferencesWidget):
         super(PlottingPreferencesWidget, self).__init__("Plotting Options")
         self.config_params = ['FITTING_PLOT_FULL_WIDTH_LEGENDS',
                               'FITTING_PLOT_LEGEND_TRUNCATE',
-                              'FITTING_PLOT_LEGEND_MAX_LINE_LENGTH']
+                              'FITTING_PLOT_LEGEND_MAX_LINE_LENGTH',
+                              'DISABLE_RESIDUAL_PLOT',
+                              'DISABLE_POLYDISPERSITY_PLOT']
 
     def _addAllWidgets(self):
         self.legendFullWidth = self.addCheckBox(
@@ -26,14 +28,28 @@ class PlottingPreferencesWidget(PreferencesWidget):
             default_number=config.FITTING_PLOT_LEGEND_MAX_LINE_LENGTH)
         self.legendLineLength.textChanged.connect(
             lambda: self._validate_input_and_stage(self.legendLineLength, 'FITTING_PLOT_LEGEND_MAX_LINE_LENGTH'))
+        self.disableResidualPlot = self.addCheckBox(
+            title="Disable Residuals Display",
+            checked=config.DISABLE_RESIDUAL_PLOT)
+        self.disableResidualPlot.clicked.connect(
+            lambda: self._stageChange('DISABLE_RESIDUAL_PLOT', self.disableResidualPlot.isChecked()))
+        self.disablePolydispersityPlot = self.addCheckBox(
+            title="Disable Polydispersity Plot Display",
+            checked=config.DISABLE_POLYDISPERSITY_PLOT)
+        self.disablePolydispersityPlot.clicked.connect(
+            lambda: self._stageChange('DISABLE_POLYDISPERSITY_PLOT', self.disablePolydispersityPlot.isChecked()))
 
     def _toggleBlockAllSignaling(self, toggle):
         self.legendFullWidth.blockSignals(toggle)
         self.legendTruncate.blockSignals(toggle)
         self.legendLineLength.blockSignals(toggle)
+        self.disableResidualPlot.blockSignals(toggle)
+        self.disablePolydispersityPlot.blockSignals(toggle)
 
     def _restoreFromConfig(self):
         self.legendFullWidth.setChecked(bool(config.FITTING_PLOT_FULL_WIDTH_LEGENDS))
         self.legendTruncate.setChecked(bool(config.FITTING_PLOT_LEGEND_TRUNCATE))
         self.legendLineLength.setText(str(config.FITTING_PLOT_LEGEND_MAX_LINE_LENGTH))
         self.legendLineLength.setStyleSheet("background-color: white")
+        self.disableResidualPlot.setChecked(config.DISABLE_RESIDUAL_PLOT)
+        self.disablePolydispersityPlot.setChecked(config.DISABLE_POLYDISPERSITY_PLOT)


### PR DESCRIPTION
## Description

This updates the preferences panel to ensure the GPU and Optimizer settings behave in the same way as all other preferences.

Also, the residual and polydispersity plot preferences was moved from the display preferences to the plotting preferences.

Fixes #2618

## How Has This Been Tested?

Run SasView, open either the Fitting Optimizer or GPU preferences and modify them. The OK, Apply, and Cancel buttons should now enable/disable and behave properly.

## Review Checklist (please remove items if they don't apply):

- [ ] Code has been reviewed
- [ ] Functionality has been tested
- [ ] Windows installer (GH artifact) has been tested (installed and worked) 
- [ ] MacOSX installer (GH artifact) has been tested (installed and worked) 
- [ ] The introduced changes comply with SasView license (BSD 3-Clause)

