### PR TITLE
Populate whats new with last version

### DIFF
--- a/src/sas/qtgui/Utilities/WhatsNew/WhatsNew.py
+++ b/src/sas/qtgui/Utilities/WhatsNew/WhatsNew.py
@@ -52,6 +52,8 @@ class WhatsNew(QDialog):
         self.setWindowTitle(f"What's New in SasView {sasview_version}")
 
         self.browser = QTextBrowser()
+        self.browser.setOpenLinks(True)
+        self.browser.setOpenExternalLinks(True)
 
         # Layout stuff
         self.mainLayout = QVBoxLayout()

--- a/src/sas/qtgui/Utilities/WhatsNew/messages/5.0.6/1.html
+++ b/src/sas/qtgui/Utilities/WhatsNew/messages/5.0.6/1.html
@@ -1,0 +1,11 @@
+<html>
+<head/>
+<body>
+
+<h1>
+    Version 5.0.6
+</h1>
+<br>
+<a href="https://www.sasview.org/docs/user/RELEASE.html#new-in-version-5-0-6">What's New in v5.0.6</a>
+</body>
+</html>


### PR DESCRIPTION
## Description

This PR, partly as a test of the way the new What's New functionality is intended to work, adds a link to the What's New in the documentation for the previous release which opens in a browser window.

## How Has This Been Tested?

Built & run locally on W10/x64. Works as expected.

## Review Checklist (please remove items if they don't apply):

- [ ] Code has been reviewed
- [x] Functionality has been tested
- [ ] Windows installer (GH artifact) has been tested (installed and worked) 
- [ ] MacOSX installer (GH artifact) has been tested (installed and worked) 
- [ ] User documentation is available and complete (if required)
- [ ] Developers documentation is available and complete (if required)
- [ ] The introduced changes comply with SasView license (BSD 3-Clause)

