### PR TITLE
Grid lines toggle for standard Plot1D

### DIFF
--- a/src/sas/qtgui/Plotting/Plotter.py
+++ b/src/sas/qtgui/Plotting/Plotter.py
@@ -170,6 +170,9 @@ class PlotterWidget(PlotterBase):
         if color is None:
             color = data.custom_color
 
+        # grid on/off, stored on self
+        ax.grid(self.grid_on)
+
         color = PlotUtilities.getValidColor(color)
         data.custom_color = color
 
@@ -317,9 +320,11 @@ class PlotterWidget(PlotterBase):
         self.actionAddText = self.contextMenu.addAction("Add Text")
         self.actionRemoveText = self.contextMenu.addAction("Remove Text")
         self.contextMenu.addSeparator()
+        self.actionToggleGrid = self.contextMenu.addAction("Toggle Grid On/Off")
         if self.show_legend:
             self.actionToggleLegend = self.contextMenu.addAction("Toggle Legend")
             self.contextMenu.addSeparator()
+        # Additional actions
         self.actionCustomizeLabel = self.contextMenu.addAction("Customize Labels")
         self.contextMenu.addSeparator()
         self.actionChangeScale = self.contextMenu.addAction("Change Scale")
@@ -339,6 +344,7 @@ class PlotterWidget(PlotterBase):
         self.actionRemoveText.triggered.connect(self.onRemoveText)
         self.actionChangeScale.triggered.connect(self.onScaleChange)
         self.actionSetGraphRange.triggered.connect(self.onSetGraphRange)
+        self.actionToggleGrid.triggered.connect(self.onGridToggle)
         self.actionResetGraphRange.triggered.connect(self.onResetGraphRange)
         self.actionWindowTitle.triggered.connect(self.onWindowsTitle)
         self.actionToggleMenu.triggered.connect(self.onToggleMenu)


### PR DESCRIPTION
## Description

Added grid lines on Plot1D, similar to those on QuickPlot. Access through the context menu.

Fixes  @smk78 's complaint

## How Has This Been Tested?

Locally on win10

## Review Checklist (please remove items if they don't apply):

- [ ] Code has been reviewed
- [ ] Functionality has been tested
- [ ] Windows installer (GH artifact) has been tested (installed and worked) 
- [ ] MacOSX installer (GH artifact) has been tested (installed and worked) 


