### PR TITLE
Moving OSX signing to nightly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -243,28 +243,8 @@ jobs:
         run: |
           cd installers/dist
           python ../../build_tools/fix_qt_folder_names_for_codesign.py SasView5.app
-          #hdiutil create SasView5.dmg -srcfolder SasView5.app -ov -format UDZO
-
-      - name: Sign executable and create dmg (OSX)
-        if: ${{ matrix.installer && startsWith(matrix.os, 'macos') }}
-        env:
-          MACOS_CERTIFICATE: ${{ secrets.MACOS_CERTIFICATE }}
-          MACOS_CERTIFICATE_PWD: ${{ secrets.MACOS_CERTIFICATE_PWD }}
-        run: |
-          echo $MACOS_CERTIFICATE | base64 --decode > certificate.p12
-          security create-keychain -p DloaAcYP build.keychain
-          security default-keychain -s build.keychain
-          security unlock-keychain -p DloaAcYP build.keychain
-          security import certificate.p12 -k build.keychain -P $MACOS_CERTIFICATE_PWD -T /usr/bin/codesign
-          security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k DloaAcYP build.keychain
-
-          cd installers/dist
-          python ../../build_tools/fix_qt_folder_names_for_codesign.py SasView5.app
-          python  ../../build_tools/code_sign_osx.py
-          codesign --verify --options=runtime --entitlements ../../build_tools/entitlements.plist --timestamp --deep --verbose=4 --force --sign "Developer ID Application: European Spallation Source Eric (W2AG9MPZ43)" SasView5.app
           hdiutil create SasView5.dmg -srcfolder SasView5.app -ov -format UDZO
-          codesign -s "Developer ID Application: European Spallation Source Eric (W2AG9MPZ43)" SasView5.dmg
-          
+
       - name: Publish installer package
         if: ${{ matrix.installer }}
         uses: actions/upload-artifact@v3

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -39,6 +39,26 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
+      - name: Sign executable and create dmg (OSX)
+        if: ${{ matrix.installer && startsWith(matrix.os, 'macos') }}
+        env:
+          MACOS_CERTIFICATE: ${{ secrets.MACOS_CERTIFICATE }}
+          MACOS_CERTIFICATE_PWD: ${{ secrets.MACOS_CERTIFICATE_PWD }}
+        run: |
+          echo $MACOS_CERTIFICATE | base64 --decode > certificate.p12
+          security create-keychain -p DloaAcYP build.keychain
+          security default-keychain -s build.keychain
+          security unlock-keychain -p DloaAcYP build.keychain
+          security import certificate.p12 -k build.keychain -P $MACOS_CERTIFICATE_PWD -T /usr/bin/codesign
+          security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k DloaAcYP build.keychain
+
+          cd installers/dist
+          python ../../build_tools/fix_qt_folder_names_for_codesign.py SasView5.app
+          python  ../../build_tools/code_sign_osx.py
+          codesign --verify --options=runtime --entitlements ../../build_tools/entitlements.plist --timestamp --deep --verbose=4 --force --sign "Developer ID Application: European Spallation Source Eric (W2AG9MPZ43)" SasView5.app
+          hdiutil create SasView5.dmg -srcfolder SasView5.app -ov -format UDZO
+          codesign -s "Developer ID Application: European Spallation Source Eric (W2AG9MPZ43)" SasView5.dmg
+          
       - name: Rename artifacts
         run: |
           mv installers/dist/SasView-Installer-windows-*/setupSasView.exe installers/dist/setupSasView-nightly-Win64.exe


### PR DESCRIPTION
## Description

Moving OSX signing to nightly builds, so that builds work from forks

Fixes # (issue/issues)

## How Has This Been Tested?
Install builds from PR and nightly 

## Review Checklist (please remove items if they don't apply):

- [ ] Code has been reviewed
- [ ] Functionality has been tested
- [ ] Windows installer (GH artifact) has been tested (installed and worked) 
- [ ] MacOSX installer (GH artifact) has been tested (installed and worked) 
- [X] The introduced changes comply with SasView license (BSD 3-Clause)

