### PR TITLE
Empty lines in data explorer

### DIFF
--- a/src/sas/qtgui/MainWindow/CategoryManager.py
+++ b/src/sas/qtgui/MainWindow/CategoryManager.py
@@ -277,8 +277,9 @@ class CategoryManager(QtWidgets.QDialog, Ui_CategoryManagerUI):
             input_to_check = str(self.txtSearch.text())
 
         # redefine the proxy model
-        self.model_proxy.filterRegularExpression = QtCore.QRegularExpression(input_to_check,
-                         QtCore.Qt.CaseInsensitive, QtCore.QRegularExpression.FixedString)
+        self.model_proxy.setFilterRegularExpression(QtCore.QRegularExpression(input_to_check,
+            QtCore.QRegularExpression.CaseInsensitiveOption |
+            QtCore.QRegularExpression.PatternOption.NoPatternOption))
 
     def onModify(self):
         """

--- a/src/sas/qtgui/MainWindow/DataExplorer.py
+++ b/src/sas/qtgui/MainWindow/DataExplorer.py
@@ -128,7 +128,7 @@ class DataExplorerWindow(DroppableDataLoadWidget):
         self.theory_model.itemChanged.connect(self.onFileListChanged)
 
         # Don't show "empty" rows with data objects
-        self.data_proxy.filterRegularExpression = "[^()]" 
+        self.data_proxy.setFilterRegularExpression(QtCore.QRegularExpression(".+"))
 
         # Create a window to allow the display name to change
         self.nameChangeBox = ChangeName(self)

--- a/src/sas/qtgui/MainWindow/DataExplorer.py
+++ b/src/sas/qtgui/MainWindow/DataExplorer.py
@@ -141,7 +141,7 @@ class DataExplorerWindow(DroppableDataLoadWidget):
         self.theory_proxy.setSourceModel(self.theory_model)
 
         # Don't show "empty" rows with data objects
-        self.theory_proxy.filterRegularExpression = "[^()]"
+        self.theory_proxy.setFilterRegularExpression(QtCore.QRegularExpression(".+"))
 
         # Theory model view
         self.freezeView.setModel(self.theory_proxy)

--- a/src/sas/qtgui/MainWindow/UnitTesting/DataExplorerTest.py
+++ b/src/sas/qtgui/MainWindow/UnitTesting/DataExplorerTest.py
@@ -110,7 +110,7 @@ class DataExplorerTest:
         assert form.model.columnCount() == 0
         assert isinstance(form.data_proxy, QSortFilterProxyModel)
         assert form.data_proxy.sourceModel() == form.model
-        assert "[^()]" == str(form.data_proxy.filterRegExp().pattern())
+        assert ".+" == str(form.data_proxy.filterRegExp().pattern())
         assert isinstance(form.treeView, QTreeView)
 
         # Models - theory
@@ -121,7 +121,7 @@ class DataExplorerTest:
         assert form.theory_model.columnCount() == 0
         assert isinstance(form.theory_proxy, QSortFilterProxyModel)
         assert form.theory_proxy.sourceModel() == form.theory_model
-        assert "[^()]" == str(form.theory_proxy.filterRegExp().pattern())
+        assert ".+" == str(form.theory_proxy.filterRegExp().pattern())
         assert isinstance(form.freezeView, QTreeView)
 
     def testWidgets(self, form):


### PR DESCRIPTION
## Description

Qt6-ize the setFilterRegularExpression syntax, such that the empty row in DataExplorer display of datasets is not shown.

Fixes #2642

