### PR TITLE
PyInstaller pinned

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -195,7 +195,7 @@ jobs:
       - name: Install utilities to build installer
         if: ${{ matrix.installer }}
         run: |
-          python -m pip install pyinstaller
+          python -m pip install pyinstaller==5.13.2
 
       - name: Build sasview with pyinstaller
         if: ${{ matrix.installer }}


### PR DESCRIPTION
## Description

CI started to pull pyinstaller 6, which is messing up the Windows install generating a single file exe.
This started right when we finished the code camp...
The proper solution is to find out what changed in the default parameters and modify the SPEC file to not generate a single executable but the "normal" file tree.

## How Has This Been Tested?

GH windows build 

## Review Checklist (please remove items if they don't apply):

- [ ] Code has been reviewed
- [ ] Functionality has been tested
- [ ] Windows installer (GH artifact) has been tested (installed and worked) 
- [ ] MacOSX installer (GH artifact) has been tested (installed and worked) 

