### PR TITLE
Remove duplicate `html5lib` from requirements file

### DIFF
--- a/build_tools/requirements.txt
+++ b/build_tools/requirements.txt
@@ -26,7 +26,6 @@ lxml
 pytools 
 cffi
 dominate
-html5lib
 importlib-resources
 bumps
 html2text


### PR DESCRIPTION
## Description

'html5lib' was listed twice in `requirements.txt`. This removes one of those instances.

**Question** Do we still need the `html5lib`? Grep shows the only other place it is listed in the entirety of SasView is in setup.py.

## Review Checklist (please remove items if they don't apply):

- [ ] Code has been reviewed
- [ ] Functionality has been tested
- [ ] Windows installer (GH artifact) has been tested (installed and worked) 
- [ ] MacOSX installer (GH artifact) has been tested (installed and worked) 
- [ ] User documentation is available and complete (if required)
- [ ] Developers documentation is available and complete (if required)
- [ ] The introduced changes comply with SasView license (BSD 3-Clause)

