### PR TITLE
2675 unable to save fitting reports

### DIFF
--- a/src/sas/qtgui/Utilities/Reports/ReportDialog.py
+++ b/src/sas/qtgui/Utilities/Reports/ReportDialog.py
@@ -64,7 +64,7 @@ class ReportDialog(QtWidgets.QDialog, Ui_ReportDialogUI):
         try:
             # pylint chokes on this line with syntax-error
             # pylint: disable=syntax-error doesn't seem to help
-            document.print(printer)
+            document.print_(printer)
         except Exception as ex:
             # Printing can return various exceptions, let's catch them all
             logging.error("Print report failed with: " + str(ex))

--- a/src/sas/qtgui/Utilities/UnitTesting/ReportDialogTest.py
+++ b/src/sas/qtgui/Utilities/UnitTesting/ReportDialogTest.py
@@ -51,7 +51,7 @@ class ReportDialogTest:
     def testOnPrint(self, widget, mocker):
         ''' Printing the report '''
         document = widget.txtBrowser.document()
-        mocker.patch.object(document, 'print')
+        mocker.patch.object(document, 'print_')
 
         # test rejected dialog
         mocker.patch.object(QtPrintSupport.QPrintDialog, 'exec_', return_value=QtWidgets.QDialog.Rejected)
@@ -60,7 +60,7 @@ class ReportDialogTest:
         widget.onPrint()
 
         # Assure printing was not done
-        assert not document.print.called
+        assert not document.print_.called
 
         # test accepted dialog
         mocker.patch.object(QtPrintSupport.QPrintDialog, 'exec_', return_value=QtWidgets.QDialog.Accepted)


### PR DESCRIPTION
## Description

Pyside6 uses `print_()` for QTextDocuments, rather than `print()`.

This will need to be cherry-picked to `release_6.0.0`

Fixes #2675

## How Has This Been Tested?

Locally on win10

## Review Checklist (please remove items if they don't apply):

- [ ] Code has been reviewed
- [ ] Functionality has been tested
- [ ] Windows installer (GH artifact) has been tested (installed and worked) 
- [ ] MacOSX installer (GH artifact) has been tested (installed and worked) 

