### PR TITLE
Fix for empty save format for grid files

### DIFF
--- a/src/sas/qtgui/Utilities/GridPanel.py
+++ b/src/sas/qtgui/Utilities/GridPanel.py
@@ -257,7 +257,7 @@ class BatchOutputPanel(QtWidgets.QMainWindow, Ui_GridPanelUI):
         time_str = time.strftime("%b %d %H %M of %Y", t)
         default_name = "Batch_Fitting_"+time_str+".csv"
 
-        wildcard = "CSV files (*.csv);;"
+        wildcard = "CSV files (*.csv)"
         caption =  'Save As'
         directory =  default_name
         filter =  wildcard


### PR DESCRIPTION
## Description

This fixes and old bug where some extra semicolons added an empty line to the available save formats for grid files in batch fitting

Fixes #2676

## How Has This Been Tested?

Locally on win10

## Review Checklist (please remove items if they don't apply):

- [ ] Code has been reviewed
- [ ] Functionality has been tested
- [ ] Windows installer (GH artifact) has been tested (installed and worked) 
- [ ] MacOSX installer (GH artifact) has been tested (installed and worked) 


