### PR TITLE
Change build rules to not double fire on PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,11 @@
 name: CI
 
 on:
-  [push, pull_request, workflow_call]
+  workflow_call:
+  pull_request:
+  push:
+    branches: [main]
+    tags: ['v*']
 
 defaults:
   run:


### PR DESCRIPTION
## Description

By reducing which pushes fire CI to only the default branch and version tags, PR builds will not get two versions of each build.

The documentation for being more specific on branches/tags for a push is [here](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-including-branches-and-tags).

Refs #2378

## How Has This Been Tested?

Look at builds on #2647 for comparison (36 builds). This does not have builds for `push`, only `pull_request` is present (18 builds).

## Review Checklist (please remove items if they don't apply):

- [ ] Code has been reviewed
- [ ] Functionality has been tested
- [ ] Windows installer (GH artifact) has been tested (installed and worked) 
- [ ] MacOSX installer (GH artifact) has been tested (installed and worked) 
- [ ] User documentation is available and complete (if required)
- [ ] Developers documentation is available and complete (if required)
- [ ] The introduced changes comply with SasView license (BSD 3-Clause)

