### PR TITLE
Re-enabled "close window" option on modal dialogs

### DIFF
--- a/src/sas/qtgui/Calculators/DataOperationUtilityPanel.py
+++ b/src/sas/qtgui/Calculators/DataOperationUtilityPanel.py
@@ -27,6 +27,7 @@ class DataOperationUtilityPanel(QtWidgets.QDialog, Ui_DataOperationUtility):
         self.communicator = self.manager.communicator()
         # disable the context help icon
         # self.setWindowFlags(self.windowFlags() & ~QtCore.Qt.WindowContextHelpButtonHint)
+        self.setWindowFlags(self.windowFlags() & ~QtCore.Qt.WindowSystemMenuHint)
 
         # To store input datafiles
         self.filenames = None

--- a/src/sas/qtgui/Calculators/DataOperationUtilityPanel.py
+++ b/src/sas/qtgui/Calculators/DataOperationUtilityPanel.py
@@ -26,7 +26,7 @@ class DataOperationUtilityPanel(QtWidgets.QDialog, Ui_DataOperationUtility):
         self.manager = parent
         self.communicator = self.manager.communicator()
         # disable the context help icon
-        self.setWindowFlags(self.windowFlags() & ~QtCore.Qt.WindowContextHelpButtonHint)
+        # self.setWindowFlags(self.windowFlags() & ~QtCore.Qt.WindowContextHelpButtonHint)
 
         # To store input datafiles
         self.filenames = None

--- a/src/sas/qtgui/Calculators/DataOperationUtilityPanel.py
+++ b/src/sas/qtgui/Calculators/DataOperationUtilityPanel.py
@@ -27,7 +27,7 @@ class DataOperationUtilityPanel(QtWidgets.QDialog, Ui_DataOperationUtility):
         self.communicator = self.manager.communicator()
         # disable the context help icon
         # self.setWindowFlags(self.windowFlags() & ~QtCore.Qt.WindowContextHelpButtonHint)
-        self.setWindowFlags(self.windowFlags() & ~QtCore.Qt.WindowSystemMenuHint)
+        # self.setWindowFlags(self.windowFlags() & ~QtCore.Qt.WindowSystemMenuHint)
 
         # To store input datafiles
         self.filenames = None

--- a/src/sas/qtgui/Calculators/DataOperationUtilityPanel.py
+++ b/src/sas/qtgui/Calculators/DataOperationUtilityPanel.py
@@ -25,9 +25,6 @@ class DataOperationUtilityPanel(QtWidgets.QDialog, Ui_DataOperationUtility):
         self.setupUi(self)
         self.manager = parent
         self.communicator = self.manager.communicator()
-        # disable the context help icon
-        # self.setWindowFlags(self.windowFlags() & ~QtCore.Qt.WindowContextHelpButtonHint)
-        # self.setWindowFlags(self.windowFlags() & ~QtCore.Qt.WindowSystemMenuHint)
 
         # To store input datafiles
         self.filenames = None

--- a/src/sas/qtgui/Calculators/DensityPanel.py
+++ b/src/sas/qtgui/Calculators/DensityPanel.py
@@ -48,7 +48,7 @@ class DensityPanel(QtWidgets.QDialog):
         self.manager = parent
         self.setupUi()
         # disable the context help icon
-        self.setWindowFlags(self.windowFlags() & ~QtCore.Qt.WindowContextHelpButtonHint)
+        # self.setWindowFlags(self.windowFlags() & ~QtCore.Qt.WindowContextHelpButtonHint)
 
         self.setupModel()
         self.setupMapper()

--- a/src/sas/qtgui/Calculators/DensityPanel.py
+++ b/src/sas/qtgui/Calculators/DensityPanel.py
@@ -47,8 +47,6 @@ class DensityPanel(QtWidgets.QDialog):
         self.mode = None
         self.manager = parent
         self.setupUi()
-        # disable the context help icon
-        # self.setWindowFlags(self.windowFlags() & ~QtCore.Qt.WindowContextHelpButtonHint)
 
         self.setupModel()
         self.setupMapper()

--- a/src/sas/qtgui/Calculators/GenericScatteringCalculator.py
+++ b/src/sas/qtgui/Calculators/GenericScatteringCalculator.py
@@ -52,8 +52,6 @@ class GenericScatteringCalculator(QtWidgets.QDialog, Ui_GenericScatteringCalcula
     def __init__(self, parent=None):
         super(GenericScatteringCalculator, self).__init__()
         self.setupUi(self)
-        # disable the context help icon
-        self.setWindowFlags(self.windowFlags() & ~QtCore.Qt.WindowContextHelpButtonHint)
         self.setFixedSize(self.minimumSizeHint())
 
         self.manager = parent

--- a/src/sas/qtgui/Calculators/KiessigPanel.py
+++ b/src/sas/qtgui/Calculators/KiessigPanel.py
@@ -14,9 +14,6 @@ class KiessigPanel(QtWidgets.QDialog, Ui_KiessigPanel):
     def __init__(self, parent=None):
         super(KiessigPanel, self).__init__()
         self.setupUi(self)
-        # disable the context help icon
-        self.setWindowFlags(self.windowFlags() & ~QtCore.Qt.WindowContextHelpButtonHint)
-
         self.setWindowTitle("Kiessig Thickness Calculator")
 
         self.manager = parent

--- a/src/sas/qtgui/Calculators/ResolutionCalculatorPanel.py
+++ b/src/sas/qtgui/Calculators/ResolutionCalculatorPanel.py
@@ -40,8 +40,6 @@ class ResolutionCalculatorPanel(QtWidgets.QDialog, Ui_ResolutionCalculatorPanel)
     def __init__(self, parent=None):
         super(ResolutionCalculatorPanel, self).__init__()
         self.setupUi(self)
-        # disable the context help icon
-        self.setWindowFlags(self.windowFlags() & ~QtCore.Qt.WindowContextHelpButtonHint)
         self.setFixedSize(self.minimumSizeHint())
 
         self.manager = parent

--- a/src/sas/qtgui/Calculators/SldPanel.py
+++ b/src/sas/qtgui/Calculators/SldPanel.py
@@ -95,8 +95,6 @@ class SldPanel(QtWidgets.QDialog):
         self.manager = parent
 
         self.setupUi()
-        # disable the context help icon
-        self.setWindowFlags(self.windowFlags() & ~QtCore.Qt.WindowContextHelpButtonHint)
         self.setFixedSize(self.minimumSizeHint())
 
         self.setupModel()

--- a/src/sas/qtgui/Calculators/SlitSizeCalculator.py
+++ b/src/sas/qtgui/Calculators/SlitSizeCalculator.py
@@ -24,8 +24,6 @@ class SlitSizeCalculator(QtWidgets.QDialog, Ui_SlitSizeCalculator):
     def __init__(self, parent=None):
         super(SlitSizeCalculator, self).__init__()
         self.setupUi(self)
-        # disable the context help icon
-        self.setWindowFlags(self.windowFlags() & ~QtCore.Qt.WindowContextHelpButtonHint)
 
         self.setWindowTitle("Slit Size Calculator")
         self._parent = parent

--- a/src/sas/qtgui/MainWindow/AboutBox.py
+++ b/src/sas/qtgui/MainWindow/AboutBox.py
@@ -12,8 +12,6 @@ class AboutBox(QtWidgets.QDialog, Ui_AboutUI):
     def __init__(self, parent=None):
         super(AboutBox, self).__init__(parent)
         self.setupUi(self)
-        # disable the context help icon
-        self.setWindowFlags(self.windowFlags() & ~QtCore.Qt.WindowContextHelpButtonHint)
 
         self.setWindowTitle("About")
 

--- a/src/sas/qtgui/MainWindow/Acknowledgements.py
+++ b/src/sas/qtgui/MainWindow/Acknowledgements.py
@@ -12,8 +12,6 @@ class Acknowledgements(QtWidgets.QDialog, Ui_Acknowledgements):
     def __init__(self, parent=None):
         super(Acknowledgements, self).__init__(parent)
         self.setupUi(self)
-        # disable the context help icon
-        self.setWindowFlags(self.windowFlags() & ~QtCore.Qt.WindowContextHelpButtonHint)
 
         self.addText()
 

--- a/src/sas/qtgui/MainWindow/CategoryManager.py
+++ b/src/sas/qtgui/MainWindow/CategoryManager.py
@@ -135,9 +135,6 @@ class CategoryManager(QtWidgets.QDialog, Ui_CategoryManagerUI):
         super(CategoryManager, self).__init__(parent)
         self.setupUi(self)
 
-        # disable the context help icon
-        self.setWindowFlags(self.windowFlags() & ~QtCore.Qt.WindowContextHelpButtonHint)
-
         self.communicator = manager.communicator()
 
         self.setWindowTitle("Category Manager")
@@ -330,8 +327,6 @@ class ChangeCategory(QtWidgets.QDialog, Ui_ChangeCategoryUI):
     def __init__(self, parent=None, categories=None, model=None):
         super(ChangeCategory, self).__init__(parent)
         self.setupUi(self)
-        # disable the context help icon
-        self.setWindowFlags(self.windowFlags() & ~QtCore.Qt.WindowContextHelpButtonHint)
 
         self.model = model
         self.parent = parent

--- a/src/sas/qtgui/MainWindow/NameChanger.py
+++ b/src/sas/qtgui/MainWindow/NameChanger.py
@@ -15,7 +15,6 @@ class ChangeName(QtWidgets.QDialog, Ui_ChangeCategoryUI):
         self._model_item = None
         self.setupUi(self)
 
-        self.setWindowFlags(self.windowFlags() & ~QtCore.Qt.WindowContextHelpButtonHint)
         self.setModal(True)
 
         self.parent = parent

--- a/src/sas/qtgui/Perspectives/Fitting/ComplexConstraint.py
+++ b/src/sas/qtgui/Perspectives/Fitting/ComplexConstraint.py
@@ -32,7 +32,7 @@ class ComplexConstraint(QtWidgets.QDialog, Ui_ComplexConstraintUI):
 
         # disable the context help icon
         windowFlags = self.windowFlags()
-        self.setWindowFlags(windowFlags & ~QtCore.Qt.WindowContextHelpButtonHint)
+        # self.setWindowFlags(windowFlags & ~QtCore.Qt.WindowContextHelpButtonHint)
 
         # Useful globals
         self.tabs = tabs

--- a/src/sas/qtgui/Perspectives/Fitting/ComplexConstraint.py
+++ b/src/sas/qtgui/Perspectives/Fitting/ComplexConstraint.py
@@ -30,10 +30,6 @@ class ComplexConstraint(QtWidgets.QDialog, Ui_ComplexConstraintUI):
         self.setupUi(self)
         self.setModal(True)
 
-        # disable the context help icon
-        windowFlags = self.windowFlags()
-        # self.setWindowFlags(windowFlags & ~QtCore.Qt.WindowContextHelpButtonHint)
-
         # Useful globals
         self.tabs = tabs
         self.params = None

--- a/src/sas/qtgui/Perspectives/Fitting/GPUOptions.py
+++ b/src/sas/qtgui/Perspectives/Fitting/GPUOptions.py
@@ -55,8 +55,6 @@ class GPUOptions(PreferencesWidget, Ui_GPUOptions):
 
         self.radio_buttons = []
 
-        # disable the context help icon
-        self.setWindowFlags(self.windowFlags() & ~QtCore.Qt.WindowContextHelpButtonHint)
         self.add_options()
         self.progressBar.setVisible(False)
         self.progressBar.setFormat(" Test %v / %m")

--- a/src/sas/qtgui/Perspectives/Fitting/MultiConstraint.py
+++ b/src/sas/qtgui/Perspectives/Fitting/MultiConstraint.py
@@ -30,10 +30,6 @@ class MultiConstraint(QtWidgets.QDialog, Ui_MultiConstraintUI):
         self.setupUi(self)
         self.setModal(True)
 
-        # disable the context help icon
-        windowFlags = self.windowFlags()
-        self.setWindowFlags(windowFlags & ~QtCore.Qt.WindowContextHelpButtonHint)
-
         self.params = params
         self.parent = parent
         # Text of the constraint

--- a/src/sas/qtgui/Plotting/AddText.py
+++ b/src/sas/qtgui/Plotting/AddText.py
@@ -11,8 +11,6 @@ class AddText(QtWidgets.QDialog, Ui_AddText):
     def __init__(self, parent=None):
         super(AddText, self).__init__()
         self.setupUi(self)
-        # disable the context help icon
-        self.setWindowFlags(self.windowFlags() & ~QtCore.Qt.WindowContextHelpButtonHint)
 
         self._font = QtGui.QFont()
         self._color = "black"

--- a/src/sas/qtgui/Plotting/ColorMap.py
+++ b/src/sas/qtgui/Plotting/ColorMap.py
@@ -27,8 +27,6 @@ class ColorMap(QtWidgets.QDialog, Ui_ColorMapUI):
 
         self.setupUi(self)
         assert(isinstance(data, Data2D))
-        # disable the context help icon
-        self.setWindowFlags(self.windowFlags() & ~QtCore.Qt.WindowContextHelpButtonHint)
 
         self.data = data
         self._cmap_orig = self._cmap = cmap if cmap is not None else DEFAULT_MAP

--- a/src/sas/qtgui/Plotting/LinearFit.py
+++ b/src/sas/qtgui/Plotting/LinearFit.py
@@ -33,8 +33,6 @@ class LinearFit(QtWidgets.QDialog, Ui_LinearFitUI):
         super(LinearFit, self).__init__(parent)
 
         self.setupUi(self)
-        # disable the context help icon
-        self.setWindowFlags(self.windowFlags() & ~QtCore.Qt.WindowContextHelpButtonHint)
 
         assert(isinstance(max_range, tuple))
         assert(isinstance(fit_range, tuple))

--- a/src/sas/qtgui/Plotting/MaskEditor.py
+++ b/src/sas/qtgui/Plotting/MaskEditor.py
@@ -23,8 +23,6 @@ class MaskEditor(QtWidgets.QDialog, Ui_MaskEditorUI):
         assert isinstance(data, Data2D)
 
         self.setupUi(self)
-        # disable the context help icon
-        self.setWindowFlags(self.windowFlags() & ~QtCore.Qt.WindowContextHelpButtonHint)
 
         self.data = data
         self.parent = parent

--- a/src/sas/qtgui/Plotting/PlotLabelProperties.py
+++ b/src/sas/qtgui/Plotting/PlotLabelProperties.py
@@ -64,8 +64,6 @@ class PlotLabelProperties(QtWidgets.QDialog, Ui_PlotLabelPropertiesUI):
 
         super(PlotLabelProperties, self).__init__(parent)
         self.setupUi(self)
-        # disable the context help icon
-        self.setWindowFlags(self.windowFlags() & ~QtCore.Qt.WindowContextHelpButtonHint)
 
         self.setFixedSize(self.minimumSizeHint())
 

--- a/src/sas/qtgui/Plotting/PlotProperties.py
+++ b/src/sas/qtgui/Plotting/PlotProperties.py
@@ -14,8 +14,6 @@ class PlotProperties(QtWidgets.QDialog, Ui_PlotPropertiesUI):
                  legend=""):
         super(PlotProperties, self).__init__(parent)
         self.setupUi(self)
-        # disable the context help icon
-        self.setWindowFlags(self.windowFlags() & ~QtCore.Qt.WindowContextHelpButtonHint)
 
         self.setFixedSize(self.minimumSizeHint())
 

--- a/src/sas/qtgui/Plotting/ScaleProperties.py
+++ b/src/sas/qtgui/Plotting/ScaleProperties.py
@@ -23,8 +23,6 @@ class ScaleProperties(QtWidgets.QDialog, Ui_scalePropertiesUI):
     def __init__(self, parent=None, init_scale_x='x', init_scale_y='y'):
         super(ScaleProperties, self).__init__(parent)
         self.setupUi(self)
-        # disable the context help icon
-        self.setWindowFlags(self.windowFlags() & ~QtCore.Qt.WindowContextHelpButtonHint)
 
         # Set up comboboxes
         self.cbX.addItems(x_values)

--- a/src/sas/qtgui/Plotting/SetGraphRange.py
+++ b/src/sas/qtgui/Plotting/SetGraphRange.py
@@ -16,8 +16,6 @@ class SetGraphRange(QtWidgets.QDialog, Ui_setGraphRangeUI):
         super(SetGraphRange, self).__init__()
 
         self.setupUi(self)
-        # disable the context help icon
-        self.setWindowFlags(self.windowFlags() & ~QtCore.Qt.WindowContextHelpButtonHint)
 
         assert(isinstance(x_range, tuple))
         assert(isinstance(y_range, tuple))

--- a/src/sas/qtgui/Plotting/WindowTitle.py
+++ b/src/sas/qtgui/Plotting/WindowTitle.py
@@ -11,8 +11,6 @@ class WindowTitle(QtWidgets.QDialog, Ui_WindowTitle):
     def __init__(self, parent=None, new_title=""):
         super(WindowTitle, self).__init__(parent)
         self.setupUi(self)
-        # disable the context help icon
-        self.setWindowFlags(self.windowFlags() & ~QtCore.Qt.WindowContextHelpButtonHint)
 
         self.txtTitle.setText(new_title)
 

--- a/src/sas/qtgui/Utilities/AddMultEditor.py
+++ b/src/sas/qtgui/Utilities/AddMultEditor.py
@@ -56,8 +56,6 @@ class AddMultEditor(QtWidgets.QDialog, Ui_AddMultEditorUI):
         self.parent = parent
 
         self.setupUi(self)
-        # disable the context help icon
-        self.setWindowFlags(self.windowFlags() & ~QtCore.Qt.WindowContextHelpButtonHint)
 
         #  uncheck self.chkOverwrite
         self.chkOverwrite.setChecked(False)

--- a/src/sas/qtgui/Utilities/FileConverter.py
+++ b/src/sas/qtgui/Utilities/FileConverter.py
@@ -42,10 +42,6 @@ class FileConverterWidget(QtWidgets.QDialog, Ui_FileConverterUI):
         self.parent = parent
         self.setupUi(self)
 
-        # disable the context help icon
-        self.setWindowFlags(self.windowFlags() & ~QtCore.Qt.WindowContextHelpButtonHint)
-
-
         self.setWindowTitle("File Converter")
 
         # i,q file fields are not editable

--- a/src/sas/qtgui/Utilities/ModelEditor.py
+++ b/src/sas/qtgui/Utilities/ModelEditor.py
@@ -14,8 +14,6 @@ class ModelEditor(QtWidgets.QDialog, Ui_ModelEditor):
     def __init__(self, parent=None, is_python=True):
         super(ModelEditor, self).__init__(parent)
         self.setupUi(self)
-        # disable the context help icon
-        self.setWindowFlags(self.windowFlags() & ~QtCore.Qt.WindowContextHelpButtonHint)
 
         self.is_python = is_python
 

--- a/src/sas/qtgui/Utilities/PluginManager.py
+++ b/src/sas/qtgui/Utilities/PluginManager.py
@@ -21,9 +21,6 @@ class PluginManager(QtWidgets.QDialog, Ui_PluginManagerUI):
         super(PluginManager, self).__init__(parent._parent)
         self.setupUi(self)
 
-        # disable the context help icon
-        self.setWindowFlags(self.windowFlags() & ~QtCore.Qt.WindowContextHelpButtonHint)
-
         self.parent = parent
         self.cmdDelete.setEnabled(False)
         self.cmdEdit.setEnabled(False)

--- a/src/sas/qtgui/Utilities/Reports/ReportDialog.py
+++ b/src/sas/qtgui/Utilities/Reports/ReportDialog.py
@@ -23,8 +23,6 @@ class ReportDialog(QtWidgets.QDialog, Ui_ReportDialogUI):
 
         super().__init__(parent)
         self.setupUi(self)
-        # disable the context help icon
-        self.setWindowFlags(self.windowFlags() & ~QtCore.Qt.WindowContextHelpButtonHint)
 
         self.report_data = report_data
 

--- a/src/sas/qtgui/Utilities/TabbedModelEditor.py
+++ b/src/sas/qtgui/Utilities/TabbedModelEditor.py
@@ -30,9 +30,6 @@ class TabbedModelEditor(QtWidgets.QDialog, Ui_TabbedModelEditor):
 
         self.setupUi(self)
 
-        # disable the context help icon
-        self.setWindowFlags(self.windowFlags() & ~QtCore.Qt.WindowContextHelpButtonHint)
-
         # globals
         self.filename = ""
         self.window_title = self.windowTitle()


### PR DESCRIPTION
## Description

Option `WindowContextHelpButtonHint` seems to have disabled the "close window" cross icon in PySide6.
The original reason for it was, as the name suggests, the removal of the question mark icon, which by default was set.

Fixes #2688 

## How Has This Been Tested?

GH Windows installer on Win10 and Win11.

## Review Checklist (please remove items if they don't apply):

- [ ] Code has been reviewed
- [ ] Functionality has been tested
- [ ] Windows installer (GH artifact) has been tested (installed and worked) 
- [ ] MacOSX installer (GH artifact) has been tested (installed and worked) 

