### PR TITLE
Point to sasdata release branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,7 +105,7 @@ jobs:
 
       - name: Fetch sources for sibling projects
         run: |
-          git clone --depth=50 --branch=master https://github.com/SasView/sasdata.git ../sasdata
+          git clone --depth=50 --branch=release_0.9.0 https://github.com/SasView/sasdata.git ../sasdata
           git clone --depth=50 --branch=master https://github.com/SasView/sasmodels.git ../sasmodels
           git clone --depth=50 --branch=master https://github.com/bumps/bumps.git ../bumps
 


### PR DESCRIPTION
## Description

This points the CI to use the sasdata release branch [release_0.9.0](https://github.com/SasView/sasdata/tree/release_0.9.0) instead of the master branch.

## How Has This Been Tested?

CI

## Review Checklist (please remove items if they don't apply):

- [ ] Code has been reviewed
- [ ] Functionality has been tested
- [ ] Windows installer (GH artifact) has been tested (installed and worked) 
- [ ] MacOSX installer (GH artifact) has been tested (installed and worked) 
- [ ] User documentation is available and complete (if required)
- [ ] Developers documentation is available and complete (if required)
- [ ] The introduced changes comply with SasView license (BSD 3-Clause)

