### PR TITLE
Nightly builds fix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -226,12 +226,6 @@ jobs:
           iscc installers/installer.iss
           mv installers/Output/setupSasView.exe installers/dist
 
-      - name: Fix qt folders
-        if: ${{ matrix.installer && startsWith(matrix.os, 'macos') }}
-        run: |
-          cd installers/dist
-          python ../../build_tools/fix_qt_folder_names_for_codesign.py SasView5.app
-
       - name: Sign executable and create dmg (OSX)
         if: ${{ matrix.installer && startsWith(matrix.os, 'macos') }}
         env:
@@ -246,16 +240,11 @@ jobs:
           security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k DloaAcYP build.keychain
 
           cd installers/dist
+          python ../../build_tools/fix_qt_folder_names_for_codesign.py SasView5.app
           python ../../build_tools/code_sign_osx.py
           codesign --verify --options=runtime --entitlements ../../build_tools/entitlements.plist --timestamp --deep --verbose=4 --force --sign "Developer ID Application: European Spallation Source Eric (W2AG9MPZ43)" SasView5.app
           hdiutil create SasView5.dmg -srcfolder SasView5.app -ov -format UDZO
           codesign -s "Developer ID Application: European Spallation Source Eric (W2AG9MPZ43)" SasView5.dmg
-
-#      - name: Build sasview installer dmg file (OSX)
-#        if: ${{ matrix.installer && startsWith(matrix.os, 'macos') }}
-#        run: |
-#          cd installers/dist
-#          hdiutil create SasView5.dmg -srcfolder SasView5.app -ov -format UDZO
 
       - name: Build sasview installer tarball (Linux)
         if: ${{ matrix.installer && startsWith(matrix.os, 'ubuntu') }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -251,7 +251,6 @@ jobs:
         if: ${{ matrix.installer && startsWith(matrix.os, 'macos') }}
         run: |
           cd installers/dist
-          python ../../build_tools/fix_qt_folder_names_for_codesign.py SasView5.app
           hdiutil create SasView5.dmg -srcfolder SasView5.app -ov -format UDZO
 
       - name: Publish installer package

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -240,17 +240,17 @@ jobs:
           security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k DloaAcYP build.keychain
 
           cd installers/dist
-          python ../../build_tools/fix_qt_folder_names_for_codesign.py SasView5.app
+          python ../../build_tools/fix_qt_folder_names_for_codesign.py SasView6.app
           python ../../build_tools/code_sign_osx.py
-          codesign --verify --options=runtime --entitlements ../../build_tools/entitlements.plist --timestamp --deep --verbose=4 --force --sign "Developer ID Application: European Spallation Source Eric (W2AG9MPZ43)" SasView5.app
-          hdiutil create SasView5.dmg -srcfolder SasView5.app -ov -format UDZO
-          codesign -s "Developer ID Application: European Spallation Source Eric (W2AG9MPZ43)" SasView5.dmg
+          codesign --verify --options=runtime --entitlements ../../build_tools/entitlements.plist --timestamp --deep --verbose=4 --force --sign "Developer ID Application: European Spallation Source Eric (W2AG9MPZ43)" SasView6.app
+          hdiutil create SasView6.dmg -srcfolder SasView6.app -ov -format UDZO
+          codesign -s "Developer ID Application: European Spallation Source Eric (W2AG9MPZ43)" SasView6.dmg
 
       - name: Build sasview installer tarball (Linux)
         if: ${{ matrix.installer && startsWith(matrix.os, 'ubuntu') }}
         run: |
           cd installers/dist
-          tar zcf sasview5.tar.gz sasview
+          tar zcf sasview6.tar.gz sasview
 
       - name: Collect a debug tarball of the installer package
         if: ${{ matrix.installer }}
@@ -268,8 +268,8 @@ jobs:
           name: SasView-Installer-${{ matrix.os }}-${{ matrix.python-version }}
           path: |
             installers/dist/setupSasView.exe
-            installers/dist/SasView5.dmg
-            installers/dist/sasview5.tar.gz
+            installers/dist/SasView6.dmg
+            installers/dist/sasview6.tar.gz
           if-no-files-found: error
 
 
@@ -379,7 +379,7 @@ jobs:
         if: ${{ startsWith(matrix.os, 'ubuntu') }}
         run: |
           # $INSTALL_PATH is already the base directory
-          tar xf "$DL_PATH/sasview5.tar.gz"
+          tar xf "$DL_PATH/sasview6.tar.gz"
 
       - name: Check installation files
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -233,6 +233,7 @@ jobs:
           python ../../build_tools/fix_qt_folder_names_for_codesign.py SasView5.app
 
       - name: Sign executable and create dmg (OSX)
+        if: ${{ matrix.installer && startsWith(matrix.os, 'macos') }}
         env:
           MACOS_CERTIFICATE: ${{ secrets.MACOS_CERTIFICATE }}
           MACOS_CERTIFICATE_PWD: ${{ secrets.MACOS_CERTIFICATE_PWD }}
@@ -247,7 +248,7 @@ jobs:
           cd installers/dist
           python ../../build_tools/code_sign_osx.py
           codesign --verify --options=runtime --entitlements ../../build_tools/entitlements.plist --timestamp --deep --verbose=4 --force --sign "Developer ID Application: European Spallation Source Eric (W2AG9MPZ43)" SasView5.app
-          hdiutil create SasView5.dmg -srcfolder SasView5.dmg -ov -format UDZO
+          hdiutil create SasView5.dmg -srcfolder SasView5.app -ov -format UDZO
           codesign -s "Developer ID Application: European Spallation Source Eric (W2AG9MPZ43)" SasView5.dmg
 
 #      - name: Build sasview installer dmg file (OSX)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -226,11 +226,11 @@ jobs:
           iscc installers/installer.iss
           mv installers/Output/setupSasView.exe installers/dist
 
-      - name: Build sasview installer dmg file (OSX)
-        if: ${{ matrix.installer && startsWith(matrix.os, 'macos') }}
-        run: |
-          cd installers/dist
-          hdiutil create SasView5.dmg -srcfolder SasView5.app -ov -format UDZO
+#      - name: Build sasview installer dmg file (OSX)
+#        if: ${{ matrix.installer && startsWith(matrix.os, 'macos') }}
+#        run: |
+#          cd installers/dist
+#          hdiutil create SasView5.dmg -srcfolder SasView5.app -ov -format UDZO
 
       - name: Build sasview installer tarball (Linux)
         if: ${{ matrix.installer && startsWith(matrix.os, 'ubuntu') }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -232,6 +232,24 @@ jobs:
           cd installers/dist
           python ../../build_tools/fix_qt_folder_names_for_codesign.py SasView5.app
 
+      - name: Sign executable and create dmg (OSX)
+        env:
+          MACOS_CERTIFICATE: ${{ secrets.MACOS_CERTIFICATE }}
+          MACOS_CERTIFICATE_PWD: ${{ secrets.MACOS_CERTIFICATE_PWD }}
+        run: |
+          echo $MACOS_CERTIFICATE | base64 --decode > certificate.p12
+          security create-keychain -p DloaAcYP build.keychain
+          security default-keychain -s build.keychain
+          security unlock-keychain -p DloaAcYP build.keychain
+          security import certificate.p12 -k build.keychain -P $MACOS_CERTIFICATE_PWD -T /usr/bin/codesign
+          security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k DloaAcYP build.keychain
+
+          cd installers/dist
+          python ../../build_tools/code_sign_osx.py
+          codesign --verify --options=runtime --entitlements ../../build_tools/entitlements.plist --timestamp --deep --verbose=4 --force --sign "Developer ID Application: European Spallation Source Eric (W2AG9MPZ43)" SasView5.app
+          hdiutil create SasView5.dmg -srcfolder SasView5.dmg -ov -format UDZO
+          codesign -s "Developer ID Application: European Spallation Source Eric (W2AG9MPZ43)" SasView5.dmg
+
 #      - name: Build sasview installer dmg file (OSX)
 #        if: ${{ matrix.installer && startsWith(matrix.os, 'macos') }}
 #        run: |
@@ -260,7 +278,7 @@ jobs:
           name: SasView-Installer-${{ matrix.os }}-${{ matrix.python-version }}
           path: |
             installers/dist/setupSasView.exe
-            installers/dist/SasView5.app
+            installers/dist/SasView5.dmg
             installers/dist/sasview5.tar.gz
           if-no-files-found: error
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -247,11 +247,11 @@ jobs:
             installers/dist/sasview-pyinstaller-dist.tar.gz
           if-no-files-found: ignore
 
-      - name: Fix qt folders and create dmg (OSX)
+      - name: Fix qt folders
         if: ${{ matrix.installer && startsWith(matrix.os, 'macos') }}
         run: |
           cd installers/dist
-          hdiutil create SasView5.dmg -srcfolder SasView5.app -ov -format UDZO
+          python ../../build_tools/fix_qt_folder_names_for_codesign.py SasView5.app
 
       - name: Publish installer package
         if: ${{ matrix.installer }}
@@ -260,7 +260,7 @@ jobs:
           name: SasView-Installer-${{ matrix.os }}-${{ matrix.python-version }}
           path: |
             installers/dist/setupSasView.exe
-            installers/dist/SasView5.dmg
+            installers/dist/SasView5.app
             installers/dist/sasview5.tar.gz
           if-no-files-found: error
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -226,6 +226,12 @@ jobs:
           iscc installers/installer.iss
           mv installers/Output/setupSasView.exe installers/dist
 
+      - name: Fix qt folders
+        if: ${{ matrix.installer && startsWith(matrix.os, 'macos') }}
+        run: |
+          cd installers/dist
+          python ../../build_tools/fix_qt_folder_names_for_codesign.py SasView5.app
+
 #      - name: Build sasview installer dmg file (OSX)
 #        if: ${{ matrix.installer && startsWith(matrix.os, 'macos') }}
 #        run: |
@@ -246,12 +252,6 @@ jobs:
           path: |
             installers/dist/sasview-pyinstaller-dist.tar.gz
           if-no-files-found: ignore
-
-#      - name: Fix qt folders
-#        if: ${{ matrix.installer && startsWith(matrix.os, 'macos') }}
-#        run: |
-#          cd installers/dist
-#          python ../../build_tools/fix_qt_folder_names_for_codesign.py SasView5.app
 
       - name: Publish installer package
         if: ${{ matrix.installer }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -247,11 +247,11 @@ jobs:
             installers/dist/sasview-pyinstaller-dist.tar.gz
           if-no-files-found: ignore
 
-      - name: Fix qt folders
-        if: ${{ matrix.installer && startsWith(matrix.os, 'macos') }}
-        run: |
-          cd installers/dist
-          python ../../build_tools/fix_qt_folder_names_for_codesign.py SasView5.app
+#      - name: Fix qt folders
+#        if: ${{ matrix.installer && startsWith(matrix.os, 'macos') }}
+#        run: |
+#          cd installers/dist
+#          python ../../build_tools/fix_qt_folder_names_for_codesign.py SasView5.app
 
       - name: Publish installer package
         if: ${{ matrix.installer }}

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -57,6 +57,7 @@ jobs:
           hdiutil attach installers/dist/SasView-Installer-macos-*/SasView5.dmg
           cp -rf /Volumes/SasView5/SasView5.app installers/dist
           cd installers/dist
+          python ../../build_tools/fix_qt_folder_names_for_codesign.py SasView5.app
           python  ../../build_tools/code_sign_osx.py
           codesign --verify --options=runtime --entitlements ../../build_tools/entitlements.plist --timestamp --deep --verbose=4 --force --sign "Developer ID Application: European Spallation Source Eric (W2AG9MPZ43)" SasView5.app
           hdiutil create SasView5.dmg -srcfolder SasView5.app -ov -format UDZO

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Rename remaining artifacts artifacts
         run: |
           mv installers/dist/SasView-Installer-windows-*/setupSasView.exe installers/dist/setupSasView-nightly-Win64.exe
-          mv installers/dist/SasView-Installer-macos-*/SasView5.dmg installers/dist/SasView-nightly-MacOSX.dmg
+          mv installers/dist/SasView-Installer-macos-*/SasView6.dmg installers/dist/SasView-nightly-MacOSX.dmg
           mv installers/dist/SasView-Installer-ubuntu-*/sasview5.tar.gz installers/dist/SasView-nightly-Linux.tar.gz
 
       - name: Notarize Release Build (OSX)

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -42,10 +42,6 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      - name: Install Macholib
-        run: |
-          python -m pip install macholib
-
       - name: Sign executable and create dmg (OSX)
         env:
           MACOS_CERTIFICATE: ${{ secrets.MACOS_CERTIFICATE }}
@@ -58,21 +54,20 @@ jobs:
           security import certificate.p12 -k build.keychain -P $MACOS_CERTIFICATE_PWD -T /usr/bin/codesign
           security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k DloaAcYP build.keychain
 
-          hdiutil attach installers/dist/SasView-Installer-macos-*/SasView5.dmg
-          cp -rf /Volumes/SasView5/SasView5.app installers/dist
+          mv installers/dist/SasView-Installer-macos-*/SasView5.app installers/dist
+          
           cd installers/dist
-          python ../../build_tools/fix_qt_folder_names_for_codesign.py SasView5.app
-          python  ../../build_tools/code_sign_osx.py
+          python ../../build_tools/code_sign_osx.py
           codesign --verify --options=runtime --entitlements ../../build_tools/entitlements.plist --timestamp --deep --verbose=4 --force --sign "Developer ID Application: European Spallation Source Eric (W2AG9MPZ43)" SasView5.app
-          hdiutil create SasView5.dmg -srcfolder SasView5.app -ov -format UDZO
-          codesign -s "Developer ID Application: European Spallation Source Eric (W2AG9MPZ43)" SasView5.dmg
+          hdiutil create SasView5.dmg -srcfolder SasView-nightly-MacOSX.dmg -ov -format UDZO
+          codesign -s "Developer ID Application: European Spallation Source Eric (W2AG9MPZ43)" SasView-nightly-MacOSX.dmg
 
       #This GH action will need to be replaced soon as altool will be deprecated late 2023
       - name: Notarize Release Build (OSX)
         uses: GuillaumeFalourd/xcode-notarize@v1
         with:
-            product-path: "installers/dist/SasView5.dmg"
-            primary-bundle-id: "org.sasview.SasView5"
+            product-path: "installers/dist/SasView-nightly-MacOSX.dmg"
+            primary-bundle-id: "org.sasview.SasView6"
             appstore-connect-username: ${{ secrets.NOTARIZATION_USERNAME }}
             appstore-connect-password: ${{ secrets.NOTARIZATION_PASSWORD }}
             verbose: True
@@ -80,12 +75,11 @@ jobs:
       - name: Staple Release Build (OSX)
         uses: BoundfoxStudios/action-xcode-staple@v1
         with:
-          product-path: "installers/dist/SasView5.dmg"
+          product-path: "installers/dist/SasView-nightly-MacOSX.dmg"
 
-      - name: Rename artifacts
+      - name: Rename remaining artifacts artifacts
         run: |
           mv installers/dist/SasView-Installer-windows-*/setupSasView.exe installers/dist/setupSasView-nightly-Win64.exe
-          mv installers/dist/SasView-Installer-macos-*/SasView5.dmg  installers/dist/SasView-nightly-MacOSX.dmg
           mv installers/dist/SasView-Installer-ubuntu-*/sasview5.tar.gz installers/dist/SasView-nightly-Linux.tar.gz
 
       - name: Upload Nightly Build Installer to GitHub releases

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -42,6 +42,10 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
+      - name: Install Macholib
+        run: |
+          python -m pip install macholib
+
       - name: Sign executable and create dmg (OSX)
         env:
           MACOS_CERTIFICATE: ${{ secrets.MACOS_CERTIFICATE }}

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -37,37 +37,6 @@ jobs:
         run: ls -R
         working-directory: installers/dist
 
-      - name: Set up Python
-        uses: actions/setup-python@v1
-        with:
-          python-version: ${{ matrix.python-version }}
-
-      - name: Install Python dependencies
-        run: |
-          python -m pip install --upgrade pip
-          python -m pip install wheel setuptools
-          python -m pip install macholib 
-
-#      - name: Sign executable and create dmg (OSX)
-#        env:
-#          MACOS_CERTIFICATE: ${{ secrets.MACOS_CERTIFICATE }}
-#          MACOS_CERTIFICATE_PWD: ${{ secrets.MACOS_CERTIFICATE_PWD }}
-#        run: |
-#          echo $MACOS_CERTIFICATE | base64 --decode > certificate.p12
-#          security create-keychain -p DloaAcYP build.keychain
-#          security default-keychain -s build.keychain
-#          security unlock-keychain -p DloaAcYP build.keychain
-#          security import certificate.p12 -k build.keychain -P $MACOS_CERTIFICATE_PWD -T /usr/bin/codesign
-#          security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k DloaAcYP build.keychain
-#
-#          mv installers/dist/SasView-Installer-macos-*/SasView5.app installers/dist
-#
-#          cd installers/dist
-#          python ../../build_tools/code_sign_osx.py
-#          codesign --verify --options=runtime --entitlements ../../build_tools/entitlements.plist --timestamp --deep --verbose=4 --force --sign "Developer ID Application: European Spallation Source Eric (W2AG9MPZ43)" SasView5.app
-#          hdiutil create SasView5.dmg -srcfolder SasView-nightly-MacOSX.dmg -ov -format UDZO
-#          codesign -s "Developer ID Application: European Spallation Source Eric (W2AG9MPZ43)" SasView-nightly-MacOSX.dmg
-
       - name: Rename remaining artifacts artifacts
         run: |
           mv installers/dist/SasView-Installer-windows-*/setupSasView.exe installers/dist/setupSasView-nightly-Win64.exe
@@ -78,7 +47,7 @@ jobs:
         uses: lando/notarize-action@v2
         with:
             product-path: "installers/dist/SasView-nightly-MacOSX.dmg"
-            primary-bundle-id: "org.sasview.SasView5"
+            primary-bundle-id: "org.sasview.SasView6"
             appstore-connect-username: ${{ secrets.NOTARIZATION_USERNAME }}
             appstore-connect-password: ${{ secrets.NOTARIZATION_PASSWORD }}
             appstore-connect-team-id: W2AG9MPZ43

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -1,9 +1,6 @@
 name: Nightly Build
 
 on:
-  pull_request:
-    branches:
-      - main  
   push:
     branches:
       - main

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -51,6 +51,8 @@ jobs:
           security import certificate.p12 -k build.keychain -P $MACOS_CERTIFICATE_PWD -T /usr/bin/codesign
           security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k DloaAcYP build.keychain
 
+          hdiutil attach installers/dist/SasView-Installer-macos-*/SasView5.dmg
+          cp -rf /Volumes/SasView5.app installers/dist
           cd installers/dist
           python  ../../build_tools/code_sign_osx.py
           codesign --verify --options=runtime --entitlements ../../build_tools/entitlements.plist --timestamp --deep --verbose=4 --force --sign "Developer ID Application: European Spallation Source Eric (W2AG9MPZ43)" SasView5.app

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -41,7 +41,7 @@ jobs:
         run: |
           mv installers/dist/SasView-Installer-windows-*/setupSasView.exe installers/dist/setupSasView-nightly-Win64.exe
           mv installers/dist/SasView-Installer-macos-*/SasView6.dmg installers/dist/SasView-nightly-MacOSX.dmg
-          mv installers/dist/SasView-Installer-ubuntu-*/sasview5.tar.gz installers/dist/SasView-nightly-Linux.tar.gz
+          mv installers/dist/SasView-Installer-ubuntu-*/sasview6.tar.gz installers/dist/SasView-nightly-Linux.tar.gz
 
       - name: Notarize Release Build (OSX)
         uses: lando/notarize-action@v2

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -55,7 +55,7 @@ jobs:
           security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k DloaAcYP build.keychain
 
           hdiutil attach installers/dist/SasView-Installer-macos-*/SasView5.dmg
-          cp -rf /Volumes/SasView5.app installers/dist
+          cp -rf /Volumes/SasView5/SasView5.app installers/dist
           cd installers/dist
           python  ../../build_tools/code_sign_osx.py
           codesign --verify --options=runtime --entitlements ../../build_tools/entitlements.plist --timestamp --deep --verbose=4 --force --sign "Developer ID Application: European Spallation Source Eric (W2AG9MPZ43)" SasView5.app

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -1,6 +1,9 @@
 name: Nightly Build
 
 on:
+  pull_request:
+    branches:
+      - main  
   push:
     branches:
       - main

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -57,7 +57,7 @@ jobs:
           mv installers/dist/SasView-Installer-macos-*/SasView5.app installers/dist
           
           cd installers/dist
-          python ../../build_tools/code_sign_osx.py
+          #python ../../build_tools/code_sign_osx.py
           codesign --verify --options=runtime --entitlements ../../build_tools/entitlements.plist --timestamp --deep --verbose=4 --force --sign "Developer ID Application: European Spallation Source Eric (W2AG9MPZ43)" SasView5.app
           hdiutil create SasView5.dmg -srcfolder SasView-nightly-MacOSX.dmg -ov -format UDZO
           codesign -s "Developer ID Application: European Spallation Source Eric (W2AG9MPZ43)" SasView-nightly-MacOSX.dmg

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -42,6 +42,12 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
+      - name: Install Python dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install wheel setuptools
+          python -m pip install macholib 
+
       - name: Sign executable and create dmg (OSX)
         env:
           MACOS_CERTIFICATE: ${{ secrets.MACOS_CERTIFICATE }}

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -48,45 +48,46 @@ jobs:
           python -m pip install wheel setuptools
           python -m pip install macholib 
 
-      - name: Sign executable and create dmg (OSX)
-        env:
-          MACOS_CERTIFICATE: ${{ secrets.MACOS_CERTIFICATE }}
-          MACOS_CERTIFICATE_PWD: ${{ secrets.MACOS_CERTIFICATE_PWD }}
+#      - name: Sign executable and create dmg (OSX)
+#        env:
+#          MACOS_CERTIFICATE: ${{ secrets.MACOS_CERTIFICATE }}
+#          MACOS_CERTIFICATE_PWD: ${{ secrets.MACOS_CERTIFICATE_PWD }}
+#        run: |
+#          echo $MACOS_CERTIFICATE | base64 --decode > certificate.p12
+#          security create-keychain -p DloaAcYP build.keychain
+#          security default-keychain -s build.keychain
+#          security unlock-keychain -p DloaAcYP build.keychain
+#          security import certificate.p12 -k build.keychain -P $MACOS_CERTIFICATE_PWD -T /usr/bin/codesign
+#          security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k DloaAcYP build.keychain
+#
+#          mv installers/dist/SasView-Installer-macos-*/SasView5.app installers/dist
+#
+#          cd installers/dist
+#          python ../../build_tools/code_sign_osx.py
+#          codesign --verify --options=runtime --entitlements ../../build_tools/entitlements.plist --timestamp --deep --verbose=4 --force --sign "Developer ID Application: European Spallation Source Eric (W2AG9MPZ43)" SasView5.app
+#          hdiutil create SasView5.dmg -srcfolder SasView-nightly-MacOSX.dmg -ov -format UDZO
+#          codesign -s "Developer ID Application: European Spallation Source Eric (W2AG9MPZ43)" SasView-nightly-MacOSX.dmg
+
+      - name: Rename remaining artifacts artifacts
         run: |
-          echo $MACOS_CERTIFICATE | base64 --decode > certificate.p12
-          security create-keychain -p DloaAcYP build.keychain
-          security default-keychain -s build.keychain
-          security unlock-keychain -p DloaAcYP build.keychain
-          security import certificate.p12 -k build.keychain -P $MACOS_CERTIFICATE_PWD -T /usr/bin/codesign
-          security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k DloaAcYP build.keychain
+          mv installers/dist/SasView-Installer-windows-*/setupSasView.exe installers/dist/setupSasView-nightly-Win64.exe
+          mv installers/dist/SasView-Installer-macos-*/SasView5.dmg installers/dist/SasView-nightly-MacOSX.dmg
+          mv installers/dist/SasView-Installer-ubuntu-*/sasview5.tar.gz installers/dist/SasView-nightly-Linux.tar.gz
 
-          mv installers/dist/SasView-Installer-macos-*/SasView5.app installers/dist
-          
-          cd installers/dist
-          python ../../build_tools/code_sign_osx.py
-          codesign --verify --options=runtime --entitlements ../../build_tools/entitlements.plist --timestamp --deep --verbose=4 --force --sign "Developer ID Application: European Spallation Source Eric (W2AG9MPZ43)" SasView5.app
-          hdiutil create SasView5.dmg -srcfolder SasView-nightly-MacOSX.dmg -ov -format UDZO
-          codesign -s "Developer ID Application: European Spallation Source Eric (W2AG9MPZ43)" SasView-nightly-MacOSX.dmg
-
-      #This GH action will need to be replaced soon as altool will be deprecated late 2023
       - name: Notarize Release Build (OSX)
-        uses: GuillaumeFalourd/xcode-notarize@v1
+        uses: lando/notarize-action@v2
         with:
             product-path: "installers/dist/SasView-nightly-MacOSX.dmg"
-            primary-bundle-id: "org.sasview.SasView6"
+            primary-bundle-id: "org.sasview.SasView5"
             appstore-connect-username: ${{ secrets.NOTARIZATION_USERNAME }}
             appstore-connect-password: ${{ secrets.NOTARIZATION_PASSWORD }}
+            appstore-connect-team-id: W2AG9MPZ43
             verbose: True
 
       - name: Staple Release Build (OSX)
         uses: BoundfoxStudios/action-xcode-staple@v1
         with:
           product-path: "installers/dist/SasView-nightly-MacOSX.dmg"
-
-      - name: Rename remaining artifacts artifacts
-        run: |
-          mv installers/dist/SasView-Installer-windows-*/setupSasView.exe installers/dist/setupSasView-nightly-Win64.exe
-          mv installers/dist/SasView-Installer-ubuntu-*/sasview5.tar.gz installers/dist/SasView-nightly-Linux.tar.gz
 
       - name: Upload Nightly Build Installer to GitHub releases
         uses: ncipollo/release-action@v1

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -57,7 +57,8 @@ jobs:
           mv installers/dist/SasView-Installer-macos-*/SasView5.app installers/dist
           
           cd installers/dist
-          #python ../../build_tools/code_sign_osx.py
+          python ../../build_tools/fix_qt_folder_names_for_codesign.py SasView5.app
+          python ../../build_tools/code_sign_osx.py
           codesign --verify --options=runtime --entitlements ../../build_tools/entitlements.plist --timestamp --deep --verbose=4 --force --sign "Developer ID Application: European Spallation Source Eric (W2AG9MPZ43)" SasView5.app
           hdiutil create SasView5.dmg -srcfolder SasView-nightly-MacOSX.dmg -ov -format UDZO
           codesign -s "Developer ID Application: European Spallation Source Eric (W2AG9MPZ43)" SasView-nightly-MacOSX.dmg

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -63,7 +63,6 @@ jobs:
           mv installers/dist/SasView-Installer-macos-*/SasView5.app installers/dist
           
           cd installers/dist
-          python ../../build_tools/fix_qt_folder_names_for_codesign.py SasView5.app
           python ../../build_tools/code_sign_osx.py
           codesign --verify --options=runtime --entitlements ../../build_tools/entitlements.plist --timestamp --deep --verbose=4 --force --sign "Developer ID Application: European Spallation Source Eric (W2AG9MPZ43)" SasView5.app
           hdiutil create SasView5.dmg -srcfolder SasView-nightly-MacOSX.dmg -ov -format UDZO

--- a/build_tools/code_sign_osx.py
+++ b/build_tools/code_sign_osx.py
@@ -15,12 +15,17 @@ zmq_dylib_list_resources = glob.glob(
     "SasView*.app/Contents/Resources/zmq/.dylibs/*.dylib", recursive=True
 )
 
+dist_info_list_resources = glob.glob(
+    "SasView*.app/Contents/MacOS/*.dist-info", recursive=True
+)
+
 sign_command = ['codesign', '--timestamp', '--options=runtime', '--verify', '--verbose=4', '--force',
                 '--sign', 'Developer ID Application: European Spallation Source Eric (W2AG9MPZ43)']
 
 
 #TODO: Check if it is necesarry to do it per file (one long list maybe enough)
-for sfile in itertools.chain(so_list, dylib_list, dylib_list_resources, zmq_dylib_list_resources):
+for sfile in itertools.chain(so_list, dylib_list, dylib_list_resources,
+                             zmq_dylib_list_resources, dist_info_list_resources):
     sign_command.append(sfile)
     subprocess.check_call(sign_command)
     sign_command.pop()

--- a/build_tools/code_sign_osx.py
+++ b/build_tools/code_sign_osx.py
@@ -6,13 +6,13 @@ import glob
 import subprocess
 import itertools
 
-so_list = glob.glob("SasView5.app/Contents/MacOS/**/*.so", recursive=True)
-dylib_list = glob.glob("SasView5.app/Contents/MacOS/**/*.dylib", recursive=True)
+so_list = glob.glob("SasView*.app/Contents/MacOS/**/*.so", recursive=True)
+dylib_list = glob.glob("SasView*.app/Contents/MacOS/**/*.dylib", recursive=True)
 dylib_list_resources = glob.glob(
-    "SasView5.app/Contents/Resources/.dylibs/*.dylib", recursive=True
+    "SasView*.app/Contents/Resources/.dylibs/*.dylib", recursive=True
 )
 zmq_dylib_list_resources = glob.glob(
-    "SasView5.app/Contents/Resources/zmq/.dylibs/*.dylib", recursive=True
+    "SasView*.app/Contents/Resources/zmq/.dylibs/*.dylib", recursive=True
 )
 
 sign_command = ['codesign', '--timestamp', '--options=runtime', '--verify', '--verbose=4', '--force',
@@ -24,4 +24,3 @@ for sfile in itertools.chain(so_list, dylib_list, dylib_list_resources, zmq_dyli
     sign_command.append(sfile)
     subprocess.check_call(sign_command)
     sign_command.pop()
-

--- a/build_tools/code_sign_osx.py
+++ b/build_tools/code_sign_osx.py
@@ -15,17 +15,13 @@ zmq_dylib_list_resources = glob.glob(
     "SasView*.app/Contents/Resources/zmq/.dylibs/*.dylib", recursive=True
 )
 
-dist_info_list_resources = glob.glob(
-    "SasView*.app/Contents/MacOS/*.dist-info", recursive=True
-)
-
 sign_command = ['codesign', '--timestamp', '--options=runtime', '--verify', '--verbose=4', '--force',
                 '--sign', 'Developer ID Application: European Spallation Source Eric (W2AG9MPZ43)']
 
 
 #TODO: Check if it is necesarry to do it per file (one long list maybe enough)
 for sfile in itertools.chain(so_list, dylib_list, dylib_list_resources,
-                             zmq_dylib_list_resources, dist_info_list_resources):
+                             zmq_dylib_list_resources):
     sign_command.append(sfile)
     subprocess.check_call(sign_command)
     sign_command.pop()

--- a/installers/sasview.spec
+++ b/installers/sasview.spec
@@ -132,7 +132,7 @@ coll = COLLECT(
 
 if platform.system() == 'Darwin':
     app = BUNDLE(coll,
-        name='SasView5.app',
+        name='SasView6.app',
         icon='../src/sas/qtgui/images/ball.icns',
-        bundle_identifier='org.sasview.SasView5',
+        bundle_identifier='org.sasview.SasView6',
         info_plist={'NSHighResolutionCapable': 'True'})


### PR DESCRIPTION
## Description
Fixing nightly build but not fully resolving an issue related to running workflows by developers from outside sasview organization. Trying to move signing to nightly_build.yml didn't work and therefore there is only notarization step done there. It seems that we may enable runs from outside developers by changing run trigger from pull_reguest to pull_reaquest_target. However, as far as I understand there is a security risk associated with it. I am not comfortable with making such a decision. 

This PR also changes names of linux and OSX packages to SasView6 (tar.gz, app and dmg). The question is whether we shouldn't drop this numbering for easier maintenance in the future. It may be however confusing for users that have multiple versions installed (at least on MAC). 
 

## Review Checklist (please remove items if they don't apply):

- [ ] Code has been reviewed
- [ ] Functionality has been tested
- [ ] Windows installer (GH artifact) has been tested (installed and worked) 
- [ ] MacOSX installer (GH artifact) has been tested (installed and worked) 
- [ ] User documentation is available and complete (if required)
- [ ] Developers documentation is available and complete (if required)
- [x] The introduced changes comply with SasView license (BSD 3-Clause)

