### PR TITLE
added missing import statement for logging to enable error messages i…

### DIFF
--- a/src/sas/qtgui/Perspectives/Fitting/SmearingWidget.py
+++ b/src/sas/qtgui/Perspectives/Fitting/SmearingWidget.py
@@ -6,6 +6,8 @@ import numpy as np
 from PySide6 import QtCore
 from PySide6 import QtGui
 from PySide6 import QtWidgets
+import logging
+logger = logging.getLogger(__name__)
 
 from sas.sascalc.fit.qsmearing import smear_selection, PySmear, PySmear2D
 from sas.qtgui.Plotting.PlotterData import Data1D


### PR DESCRIPTION
…n a pop up window when slit width is set larger than slit length

## Description

This PR returns the missing import statement for logging in the smearing widget.

Fixes #2708 

## How Has This Been Tested?

Simulated data using the sphere model in the GUI with slit smearing at the following three conditions:
1. length=0.1, width=0
2. length=0.1, width=0.1
3. length=0, width=0.1
Conditions 2 and 3 should result in an error message being presented in a pop-up window that explains the proper usage of the length and width terms for slit smearing. "CRITICAL" messages should also appear in the log explorer.  Condition 1 should run normally and simulate the slit-smeared data.

## Review Checklist (please remove items if they don't apply):
- [ ] Code has been reviewed
- [ ] Functionality has been tested
- [ ] Windows installer (GH artifact) has been tested (installed and worked) 
- [ ] MacOSX installer (GH artifact) has been tested (installed and worked) 
- [ ] User documentation is available and complete (if required)
- [ ] Developers documentation is available and complete (if required)
- [ ] The introduced changes comply with SasView license (BSD 3-Clause)

