### PR TITLE
Constraint on parameter raises error

### DIFF
--- a/src/sas/qtgui/Perspectives/Fitting/FittingWidget.py
+++ b/src/sas/qtgui/Perspectives/Fitting/FittingWidget.py
@@ -780,7 +780,7 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         # but let's check the correctness.
         assert len(selected_rows) == 2
 
-        params_list = [s.data(role=QtCore.Qt.UserRole) for s in selected_rows]
+        params_list = [s.data() for s in selected_rows]
         # Create and display the widget for param1 and param2
         mc_widget = MultiConstraint(self, params=params_list)
         # Check if any of the parameters are polydisperse
@@ -1015,6 +1015,7 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
             max_t = model.item(row, max_col).text()
             # Create a Constraint object
             constraint = Constraint(param=param, value=value, min=min_t, max=max_t)
+            constraint.active = False
             # Create a new item and add the Constraint object as a child
             item = QtGui.QStandardItem()
             item.setData(constraint)
@@ -1042,7 +1043,7 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         current_list = self.tabToList[self.tabFitting.currentIndex()]
         model_key = self.tabToKey[self.tabFitting.currentIndex()]
 
-        params_list = [s.data(role=QtCore.Qt.UserRole) for s in current_list.selectionModel().selectedRows()
+        params_list = [s.data() for s in current_list.selectionModel().selectedRows()
                    if self.isCheckable(s.row(), model_key=model_key)]
         assert len(params_list) == 1
         row = current_list.selectionModel().selectedRows()[0].row()

--- a/src/sas/qtgui/Perspectives/Fitting/FittingWidget.py
+++ b/src/sas/qtgui/Perspectives/Fitting/FittingWidget.py
@@ -1087,7 +1087,7 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         """
         current_list = self.tabToList[self.tabFitting.currentIndex()]
         model_key = self.tabToKey[self.tabFitting.currentIndex()]
-        params = [s.data(role=QtCore.Qt.UserRole) for s in current_list.selectionModel().selectedRows()
+        params = [s.data() for s in current_list.selectionModel().selectedRows()
                    if self.isCheckable(s.row(), model_key=model_key)]
         for param in params:
             self.deleteConstraintOnParameter(param=param, model_key=model_key)


### PR DESCRIPTION
## Description

Some of the logic was incorrect, when setting the single-parameter constraint and when querying the underlying model information.
Now, item query returns proper parameter names, and the context menu is properly constructed (i.e. no "Edit constraint" on simple value constraint added)


Fixes #2695 

## How Has This Been Tested?

Local dev build on Win10

## Review Checklist (please remove items if they don't apply):

- [x] Code has been reviewed
- [x] Functionality has been tested
- [x] Windows installer (GH artifact) has been tested (installed and worked) 
- [x] MacOSX installer (GH artifact) has been tested (installed and worked) 


