### PR TITLE
FIX: fix model date format in the user model docstring

### DIFF
--- a/src/sas/qtgui/Utilities/TabbedModelEditor.py
+++ b/src/sas/qtgui/Utilities/TabbedModelEditor.py
@@ -539,7 +539,7 @@ class TabbedModelEditor(QtWidgets.QDialog, Ui_TabbedModelEditor):
             'name': name,
             'title': 'User model for ' + name,
             'description': desc_str,
-            'date': datetime.datetime.now().strftime('%YYYY-%mm-%dd'),
+            'date': datetime.datetime.now().strftime('%Y-%m-%d'),
         }
 
         # Write out parameters


### PR DESCRIPTION
## Description

This PR fixes the date format appearing in the "Authorship and Verification" section of the generated user model. Before the fix, the dates were displayed as `2024YYY-01m-16d`. After the fix, they look like: `2024-01-16`.

It's part of the https://github.com/SasView/sasview/wiki/ContributorCampXII camp.

Fixes # (issue/issues)

## How Has This Been Tested?

The fix was tested by comparing the output of the generated models before (with v6.0.0-alpha1) and after the fix.

### Before:
<img width="688" alt="image" src="https://github.com/SasView/sasview/assets/13209176/c6433653-997a-4f53-945a-4af89535ab7c">

### After:
<img width="688" alt="image" src="https://github.com/SasView/sasview/assets/13209176/e1043357-8a89-40fc-bf1e-7730843bc314">


## Review Checklist (please remove items if they don't apply):

- [ ] Code has been reviewed
- [ ] Functionality has been tested
- [ ] Windows installer (GH artifact) has been tested (installed and worked) 
- [ ] MacOSX installer (GH artifact) has been tested (installed and worked) 
- [ ] User documentation is available and complete (if required)
- [ ] Developers documentation is available and complete (if required)
- [ ] The introduced changes comply with SasView license (BSD 3-Clause)

