### PR TITLE
2715: C files not loaded in tabbed model editor (6.0.0a)

### DIFF
--- a/src/sas/qtgui/Utilities/TabbedModelEditor.py
+++ b/src/sas/qtgui/Utilities/TabbedModelEditor.py
@@ -205,7 +205,7 @@ class TabbedModelEditor(QtWidgets.QDialog, Ui_TabbedModelEditor):
         self.editor_widget.txtEditor.setToolTip("")
 
         # See if there is filename.c present
-        c_path = Path(str(self.filename.parent)) / self.filename.name.replace(".py", ".c")
+        c_path = self.filename.parent / self.filename.name.replace(".py", ".c")
         if not c_path.exists() or ".rst" in c_path.name: return
         # add a tab with the same highlighting
         c_display_name = c_path.name

--- a/src/sas/qtgui/Utilities/TabbedModelEditor.py
+++ b/src/sas/qtgui/Utilities/TabbedModelEditor.py
@@ -205,7 +205,7 @@ class TabbedModelEditor(QtWidgets.QDialog, Ui_TabbedModelEditor):
         self.editor_widget.txtEditor.setToolTip("")
 
         # See if there is filename.c present
-        c_path = Path(str(self.filename.parent) + self.filename.name.replace(".py", ".c"))
+        c_path = Path(str(self.filename.parent)) / self.filename.name.replace(".py", ".c")
         if not c_path.exists() or ".rst" in c_path.name: return
         # add a tab with the same highlighting
         c_display_name = c_path.name


### PR DESCRIPTION
## Description

This fixes the issue related to loading c fils into the tabbed model editor introduced by the merge of #2576.

Fixes #2715

## Review Checklist (please remove items if they don't apply):

- [ ] Code has been reviewed
- [ ] Functionality has been tested
- [ ] Windows installer (GH artifact) has been tested (installed and worked) 
- [ ] MacOSX installer (GH artifact) has been tested (installed and worked) 
- [ ] User documentation is available and complete (if required)
- [ ] Developers documentation is available and complete (if required)
- [ ] The introduced changes comply with SasView license (BSD 3-Clause)

