### PR TITLE
fix order of operations (explicitly add .py extension before concaten…

### DIFF
--- a/src/sas/qtgui/Utilities/TabbedModelEditor.py
+++ b/src/sas/qtgui/Utilities/TabbedModelEditor.py
@@ -145,7 +145,7 @@ class TabbedModelEditor(QtWidgets.QDialog, Ui_TabbedModelEditor):
                 if os.path.isfile(user_model_name):
                     filename = user_model_name
                 else:
-                    filename = MAIN_DOC_SRC / "user" / "models" / "src" / self.load_file + ".py"
+                    filename = MAIN_DOC_SRC / "user" / "models" / "src" / (self.load_file + ".py")
             else:
                 filename = MAIN_DOC_SRC / self.load_file.replace(".html", ".rst")
                 self.is_python = False


### PR DESCRIPTION
## Description

Please include a summary of the change and which issue is fixed. List any dependencies that are required for this change.

Fixes # (issue/issues)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

 - Running GUI, when loading a plugin model into "Fit Panel", and then pressing "Help" button, followed by "Edit" button, I get an error: 
 ```
23:22:53 - sas.qtgui.Perspectives.Fitting.FittingWidget - ERROR - Traceback (most recent call last):
  File "/Users/bbm/dev/sasview/src/sas/qtgui/Utilities/DocViewWidget.py", line 54, in onEdit
    self.editorWindow = TabbedModelEditor(parent=self.parent,
                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/bbm/dev/sasview/src/sas/qtgui/Utilities/TabbedModelEditor.py", line 51, in __init__
    self.onLoad(at_launch=True)
  File "/Users/bbm/dev/sasview/src/sas/qtgui/Utilities/TabbedModelEditor.py", line 148, in onLoad
    filename = MAIN_DOC_SRC / "user" / "models" / "src" / self.load_file + ".py"
               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~
TypeError: unsupported operand type(s) for +: 'PosixPath' and 'str'

```
After explicitly performing string concatenation before Path concatenation (see patch) the error is no longer triggered.

## Review Checklist (please remove items if they don't apply):

- [ ] Code has been reviewed
- [ ] Functionality has been tested
- [ ] Windows installer (GH artifact) has been tested (installed and worked) 
- [ ] MacOSX installer (GH artifact) has been tested (installed and worked) 
- [ ] User documentation is available and complete (if required)
- [ ] Developers documentation is available and complete (if required)
- [ ] The introduced changes comply with SasView license (BSD 3-Clause)

