### PR TITLE
2356 correct behaviour add all constraints

### DIFF
--- a/src/sas/qtgui/Perspectives/Fitting/ComplexConstraint.py
+++ b/src/sas/qtgui/Perspectives/Fitting/ComplexConstraint.py
@@ -357,10 +357,10 @@ class ComplexConstraint(QtWidgets.QDialog, Ui_ComplexConstraintUI):
         # loop over parameters in constrained model
         index1 = self.cbModel1.currentIndex()
         index2 = self.cbModel2.currentIndex()
-        items1 = self.tabs[index1].kernel_module.params
-        items2 = self.params[index2]
+        items1 = self.tabs[index1].main_params_to_fit + self.tabs[index1].poly_params_to_fit
+        items2 = self.tabs[index2].main_params_to_fit + self.tabs[index2].poly_params_to_fit
         # create an empty list to store redefined constraints
-        redefined_constraints = []
+git        redefined_constraints = []
         for item in items1:
             if item not in items2: continue
             param = item

--- a/src/sas/qtgui/Perspectives/Fitting/ComplexConstraint.py
+++ b/src/sas/qtgui/Perspectives/Fitting/ComplexConstraint.py
@@ -360,7 +360,7 @@ class ComplexConstraint(QtWidgets.QDialog, Ui_ComplexConstraintUI):
         items1 = self.tabs[index1].main_params_to_fit + self.tabs[index1].poly_params_to_fit
         items2 = self.tabs[index2].main_params_to_fit + self.tabs[index2].poly_params_to_fit
         # create an empty list to store redefined constraints
-git        redefined_constraints = []
+        redefined_constraints = []
         for item in items1:
             if item not in items2: continue
             param = item


### PR DESCRIPTION
## Description

Modifies the behaviour of the Complex Constraint Add All button in the way that seems more logical/intuitive TO ME. All fittable (including polydisperse) parameters in two fitting pages are constrained, while the fixed parameters are ignored. 

Previously one had the following:
![image](https://github.com/SasView/sasview/assets/10974838/ad82023e-246f-43cf-87ec-9c5a59e65282)

And with the proposed change one gets:
![image](https://github.com/SasView/sasview/assets/10974838/7ecabf35-6978-492f-ba38-0e05c211ebcd)

Fixes # 2356

## How Has This Been Tested?

Tested locally with two sets of data fitted by a core-shell model where radius and thickness are polydispersed and polydispersity is fittable, while the SLDs are different.

## Review Checklist (please remove items if they don't apply):

- [ ] Code has been reviewed
- [ ] Functionality has been tested
- [ ] Windows installer (GH artifact) has been tested (installed and worked) 
- [ ] MacOSX installer (GH artifact) has been tested (installed and worked) 
- [ ] User documentation is available and complete (if required)
- [ ] Developers documentation is available and complete (if required)
- [ ] The introduced changes comply with SasView license (BSD 3-Clause)

