### PR TITLE
Define distributions on the UI

### DIFF
--- a/src/sas/qtgui/Perspectives/Fitting/FittingWidget.py
+++ b/src/sas/qtgui/Perspectives/Fitting/FittingWidget.py
@@ -168,6 +168,7 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         new_font = 'font-family: -apple-system, "Helvetica Neue", "Ubuntu";'
         self.label_17.setStyleSheet(new_font)
         self.label_19.setStyleSheet(new_font)
+        self.groupBox_3.setTitle(QtCore.QCoreApplication.translate("FittingWidgetUI", u"Number-average Polydispersity and Orientational Distribution", None))
 
     def info(self, type, value, tb):
         logger.error("".join(traceback.format_exception(type, value, tb)))

--- a/src/sas/qtgui/Perspectives/Fitting/FittingWidget.py
+++ b/src/sas/qtgui/Perspectives/Fitting/FittingWidget.py
@@ -168,7 +168,6 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         new_font = 'font-family: -apple-system, "Helvetica Neue", "Ubuntu";'
         self.label_17.setStyleSheet(new_font)
         self.label_19.setStyleSheet(new_font)
-        self.groupBox_3.setTitle(QtCore.QCoreApplication.translate("FittingWidgetUI", u"Number-average Polydispersity and Orientational Distribution", None))
 
     def info(self, type, value, tb):
         logger.error("".join(traceback.format_exception(type, value, tb)))

--- a/src/sas/qtgui/Perspectives/Fitting/UI/FittingWidgetUI.ui
+++ b/src/sas/qtgui/Perspectives/Fitting/UI/FittingWidgetUI.ui
@@ -360,7 +360,7 @@
        <item row="0" column="0">
         <widget class="QGroupBox" name="groupBox_3">
          <property name="title">
-          <string>Polydispersity and Orientational Distribution</string>
+          <string>Number-average Polydispersity and Orientational Distribution</string>
          </property>
          <layout class="QGridLayout" name="gridLayout_9">
           <item row="0" column="0">


### PR DESCRIPTION
## Description

This PR addresses a criticism aired in #2390 that Users seem confused by what type of average our polydispersity distributions represent, even though this is clearly stated in the docs and on our FAQ webpage. The specific request was that something be added to the UI.

The solution provided is shown here:
![image](https://github.com/SasView/sasview/assets/10938679/5f36ad80-f1ff-41b2-91c3-68e896b0743a)

## How Has This Been Tested?
Tested as a developer build on W10/x64.

## Review Checklist (please remove items if they don't apply):

- [ ] Code has been reviewed
- [x] Functionality has been tested
- [ ] Windows installer (GH artifact) has been tested (installed and worked) 
- [ ] MacOSX installer (GH artifact) has been tested (installed and worked) 
