### PR TITLE
2746 fixed running tests locally

### DIFF
--- a/test/utest_sasview.py
+++ b/test/utest_sasview.py
@@ -7,7 +7,7 @@ import sys
 
 import logging
 import logging.config
-LOGGER_CONFIG_FILE = os.path.join(os.path.abspath(os.path.dirname(__file__)), 'system', 'log.ini')
+LOGGER_CONFIG_FILE = os.path.join(os.path.abspath(os.path.dirname(__file__)), 'logging.ini')
 logging.config.fileConfig(LOGGER_CONFIG_FILE)
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
## Description
Previously the `logging` library was looking for a config at `test/system/log.ini` when the file was actually located in `src/sas/system/log.ini`, which made it crash upon startup. Note that this was already fixed when running single tests, so it is likely an oversight. Usually tests are run using pytest which isn't affected by this, and thus it has flown under the radar for quite a while. 

Fixes # (issue/issues)
https://github.com/SasView/sasview/issues/2746

## How Has This Been Tested?
This only affects running all tests locally with the command `python test/utest_sasview.py`. Without this commit, it doesn't work. 

## Review Checklist (please remove items if they don't apply):

- [ ] Code has been reviewed
- [ ] Functionality has been tested
