### PR TITLE
Explicit requirements for Python 3.11

### DIFF
--- a/INSTALL.txt
+++ b/INSTALL.txt
@@ -1,7 +1,8 @@
 Quick Intro for Building Sasview
 ================================
 
-Note - at the current time sasview will only run in gui form under Python 3.
+Note - at the current time sasview will only run in gui form under Python 3.11
+and later.
 
 Before trying to install and run sasview you'll need to check what
 dependencies are required:


### PR DESCRIPTION
## Description

After adding #2576 the requirements for Python version changed. We now need >=3.11.
This spells it out explicitly in the INSTALL.txt instructions.

