### PR TITLE
2100 2726 2752 slicer bugfixes

### DIFF
--- a/src/sas/qtgui/Plotting/Plotter2D.py
+++ b/src/sas/qtgui/Plotting/Plotter2D.py
@@ -392,6 +392,27 @@ class Plotter2DWidget(PlotterBase):
         """
         Update slicer plot on Data2D change
         """
+        if not hasattr(self, '_item'): return
+        item = self._item
+        if self._item.parent() is not None:
+            item = self._item.parent()
+
+        # Get all plots for current item
+        plots = GuiUtils.plotsFromModel("", item)
+        if plots is None: return
+        slicer_caption = 'Slicer' + self.data0.name
+        # See if current item plots contain slicer plot
+        has_plot = False
+        for plot in plots:
+            if not hasattr(plot, 'type_id') or plot.type_id is None: continue
+            if slicer_caption in plot.type_id: has_plot = True
+        # return prematurely if no slicer plot found
+        if not has_plot: return
+
+        # Now that we've identified the right plot, update the 2D data the slicer uses
+        self.slicer.data = self.data0
+        # Replot now that the 2D data is updated
+        self.slicer._post_data()
 
     def setSlicer(self, slicer, reset=True):
         """

--- a/src/sas/qtgui/Plotting/Plotter2D.py
+++ b/src/sas/qtgui/Plotting/Plotter2D.py
@@ -136,6 +136,7 @@ class Plotter2DWidget(PlotterBase):
                       update=update)
 
         self.updateCircularAverage()
+        self.updateSlicer()
 
     def calculateDepth(self):
         """
@@ -338,8 +339,7 @@ class Plotter2DWidget(PlotterBase):
         else:
             new_plot.yaxis("\\rm{Intensity} ", "cm^{-1}")
 
-        new_plot.group_id = "2daverage" + self.data0.name
-        new_plot.id = "Circ avg " + self.data0.name
+        new_plot.id = "2daverage" + self.data0.name
         new_plot.is_data = True
 
         return new_plot
@@ -375,8 +375,8 @@ class Plotter2DWidget(PlotterBase):
         # See if current item plots contain 2D average plot
         has_plot = False
         for plot in plots:
-            if plot.group_id is None: continue
-            if ca_caption in plot.group_id: has_plot = True
+            if plot.id is None: continue
+            if ca_caption in plot.id: has_plot = True
         # return prematurely if no circular average plot found
         if not has_plot: return
 
@@ -387,6 +387,11 @@ class Plotter2DWidget(PlotterBase):
         GuiUtils.updateModelItemWithPlot(item, new_plot, new_plot.id)
         # Show the new plot, if already visible
         self.manager.communicator.plotUpdateSignal.emit([new_plot])
+
+    def updateSlicer(self):
+        """
+        Update slicer plot on Data2D change
+        """
 
     def setSlicer(self, slicer, reset=True):
         """

--- a/src/sas/qtgui/Plotting/Plotter2D.py
+++ b/src/sas/qtgui/Plotting/Plotter2D.py
@@ -401,6 +401,47 @@ class Plotter2DWidget(PlotterBase):
         # Clear current slicer
         if self.slicer is not None:
             self.slicer.clear()
+
+        # Clear the old slicer plots so they don't reappear later
+        if hasattr(self, '_item'):
+            item = self._item
+            if self._item.parent() is not None:
+                item = self._item.parent()
+
+            # Go through all items and see if they are a plot. The checks done here are not as thorough
+            # as GuiUtils.deleteRedundantPlots (which this takes a lot from). Will this cause problems?
+            # Primary concern is the check (plot_data.plot_role == DataRole.ROLE_DELETABLE) as I don't
+            # know what it does. The other checks seem to be related to keeping the new plots for that function
+            tempPlotsToRemove = []
+            slicer_type_id = 'Slicer' + self.data0.name
+            for itemIndex in range(item.rowCount()):
+                # GuiUtils.plotsFromModel tests if the data is of type Data1D or Data2D to determine
+                # if it is a plot, so let's try that
+                if isinstance(item.child(itemIndex).data(), (Data1D, Data2D)):
+                    # First take care of this item, then we'll take care of its children
+                    if hasattr(item.child(itemIndex).data(), 'type_id'):
+                        if slicer_type_id in item.child(itemIndex).data().type_id:
+                            # Store this plot to be removed later. Removing now
+                            # will cause the next plot to be skipped
+                            tempPlotsToRemove.append(item.child(itemIndex))
+                # It looks like the slicers are children of items that do not have data of instance Data1D or Data2D.
+                # Now do the children (1 level deep as is done in GuiUtils.plotsFromModel). Note that the slicers always
+                # seem to be the first entry (index2 == 0)
+                for itemIndex2 in range(item.child(itemIndex).rowCount()):
+                    # Repeat what we did above (these if statements could probably be combined
+                    # into one, but I'm not confident enough with how these work to say it wouldn't
+                    # have issues if combined)
+                    if isinstance(item.child(itemIndex).child(itemIndex2).data(), (Data1D, Data2D)):
+                        if hasattr(item.child(itemIndex).child(itemIndex2).data(), 'type_id'):
+                            if slicer_type_id in item.child(itemIndex).child(itemIndex2).data().type_id:
+                                # Remove the parent since each slicer seems to generate a new entry in item
+                                tempPlotsToRemove.append(item.child(itemIndex))
+            # Remove all the parent plots with matching criteria
+            for plot in tempPlotsToRemove:
+                item.removeRow(plot.row())
+            # Delete the temporary list of plots to remove
+            del tempPlotsToRemove
+
         # Create a new slicer
         self.slicer_z += 1
         self.slicer = slicer(self, self.ax, item=self._item, zorder=self.slicer_z)

--- a/src/sas/qtgui/Plotting/Slicers/AnnulusSlicer.py
+++ b/src/sas/qtgui/Plotting/Slicers/AnnulusSlicer.py
@@ -139,6 +139,7 @@ class AnnulusInteractor(BaseInteractor, SlicerModel):
             new_plot.yaxis("\\rm{Residuals} ", "/")
 
         new_plot.id = "AnnulusPhi" + self.data.name
+        new_plot.type_id = "Slicer" + self.data.name # Used to remove plots after changing slicer so they don't keep showing up after closed
         new_plot.is_data = True
         new_plot.xtransform = "x"
         new_plot.ytransform = "y"

--- a/src/sas/qtgui/Plotting/Slicers/AnnulusSlicer.py
+++ b/src/sas/qtgui/Plotting/Slicers/AnnulusSlicer.py
@@ -138,7 +138,6 @@ class AnnulusInteractor(BaseInteractor, SlicerModel):
             new_plot.ytransform = 'y'
             new_plot.yaxis("\\rm{Residuals} ", "/")
 
-        new_plot.group_id = "AnnulusPhi" + self.data.name
         new_plot.id = "AnnulusPhi" + self.data.name
         new_plot.is_data = True
         new_plot.xtransform = "x"

--- a/src/sas/qtgui/Plotting/Slicers/BoxSlicer.py
+++ b/src/sas/qtgui/Plotting/Slicers/BoxSlicer.py
@@ -245,6 +245,7 @@ class BoxInteractor(BaseInteractor, SlicerModel):
 
         #new_plot. = "2daverage" + self.data.name
         new_plot.id = (self.averager.__name__) + self.data.name
+        new_plot.type_id = "Slicer" + self.data.name # Used to remove plots after changing slicer so they don't keep showing up after closed
         new_plot.is_data = True
         item = self._item
         if self._item.parent() is not None:

--- a/src/sas/qtgui/Plotting/Slicers/BoxSlicer.py
+++ b/src/sas/qtgui/Plotting/Slicers/BoxSlicer.py
@@ -90,7 +90,7 @@ class BoxInteractor(BaseInteractor, SlicerModel):
                                       center_x=self.center_x,
                                       center_y=self.center_y)
 
-        # draw the rectangle and plost the data 1D resulting
+        # draw the rectangle and plot the data 1D resulting
         # of averaging data2D
         self.update()
         self._post_data()
@@ -448,7 +448,7 @@ class VerticalDoubleLine(BaseInteractor):
         # Center coordinates
         self.center_x = center_x
         self.center_y = center_y
-        # defined end points vertical lignes and their saved values
+        # defined end points vertical lines and their saved values
         self.y1 = y + self.center_y
         self.save_y1 = self.y1
 
@@ -757,7 +757,7 @@ class HorizontalDoubleLine(BaseInteractor):
         self.y2 = self.center_y - delta
         self.half_height = numpy.fabs(self.y1) - self.center_y
         self.has_move = True
-        self.base.base.update()
+        self.base.update()
 
     def setCursor(self, x, y):
         """

--- a/src/sas/qtgui/Plotting/Slicers/BoxSlicer.py
+++ b/src/sas/qtgui/Plotting/Slicers/BoxSlicer.py
@@ -245,7 +245,6 @@ class BoxInteractor(BaseInteractor, SlicerModel):
 
         #new_plot. = "2daverage" + self.data.name
         new_plot.id = (self.averager.__name__) + self.data.name
-        new_plot.group_id = new_plot.id
         new_plot.is_data = True
         item = self._item
         if self._item.parent() is not None:

--- a/src/sas/qtgui/Plotting/Slicers/SectorSlicer.py
+++ b/src/sas/qtgui/Plotting/Slicers/SectorSlicer.py
@@ -180,7 +180,7 @@ class SectorInteractor(BaseInteractor, SlicerModel):
             new_plot.ytransform = 'y'
             new_plot.yaxis("\\rm{Residuals} ", "/")
 
-        new_plot.group_id = "2daverage" + self.data.name
+        new_plot.group_id = "SectorQ" + self.data.name
         new_plot.id = "SectorQ" + self.data.name
         new_plot.is_data = True
         item = self._item

--- a/src/sas/qtgui/Plotting/Slicers/SectorSlicer.py
+++ b/src/sas/qtgui/Plotting/Slicers/SectorSlicer.py
@@ -180,7 +180,6 @@ class SectorInteractor(BaseInteractor, SlicerModel):
             new_plot.ytransform = 'y'
             new_plot.yaxis("\\rm{Residuals} ", "/")
 
-        new_plot.group_id = "SectorQ" + self.data.name
         new_plot.id = "SectorQ" + self.data.name
         new_plot.is_data = True
         item = self._item

--- a/src/sas/qtgui/Plotting/Slicers/SectorSlicer.py
+++ b/src/sas/qtgui/Plotting/Slicers/SectorSlicer.py
@@ -385,13 +385,13 @@ class SideInteractor(BaseInteractor):
         else:
             self.phi = numpy.fabs(self.phi)
         if side:
-            self.theta = mline.alpha + self.phi
+            self.theta = mline.theta + self.phi
 
         if mline is not None:
             if delta != 0:
                 self.theta2 = mline + delta
             else:
-                self.theta2 = mline.alpha
+                self.theta2 = mline.theta
         if delta == 0:
             theta3 = self.theta + delta
         else:

--- a/src/sas/qtgui/Plotting/Slicers/SectorSlicer.py
+++ b/src/sas/qtgui/Plotting/Slicers/SectorSlicer.py
@@ -181,6 +181,7 @@ class SectorInteractor(BaseInteractor, SlicerModel):
             new_plot.yaxis("\\rm{Residuals} ", "/")
 
         new_plot.id = "SectorQ" + self.data.name
+        new_plot.type_id = "Slicer" + self.data.name # Used to remove plots after changing slicer so they don't keep showing up after closed
         new_plot.is_data = True
         item = self._item
         if self._item.parent() is not None:

--- a/src/sas/qtgui/Plotting/Slicers/WedgeSlicer.py
+++ b/src/sas/qtgui/Plotting/Slicers/WedgeSlicer.py
@@ -212,7 +212,6 @@ class WedgeInteractor(BaseInteractor, SlicerModel):
         new_plot.yaxis("\\rm{Intensity} ", "cm^{-1}")
 
         new_plot.id = str(self.averager.__name__) + self.data.name
-        new_plot.group_id = new_plot.id
         new_plot.is_data = True
         item = self._item
         if self._item.parent() is not None:

--- a/src/sas/qtgui/Plotting/Slicers/WedgeSlicer.py
+++ b/src/sas/qtgui/Plotting/Slicers/WedgeSlicer.py
@@ -212,6 +212,7 @@ class WedgeInteractor(BaseInteractor, SlicerModel):
         new_plot.yaxis("\\rm{Intensity} ", "cm^{-1}")
 
         new_plot.id = str(self.averager.__name__) + self.data.name
+        new_plot.type_id = "Slicer" + self.data.name # Used to remove plots after changing slicer so they don't keep showing up after closed
         new_plot.is_data = True
         item = self._item
         if self._item.parent() is not None:


### PR DESCRIPTION
## Description

Fixes slicer related bugs previously reported

For #2100:
- Adds the updateSlicer function in Plotter2D.py (primarily affects theoretical 2D data)

For #2726:
- Changes alpha (which was likely an angle) to theta in SectorSlicer.py

For #2752:
- Removes the group_id property from the plots as it functionally a duplicate of id. This change also eliminated the incorrect group_id in SectorSlicer.py that caused it to identify as the circular average
- Adds type_id which for all slicers is set to "Slicer" + name of the 2D data. This is used with an addition to setSlicer in Plotter2D.py to identify old slicer plots and remove them from the list. This will not remove the plot window, but will prevent it from reappearing if closed and the 2D data is replotted (primarily affects theoretical 2D data)

Fixes # (issue/issues)

## How Has This Been Tested?

Tested on Windows 10

## Review Checklist (please remove items if they don't apply):

- [ ] Code has been reviewed
- [ ] Functionality has been tested
- [ ] Windows installer (GH artifact) has been tested (installed and worked) 
- [ ] MacOSX installer (GH artifact) has been tested (installed and worked) 
- [ ] Developers documentation is available and complete (if required)
- [ ] The introduced changes comply with SasView license (BSD 3-Clause)

