### PR TITLE
2789: phantom perspective windows

### DIFF
--- a/src/sas/qtgui/MainWindow/GuiManager.py
+++ b/src/sas/qtgui/MainWindow/GuiManager.py
@@ -422,7 +422,7 @@ class GuiManager:
             self.loadedPerspectives[self._current_perspective.name] = self._current_perspective
 
             self._workspace.workspace.removeSubWindow(self._current_perspective)
-            self._workspace.workspace.closeActiveSubWindow()
+            self._workspace.workspace.removeSubWindow(self.subwindow)
 
         # Get new perspective - note that _current_perspective is of type Optional[Perspective],
         # but new_perspective is of type Perspective, thus call to Perspective members are safe


### PR DESCRIPTION
## Description

Closes the actual subwindow object, not the active window, when switching perspectives, to ensure the window is closed.

Fixes #2789

## Review Checklist (please remove items if they don't apply):

- [ ] Code has been reviewed
- [ ] Functionality has been tested
- [ ] Windows installer (GH artifact) has been tested (installed and worked) 
- [ ] MacOSX installer (GH artifact) has been tested (installed and worked) 
- [ ] The introduced changes comply with SasView license (BSD 3-Clause)

