### PR TITLE
Quote file names in ConvertUI

### DIFF
--- a/src/sas/qtgui/convertUI.py
+++ b/src/sas/qtgui/convertUI.py
@@ -24,8 +24,8 @@ def pyrrc(in_file, out_file):
     """
     Run the qt resource compiler
     """
-    run_line = f'pyside6-rcc "{in_file}" -o "{out_file}"'
-    os.system(run_line)
+    run_line = ["pyside6-rcc", in_file, "-o" ,out_file]
+    subprocess.run(run_line)
 
 
 def pyuic(in_file, out_file):
@@ -34,8 +34,8 @@ def pyuic(in_file, out_file):
     """
     in_file2 = os.path.abspath(in_file)
     out_file2 = os.path.abspath(out_file)
-    run_line = f'pyside6-uic "{in_file2}" -o "{out_file2}"'
-    os.system(run_line)
+    run_line = ["pyside6-uic", in_file2 "-o", out_file2]
+    subprocess.run(run_line)
 
 def file_in_newer(file_in, file_out):
     """

--- a/src/sas/qtgui/convertUI.py
+++ b/src/sas/qtgui/convertUI.py
@@ -25,7 +25,7 @@ def pyrrc(in_file, out_file):
     Run the qt resource compiler
     """
     run_line = ["pyside6-rcc", in_file, "-o" ,out_file]
-    subprocess.run(run_line)
+    subprocess.run(run_line, check=True)
 
 
 def pyuic(in_file, out_file):
@@ -35,7 +35,7 @@ def pyuic(in_file, out_file):
     in_file2 = os.path.abspath(in_file)
     out_file2 = os.path.abspath(out_file)
     run_line = ["pyside6-uic", in_file2 "-o", out_file2]
-    subprocess.run(run_line)
+    subprocess.run(run_line, check=True)
 
 def file_in_newer(file_in, file_out):
     """

--- a/src/sas/qtgui/convertUI.py
+++ b/src/sas/qtgui/convertUI.py
@@ -24,7 +24,7 @@ def pyrrc(in_file, out_file):
     """
     Run the qt resource compiler
     """
-    run_line = f"pyside6-rcc {in_file} -o {out_file}"
+    run_line = f'pyside6-rcc "{in_file}" -o "{out_file}"'
     os.system(run_line)
 
 
@@ -34,7 +34,7 @@ def pyuic(in_file, out_file):
     """
     in_file2 = os.path.abspath(in_file)
     out_file2 = os.path.abspath(out_file)
-    run_line = "pyside6-uic " + in_file2 + " -o " + out_file2
+    run_line = f'pyside6-uic "{in_file2}" -o "{out_file2}"'
     os.system(run_line)
 
 def file_in_newer(file_in, file_out):


### PR DESCRIPTION
## Description

Please include a summary of the change and which issue is fixed. List any dependencies that are required for this change.
Fixed issue: convertUI does not create a outfiles when a space is present in a folder of the path. The issue was fixed properly quoting the files name in the convert UI.
Fixes #2791 

## How Has This Been Tested?
After this change,  run.py can start the application


## Review Checklist (please remove items if they don't apply):

- [ ] Code has been reviewed
- [ ] Functionality has been tested
- [ ] Windows installer (GH artifact) has been tested (installed and worked) 
- [ ] MacOSX installer (GH artifact) has been tested (installed and worked) 
- [ ] User documentation is available and complete (if required)
- [ ] Developers documentation is available and complete (if required)
- [ ] The introduced changes comply with SasView license (BSD 3-Clause)

