### PR TITLE
2719, 2727, 2733: Documentation Editor Fixes

### DIFF
--- a/src/sas/qtgui/Utilities/AddMultEditor.py
+++ b/src/sas/qtgui/Utilities/AddMultEditor.py
@@ -295,10 +295,6 @@ class AddMultEditor(QtWidgets.QDialog, Ui_AddMultEditorUI):
     def onHelp(self):
         """ Display related help section """
 
-        try:
-            help_location = GuiUtils.HELP_DIRECTORY_LOCATION + \
-                            "/user/qtgui/Perspectives/Fitting/fitting_help.html#add-multiply-models"
-            webbrowser.open('file://' + os.path.realpath(help_location))
-        except AttributeError:
-            # No manager defined - testing and standalone runs
-            pass
+        help_location = "/user/qtgui/Perspectives/Fitting/fitting_help.html#add-multiply-models"
+        self.parent.showHelp(help_location)
+

--- a/src/sas/qtgui/Utilities/DocRegenInProgess.py
+++ b/src/sas/qtgui/Utilities/DocRegenInProgess.py
@@ -14,8 +14,6 @@ class DocRegenProgress(QtWidgets.QWidget, Ui_DocRegenProgress):
         self.setupUi(self)
         self.parent = parent
 
-        self.setWindowTitle("Documentation Regenerating")
-        self.label.setText("Regeneration In Progress")
         self.textBrowser.setText("Placeholder Text.")
         self.file_watcher = QtCore.QFileSystemWatcher()
         self.addSignals()

--- a/src/sas/qtgui/Utilities/DocViewWidget.py
+++ b/src/sas/qtgui/Utilities/DocViewWidget.py
@@ -101,7 +101,6 @@ class DocViewWindow(QtWidgets.QDialog, Ui_DocViewerWindow):
         user_models = Path(models.find_plugins_dir())
         html_path = HELP_DIRECTORY_LOCATION
         rst_path = MAIN_DOC_SRC
-        rst_py_path = MAIN_PY_SRC
         base_path = self.source.parent.parts
         url_str = str(self.source)
 
@@ -112,18 +111,16 @@ class DocViewWindow(QtWidgets.QDialog, Ui_DocViewerWindow):
             return
 
         if "models" in base_path:
-            model_name = self.source.name.replace("html", "py")
-            regen_string = rst_py_path / model_name
-            user_model_name = user_models / model_name
+            user_model_name = user_models / self.source.name.replace("html", "py")
 
             # Test if this is a user defined model, and if its HTML does not exist or is older than python source file
             if os.path.isfile(user_model_name):
-                if self.newer(regen_string, user_model_name):
-                    self.regenerateHtml(model_name)
+                if self.newer(user_model_name, url_str):
+                    self.regenerateHtml(user_model_name)
 
             # Test to see if HTML does not exist or is older than python file
-            elif self.newer(regen_string, self.source):
-                self.regenerateHtml(model_name)
+            elif self.newer(self.source, url_str):
+                self.regenerateHtml(self.source.name)
             # Regenerate RST then HTML if no model file found OR if HTML is older than equivalent .py    
 
         elif "index" in url_str:
@@ -156,7 +153,10 @@ class DocViewWindow(QtWidgets.QDialog, Ui_DocViewerWindow):
         :return: Is the ReST file newer than the HTML file? Returned as a boolean.
         """
         try:
-            return not os.path.exists(html) or os.path.getmtime(src) > os.path.getmtime(html)
+            html_exists = os.path.exists(html)
+            rst_time = os.path.getmtime(src)
+            html_time = os.path.getmtime(html)
+            return not html_exists or rst_time > html_time
         except Exception as e:
             # Catch exception for debugging
             return True

--- a/src/sas/qtgui/Utilities/DocViewWidget.py
+++ b/src/sas/qtgui/Utilities/DocViewWidget.py
@@ -12,6 +12,15 @@ from sas.qtgui.Utilities.TabbedModelEditor import TabbedModelEditor
 from sas.sascalc.fit import models
 from sas.sascalc.doc_regen.makedocumentation import make_documentation, HELP_DIRECTORY_LOCATION, MAIN_PY_SRC, MAIN_DOC_SRC
 
+HTML_404 = '''
+<html>
+<body>
+<p>Unable to find documentation.</p>
+<p>Developers: please build the documentation and try again.</p>
+</body>
+</html>
+'''
+
 
 class DocViewWindow(QtWidgets.QDialog, Ui_DocViewerWindow):
     """
@@ -96,6 +105,12 @@ class DocViewWindow(QtWidgets.QDialog, Ui_DocViewerWindow):
         base_path = self.source.parent.parts
         url_str = str(self.source)
 
+        if not MAIN_DOC_SRC.exists() and not HELP_DIRECTORY_LOCATION.exists():
+            # The user docs were never built - disable edit button and do not attempt doc regen
+            self.editButton.setEnabled(False)
+            self.load404()
+            return
+
         if "models" in base_path:
             model_name = self.source.name.replace("html", "py")
             regen_string = rst_py_path / model_name
@@ -157,6 +172,10 @@ class DocViewWindow(QtWidgets.QDialog, Ui_DocViewerWindow):
         self.webEngineViewer.load(url)
 
         # Show widget
+        self.onShow()
+
+    def load404(self):
+        self.webEngineViewer.setHtml(HTML_404)
         self.onShow()
     
     def refresh(self):

--- a/src/sas/qtgui/Utilities/DocViewWidget.py
+++ b/src/sas/qtgui/Utilities/DocViewWidget.py
@@ -195,9 +195,9 @@ class DocViewWindow(QtWidgets.QDialog, Ui_DocViewerWindow):
 
         # Check if the URL string contains a fragment (jump link)
         if '#' in url.name:
-            url, fragment = url.name.split('#', 1)
+            url_str, fragment = str(url.absolute()).split('#', 1)
             # Convert path to a QUrl needed for QWebViewerEngine
-            abs_url = QtCore.QUrl.fromLocalFile(url)
+            abs_url = QtCore.QUrl.fromLocalFile(url_str)
             abs_url.setFragment(fragment)
         else:
             # Convert path to a QUrl needed for QWebViewerEngine

--- a/src/sas/qtgui/Utilities/UI/DocRegenInProgress.ui
+++ b/src/sas/qtgui/Utilities/UI/DocRegenInProgress.ui
@@ -7,17 +7,17 @@
     <x>0</x>
     <y>0</y>
     <width>378</width>
-    <height>100</height>
+    <height>400</height>
    </rect>
   </property>
   <property name="windowTitle">
-   <string>Form</string>
+   <string>Documentation Generation Progress Window</string>
   </property>
   <layout class="QGridLayout" name="gridLayout_3">
    <item row="0" column="0">
     <widget class="QLabel" name="label">
      <property name="text">
-      <string>TextLabel</string>
+      <string>::Documentation Generation In Progress::</string>
      </property>
      <property name="alignment">
       <set>Qt::AlignCenter</set>
@@ -25,6 +25,13 @@
     </widget>
    </item>
    <item row="1" column="0">
+    <widget class="QLabel" name="label1">
+     <property name="text">
+      <string>This process may take a few minutes.</string>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="0">
     <widget class="QTextBrowser" name="textBrowser"/>
    </item>
   </layout>

--- a/src/sas/sascalc/doc_regen/makedocumentation.py
+++ b/src/sas/sascalc/doc_regen/makedocumentation.py
@@ -80,7 +80,7 @@ def get_main_docs() -> list[Union[Path, os.path, str]]:
 
     :return: A list of python files """
     # The order in which these are added is important. if ABSOLUTE_TARGET_PLUGINS goes first, then we're not compiling the .py file stored in .sasview/plugin_models
-    TARGETS = get_py(ABSOLUTE_TARGET_MAIN) + get_py(PLUGIN_PY_SRC)
+    TARGETS = get_py(MAIN_PY_SRC) + get_py(PLUGIN_PY_SRC)
     base_targets = [basename(string) for string in TARGETS]
 
     # Removes duplicate instances of the same file copied from plugins folder to source-temp/user/models/src/
@@ -99,8 +99,9 @@ def call_regenmodel(filepath: list[Union[Path, os.path, str]]):
     """
     from sas.sascalc.doc_regen.regenmodel import run_sphinx, process_model
     filepaths = [Path(path) for path in filepath]
-    rst_files = [process_model(py_file, True) for py_file in filepaths]
-    run_sphinx(filepath, rst_files)
+    rst_files = [Path(process_model(py_file, True)) for py_file in filepaths]
+    output_path = MAIN_BUILD_SRC / "user" / "models"
+    run_sphinx(rst_files, output_path)
 
 
 def generate_html(single_file: Union[Path, os.path, str, list] = "", rst: bool = False):
@@ -115,7 +116,7 @@ def generate_html(single_file: Union[Path, os.path, str, list] = "", rst: bool =
             f.truncate(0)
     DOCTREES = MAIN_BUILD_SRC / "doctrees"
     if rst is False:
-        single_rst = USER_DOC_SRC / "user" / "models" / single_file.replace('.py', '.rst')
+        single_rst = USER_DOC_SRC / "user" / "models" / single_file.name.replace('.py', '.rst')
     else:
         single_rst = Path(single_file)
     rst_path = list(single_rst.parts)

--- a/src/sas/sascalc/doc_regen/makedocumentation.py
+++ b/src/sas/sascalc/doc_regen/makedocumentation.py
@@ -116,7 +116,7 @@ def generate_html(single_file: Union[Path, os.path, str, list] = "", rst: bool =
             f.truncate(0)
     DOCTREES = MAIN_BUILD_SRC / "doctrees"
     if rst is False:
-        single_rst = USER_DOC_SRC / "user" / "models" / single_file.name.replace('.py', '.rst')
+        single_rst = MAIN_DOC_SRC / "user" / "models" / single_file.name.replace('.py', '.rst')
     else:
         single_rst = Path(single_file)
     rst_path = list(single_rst.parts)

--- a/src/sas/sascalc/doc_regen/makedocumentation.py
+++ b/src/sas/sascalc/doc_regen/makedocumentation.py
@@ -56,9 +56,9 @@ def create_user_files_if_needed():
         with open(DOC_LOG, "w") as f:
             # Write an empty file to eliminate any potential future file creation conflicts
             pass
-    if not MAIN_DOC_SRC.exists():
+    if not MAIN_DOC_SRC.exists() and ORIGINAL_DOCS_SRC.exists():
         shutil.copytree(ORIGINAL_DOCS_SRC, MAIN_DOC_SRC)
-    if not MAIN_BUILD_SRC.exists():
+    if not MAIN_BUILD_SRC.exists() and ORIGINAL_DOC_BUILD.exists():
         shutil.copytree(ORIGINAL_DOC_BUILD, MAIN_BUILD_SRC)
 
 

--- a/src/sas/sascalc/doc_regen/makedocumentation.py
+++ b/src/sas/sascalc/doc_regen/makedocumentation.py
@@ -119,11 +119,6 @@ def generate_html(single_file: Union[Path, os.path, str, list] = "", rst: bool =
         single_rst = MAIN_DOC_SRC / "user" / "models" / single_file.name.replace('.py', '.rst')
     else:
         single_rst = Path(single_file)
-    rst_path = list(single_rst.parts)
-    rst_str = "/".join(rst_path)
-    if rst_str.endswith("models/") or rst_str.endswith("user/"):
-        # (re)sets value to empty string if nothing was entered
-        single_rst = ""
     os.environ['SAS_NO_HIGHLIGHT'] = '1'
     command = [
         sys.executable,

--- a/src/sas/sascalc/doc_regen/regenmodel.py
+++ b/src/sas/sascalc/doc_regen/regenmodel.py
@@ -391,7 +391,7 @@ def process_model(py_file: str, force=False) -> str:
     return rst_file
 
 
-def run_sphinx(rst_files: list[str], output: list[str]):
+def run_sphinx(rst_files: list[str], output: str):
     """Use sphinx to build *rst_files*, storing the html in *output*.
 
     :param rst_files: A list of ReST file names/paths to be processed into HTML.
@@ -399,7 +399,7 @@ def run_sphinx(rst_files: list[str], output: list[str]):
     """
 
     print("Building index...")
-    conf_dir = dirname(realpath(__file__))
+    conf_dir = MAIN_DOC_SRC
     with open(joinpath(TARGET_DIR, 'index.rst'), 'w') as fid:
         fid.write(".. toctree::\n\n")
         for path in rst_files:

--- a/src/sas/sascalc/doc_regen/regentoc.py
+++ b/src/sas/sascalc/doc_regen/regentoc.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 import sys
 # make sure sasmodels is on the path
 sys.path.append('..')
@@ -9,12 +7,7 @@ from os.path import basename, exists, join as joinpath
 from sasmodels.core import load_model_info
 from sas.sascalc.doc_regen.makedocumentation import MAIN_DOC_SRC
 
-try:
-    from typing import Optional, IO, BinaryIO, List, Dict
-except ImportError:
-    pass
-else:
-    from sasmodels.modelinfo import ModelInfo
+from typing import Optional, IO, BinaryIO, List, Dict
 
 TEMPLATE = """\
 ..
@@ -144,5 +137,9 @@ def generate_toc(model_files: list[str]):
         f.close()
 
 
+def main(files):
+    generate_toc(model_files=files)
+
+
 if __name__ == "__main__":
-    generate_toc(sys.argv[1:])
+    main(sys.argv[1:])


### PR DESCRIPTION
## Description

Several issues related to the documentation editor are fixed with this pull request.

Fixes #2719 - Plugin model documentation is now built and displayed as expected.
Fixes #2727 - SasView now starts if the documentation has not been built, which was the underlying cause of the error.
Fixes #2733 - No longer seeing the index error.

## How Has This Been Tested?

Tested locally and tested the installer from the latest push.

## Review Checklist (please remove items if they don't apply):

- [ ] Code has been reviewed
- [ ] Functionality has been tested
- [ ] Windows installer (GH artifact) has been tested (installed and worked) 
- [ ] MacOSX installer (GH artifact) has been tested (installed and worked) 
- [ ] Developers documentation is available and complete (if required)

