### PR TITLE
2806: Remove all imports of deprecated imp module

### DIFF
--- a/docs/sphinx-docs/build_sphinx.py
+++ b/docs/sphinx-docs/build_sphinx.py
@@ -12,7 +12,7 @@ import subprocess
 import os
 from os.path import join as joinpath, abspath, dirname, isdir, exists, relpath
 import shutil
-import imp
+from importlib.machinery import SourceFileLoader
 
 from glob import glob
 from distutils.dir_util import copy_tree
@@ -63,7 +63,7 @@ BUMPS_SOURCE = joinpath(BUMPS_DOCS, "guide")
 BUMPS_TARGET = joinpath(SPHINX_PERSPECTIVES, "Fitting")
 
 
-run = imp.load_source('run', joinpath(SASVIEW_ROOT, 'run.py'))
+run = SourceFileLoader('run', joinpath(SASVIEW_ROOT, 'run.py')).load_module()
 run.prepare()
 
 

--- a/src/sas/qtgui/Utilities/GuiUtils.py
+++ b/src/sas/qtgui/Utilities/GuiUtils.py
@@ -6,7 +6,6 @@ import numbers
 import os
 import re
 import sys
-import imp
 import warnings
 import webbrowser
 import urllib.parse

--- a/test/run_one.py
+++ b/test/run_one.py
@@ -4,7 +4,7 @@ import os
 import sys
 import xmlrunner
 import unittest
-import imp
+from importlib.machinery import SourceFileLoader
 from os.path import abspath, dirname, split as splitpath, join as joinpath
 
 import logging
@@ -19,7 +19,7 @@ if len(sys.argv) < 2:
     sys.exit(-1)
 
 run_py = joinpath(dirname(dirname(abspath(__file__))), 'run.py')
-run = imp.load_source('sasview_run', run_py)
+run = SourceFileLoader('sasview_run', run_py).load_module()
 run.prepare()
 
 #print("\n".join(sys.path))
@@ -31,5 +31,5 @@ print("=== testing:",sys.argv[1])
 sys.argv = [sys.argv[0]]
 os.chdir(test_path)
 sys.path.insert(0, test_path)
-test = imp.load_source('tests',test_file)
+test = SourceFileLoader('tests', test_file).load_module()
 unittest.main(test, testRunner=xmlrunner.XMLTestRunner(output='logs'))


### PR DESCRIPTION
## Description
This removes all references to the `imp` module that has been deprecated since Python v3.4 and fully removed in Python v3.12, in favor of `importlib` resources. The old module was still in three places, GuiUtils (unused), build_sphinx (breaking py3.12), and run_one (used occasionally).

Fixes #2806

## How Has This Been Tested?
The docs build, and running a single test file with run_one succeeds.

## Review Checklist (please remove items if they don't apply):

- [ ] Code has been reviewed
- [ ] Functionality has been tested
- [ ] Windows installer (GH artifact) has been tested (installed and worked) 
- [ ] MacOSX installer (GH artifact) has been tested (installed and worked)

