### PR TITLE
2806 [6.0.0]: Remove imp module

### DIFF
--- a/docs/sphinx-docs/build_sphinx.py
+++ b/docs/sphinx-docs/build_sphinx.py
@@ -12,7 +12,7 @@ import subprocess
 import os
 from os.path import join as joinpath, abspath, dirname, isdir, exists, relpath
 import shutil
-import imp
+from importlib.machinery import SourceFileLoader
 
 from glob import glob
 from distutils.dir_util import copy_tree
@@ -73,7 +73,7 @@ BUMPS_SOURCE = joinpath(BUMPS_DOCS, "guide")
 BUMPS_TARGET = joinpath(SPHINX_PERSPECTIVES, "Fitting")
 
 
-run = imp.load_source('run', joinpath(SASVIEW_ROOT, 'run.py'))
+run = SourceFileLoader('run', joinpath(SASVIEW_ROOT, 'run.py')).load_module()
 run.prepare()
 
 

--- a/src/sas/qtgui/MainWindow/PackageGatherer.py
+++ b/src/sas/qtgui/MainWindow/PackageGatherer.py
@@ -86,7 +86,7 @@ class PackageGatherer:
                             'dis', 'distutils', 'doctest', 'email', 'encodings', 'ensurepip', 'enum', 'filecmp',
                             'fileinput', 'fnmatch', 'formatter', 'fractions', 'ftplib', 'functools', 'genericpath',
                             'getopt', 'getpass', 'gettext', 'glob', 'graphlib', 'gzip', 'hashlib', 'heapq', 'hmac',
-                            'html', 'http', 'idlelib', 'imaplib', 'imghdr', 'imp', 'importlib', 'inspect', 'io',
+                            'html', 'http', 'idlelib', 'imaplib', 'imghdr', 'importlib', 'inspect', 'io',
                             'ipaddress', 'json', 'keyword', 'lib2to3', 'linecache', 'locale', 'logging', 'lzma',
                             'mailbox', 'mailcap', 'mimetypes', 'modulefinder', 'msilib', 'multiprocessing', 'netrc',
                             'nntplib', 'ntpath', 'nturl2path', 'numbers', 'opcode', 'operator', 'optparse', 'os',

--- a/src/sas/qtgui/Utilities/GuiUtils.py
+++ b/src/sas/qtgui/Utilities/GuiUtils.py
@@ -6,7 +6,6 @@ import numbers
 import os
 import re
 import sys
-import imp
 import warnings
 import webbrowser
 import urllib.parse

--- a/test/run_one.py
+++ b/test/run_one.py
@@ -4,7 +4,7 @@ import os
 import sys
 import xmlrunner
 import unittest
-import imp
+from importlib.machinery import SourceFileLoader
 from os.path import abspath, dirname, split as splitpath, join as joinpath
 
 import logging
@@ -19,7 +19,7 @@ if len(sys.argv) < 2:
     sys.exit(-1)
 
 run_py = joinpath(dirname(dirname(abspath(__file__))), 'run.py')
-run = imp.load_source('sasview_run', run_py)
+run = SourceFileLoader('sasview_run', run_py).load_module()
 run.prepare()
 
 #print("\n".join(sys.path))
@@ -31,5 +31,5 @@ print("=== testing:",sys.argv[1])
 sys.argv = [sys.argv[0]]
 os.chdir(test_path)
 sys.path.insert(0, test_path)
-test = imp.load_source('tests',test_file)
+test = SourceFileLoader('tests', test_file).load_module()
 unittest.main(test, testRunner=xmlrunner.XMLTestRunner(output='logs'))


### PR DESCRIPTION
This is a `cherry-pick` of the commits from #2807 in a branch built off `release_6.0.0`. A quick functionality review should be done.