### PR TITLE
Fix Ubuntu (latest) tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,6 +81,7 @@ jobs:
       - name: Install X11 libraries (Linux)
         if: ${{ startsWith(matrix.os, 'ubuntu') }}
         run: |
+          sudo apt-get update
           sudo apt install libxkbcommon-x11-0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 libxcb-xinerama0 libxcb-xfixes0 x11-utils xvfb libegl-dev
 
       - name: Install Python dependencies
@@ -398,6 +399,7 @@ jobs:
       - name: Install X11 libraries (Linux)
         if: ${{ startsWith(matrix.os, 'ubuntu') }}
         run: |
+          sudo apt-get update
           sudo apt install libxkbcommon-x11-0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 libxcb-xinerama0 libxcb-xfixes0 x11-utils xvfb
 
       - name: Try running the installation (Linux)

--- a/.github/workflows/matrix.py
+++ b/.github/workflows/matrix.py
@@ -28,7 +28,7 @@ jobs = []
 os_release_list = [
 #    'ubuntu-20.04',
 #    'windows-latest',
-#    'macos-latest',
+#    'macos-latest', 
 ]
 
 # List of OS images to use for release tests

--- a/.github/workflows/matrix.py
+++ b/.github/workflows/matrix.py
@@ -26,9 +26,9 @@ jobs = []
 #   dynamically linked by pyinstaller.
 #   https://pyinstaller.readthedocs.io/en/stable/usage.html#making-gnu-linux-apps-forward-compatible
 os_release_list = [
-#    'ubuntu-20.04',
-#    'windows-latest',
-#    'macos-latest', 
+    'ubuntu-20.04',
+    'windows-latest',
+    'macos-latest', 
 ]
 
 # List of OS images to use for release tests

--- a/.github/workflows/matrix.py
+++ b/.github/workflows/matrix.py
@@ -28,7 +28,7 @@ jobs = []
 os_release_list = [
     'ubuntu-20.04',
     'windows-latest',
-    'macos-latest', 
+    'macos-latest',
 ]
 
 # List of OS images to use for release tests

--- a/.github/workflows/matrix.py
+++ b/.github/workflows/matrix.py
@@ -26,9 +26,9 @@ jobs = []
 #   dynamically linked by pyinstaller.
 #   https://pyinstaller.readthedocs.io/en/stable/usage.html#making-gnu-linux-apps-forward-compatible
 os_release_list = [
-    'ubuntu-20.04',
-    'windows-latest',
-    'macos-latest',
+#    'ubuntu-20.04',
+#    'windows-latest',
+#    'macos-latest',
 ]
 
 # List of OS images to use for release tests


### PR DESCRIPTION
As mentioned in #2812, the CI system was previously failing for ubuntu (latest). Though the problem seems to have solved itself, this PR ensures it will not happen again. 