### PR TITLE
2813: Move to pyinstaller v6+ for MacOS and Ubuntu

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -194,8 +194,13 @@ jobs:
 
       ### Build the installer (if enabled)
 
-      - name: Install utilities to build installer
-        if: ${{ matrix.installer }}
+      - name: Install utilities to build installer (Windows)
+        if: ${{ matrix.installer && startsWith(matrix.os, 'windows') }}
+        run: |
+          python -m pip install pyinstaller==5.13.2
+
+      - name: Install utilities to build installer (MacOS and Ubuntu)
+        if: ${{ matrix.installer && (startsWith(matrix.os, 'ubuntu') || startsWith(matrix.os, 'ubuntu'))}}
         run: |
           python -m pip install pyinstaller>=6
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -197,7 +197,7 @@ jobs:
       - name: Install utilities to build installer
         if: ${{ matrix.installer }}
         run: |
-          python -m pip install pyinstaller==5.13.2
+          python -m pip install pyinstaller>=6
 
       - name: Build sasview with pyinstaller
         if: ${{ matrix.installer }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -199,8 +199,13 @@ jobs:
         run: |
           python -m pip install pyinstaller==5.13.2
 
-      - name: Install utilities to build installer (MacOS and Ubuntu)
-        if: ${{ matrix.installer && (startsWith(matrix.os, 'ubuntu') || startsWith(matrix.os, 'ubuntu'))}}
+      - name: Install utilities to build installer (Ubuntu)
+        if: ${{ matrix.installer && startsWith(matrix.os, 'ubuntu')}}
+        run: |
+          python -m pip install pyinstaller>=6
+
+      - name: Install utilities to build installer (MacOS)
+        if: ${{ matrix.installer && startsWith(matrix.os, 'macos')}}
         run: |
           python -m pip install pyinstaller>=6
 

--- a/installers/installer.iss
+++ b/installers/installer.iss
@@ -26,7 +26,7 @@ UsedUserAreasWarning=no
 LicenseFile=license.txt
 ArchitecturesInstallIn64BitMode=x64
 OutputBaseFilename=setupSasView
-SetupIconFile=dist\sasview\images\ball.ico
+; SetupIconFile=dist\sasview\images\ball.ico
 
 
 ; Uncomment the following line to run in non administrative install mode (install for current user only.)

--- a/installers/installer.iss
+++ b/installers/installer.iss
@@ -26,7 +26,7 @@ UsedUserAreasWarning=no
 LicenseFile=license.txt
 ArchitecturesInstallIn64BitMode=x64
 OutputBaseFilename=setupSasView
-; SetupIconFile=dist\sasview\images\ball.ico
+SetupIconFile=dist\sasview\images\ball.ico
 
 
 ; Uncomment the following line to run in non administrative install mode (install for current user only.)


### PR DESCRIPTION
## Description

On MacOS, the new DocViewWidget was displaying a blank page for all help files. Looking through debugging results (performed by @pkienzle), MacOS was unable to find `qtwebengine_locales`, a package shipped with PySide. A google search led me to https://github.com/pyinstaller/pyinstaller/issues/4361 describing an issue where MacOS file structures were being changed during the build process, which was fixed in https://github.com/pyinstaller/pyinstaller/pull/7619. The pyinstaller fix was included in v6.0.0 release according to the [release changelog](https://pyinstaller.org/en/v6.0.0/CHANGES.html#id1). MacOS and Ubuntu use pyinstaller v6.4.0.

Potential imporvements:
 - Remove `>=6` for the pyinstaller version
 - Get Windows build to work on latest version of pyinstaller

**NOTE** INNO cannot find the files in the as-built file structure using pyinstaller v6.4.0 for Windows, so it continues to use the older version for now. This may change at some point for this PR, or will become an issue. See action https://github.com/SasView/sasview/actions/runs/8175225555/job/22354071932 (ball.ico file cannot be found).

Fixes #2813

## How Has This Been Tested?

I downloaded the installers from the successful build for both Windows and Mac. Both load as expected and the docs appear whenever a help button is clicked.

## Review Checklist:

**Documentation** (check at least one)
- [x] There is **nothing** that needs documenting
- [ ] Documentation changes are **in this PR**
- [ ] There is an **issue** open for the documentation (link?)

**Installers**
- [x] There is a chance this will affect the **installers**, if so
  - [ ] **Windows** installer (GH artifact) has been tested (installed and worked) 
  - [ ] **MacOSX** installer (GH artifact) has been tested (installed and worked) 

**Licencing** (untick if necessary)
- [x] The introduced changes comply with SasView license (BSD 3-Clause)

