### PR TITLE
Revert "Quote file names in ConvertUI"

### DIFF
--- a/src/sas/qtgui/convertUI.py
+++ b/src/sas/qtgui/convertUI.py
@@ -24,8 +24,8 @@ def pyrrc(in_file, out_file):
     """
     Run the qt resource compiler
     """
-    run_line = ["pyside6-rcc", in_file, "-o" ,out_file]
-    subprocess.run(run_line, check=True)
+    run_line = f"pyside6-rcc {in_file} -o {out_file}"
+    os.system(run_line)
 
 
 def pyuic(in_file, out_file):
@@ -34,8 +34,8 @@ def pyuic(in_file, out_file):
     """
     in_file2 = os.path.abspath(in_file)
     out_file2 = os.path.abspath(out_file)
-    run_line = ["pyside6-uic", in_file2 "-o", out_file2]
-    subprocess.run(run_line, check=True)
+    run_line = "pyside6-uic " + in_file2 + " -o " + out_file2
+    os.system(run_line)
 
 def file_in_newer(file_in, file_out):
     """


### PR DESCRIPTION
It seems that Mac Installer is failing because of this merge. Testing if this actually the case