### PR TITLE
fix problem with starting due to UI issue

### DIFF
--- a/src/sas/qtgui/convertUI.py
+++ b/src/sas/qtgui/convertUI.py
@@ -4,6 +4,7 @@
 #  Arguments: -f -> Force the UI elements to be rebuilt, even if they exist
 import os
 import sys
+import subprocess
 
 def run_compiler(compiler_main, name, *args):
     """ Wrapper to run a compiler, either pyrrc or pyuic"""
@@ -34,7 +35,7 @@ def pyuic(in_file, out_file):
     """
     in_file2 = os.path.abspath(in_file)
     out_file2 = os.path.abspath(out_file)
-    run_line = ["pyside6-uic", in_file2 "-o", out_file2]
+    run_line = ["pyside6-uic", in_file2, "-o", out_file2]
     subprocess.run(run_line, check=True)
 
 def file_in_newer(file_in, file_out):


### PR DESCRIPTION
## Description

Fixed forgotten comma and missing import statement from previous merge

Fixes # (issue/issues)

## How Has This Been Tested?

The installer CI build output was checked for errors. Note that last time the build failed with a traceback but created an artifact (that could not open) anyway and gave a green "passed" checkmark.  This time no errors were visible.

Next, the windows installer was downloaded and the program started. opened some docs and then tested the new doc viewer by opening he doc for a plugin model. Since this change only affects the path (to avoid issues with a space in the path etc) in the UI builder, the fact that the UI.py files built properly suggests that it all works.

## Review Checklist:

[if using the editor, use `[x]` in place of `[ ]` to check a box]

**Documentation** (check at least one)
- [X ] There is **nothing** that needs documenting
- [ ] Documentation changes are **in this PR**
- [ ] There is an **issue** open for the documentation (link?)

**Installers**
- [ ] There is a chance this will affect the **installers**, if so
  - [ ] **Windows** installer (GH artifact) has been tested (installed and worked) 
  - [ ] **MacOSX** installer (GH artifact) has been tested (installed and worked) 

**Licencing** (untick if necessary)
- [x] The introduced changes comply with SasView license (BSD 3-Clause)

