### PR TITLE
Fix issue related to path typing

### DIFF
--- a/src/sas/qtgui/Utilities/DocViewWidget.py
+++ b/src/sas/qtgui/Utilities/DocViewWidget.py
@@ -2,7 +2,6 @@ import sys
 import os
 import logging
 from pathlib import Path
-from typing import Union
 
 from PySide6 import QtCore, QtWidgets, QtWebEngineCore
 from twisted.internet import threads
@@ -10,7 +9,7 @@ from twisted.internet import threads
 from .UI.DocViewWidgetUI import Ui_DocViewerWindow
 from sas.qtgui.Utilities.TabbedModelEditor import TabbedModelEditor
 from sas.sascalc.fit import models
-from sas.sascalc.doc_regen.makedocumentation import make_documentation, HELP_DIRECTORY_LOCATION, MAIN_PY_SRC, MAIN_DOC_SRC
+from sas.sascalc.doc_regen.makedocumentation import make_documentation, HELP_DIRECTORY_LOCATION, MAIN_DOC_SRC, PATH_LIKE
 
 HTML_404 = '''
 <html>
@@ -145,7 +144,7 @@ class DocViewWindow(QtWidgets.QDialog, Ui_DocViewerWindow):
             self.loadHtml() #loads the html file specified in the source url to the QWebViewer
 
     @staticmethod
-    def newer(src: Union[Path, os.path, str], html: Union[Path, os.path, str]) -> bool:
+    def newer(src: PATH_LIKE, html: PATH_LIKE) -> bool:
         """Compare two files to determine if a file regeneration is required.
 
         :param src: The ReST file that might need regeneration.
@@ -204,7 +203,7 @@ class DocViewWindow(QtWidgets.QDialog, Ui_DocViewerWindow):
             abs_url = QtCore.QUrl.fromLocalFile(url)
         return abs_url
 
-    def regenerateHtml(self, file_name: Union[Path, os.path, str]):
+    def regenerateHtml(self, file_name: PATH_LIKE):
         """Regenerate the documentation for the file passed to the method
 
         :param file_name: A file-path like object that needs regeneration.
@@ -216,7 +215,7 @@ class DocViewWindow(QtWidgets.QDialog, Ui_DocViewerWindow):
         self.regen_in_progress = True
 
     @staticmethod
-    def regenerateDocs(target: Union[Path, os.path, str] = None):
+    def regenerateDocs(target: PATH_LIKE = None):
         """Regenerates documentation for a specific file (target) in a subprocess
 
         :param target: A file-path like object that needs regeneration.

--- a/src/sas/sascalc/doc_regen/makedocumentation.py
+++ b/src/sas/sascalc/doc_regen/makedocumentation.py
@@ -14,6 +14,8 @@ from sas.sascalc.fit import models
 from sas.system.version import __version__
 from sas.system.user import get_user_dir
 
+PATH_LIKE = Union[Path, str, os.PathLike]
+
 # Path constants related to the directories and files used in documentation regeneration processes
 USER_DIRECTORY = Path(get_user_dir())
 USER_DOC_BASE = USER_DIRECTORY / "doc"
@@ -62,7 +64,7 @@ def create_user_files_if_needed():
         shutil.copytree(ORIGINAL_DOC_BUILD, MAIN_BUILD_SRC)
 
 
-def get_py(directory: Union[Path, os.path, str]) -> list[Union[Path, os.path, str]]:
+def get_py(directory: PATH_LIKE) -> list[PATH_LIKE]:
     """Find all python files within a directory that are meant for sphinx and return those file-paths as a list.
 
     :param directory: A file path-like object to find all python files contained there-in.
@@ -74,7 +76,7 @@ def get_py(directory: Union[Path, os.path, str]) -> list[Union[Path, os.path, st
         return PY_FILES
 
 
-def get_main_docs() -> list[Union[Path, os.path, str]]:
+def get_main_docs() -> list[PATH_LIKE]:
     """Generates a list of all .py files to be passed into compiling functions found in the main source code, as well as
     in the user plugin model directory.
 
@@ -92,7 +94,7 @@ def get_main_docs() -> list[Union[Path, os.path, str]]:
     return TARGETS
 
 
-def call_regenmodel(filepath: list[Union[Path, os.path, str]]):
+def call_regenmodel(filepath: list[PATH_LIKE]):
     """Runs regenmodel.py or regentoc.py (specified in parameter regen_py) with all found PY_FILES.
 
     :param filepath: A file-path like object or list of file-path like objects to regenerate.
@@ -104,7 +106,7 @@ def call_regenmodel(filepath: list[Union[Path, os.path, str]]):
     run_sphinx(rst_files, output_path)
 
 
-def generate_html(single_file: Union[Path, os.path, str, list] = "", rst: bool = False):
+def generate_html(single_file: Union[PATH_LIKE, list[PATH_LIKE]] = "", rst: bool = False):
     """Generates HTML from an RST using a subprocess. Based off of syntax provided in Makefile found in /sasmodels/doc/
 
     :param single_file: A file name that needs the html regenerated.
@@ -156,7 +158,7 @@ def call_all_files():
     generate_toc(TARGETS)
 
 
-def call_one_file(file: Union[Path, os.path, str]):
+def call_one_file(file: PATH_LIKE):
     """A master method to regenerate a single file that is passed to the method.
 
     :param file: A file name that needs the html regenerated.
@@ -177,7 +179,7 @@ def call_one_file(file: Union[Path, os.path, str]):
     generate_toc(TARGETS)
 
 
-def make_documentation(target: Union[Path, os.path, str] = "."):
+def make_documentation(target: PATH_LIKE = "."):
     """Similar to call_one_file, but will fall back to calling all files and regenerating everything if an error occurs.
 
     :param target: A file name that needs the html regenerated.


### PR DESCRIPTION
## Description

This takes `os.path` out of typing and replaces it with `os.Pathlike`

## Review Checklist:

[if using the editor, use `[x]` in place of `[ ]` to check a box]

**Documentation** (check at least one)
- [ x ] There is **nothing** that needs documenting
- [ ] Documentation changes are **in this PR**
- [ ] There is an **issue** open for the documentation (link?)

**Installers**
- [x] There is a chance this will affect the **installers**, if so
  - [ ] **Windows** installer (GH artifact) has been tested (installed and worked) 
  - [ ] **MacOSX** installer (GH artifact) has been tested (installed and worked) 

**Licencing** (untick if necessary)
- [x] The introduced changes comply with SasView license (BSD 3-Clause)

