### PR TITLE
Add a button group to allow for proper logic of radio buttons

### DIFF
--- a/src/sas/qtgui/Perspectives/Fitting/GPUOptions.py
+++ b/src/sas/qtgui/Perspectives/Fitting/GPUOptions.py
@@ -54,7 +54,6 @@ class GPUOptions(PreferencesWidget, Ui_GPUOptions):
         self.setupUi(self)
 
         self.radio_buttons = []
-
         self.add_options()
         self.progressBar.setVisible(False)
         self.progressBar.setFormat(" Test %v / %m")
@@ -88,6 +87,10 @@ class GPUOptions(PreferencesWidget, Ui_GPUOptions):
 
         self.cl_options = {}
 
+        # Create a button group for the radio buttons
+        self.radio_group = QtWidgets.QButtonGroup()
+
+        # Create a radio button for each openCL option and add to layout
         for title, descr in cl_tuple:
 
             # Create an item for each openCL option
@@ -95,7 +98,7 @@ class GPUOptions(PreferencesWidget, Ui_GPUOptions):
             radio_button.setObjectName(_fromUtf8(descr))
             radio_button.setText(_translate("GPUOptions", descr, None))
             self.optionsLayout.addWidget(radio_button)
-
+            self.radio_group.addButton(radio_button)
             if title.lower() == config.SAS_OPENCL.lower():
                 radio_button.setChecked(True)
 


### PR DESCRIPTION
## Description

When opencl is not present, the only option on the GPU Options dialog is "No OpenCL".
However, this "radio" button could be deselected and deselecting it caused issues when running tests.

This has been fixed by adding a QButtonGroup to add all the radio buttons into a layout.

Fixes #2841 

## How Has This Been Tested?

Local Win10 build

## Review Checklist:

[if using the editor, use `[x]` in place of `[ ]` to check a box]

**Documentation** (check at least one)
- [X ] There is **nothing** that needs documenting
- [ ] Documentation changes are **in this PR**
- [ ] There is an **issue** open for the documentation (link?)

**Installers**
- [ ] There is a chance this will affect the **installers**, if so
  - [ ] **Windows** installer (GH artifact) has been tested (installed and worked) 
  - [ ] **MacOSX** installer (GH artifact) has been tested (installed and worked) 

**Licencing** (untick if necessary)
- [x] The introduced changes comply with SasView license (BSD 3-Clause)

