### PR TITLE
2761 maintenance rename all used UI element names to something useful

### DIFF
--- a/src/sas/qtgui/Calculators/DensityPanel.py
+++ b/src/sas/qtgui/Calculators/DensityPanel.py
@@ -57,15 +57,15 @@ class DensityPanel(QtWidgets.QDialog):
         self.setFixedSize(self.minimumSizeHint())
 
         # set validators
-        #self.ui.editMolecularFormula.setValidator(FormulaValidator(self.ui.editMolecularFormula))
+        #self.ui.txtEditMolecularFormula.setValidator(FormulaValidator(self.ui.txtEditMolecularFormula))
 
         rx = QtCore.QRegularExpression("[+\-]?(?:0|[1-9]\d*)(?:\.\d*)?(?:[eE][+\-]?\d+)?")
-        self.ui.editMolarVolume.setValidator(QtGui.QRegularExpressionValidator(rx, self.ui.editMolarVolume))
-        self.ui.editMassDensity.setValidator(QtGui.QRegularExpressionValidator(rx, self.ui.editMassDensity))
+        self.ui.txtEditMolarVolume.setValidator(QtGui.QRegularExpressionValidator(rx, self.ui.txtEditMolarVolume))
+        self.ui.txtEditMassDensity.setValidator(QtGui.QRegularExpressionValidator(rx, self.ui.txtEditMassDensity))
 
         # signals
-        self.ui.editMolarVolume.textEdited.connect(functools.partial(self.setMode, MODES.VOLUME_TO_DENSITY))
-        self.ui.editMassDensity.textEdited.connect(functools.partial(self.setMode, MODES.DENSITY_TO_VOLUME))
+        self.ui.txtEditMolarVolume.textEdited.connect(functools.partial(self.setMode, MODES.VOLUME_TO_DENSITY))
+        self.ui.txtEditMassDensity.textEdited.connect(functools.partial(self.setMode, MODES.DENSITY_TO_VOLUME))
 
         self.ui.buttonBox.button(QtWidgets.QDialogButtonBox.Reset).clicked.connect(self.modelReset)
         self.ui.buttonBox.button(QtWidgets.QDialogButtonBox.Help).clicked.connect(self.displayHelp)
@@ -79,9 +79,9 @@ class DensityPanel(QtWidgets.QDialog):
 
         self.model.dataChanged.connect(self.dataChanged)
 
-        self.ui.editMolarVolume.textEdited.connect(self.volumeChanged)
-        self.ui.editMassDensity.textEdited.connect(self.massChanged)
-        self.ui.editMolecularFormula.textEdited.connect(self.formulaChanged)
+        self.ui.txtEditMolarVolume.textEdited.connect(self.volumeChanged)
+        self.ui.txtEditMassDensity.textEdited.connect(self.massChanged)
+        self.ui.txtEditMolecularFormula.textEdited.connect(self.formulaChanged)
 
         self.modelReset()
 
@@ -90,10 +90,10 @@ class DensityPanel(QtWidgets.QDialog):
         self.mapper.setModel(self.model)
         self.mapper.setOrientation(QtCore.Qt.Vertical)
 
-        self.mapper.addMapping(self.ui.editMolecularFormula, MODEL.MOLECULAR_FORMULA)
-        self.mapper.addMapping(self.ui.editMolarMass       , MODEL.MOLAR_MASS)
-        self.mapper.addMapping(self.ui.editMolarVolume     , MODEL.MOLAR_VOLUME)
-        self.mapper.addMapping(self.ui.editMassDensity     , MODEL.MASS_DENSITY)
+        self.mapper.addMapping(self.ui.txtEditMolecularFormula, MODEL.MOLECULAR_FORMULA)
+        self.mapper.addMapping(self.ui.txtEditMolarMass       , MODEL.MOLAR_MASS)
+        self.mapper.addMapping(self.ui.txtEditMolarVolume     , MODEL.MOLAR_VOLUME)
+        self.mapper.addMapping(self.ui.txtEditMassDensity     , MODEL.MASS_DENSITY)
 
         self.mapper.toFirst()
 

--- a/src/sas/qtgui/Calculators/GenericScatteringCalculator.py
+++ b/src/sas/qtgui/Calculators/GenericScatteringCalculator.py
@@ -120,8 +120,8 @@ class GenericScatteringCalculator(QtWidgets.QDialog, Ui_GenericScatteringCalcula
         self.cmdSave.clicked.connect(self.onSaveFile)
 
         # checkboxes
-        self.checkboxNucData.stateChanged.connect(self.change_data_type)
-        self.checkboxMagData.stateChanged.connect(self.change_data_type)
+        self.chkNucData.stateChanged.connect(self.change_data_type)
+        self.chkMagData.stateChanged.connect(self.change_data_type)
 
         self.cmdDraw.clicked.connect(lambda: self.plot3d(has_arrow=True))
         self.cmdDrawpoints.clicked.connect(lambda: self.plot3d(has_arrow=False))
@@ -150,8 +150,8 @@ class GenericScatteringCalculator(QtWidgets.QDialog, Ui_GenericScatteringCalcula
         self.txtUpPhi.textChanged.connect(self.update_polarisation_coords)
 
         # setup initial configuration
-        self.checkboxNucData.setEnabled(False)
-        self.checkboxMagData.setEnabled(False)
+        self.chkNucData.setEnabled(False)
+        self.chkMagData.setEnabled(False)
         self.change_data_type()
         # verify that the new enabled files are compatible
         
@@ -493,8 +493,8 @@ class GenericScatteringCalculator(QtWidgets.QDialog, Ui_GenericScatteringCalcula
         enabled to allow the user to specify a simple rectangular lattice.
         """
         # update information on which files are enabled
-        self.is_nuc = self.checkboxNucData.isChecked()
-        self.is_mag = self.checkboxMagData.isChecked()
+        self.is_nuc = self.chkNucData.isChecked()
+        self.is_mag = self.chkMagData.isChecked()
         # enable the corresponding text displays to show this to the user clearly
         self.txtNucData.setEnabled(self.is_nuc)
         self.txtMagData.setEnabled(self.is_mag)
@@ -757,11 +757,11 @@ class GenericScatteringCalculator(QtWidgets.QDialog, Ui_GenericScatteringCalcula
         logging.info("Load Complete")
         # Once data files are loaded allow them to be enabled and then enable them
         if load_nuc:
-            self.checkboxNucData.setEnabled(True)
-            self.checkboxNucData.setChecked(True)
+            self.chkNucData.setEnabled(True)
+            self.chkNucData.setChecked(True)
         else:
-            self.checkboxMagData.setEnabled(True)
-            self.checkboxMagData.setChecked(True)
+            self.chkMagData.setEnabled(True)
+            self.chkMagData.setChecked(True)
         self.update_gui()
         # reset verification now we have loaded new files
         self.verify = False
@@ -1055,10 +1055,10 @@ class GenericScatteringCalculator(QtWidgets.QDialog, Ui_GenericScatteringCalcula
             self.cmdMagLoad.setEnabled(True)
             self.cmdMagLoad.setText('Load')
             # disable all file checkboxes, as no files are now loaded
-            self.checkboxNucData.setEnabled(False)
-            self.checkboxMagData.setEnabled(False)
-            self.checkboxNucData.setChecked(False)
-            self.checkboxMagData.setChecked(False)
+            self.chkNucData.setEnabled(False)
+            self.chkMagData.setEnabled(False)
+            self.chkNucData.setChecked(False)
+            self.chkMagData.setChecked(False)
             # reset all file data to its default empty state
             self.is_nuc = False
             self.is_mag = False

--- a/src/sas/qtgui/Calculators/GenericScatteringCalculator.py
+++ b/src/sas/qtgui/Calculators/GenericScatteringCalculator.py
@@ -248,7 +248,7 @@ class GenericScatteringCalculator(QtWidgets.QDialog, Ui_GenericScatteringCalcula
         new_font = 'font-family: -apple-system, "Helvetica Neue", "Ubuntu";'
         self.lblUnitSolventSLD.setStyleSheet(new_font)
         self.lblUnitVolume.setStyleSheet(new_font)
-        self.lbl5.setStyleSheet(new_font)
+        self.lblAngstromQx.setStyleSheet(new_font)
         self.lblUnitMx.setStyleSheet(new_font)
         self.lblUnitMy.setStyleSheet(new_font)
         self.lblUnitMz.setStyleSheet(new_font)

--- a/src/sas/qtgui/Calculators/KiessigPanel.py
+++ b/src/sas/qtgui/Calculators/KiessigPanel.py
@@ -23,8 +23,8 @@ class KiessigPanel(QtWidgets.QDialog, Ui_KiessigPanel):
         self.deltaq_in.setValidator(QtGui.QRegularExpressionValidator(rx, self.deltaq_in))
 
         # signals
-        self.helpButton.clicked.connect(self.onHelp)
-        self.closeButton.clicked.connect(self.onClose)
+        self.cmdHelp.clicked.connect(self.onHelp)
+        self.cmdClose.clicked.connect(self.onClose)
         self.deltaq_in.textChanged.connect(self.onCompute)
         self.deltaq_in.setText("0.05")
 

--- a/src/sas/qtgui/Calculators/SldPanel.py
+++ b/src/sas/qtgui/Calculators/SldPanel.py
@@ -102,13 +102,13 @@ class SldPanel(QtWidgets.QDialog):
 
     def _getOutputs(self):
         return {
-            MODEL.NEUTRON_SLD_REAL: self.ui.editNeutronSldReal,
-            MODEL.NEUTRON_SLD_IMAG: self.ui.editNeutronSldImag,
-            MODEL.XRAY_SLD_REAL: self.ui.editXraySldReal,
-            MODEL.XRAY_SLD_IMAG: self.ui.editXraySldImag,
-            MODEL.NEUTRON_INC_XS: self.ui.editNeutronIncXs,
-            MODEL.NEUTRON_ABS_XS: self.ui.editNeutronAbsXs,
-            MODEL.NEUTRON_LENGTH: self.ui.editNeutronLength
+            MODEL.NEUTRON_SLD_REAL: self.ui.txtEditNeutronSldReal,
+            MODEL.NEUTRON_SLD_IMAG: self.ui.txtEditNeutronSldImag,
+            MODEL.XRAY_SLD_REAL: self.ui.txtEditXraySldReal,
+            MODEL.XRAY_SLD_IMAG: self.ui.txtEditXraySldImag,
+            MODEL.NEUTRON_INC_XS: self.ui.txtEditNeutronIncXs,
+            MODEL.NEUTRON_ABS_XS: self.ui.txtEditNeutronAbsXs,
+            MODEL.NEUTRON_LENGTH: self.ui.txtEditNeutronLength
         }
 
     def setupUi(self):
@@ -117,20 +117,20 @@ class SldPanel(QtWidgets.QDialog):
 
         # set validators
         # TODO: GuiUtils.FormulaValidator() crashes with Qt5 - fix
-        #self.ui.editMolecularFormula.setValidator(GuiUtils.FormulaValidator(self.ui.editMolecularFormula))
+        #self.ui.txtEditMolecularFormula.setValidator(GuiUtils.FormulaValidator(self.ui.txtEditMolecularFormula))
 
         # No need for recalculate
-        self.ui.recalculateButton.setVisible(False)
+        self.ui.cmdRecalculate.setVisible(False)
 
         rx = QtCore.QRegularExpression("[+\-]?(?:0|[1-9]\d*)(?:\.\d*)?(?:[eE][+\-]?\d+)?")
-        self.ui.editMassDensity.setValidator(QtGui.QRegularExpressionValidator(rx, self.ui.editMassDensity))
-        self.ui.editNeutronWavelength.setValidator(QtGui.QRegularExpressionValidator(rx, self.ui.editNeutronWavelength))
-        self.ui.editXrayWavelength.setValidator(QtGui.QRegularExpressionValidator(rx, self.ui.editXrayWavelength))
+        self.ui.txtEditMassDensity.setValidator(QtGui.QRegularExpressionValidator(rx, self.ui.txtEditMassDensity))
+        self.ui.txtEditNeutronWavelength.setValidator(QtGui.QRegularExpressionValidator(rx, self.ui.txtEditNeutronWavelength))
+        self.ui.txtEditXrayWavelength.setValidator(QtGui.QRegularExpressionValidator(rx, self.ui.txtEditXrayWavelength))
 
         # signals
-        self.ui.helpButton.clicked.connect(self.displayHelp)
-        self.ui.closeButton.clicked.connect(self.closePanel)
-        self.ui.recalculateButton.clicked.connect(self.calculateSLD)
+        self.ui.cmdHelp.clicked.connect(self.displayHelp)
+        self.ui.cmdClose.clicked.connect(self.closePanel)
+        self.ui.cmdRecalculate.clicked.connect(self.calculateSLD)
 
     def calculateSLD(self):
         self.recalculateSLD()
@@ -147,10 +147,10 @@ class SldPanel(QtWidgets.QDialog):
 
         #self.model.dataChanged.connect(self.dataChanged)
 
-        self.ui.editMassDensity.textChanged.connect(self.recalculateSLD)
-        self.ui.editMolecularFormula.textChanged.connect(self.recalculateSLD)
-        self.ui.editNeutronWavelength.textChanged.connect(self.recalculateSLD)
-        self.ui.editXrayWavelength.textChanged.connect(self.recalculateSLD)
+        self.ui.txtEditMassDensity.textChanged.connect(self.recalculateSLD)
+        self.ui.txtEditMolecularFormula.textChanged.connect(self.recalculateSLD)
+        self.ui.txtEditNeutronWavelength.textChanged.connect(self.recalculateSLD)
+        self.ui.txtEditXrayWavelength.textChanged.connect(self.recalculateSLD)
 
         self.modelReset()
 
@@ -158,10 +158,10 @@ class SldPanel(QtWidgets.QDialog):
         self.mapper = QtWidgets.QDataWidgetMapper(self)
         self.mapper.setModel(self.model)
         self.mapper.setOrientation(QtCore.Qt.Vertical)
-        self.mapper.addMapping(self.ui.editMolecularFormula , MODEL.MOLECULAR_FORMULA)
-        self.mapper.addMapping(self.ui.editMassDensity      , MODEL.MASS_DENSITY)
-        self.mapper.addMapping(self.ui.editNeutronWavelength, MODEL.NEUTRON_WAVELENGTH)
-        self.mapper.addMapping(self.ui.editXrayWavelength   , MODEL.XRAY_WAVELENGTH)
+        self.mapper.addMapping(self.ui.txtEditMolecularFormula , MODEL.MOLECULAR_FORMULA)
+        self.mapper.addMapping(self.ui.txtEditMassDensity      , MODEL.MASS_DENSITY)
+        self.mapper.addMapping(self.ui.txtEditNeutronWavelength, MODEL.NEUTRON_WAVELENGTH)
+        self.mapper.addMapping(self.ui.txtEditXrayWavelength   , MODEL.XRAY_WAVELENGTH)
 
         for key, edit in self._getOutputs().items():
             self.mapper.addMapping(edit, key)
@@ -179,10 +179,10 @@ class SldPanel(QtWidgets.QDialog):
             self.recalculateSLD()
 
     def recalculateSLD(self):
-        formula = self.ui.editMolecularFormula.text()
-        density = self.ui.editMassDensity.text()
-        neutronWavelength = self.ui.editNeutronWavelength.text()
-        xrayWavelength = self.ui.editXrayWavelength.text()
+        formula = self.ui.txtEditMolecularFormula.text()
+        density = self.ui.txtEditMassDensity.text()
+        neutronWavelength = self.ui.txtEditNeutronWavelength.text()
+        xrayWavelength = self.ui.txtEditXrayWavelength.text()
 
         if not formula or not density:
             return
@@ -199,35 +199,35 @@ class SldPanel(QtWidgets.QDialog):
             self.model.item(MODEL.NEUTRON_ABS_XS).setText(format(results.neutron_abs_xs))
             self.model.item(MODEL.NEUTRON_LENGTH).setText(format(results.neutron_length))
             self.model.item(MODEL.NEUTRON_LENGTH).setEnabled(True)
-            self.ui.editNeutronSldReal.setEnabled(True)
-            self.ui.editNeutronSldImag.setEnabled(True)
-            self.ui.editNeutronIncXs.setEnabled(True)
-            self.ui.editNeutronLength.setEnabled(True)
-            self.ui.editNeutronAbsXs.setEnabled(True)
+            self.ui.txtEditNeutronSldReal.setEnabled(True)
+            self.ui.txtEditNeutronSldImag.setEnabled(True)
+            self.ui.txtEditNeutronIncXs.setEnabled(True)
+            self.ui.txtEditNeutronLength.setEnabled(True)
+            self.ui.txtEditNeutronAbsXs.setEnabled(True)
         else:
             self.model.item(MODEL.NEUTRON_SLD_REAL).setText("")
             self.model.item(MODEL.NEUTRON_SLD_IMAG).setText("")
             self.model.item(MODEL.NEUTRON_INC_XS).setText("")
             self.model.item(MODEL.NEUTRON_ABS_XS).setText("")
             self.model.item(MODEL.NEUTRON_LENGTH).setText("")
-            self.ui.editNeutronSldReal.setEnabled(False)
-            self.ui.editNeutronSldImag.setEnabled(False)
-            self.ui.editNeutronIncXs.setEnabled(False)
-            self.ui.editNeutronLength.setEnabled(False)
-            self.ui.editNeutronAbsXs.setEnabled(False)
+            self.ui.txtEditNeutronSldReal.setEnabled(False)
+            self.ui.txtEditNeutronSldImag.setEnabled(False)
+            self.ui.txtEditNeutronIncXs.setEnabled(False)
+            self.ui.txtEditNeutronLength.setEnabled(False)
+            self.ui.txtEditNeutronAbsXs.setEnabled(False)
 
         if xrayWavelength and float(xrayWavelength) > np.finfo(float).eps:
             results = xraySldAlgorithm(str(formula), float(density), float(xrayWavelength))
 
             self.model.item(MODEL.XRAY_SLD_REAL).setText(format(results.xray_sld_real))
             self.model.item(MODEL.XRAY_SLD_IMAG).setText(format(results.xray_sld_imag))
-            self.ui.editXraySldReal.setEnabled(True)
-            self.ui.editXraySldImag.setEnabled(True)
+            self.ui.txtEditXraySldReal.setEnabled(True)
+            self.ui.txtEditXraySldImag.setEnabled(True)
         else:
             self.model.item(MODEL.XRAY_SLD_REAL).setText("")
             self.model.item(MODEL.XRAY_SLD_IMAG).setText("")
-            self.ui.editXraySldReal.setEnabled(False)
-            self.ui.editXraySldImag.setEnabled(False)
+            self.ui.txtEditXraySldReal.setEnabled(False)
+            self.ui.txtEditXraySldImag.setEnabled(False)
 
     def modelReset(self):
         #self.model.beginResetModel()

--- a/src/sas/qtgui/Calculators/SlitSizeCalculator.py
+++ b/src/sas/qtgui/Calculators/SlitSizeCalculator.py
@@ -31,9 +31,9 @@ class SlitSizeCalculator(QtWidgets.QDialog, Ui_SlitSizeCalculator):
         self.thickness = SlitlengthCalculator()
 
         # signals
-        self.helpButton.clicked.connect(self.onHelp)
-        self.browseButton.clicked.connect(self.onBrowse)
-        self.closeButton.clicked.connect(self.onClose)
+        self.cmdHelp.clicked.connect(self.onHelp)
+        self.cmdBrowse.clicked.connect(self.onBrowse)
+        self.cmdClose.clicked.connect(self.onClose)
 
         # no reason to have this widget resizable
         self.setFixedSize(self.minimumSizeHint())
@@ -65,7 +65,7 @@ class SlitSizeCalculator(QtWidgets.QDialog, Ui_SlitSizeCalculator):
             logging.error(ex)
             return
 
-        self.data_file.setText(os.path.basename(path_str))
+        self.txtDataFile.setText(os.path.basename(path_str))
         self.calculateSlitSize(data)
 
     def chooseFile(self):
@@ -91,12 +91,12 @@ class SlitSizeCalculator(QtWidgets.QDialog, Ui_SlitSizeCalculator):
         """
         Clear the content of output LineEdits
         """
-        self.slit_length_out.setText("ERROR!")
-        self.unit_out.clear()
+        self.txtSlitLengthOut.setText("ERROR!")
+        self.txtUnitOut.clear()
 
     def calculateSlitSize(self, data=None):
         """
-        Computes slit lenght from given 1D data
+        Computes slit length from given 1D data
         """
         if data is None:
             self.clearResults()
@@ -128,8 +128,8 @@ class SlitSizeCalculator(QtWidgets.QDialog, Ui_SlitSizeCalculator):
             return
 
         slit_length_str = "{:.5f}".format(slit_length)
-        self.slit_length_out.setText(slit_length_str)
+        self.txtSlitLengthOut.setText(slit_length_str)
 
         #Display unit, which most likely needs to be 1/Ang but needs to be confirmed
-        self.unit_out.setText("[Unknown]")
+        self.txtUnitOut.setText("[Unknown]")
 

--- a/src/sas/qtgui/Calculators/UI/DensityPanel.ui
+++ b/src/sas/qtgui/Calculators/UI/DensityPanel.ui
@@ -27,14 +27,14 @@
    <item row="0" column="0">
     <layout class="QGridLayout" name="gridLayout">
      <item row="0" column="0">
-      <widget class="QLabel" name="labelMolecularFormula">
+      <widget class="QLabel" name="lblMolecularFormula">
        <property name="text">
         <string>Molecular Formula</string>
        </property>
       </widget>
      </item>
      <item row="0" column="1">
-      <widget class="QLineEdit" name="editMolecularFormula">
+      <widget class="QLineEdit" name="txtEditMolecularFormula">
        <property name="minimumSize">
         <size>
          <width>61</width>
@@ -53,21 +53,21 @@
       </widget>
      </item>
      <item row="0" column="2">
-      <widget class="QLabel" name="labelExampleMolecularFormula">
+      <widget class="QLabel" name="lblExampleMolecularFormula">
        <property name="text">
         <string>e.g. H2O</string>
        </property>
       </widget>
      </item>
      <item row="1" column="0">
-      <widget class="QLabel" name="labelMolarMass">
+      <widget class="QLabel" name="lblMolarMass">
        <property name="text">
         <string>Molar Mass</string>
        </property>
       </widget>
      </item>
      <item row="1" column="1">
-      <widget class="QLineEdit" name="editMolarMass">
+      <widget class="QLineEdit" name="txtEditMolarMass">
        <property name="minimumSize">
         <size>
          <width>61</width>
@@ -92,7 +92,7 @@
       </widget>
      </item>
      <item row="1" column="2">
-      <widget class="QLabel" name="labelExampleMolarMass">
+      <widget class="QLabel" name="lblExampleMolarMass">
        <property name="text">
         <string>g/mol</string>
        </property>
@@ -121,14 +121,14 @@
       </widget>
      </item>
      <item row="3" column="0">
-      <widget class="QLabel" name="labelMolarVolume">
+      <widget class="QLabel" name="lblMolarVolume">
        <property name="text">
         <string>Molar Volume</string>
        </property>
       </widget>
      </item>
      <item row="3" column="1">
-      <widget class="QLineEdit" name="editMolarVolume">
+      <widget class="QLineEdit" name="txtEditMolarVolume">
        <property name="minimumSize">
         <size>
          <width>61</width>
@@ -147,21 +147,21 @@
       </widget>
      </item>
      <item row="3" column="2">
-      <widget class="QLabel" name="labelExampleMolarVolume">
+      <widget class="QLabel" name="lblExampleMolarVolume">
        <property name="text">
         <string>cm³/mol</string>
        </property>
       </widget>
      </item>
      <item row="4" column="0">
-      <widget class="QLabel" name="labelMassDensity">
+      <widget class="QLabel" name="lblMassDensity">
        <property name="text">
         <string>Mass Density</string>
        </property>
       </widget>
      </item>
      <item row="4" column="1">
-      <widget class="QLineEdit" name="editMassDensity">
+      <widget class="QLineEdit" name="txtEditMassDensity">
        <property name="minimumSize">
         <size>
          <width>61</width>
@@ -180,7 +180,7 @@
       </widget>
      </item>
      <item row="4" column="2">
-      <widget class="QLabel" name="labelExampleMassDensity">
+      <widget class="QLabel" name="lblExampleMassDensity">
        <property name="text">
         <string>g/cm³</string>
        </property>
@@ -229,10 +229,10 @@
   </layout>
  </widget>
  <tabstops>
-  <tabstop>editMolecularFormula</tabstop>
-  <tabstop>editMolarMass</tabstop>
-  <tabstop>editMolarVolume</tabstop>
-  <tabstop>editMassDensity</tabstop>
+  <tabstop>txtEditMolecularFormula</tabstop>
+  <tabstop>txtEditMolarMass</tabstop>
+  <tabstop>txtEditMolarVolume</tabstop>
+  <tabstop>txtEditMassDensity</tabstop>
   <tabstop>buttonBox</tabstop>
  </tabstops>
  <resources/>

--- a/src/sas/qtgui/Calculators/UI/DensityPanel.ui
+++ b/src/sas/qtgui/Calculators/UI/DensityPanel.ui
@@ -27,7 +27,7 @@
    <item row="0" column="0">
     <layout class="QGridLayout" name="gridLayout">
      <item row="0" column="0">
-      <widget class="QLabel" name="label_1">
+      <widget class="QLabel" name="labelMolecularFormula">
        <property name="text">
         <string>Molecular Formula</string>
        </property>
@@ -53,14 +53,14 @@
       </widget>
      </item>
      <item row="0" column="2">
-      <widget class="QLabel" name="label_3">
+      <widget class="QLabel" name="labelExampleMolecularFormula">
        <property name="text">
         <string>e.g. H2O</string>
        </property>
       </widget>
      </item>
      <item row="1" column="0">
-      <widget class="QLabel" name="label_2">
+      <widget class="QLabel" name="labelMolarMass">
        <property name="text">
         <string>Molar Mass</string>
        </property>
@@ -92,7 +92,7 @@
       </widget>
      </item>
      <item row="1" column="2">
-      <widget class="QLabel" name="label_4">
+      <widget class="QLabel" name="labelExampleMolarMass">
        <property name="text">
         <string>g/mol</string>
        </property>
@@ -121,7 +121,7 @@
       </widget>
      </item>
      <item row="3" column="0">
-      <widget class="QLabel" name="label_5">
+      <widget class="QLabel" name="labelMolarVolume">
        <property name="text">
         <string>Molar Volume</string>
        </property>
@@ -147,14 +147,14 @@
       </widget>
      </item>
      <item row="3" column="2">
-      <widget class="QLabel" name="label_6">
+      <widget class="QLabel" name="labelExampleMolarVolume">
        <property name="text">
         <string>cm³/mol</string>
        </property>
       </widget>
      </item>
      <item row="4" column="0">
-      <widget class="QLabel" name="label_7">
+      <widget class="QLabel" name="labelMassDensity">
        <property name="text">
         <string>Mass Density</string>
        </property>
@@ -180,7 +180,7 @@
       </widget>
      </item>
      <item row="4" column="2">
-      <widget class="QLabel" name="label_8">
+      <widget class="QLabel" name="labelExampleMassDensity">
        <property name="text">
         <string>g/cm³</string>
        </property>

--- a/src/sas/qtgui/Calculators/UI/GenericScatteringCalculator.ui
+++ b/src/sas/qtgui/Calculators/UI/GenericScatteringCalculator.ui
@@ -92,7 +92,7 @@
          </widget>
         </item>
         <item row="0" column="1">
-         <widget class="QCheckBox" name="checkboxNucData">
+         <widget class="QCheckBox" name="chkNucData">
           <property name="text">
            <string/>
           </property>
@@ -171,7 +171,7 @@
          </widget>
         </item>
         <item row="1" column="1">
-         <widget class="QCheckBox" name="checkboxMagData">
+         <widget class="QCheckBox" name="chkMagData">
           <property name="text">
            <string/>
           </property>
@@ -1988,9 +1988,9 @@ Number of Qbins &amp;isin; [2, 1000].</string>
   </layout>
  </widget>
  <tabstops>
-  <tabstop>checkboxNucData</tabstop>
+  <tabstop>chkNucData</tabstop>
   <tabstop>txtNucData</tabstop>
-  <tabstop>checkboxMagData</tabstop>
+  <tabstop>chkMagData</tabstop>
   <tabstop>txtMagData</tabstop>
   <tabstop>cbShape</tabstop>
   <tabstop>cmdNucLoad</tabstop>

--- a/src/sas/qtgui/Calculators/UI/GenericScatteringCalculator.ui
+++ b/src/sas/qtgui/Calculators/UI/GenericScatteringCalculator.ui
@@ -1007,7 +1007,7 @@ Not editable.</string>
       <item row="0" column="0">
        <layout class="QGridLayout" name="gridLayout_3">
         <item row="1" column="2">
-         <widget class="QLabel" name="lbl5">
+         <widget class="QLabel" name="lblAngstromQx">
           <property name="font">
            <font>
             <bold>false</bold>
@@ -1446,7 +1446,7 @@ Number of Qbins &amp;isin; [2, 1000].</string>
          </widget>
         </item>
         <item row="5" column="2">
-         <widget class="QLabel" name="lbl2">
+         <widget class="QLabel" name="lblBackgdUnit">
           <property name="font">
            <font>
             <bold>false</bold>

--- a/src/sas/qtgui/Calculators/UI/KiessigPanel.ui
+++ b/src/sas/qtgui/Calculators/UI/KiessigPanel.ui
@@ -33,7 +33,7 @@
       <item row="0" column="0">
        <layout class="QHBoxLayout" name="horizontalLayout">
         <item>
-         <widget class="QLabel" name="label">
+         <widget class="QLabel" name="labelKiessigFringeWidth">
           <property name="text">
            <string>Kiessig Fringe Width (Delta Q)</string>
           </property>
@@ -56,7 +56,7 @@
          </widget>
         </item>
         <item>
-         <widget class="QLabel" name="label_2">
+         <widget class="QLabel" name="labelUnitKiessigFringeWidth">
           <property name="text">
            <string>1/Å</string>
           </property>
@@ -76,7 +76,7 @@
       <item row="0" column="0">
        <layout class="QHBoxLayout" name="horizontalLayout_2">
         <item>
-         <widget class="QLabel" name="label_3">
+         <widget class="QLabel" name="labelThickness">
           <property name="text">
            <string>Thickness (or Diameter)               </string>
           </property>
@@ -102,7 +102,7 @@
          </widget>
         </item>
         <item>
-         <widget class="QLabel" name="label_4">
+         <widget class="QLabel" name="labelUnitThicknessAngstrom">
           <property name="text">
            <string>   Å</string>
           </property>

--- a/src/sas/qtgui/Calculators/UI/KiessigPanel.ui
+++ b/src/sas/qtgui/Calculators/UI/KiessigPanel.ui
@@ -33,7 +33,7 @@
       <item row="0" column="0">
        <layout class="QHBoxLayout" name="horizontalLayout">
         <item>
-         <widget class="QLabel" name="labelKiessigFringeWidth">
+         <widget class="QLabel" name="lblKiessigFringeWidth">
           <property name="text">
            <string>Kiessig Fringe Width (Delta Q)</string>
           </property>
@@ -56,7 +56,7 @@
          </widget>
         </item>
         <item>
-         <widget class="QLabel" name="labelUnitKiessigFringeWidth">
+         <widget class="QLabel" name="lblUnitKiessigFringeWidth">
           <property name="text">
            <string>1/Å</string>
           </property>
@@ -76,7 +76,7 @@
       <item row="0" column="0">
        <layout class="QHBoxLayout" name="horizontalLayout_2">
         <item>
-         <widget class="QLabel" name="labelThickness">
+         <widget class="QLabel" name="lblThickness">
           <property name="text">
            <string>Thickness (or Diameter)               </string>
           </property>
@@ -102,7 +102,7 @@
          </widget>
         </item>
         <item>
-         <widget class="QLabel" name="labelUnitThicknessAngstrom">
+         <widget class="QLabel" name="lblUnitThicknessAngstrom">
           <property name="text">
            <string>   Å</string>
           </property>
@@ -127,7 +127,7 @@
     </spacer>
    </item>
    <item row="3" column="1">
-    <widget class="QPushButton" name="closeButton">
+    <widget class="QPushButton" name="cmdClose">
      <property name="toolTip">
       <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Close this window.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
      </property>
@@ -137,7 +137,7 @@
     </widget>
    </item>
    <item row="3" column="2">
-    <widget class="QPushButton" name="helpButton">
+    <widget class="QPushButton" name="cmdHelp">
      <property name="toolTip">
       <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Help using the Kiessing fringe calculator.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
      </property>
@@ -151,8 +151,8 @@
  <tabstops>
   <tabstop>deltaq_in</tabstop>
   <tabstop>lengthscale_out</tabstop>
-  <tabstop>closeButton</tabstop>
-  <tabstop>helpButton</tabstop>
+  <tabstop>cmdClose</tabstop>
+  <tabstop>cmdHelp</tabstop>
  </tabstops>
  <resources/>
  <connections/>

--- a/src/sas/qtgui/Calculators/UI/ResolutionCalculatorPanelUI.ui
+++ b/src/sas/qtgui/Calculators/UI/ResolutionCalculatorPanelUI.ui
@@ -72,7 +72,7 @@
       <item row="0" column="0">
        <layout class="QGridLayout" name="gridLayout_5">
         <item row="0" column="0">
-         <widget class="QLabel" name="labelSource">
+         <widget class="QLabel" name="lblSource">
           <property name="minimumSize">
            <size>
             <width>26</width>
@@ -223,7 +223,7 @@
          </widget>
         </item>
         <item row="2" column="0" colspan="2">
-         <widget class="QLabel" name="labelWavelength">
+         <widget class="QLabel" name="lblWavelength">
           <property name="minimumSize">
            <size>
             <width>84</width>
@@ -286,7 +286,7 @@
          </widget>
         </item>
         <item row="3" column="0" colspan="2">
-         <widget class="QLabel" name="labelWavelengthSpread">
+         <widget class="QLabel" name="lblWavelengthSpread">
           <property name="minimumSize">
            <size>
             <width>134</width>
@@ -324,7 +324,7 @@
          </widget>
         </item>
         <item row="4" column="0" colspan="2">
-         <widget class="QLabel" name="labelSourceApertureSize">
+         <widget class="QLabel" name="lblSourceApertureSize">
           <property name="minimumSize">
            <size>
             <width>143</width>
@@ -368,7 +368,7 @@
          </widget>
         </item>
         <item row="4" column="4">
-         <widget class="QLabel" name="labelSourceApertureSizeUnit">
+         <widget class="QLabel" name="lblSourceApertureSizeUnit">
           <property name="minimumSize">
            <size>
             <width>22</width>
@@ -384,7 +384,7 @@
          </widget>
         </item>
         <item row="5" column="0" colspan="2">
-         <widget class="QLabel" name="labelSampleApertureSize">
+         <widget class="QLabel" name="lblSampleApertureSize">
           <property name="minimumSize">
            <size>
             <width>147</width>
@@ -428,7 +428,7 @@
          </widget>
         </item>
         <item row="5" column="4">
-         <widget class="QLabel" name="labelSampleApertureSizeUnit">
+         <widget class="QLabel" name="lblSampleApertureSizeUnit">
           <property name="sizePolicy">
            <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
             <horstretch>0</horstretch>
@@ -447,7 +447,7 @@
          </widget>
         </item>
         <item row="6" column="0" colspan="3">
-         <widget class="QLabel" name="labelSourceSampleApertureDistance">
+         <widget class="QLabel" name="lblSourceSampleApertureDistance">
           <property name="minimumSize">
            <size>
             <width>220</width>
@@ -491,7 +491,7 @@
          </widget>
         </item>
         <item row="6" column="4">
-         <widget class="QLabel" name="labelSourceSampleApertureDistanceUnit">
+         <widget class="QLabel" name="lblSourceSampleApertureDistanceUnit">
           <property name="minimumSize">
            <size>
             <width>22</width>
@@ -504,7 +504,7 @@
          </widget>
         </item>
         <item row="7" column="0" colspan="3">
-         <widget class="QLabel" name="labelSampleApertureDetectorDistance">
+         <widget class="QLabel" name="lblSampleApertureDetectorDistance">
           <property name="minimumSize">
            <size>
             <width>225</width>
@@ -539,7 +539,7 @@
          </widget>
         </item>
         <item row="7" column="4">
-         <widget class="QLabel" name="labelSampleApertureDetectorDistanceUnit">
+         <widget class="QLabel" name="lblSampleApertureDetectorDistanceUnit">
           <property name="minimumSize">
            <size>
             <width>22</width>
@@ -552,7 +552,7 @@
          </widget>
         </item>
         <item row="8" column="0" colspan="2">
-         <widget class="QLabel" name="labelSampleOffset">
+         <widget class="QLabel" name="lblSampleOffset">
           <property name="minimumSize">
            <size>
             <width>100</width>
@@ -587,7 +587,7 @@
          </widget>
         </item>
         <item row="8" column="4">
-         <widget class="QLabel" name="labelSampleOffsetUnit">
+         <widget class="QLabel" name="lblSampleOffsetUnit">
           <property name="minimumSize">
            <size>
             <width>22</width>
@@ -600,7 +600,7 @@
          </widget>
         </item>
         <item row="9" column="0" colspan="3">
-         <widget class="QLabel" name="labelPixelNumberDetector">
+         <widget class="QLabel" name="lblPixelNumberDetector">
           <property name="minimumSize">
            <size>
             <width>175</width>
@@ -635,7 +635,7 @@
          </widget>
         </item>
         <item row="10" column="0" colspan="2">
-         <widget class="QLabel" name="labelDetectorPixelSize">
+         <widget class="QLabel" name="lblDetectorPixelSize">
           <property name="minimumSize">
            <size>
             <width>129</width>
@@ -670,7 +670,7 @@
          </widget>
         </item>
         <item row="10" column="4">
-         <widget class="QLabel" name="labelDetectorPixelSizeUnit">
+         <widget class="QLabel" name="lblDetectorPixelSizeUnit">
           <property name="minimumSize">
            <size>
             <width>22</width>
@@ -753,7 +753,7 @@
       <item row="0" column="0">
        <layout class="QGridLayout" name="gridLayout">
         <item row="0" column="0">
-         <widget class="QLabel" name="labelQx">
+         <widget class="QLabel" name="lblQx">
           <property name="minimumSize">
            <size>
             <width>21</width>
@@ -801,7 +801,7 @@
          </widget>
         </item>
         <item row="1" column="0">
-         <widget class="QLabel" name="labelQy">
+         <widget class="QLabel" name="lblQy">
           <property name="minimumSize">
            <size>
             <width>21</width>
@@ -943,7 +943,7 @@
          </widget>
         </item>
         <item row="1" column="0">
-         <widget class="QLabel" name="labelSigma_lamd">
+         <widget class="QLabel" name="lblSigma_lamd">
           <property name="minimumSize">
            <size>
             <width>87</width>
@@ -1044,7 +1044,7 @@
          </widget>
         </item>
         <item row="1" column="4">
-         <widget class="QLabel" name="label1DSigma">
+         <widget class="QLabel" name="lbl1DSigma">
           <property name="minimumSize">
            <size>
             <width>87</width>
@@ -1108,7 +1108,7 @@
          </widget>
         </item>
         <item row="0" column="0">
-         <widget class="QLabel" name="labelSigma_x">
+         <widget class="QLabel" name="lblSigma_x">
           <property name="minimumSize">
            <size>
             <width>87</width>

--- a/src/sas/qtgui/Calculators/UI/ResolutionCalculatorPanelUI.ui
+++ b/src/sas/qtgui/Calculators/UI/ResolutionCalculatorPanelUI.ui
@@ -72,7 +72,7 @@
       <item row="0" column="0">
        <layout class="QGridLayout" name="gridLayout_5">
         <item row="0" column="0">
-         <widget class="QLabel" name="label_26">
+         <widget class="QLabel" name="labelSource">
           <property name="minimumSize">
            <size>
             <width>26</width>
@@ -223,7 +223,7 @@
          </widget>
         </item>
         <item row="2" column="0" colspan="2">
-         <widget class="QLabel" name="label_27">
+         <widget class="QLabel" name="labelWavelength">
           <property name="minimumSize">
            <size>
             <width>84</width>
@@ -286,7 +286,7 @@
          </widget>
         </item>
         <item row="3" column="0" colspan="2">
-         <widget class="QLabel" name="label_28">
+         <widget class="QLabel" name="labelWavelengthSpread">
           <property name="minimumSize">
            <size>
             <width>134</width>
@@ -324,7 +324,7 @@
          </widget>
         </item>
         <item row="4" column="0" colspan="2">
-         <widget class="QLabel" name="label_29">
+         <widget class="QLabel" name="labelSourceApertureSize">
           <property name="minimumSize">
            <size>
             <width>143</width>
@@ -368,7 +368,7 @@
          </widget>
         </item>
         <item row="4" column="4">
-         <widget class="QLabel" name="label_39">
+         <widget class="QLabel" name="labelSourceApertureSizeUnit">
           <property name="minimumSize">
            <size>
             <width>22</width>
@@ -384,7 +384,7 @@
          </widget>
         </item>
         <item row="5" column="0" colspan="2">
-         <widget class="QLabel" name="label_30">
+         <widget class="QLabel" name="labelSampleApertureSize">
           <property name="minimumSize">
            <size>
             <width>147</width>
@@ -428,7 +428,7 @@
          </widget>
         </item>
         <item row="5" column="4">
-         <widget class="QLabel" name="label_40">
+         <widget class="QLabel" name="labelSampleApertureSizeUnit">
           <property name="sizePolicy">
            <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
             <horstretch>0</horstretch>
@@ -447,7 +447,7 @@
          </widget>
         </item>
         <item row="6" column="0" colspan="3">
-         <widget class="QLabel" name="label_31">
+         <widget class="QLabel" name="labelSourceSampleApertureDistance">
           <property name="minimumSize">
            <size>
             <width>220</width>
@@ -491,7 +491,7 @@
          </widget>
         </item>
         <item row="6" column="4">
-         <widget class="QLabel" name="label_41">
+         <widget class="QLabel" name="labelSourceSampleApertureDistanceUnit">
           <property name="minimumSize">
            <size>
             <width>22</width>
@@ -504,7 +504,7 @@
          </widget>
         </item>
         <item row="7" column="0" colspan="3">
-         <widget class="QLabel" name="label_32">
+         <widget class="QLabel" name="labelSampleApertureDetectorDistance">
           <property name="minimumSize">
            <size>
             <width>225</width>
@@ -539,7 +539,7 @@
          </widget>
         </item>
         <item row="7" column="4">
-         <widget class="QLabel" name="label_42">
+         <widget class="QLabel" name="labelSampleApertureDetectorDistanceUnit">
           <property name="minimumSize">
            <size>
             <width>22</width>
@@ -552,7 +552,7 @@
          </widget>
         </item>
         <item row="8" column="0" colspan="2">
-         <widget class="QLabel" name="label_33">
+         <widget class="QLabel" name="labelSampleOffset">
           <property name="minimumSize">
            <size>
             <width>100</width>
@@ -587,7 +587,7 @@
          </widget>
         </item>
         <item row="8" column="4">
-         <widget class="QLabel" name="label_43">
+         <widget class="QLabel" name="labelSampleOffsetUnit">
           <property name="minimumSize">
            <size>
             <width>22</width>
@@ -600,7 +600,7 @@
          </widget>
         </item>
         <item row="9" column="0" colspan="3">
-         <widget class="QLabel" name="label_34">
+         <widget class="QLabel" name="labelPixelNumberDetector">
           <property name="minimumSize">
            <size>
             <width>175</width>
@@ -635,7 +635,7 @@
          </widget>
         </item>
         <item row="10" column="0" colspan="2">
-         <widget class="QLabel" name="label_35">
+         <widget class="QLabel" name="labelDetectorPixelSize">
           <property name="minimumSize">
            <size>
             <width>129</width>
@@ -670,7 +670,7 @@
          </widget>
         </item>
         <item row="10" column="4">
-         <widget class="QLabel" name="label_45">
+         <widget class="QLabel" name="labelDetectorPixelSizeUnit">
           <property name="minimumSize">
            <size>
             <width>22</width>
@@ -753,7 +753,7 @@
       <item row="0" column="0">
        <layout class="QGridLayout" name="gridLayout">
         <item row="0" column="0">
-         <widget class="QLabel" name="label_21">
+         <widget class="QLabel" name="labelQx">
           <property name="minimumSize">
            <size>
             <width>21</width>
@@ -801,7 +801,7 @@
          </widget>
         </item>
         <item row="1" column="0">
-         <widget class="QLabel" name="label_22">
+         <widget class="QLabel" name="labelQy">
           <property name="minimumSize">
            <size>
             <width>21</width>
@@ -943,7 +943,7 @@
          </widget>
         </item>
         <item row="1" column="0">
-         <widget class="QLabel" name="label_2">
+         <widget class="QLabel" name="labelSigma_lamd">
           <property name="minimumSize">
            <size>
             <width>87</width>
@@ -1044,7 +1044,7 @@
          </widget>
         </item>
         <item row="1" column="4">
-         <widget class="QLabel" name="label_6">
+         <widget class="QLabel" name="label1DSigma">
           <property name="minimumSize">
            <size>
             <width>87</width>
@@ -1063,7 +1063,7 @@
          </widget>
         </item>
         <item row="0" column="4">
-         <widget class="QLabel" name="label_5">
+         <widget class="QLabel" name="labelSigma_y">
           <property name="minimumSize">
            <size>
             <width>87</width>
@@ -1108,7 +1108,7 @@
          </widget>
         </item>
         <item row="0" column="0">
-         <widget class="QLabel" name="label">
+         <widget class="QLabel" name="labelSigma_x">
           <property name="minimumSize">
            <size>
             <width>87</width>

--- a/src/sas/qtgui/Calculators/UI/SldPanel.ui
+++ b/src/sas/qtgui/Calculators/UI/SldPanel.ui
@@ -44,7 +44,7 @@
      </property>
      <layout class="QGridLayout" name="gridLayoutOutput">
       <item row="0" column="1">
-       <widget class="QLineEdit" name="editNeutronSldReal">
+       <widget class="QLineEdit" name="txtEditNeutronSldReal">
         <property name="enabled">
          <bool>true</bool>
         </property>
@@ -54,21 +54,21 @@
        </widget>
       </item>
       <item row="0" column="0">
-       <widget class="QLabel" name="labelNeutronSLD">
+       <widget class="QLabel" name="lblNeutronSLD">
         <property name="text">
          <string>Neutron SLD</string>
         </property>
        </widget>
       </item>
       <item row="5" column="0">
-       <widget class="QLabel" name="labelNeutron1eLength">
+       <widget class="QLabel" name="lblNeutron1eLength">
         <property name="text">
          <string>Neutron 1/e length</string>
         </property>
        </widget>
       </item>
       <item row="3" column="1">
-       <widget class="QLineEdit" name="editNeutronIncXs">
+       <widget class="QLineEdit" name="txtEditNeutronIncXs">
         <property name="enabled">
          <bool>true</bool>
         </property>
@@ -78,28 +78,28 @@
        </widget>
       </item>
       <item row="3" column="0">
-       <widget class="QLabel" name="labelNeutronIncXs">
+       <widget class="QLabel" name="lblNeutronIncXs">
         <property name="text">
          <string>Neutron Inc. Xs</string>
         </property>
        </widget>
       </item>
       <item row="0" column="2">
-       <widget class="QLabel" name="label_i_NeutronSLD">
+       <widget class="QLabel" name="lbl_i_NeutronSLD">
         <property name="text">
          <string>-i</string>
         </property>
        </widget>
       </item>
       <item row="1" column="2">
-       <widget class="QLabel" name="label_i_XRaySLD">
+       <widget class="QLabel" name="lbl_i_XRaySLD">
         <property name="text">
          <string>-i</string>
         </property>
        </widget>
       </item>
       <item row="0" column="3">
-       <widget class="QLineEdit" name="editNeutronSldImag">
+       <widget class="QLineEdit" name="txtEditNeutronSldImag">
         <property name="enabled">
          <bool>true</bool>
         </property>
@@ -109,14 +109,14 @@
        </widget>
       </item>
       <item row="5" column="2" colspan="2">
-       <widget class="QLabel" name="labelNeutron1eLengthUnit">
+       <widget class="QLabel" name="lblNeutron1eLengthUnit">
         <property name="text">
          <string>cm</string>
         </property>
        </widget>
       </item>
       <item row="5" column="1">
-       <widget class="QLineEdit" name="editNeutronLength">
+       <widget class="QLineEdit" name="txtEditNeutronLength">
         <property name="enabled">
          <bool>true</bool>
         </property>
@@ -126,14 +126,14 @@
        </widget>
       </item>
       <item row="4" column="2" colspan="2">
-       <widget class="QLabel" name="labelNeutronAbsXsUnit">
+       <widget class="QLabel" name="lblNeutronAbsXsUnit">
         <property name="text">
          <string>1/cm</string>
         </property>
        </widget>
       </item>
       <item row="4" column="1">
-       <widget class="QLineEdit" name="editNeutronAbsXs">
+       <widget class="QLineEdit" name="txtEditNeutronAbsXs">
         <property name="enabled">
          <bool>true</bool>
         </property>
@@ -143,35 +143,35 @@
        </widget>
       </item>
       <item row="4" column="0">
-       <widget class="QLabel" name="labelNeutronAbsXs">
+       <widget class="QLabel" name="lblNeutronAbsXs">
         <property name="text">
          <string>Neutron Abs. Xs</string>
         </property>
        </widget>
       </item>
       <item row="3" column="2" colspan="2">
-       <widget class="QLabel" name="labelNeutronIncXsUnit">
+       <widget class="QLabel" name="lblNeutronIncXsUnit">
         <property name="text">
          <string>1/cm</string>
         </property>
        </widget>
       </item>
       <item row="1" column="4">
-       <widget class="QLabel" name="labelXRaySLDUnit">
+       <widget class="QLabel" name="lblXRaySLDUnit">
         <property name="text">
          <string>1/Å²</string>
         </property>
        </widget>
       </item>
       <item row="1" column="0">
-       <widget class="QLabel" name="labelXRaySLD">
+       <widget class="QLabel" name="lblXRaySLD">
         <property name="text">
          <string>X-Ray SLD</string>
         </property>
        </widget>
       </item>
       <item row="0" column="4">
-       <widget class="QLabel" name="labelNeutronSLDUnit">
+       <widget class="QLabel" name="lblNeutronSLDUnit">
         <property name="text">
          <string>1/Å²</string>
         </property>
@@ -200,7 +200,7 @@
        </widget>
       </item>
       <item row="1" column="1">
-       <widget class="QLineEdit" name="editXraySldReal">
+       <widget class="QLineEdit" name="txtEditXraySldReal">
         <property name="enabled">
          <bool>true</bool>
         </property>
@@ -210,7 +210,7 @@
        </widget>
       </item>
       <item row="1" column="3">
-       <widget class="QLineEdit" name="editXraySldImag">
+       <widget class="QLineEdit" name="txtEditXraySldImag">
         <property name="enabled">
          <bool>true</bool>
         </property>
@@ -229,55 +229,55 @@
      </property>
      <layout class="QGridLayout" name="gridLayoutInput">
       <item row="1" column="0">
-       <widget class="QLabel" name="labelMassDensity">
+       <widget class="QLabel" name="lblMassDensity">
         <property name="text">
          <string>Mass Density</string>
         </property>
        </widget>
       </item>
       <item row="1" column="2">
-       <widget class="QLabel" name="labelUnitMassDensity">
+       <widget class="QLabel" name="lblUnitMassDensity">
         <property name="text">
          <string>g/cm³</string>
         </property>
        </widget>
       </item>
       <item row="0" column="2">
-       <widget class="QLabel" name="labelExampleMolecularFormula">
+       <widget class="QLabel" name="lblExampleMolecularFormula">
         <property name="text">
          <string>e.g. H2O</string>
         </property>
        </widget>
       </item>
       <item row="0" column="1">
-       <widget class="QLineEdit" name="editMolecularFormula"/>
+       <widget class="QLineEdit" name="txtEditMolecularFormula"/>
       </item>
       <item row="1" column="1">
-       <widget class="QLineEdit" name="editMassDensity"/>
+       <widget class="QLineEdit" name="txtEditMassDensity"/>
       </item>
       <item row="2" column="2">
-       <widget class="QLabel" name="labelUnitNeutronWavelength">
+       <widget class="QLabel" name="lblUnitNeutronWavelength">
         <property name="text">
          <string>Å</string>
         </property>
        </widget>
       </item>
       <item row="0" column="0">
-       <widget class="QLabel" name="labelMolecularFormula">
+       <widget class="QLabel" name="lblMolecularFormula">
         <property name="text">
          <string>Molecular Formula</string>
         </property>
        </widget>
       </item>
       <item row="2" column="0">
-       <widget class="QLabel" name="labelNeutronWavelength">
+       <widget class="QLabel" name="lblNeutronWavelength">
         <property name="text">
          <string>Neutron Wavelength</string>
         </property>
        </widget>
       </item>
       <item row="2" column="1">
-       <widget class="QLineEdit" name="editNeutronWavelength">
+       <widget class="QLineEdit" name="txtEditNeutronWavelength">
         <property name="styleSheet">
          <string notr="true"/>
         </property>
@@ -287,17 +287,17 @@
        </widget>
       </item>
       <item row="3" column="1">
-       <widget class="QLineEdit" name="editXrayWavelength"/>
+       <widget class="QLineEdit" name="txtEditXrayWavelength"/>
       </item>
       <item row="3" column="0">
-       <widget class="QLabel" name="labelXRayWavelength">
+       <widget class="QLabel" name="lblXRayWavelength">
         <property name="text">
          <string>X-Ray Wavelength</string>
         </property>
        </widget>
       </item>
       <item row="3" column="2">
-       <widget class="QLabel" name="labelUnitXRayWavelength">
+       <widget class="QLabel" name="lblUnitXRayWavelength">
         <property name="text">
          <string>Å</string>
         </property>
@@ -322,7 +322,7 @@
      </property>
      <layout class="QGridLayout" name="gridLayout">
       <item row="0" column="0">
-       <widget class="QPushButton" name="recalculateButton">
+       <widget class="QPushButton" name="cmdRecalculate">
         <property name="enabled">
          <bool>true</bool>
         </property>
@@ -354,7 +354,7 @@
        </spacer>
       </item>
       <item row="0" column="2">
-       <widget class="QPushButton" name="closeButton">
+       <widget class="QPushButton" name="cmdClose">
         <property name="minimumSize">
          <size>
           <width>0</width>
@@ -367,7 +367,7 @@
        </widget>
       </item>
       <item row="0" column="3">
-       <widget class="QPushButton" name="helpButton">
+       <widget class="QPushButton" name="cmdHelp">
         <property name="minimumSize">
          <size>
           <width>0</width>
@@ -385,20 +385,20 @@
   </layout>
  </widget>
  <tabstops>
-  <tabstop>editMolecularFormula</tabstop>
-  <tabstop>editMassDensity</tabstop>
-  <tabstop>editNeutronWavelength</tabstop>
-  <tabstop>editXrayWavelength</tabstop>
-  <tabstop>editNeutronSldReal</tabstop>
-  <tabstop>editNeutronSldImag</tabstop>
-  <tabstop>editXraySldReal</tabstop>
-  <tabstop>editXraySldImag</tabstop>
-  <tabstop>editNeutronIncXs</tabstop>
-  <tabstop>editNeutronAbsXs</tabstop>
-  <tabstop>editNeutronLength</tabstop>
-  <tabstop>closeButton</tabstop>
-  <tabstop>helpButton</tabstop>
-  <tabstop>recalculateButton</tabstop>
+  <tabstop>txtEditMolecularFormula</tabstop>
+  <tabstop>txtEditMassDensity</tabstop>
+  <tabstop>txtEditNeutronWavelength</tabstop>
+  <tabstop>txtEditXrayWavelength</tabstop>
+  <tabstop>txtEditNeutronSldReal</tabstop>
+  <tabstop>txtEditNeutronSldImag</tabstop>
+  <tabstop>txtEditXraySldReal</tabstop>
+  <tabstop>txtEditXraySldImag</tabstop>
+  <tabstop>txtEditNeutronIncXs</tabstop>
+  <tabstop>txtEditNeutronAbsXs</tabstop>
+  <tabstop>txtEditNeutronLength</tabstop>
+  <tabstop>cmdClose</tabstop>
+  <tabstop>cmdHelp</tabstop>
+  <tabstop>cmdRecalculate</tabstop>
  </tabstops>
  <resources/>
  <connections/>

--- a/src/sas/qtgui/Calculators/UI/SldPanel.ui
+++ b/src/sas/qtgui/Calculators/UI/SldPanel.ui
@@ -54,14 +54,14 @@
        </widget>
       </item>
       <item row="0" column="0">
-       <widget class="QLabel" name="label_17">
+       <widget class="QLabel" name="labelNeutronSLD">
         <property name="text">
          <string>Neutron SLD</string>
         </property>
        </widget>
       </item>
       <item row="5" column="0">
-       <widget class="QLabel" name="label_3">
+       <widget class="QLabel" name="labelNeutron1eLength">
         <property name="text">
          <string>Neutron 1/e length</string>
         </property>
@@ -78,21 +78,21 @@
        </widget>
       </item>
       <item row="3" column="0">
-       <widget class="QLabel" name="label_21">
+       <widget class="QLabel" name="labelNeutronIncXs">
         <property name="text">
          <string>Neutron Inc. Xs</string>
         </property>
        </widget>
       </item>
       <item row="0" column="2">
-       <widget class="QLabel" name="label_18">
+       <widget class="QLabel" name="label_i_NeutronSLD">
         <property name="text">
          <string>-i</string>
         </property>
        </widget>
       </item>
       <item row="1" column="2">
-       <widget class="QLabel" name="label_20">
+       <widget class="QLabel" name="label_i_XRaySLD">
         <property name="text">
          <string>-i</string>
         </property>
@@ -109,7 +109,7 @@
        </widget>
       </item>
       <item row="5" column="2" colspan="2">
-       <widget class="QLabel" name="label_4">
+       <widget class="QLabel" name="labelNeutron1eLengthUnit">
         <property name="text">
          <string>cm</string>
         </property>
@@ -126,7 +126,7 @@
        </widget>
       </item>
       <item row="4" column="2" colspan="2">
-       <widget class="QLabel" name="label_24">
+       <widget class="QLabel" name="labelNeutronAbsXsUnit">
         <property name="text">
          <string>1/cm</string>
         </property>
@@ -143,35 +143,35 @@
        </widget>
       </item>
       <item row="4" column="0">
-       <widget class="QLabel" name="label_23">
+       <widget class="QLabel" name="labelNeutronAbsXs">
         <property name="text">
          <string>Neutron Abs. Xs</string>
         </property>
        </widget>
       </item>
       <item row="3" column="2" colspan="2">
-       <widget class="QLabel" name="label_22">
+       <widget class="QLabel" name="labelNeutronIncXsUnit">
         <property name="text">
          <string>1/cm</string>
         </property>
        </widget>
       </item>
       <item row="1" column="4">
-       <widget class="QLabel" name="label_6">
+       <widget class="QLabel" name="labelXRaySLDUnit">
         <property name="text">
          <string>1/Å²</string>
         </property>
        </widget>
       </item>
       <item row="1" column="0">
-       <widget class="QLabel" name="label_19">
+       <widget class="QLabel" name="labelXRaySLD">
         <property name="text">
          <string>X-Ray SLD</string>
         </property>
        </widget>
       </item>
       <item row="0" column="4">
-       <widget class="QLabel" name="label_5">
+       <widget class="QLabel" name="labelNeutronSLDUnit">
         <property name="text">
          <string>1/Å²</string>
         </property>
@@ -229,21 +229,21 @@
      </property>
      <layout class="QGridLayout" name="gridLayoutInput">
       <item row="1" column="0">
-       <widget class="QLabel" name="label_8">
+       <widget class="QLabel" name="labelMassDensity">
         <property name="text">
          <string>Mass Density</string>
         </property>
        </widget>
       </item>
       <item row="1" column="2">
-       <widget class="QLabel" name="label_16">
+       <widget class="QLabel" name="labelUnitMassDensity">
         <property name="text">
          <string>g/cm³</string>
         </property>
        </widget>
       </item>
       <item row="0" column="2">
-       <widget class="QLabel" name="label_10">
+       <widget class="QLabel" name="labelExampleMolecularFormula">
         <property name="text">
          <string>e.g. H2O</string>
         </property>
@@ -256,21 +256,21 @@
        <widget class="QLineEdit" name="editMassDensity"/>
       </item>
       <item row="2" column="2">
-       <widget class="QLabel" name="label_12">
+       <widget class="QLabel" name="labelUnitNeutronWavelength">
         <property name="text">
          <string>Å</string>
         </property>
        </widget>
       </item>
       <item row="0" column="0">
-       <widget class="QLabel" name="label_9">
+       <widget class="QLabel" name="labelMolecularFormula">
         <property name="text">
          <string>Molecular Formula</string>
         </property>
        </widget>
       </item>
       <item row="2" column="0">
-       <widget class="QLabel" name="label_11">
+       <widget class="QLabel" name="labelNeutronWavelength">
         <property name="text">
          <string>Neutron Wavelength</string>
         </property>
@@ -290,14 +290,14 @@
        <widget class="QLineEdit" name="editXrayWavelength"/>
       </item>
       <item row="3" column="0">
-       <widget class="QLabel" name="label_13">
+       <widget class="QLabel" name="labelXRayWavelength">
         <property name="text">
          <string>X-Ray Wavelength</string>
         </property>
        </widget>
       </item>
       <item row="3" column="2">
-       <widget class="QLabel" name="label">
+       <widget class="QLabel" name="labelUnitXRayWavelength">
         <property name="text">
          <string>Å</string>
         </property>

--- a/src/sas/qtgui/Calculators/UI/SlitSizeCalculator.ui
+++ b/src/sas/qtgui/Calculators/UI/SlitSizeCalculator.ui
@@ -30,7 +30,7 @@
       <item row="0" column="0">
        <layout class="QHBoxLayout" name="horizontalLayout">
         <item>
-         <widget class="QLabel" name="label">
+         <widget class="QLabel" name="labelData">
           <property name="text">
            <string>Data</string>
           </property>
@@ -76,7 +76,7 @@
       <item row="0" column="0">
        <layout class="QHBoxLayout" name="horizontalLayout_2">
         <item>
-         <widget class="QLabel" name="label_3">
+         <widget class="QLabel" name="labelSlitSize">
           <property name="text">
            <string>Slit Size (FWHM/2):</string>
           </property>
@@ -100,7 +100,7 @@
       <item row="0" column="1">
        <layout class="QHBoxLayout" name="horizontalLayout_3">
         <item>
-         <widget class="QLabel" name="label_2">
+         <widget class="QLabel" name="labelSlitSizeUnit">
           <property name="text">
            <string>Unit:</string>
           </property>

--- a/src/sas/qtgui/Calculators/UI/SlitSizeCalculator.ui
+++ b/src/sas/qtgui/Calculators/UI/SlitSizeCalculator.ui
@@ -30,14 +30,14 @@
       <item row="0" column="0">
        <layout class="QHBoxLayout" name="horizontalLayout">
         <item>
-         <widget class="QLabel" name="labelData">
+         <widget class="QLabel" name="lblData">
           <property name="text">
            <string>Data</string>
           </property>
          </widget>
         </item>
         <item>
-         <widget class="QLineEdit" name="data_file">
+         <widget class="QLineEdit" name="txtDataFile">
           <property name="minimumSize">
            <size>
             <width>200</width>
@@ -76,14 +76,14 @@
       <item row="0" column="0">
        <layout class="QHBoxLayout" name="horizontalLayout_2">
         <item>
-         <widget class="QLabel" name="labelSlitSize">
+         <widget class="QLabel" name="lblSlitSize">
           <property name="text">
            <string>Slit Size (FWHM/2):</string>
           </property>
          </widget>
         </item>
         <item>
-         <widget class="QLineEdit" name="slit_length_out">
+         <widget class="QLineEdit" name="txtSlitLengthOut">
           <property name="minimumSize">
            <size>
             <width>110</width>
@@ -100,14 +100,14 @@
       <item row="0" column="1">
        <layout class="QHBoxLayout" name="horizontalLayout_3">
         <item>
-         <widget class="QLabel" name="labelSlitSizeUnit">
+         <widget class="QLabel" name="lblSlitSizeUnit">
           <property name="text">
            <string>Unit:</string>
           </property>
          </widget>
         </item>
         <item>
-         <widget class="QLineEdit" name="unit_out">
+         <widget class="QLineEdit" name="txtUnitOut">
           <property name="minimumSize">
            <size>
             <width>100</width>
@@ -125,7 +125,7 @@
     </widget>
    </item>
    <item row="0" column="2">
-    <widget class="QPushButton" name="browseButton">
+    <widget class="QPushButton" name="cmdBrowse">
      <property name="toolTip">
       <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Compute the thickness or diameter.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
      </property>
@@ -135,7 +135,7 @@
     </widget>
    </item>
    <item row="4" column="2">
-    <widget class="QPushButton" name="helpButton">
+    <widget class="QPushButton" name="cmdHelp">
      <property name="toolTip">
       <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Help using the Kiessing fringe calculator.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
      </property>
@@ -158,7 +158,7 @@
     </spacer>
    </item>
    <item row="4" column="1">
-    <widget class="QPushButton" name="closeButton">
+    <widget class="QPushButton" name="cmdClose">
      <property name="toolTip">
       <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Close this window.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
      </property>
@@ -183,12 +183,12 @@
   </layout>
  </widget>
  <tabstops>
-  <tabstop>data_file</tabstop>
-  <tabstop>browseButton</tabstop>
-  <tabstop>slit_length_out</tabstop>
-  <tabstop>unit_out</tabstop>
-  <tabstop>closeButton</tabstop>
-  <tabstop>helpButton</tabstop>
+  <tabstop>txtDataFile</tabstop>
+  <tabstop>cmdBrowse</tabstop>
+  <tabstop>txtSlitLengthOut</tabstop>
+  <tabstop>txtUnitOut</tabstop>
+  <tabstop>cmdClose</tabstop>
+  <tabstop>cmdHelp</tabstop>
  </tabstops>
  <resources/>
  <connections/>

--- a/src/sas/qtgui/MainWindow/UI/AboutUI.ui
+++ b/src/sas/qtgui/MainWindow/UI/AboutUI.ui
@@ -25,7 +25,7 @@
     </widget>
    </item>
    <item row="0" column="1">
-    <widget class="QLabel" name="lbllSasView">
+    <widget class="QLabel" name="lblSasView">
      <property name="text">
       <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-size:36pt;&quot;&gt;SasView&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
      </property>

--- a/src/sas/qtgui/MainWindow/UI/AboutUI.ui
+++ b/src/sas/qtgui/MainWindow/UI/AboutUI.ui
@@ -25,7 +25,7 @@
     </widget>
    </item>
    <item row="0" column="1">
-    <widget class="QLabel" name="label_2">
+    <widget class="QLabel" name="labelSasView">
      <property name="text">
       <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-size:36pt;&quot;&gt;SasView&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
      </property>

--- a/src/sas/qtgui/MainWindow/UI/AboutUI.ui
+++ b/src/sas/qtgui/MainWindow/UI/AboutUI.ui
@@ -15,7 +15,7 @@
   </property>
   <layout class="QGridLayout" name="gridLayout_3">
    <item row="0" column="0" rowspan="2">
-    <widget class="QLabel" name="label">
+    <widget class="QLabel" name="lblEmpty">
      <property name="text">
       <string/>
      </property>
@@ -25,7 +25,7 @@
     </widget>
    </item>
    <item row="0" column="1">
-    <widget class="QLabel" name="labelSasView">
+    <widget class="QLabel" name="lbllSasView">
      <property name="text">
       <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-size:36pt;&quot;&gt;SasView&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
      </property>

--- a/src/sas/qtgui/MainWindow/UI/AcknowledgementsUI.ui
+++ b/src/sas/qtgui/MainWindow/UI/AcknowledgementsUI.ui
@@ -9,8 +9,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>468</width>
-    <height>316</height>
+    <width>482</width>
+    <height>319</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -24,7 +24,7 @@
   </property>
   <layout class="QGridLayout" name="gridLayout">
    <item row="0" column="0">
-    <widget class="QLabel" name="label">
+    <widget class="QLabel" name="lbl">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Preferred" vsizetype="MinimumExpanding">
        <horstretch>0</horstretch>
@@ -64,15 +64,18 @@
      </property>
      <property name="html">
       <string>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
-&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
+&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;meta charset=&quot;utf-8&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
-&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'MS Shell Dlg 2'; font-size:7.8pt; font-weight:400; font-style:normal;&quot;&gt;
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:8.25pt;&quot;&gt;This work benefited from the use of the SasView application, originally developed under NSF Award DMR-0520547. SasView also contains code developed with funding from the EU Horizon 2020 programme under the SINE2020 project Grant No 654000.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+hr { height: 1px; border-width: 0; }
+li.unchecked::marker { content: &quot;\2610&quot;; }
+li.checked::marker { content: &quot;\2612&quot;; }
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'Segoe UI'; font-size:9pt; font-weight:400; font-style:normal;&quot;&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:'MS Shell Dlg 2'; font-size:8.25pt;&quot;&gt;This work benefited from the use of the SasView application, originally developed under NSF Award DMR-0520547. SasView also contains code developed with funding from the EU Horizon 2020 programme under the SINE2020 project Grant No 654000.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
      </property>
     </widget>
    </item>
    <item row="2" column="0">
-    <widget class="QLabel" name="label_2">
+    <widget class="QLabel" name="lbl_2">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
        <horstretch>0</horstretch>
@@ -106,15 +109,18 @@ p, li { white-space: pre-wrap; }
      </property>
      <property name="html">
       <string>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
-&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
+&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;meta charset=&quot;utf-8&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
-&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'MS Shell Dlg 2'; font-size:7.8pt; font-weight:400; font-style:normal;&quot;&gt;
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:8.25pt;&quot;&gt;M. Doucet et al. SasView Version 5.0.3, Zenodo, 10.5281/zenodo.3930098&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+hr { height: 1px; border-width: 0; }
+li.unchecked::marker { content: &quot;\2610&quot;; }
+li.checked::marker { content: &quot;\2612&quot;; }
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'Segoe UI'; font-size:9pt; font-weight:400; font-style:normal;&quot;&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:'MS Shell Dlg 2'; font-size:8.25pt;&quot;&gt;M. Doucet et al. SasView Version 5.0.3, Zenodo, 10.5281/zenodo.3930098&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
      </property>
     </widget>
    </item>
    <item row="4" column="0">
-    <widget class="QLabel" name="label_3">
+    <widget class="QLabel" name="lbl_3">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Preferred" vsizetype="MinimumExpanding">
        <horstretch>0</horstretch>

--- a/src/sas/qtgui/MainWindow/UI/AcknowledgementsUI.ui
+++ b/src/sas/qtgui/MainWindow/UI/AcknowledgementsUI.ui
@@ -24,7 +24,7 @@
   </property>
   <layout class="QGridLayout" name="gridLayout">
    <item row="0" column="0">
-    <widget class="QLabel" name="lbl">
+    <widget class="QLabel" name="lblEnsureLongTermSupport">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Preferred" vsizetype="MinimumExpanding">
        <horstretch>0</horstretch>
@@ -75,7 +75,7 @@ li.checked::marker { content: &quot;\2612&quot;; }
     </widget>
    </item>
    <item row="2" column="0">
-    <widget class="QLabel" name="lbl_2">
+    <widget class="QLabel" name="lblReferenceSasViewAs">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
        <horstretch>0</horstretch>
@@ -120,7 +120,7 @@ li.checked::marker { content: &quot;\2612&quot;; }
     </widget>
    </item>
    <item row="4" column="0">
-    <widget class="QLabel" name="lbl_3">
+    <widget class="QLabel" name="lblReferenceTheModel">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Preferred" vsizetype="MinimumExpanding">
        <horstretch>0</horstretch>

--- a/src/sas/qtgui/MainWindow/UI/CategoryManagerUI.ui
+++ b/src/sas/qtgui/MainWindow/UI/CategoryManagerUI.ui
@@ -66,7 +66,7 @@
         <item>
          <layout class="QHBoxLayout" name="horizontalLayout_2">
           <item>
-           <widget class="QLabel" name="labelSearch">
+           <widget class="QLabel" name="lblSearch">
             <property name="text">
              <string>Search</string>
             </property>

--- a/src/sas/qtgui/MainWindow/UI/CategoryManagerUI.ui
+++ b/src/sas/qtgui/MainWindow/UI/CategoryManagerUI.ui
@@ -66,7 +66,7 @@
         <item>
          <layout class="QHBoxLayout" name="horizontalLayout_2">
           <item>
-           <widget class="QLabel" name="label">
+           <widget class="QLabel" name="labelSearch">
             <property name="text">
              <string>Search</string>
             </property>

--- a/src/sas/qtgui/MainWindow/UI/TabbedFileLoadUI.ui
+++ b/src/sas/qtgui/MainWindow/UI/TabbedFileLoadUI.ui
@@ -14,7 +14,7 @@
    <string>TabWidget</string>
   </property>
   <property name="windowIcon">
-   <iconset>
+   <iconset resource="../../UI/main_resources.qrc">
     <normaloff>:/res/ball.ico</normaloff>:/res/ball.ico</iconset>
   </property>
   <property name="currentIndex">

--- a/src/sas/qtgui/MainWindow/UI/TabbedFileLoadUI.ui
+++ b/src/sas/qtgui/MainWindow/UI/TabbedFileLoadUI.ui
@@ -14,7 +14,7 @@
    <string>TabWidget</string>
   </property>
   <property name="windowIcon">
-   <iconset resource="../../UI/main_resources.qrc">
+   <iconset>
     <normaloff>:/res/ball.ico</normaloff>:/res/ball.ico</iconset>
   </property>
   <property name="currentIndex">

--- a/src/sas/qtgui/Perspectives/Corfunc/CorfuncPerspective.py
+++ b/src/sas/qtgui/Perspectives/Corfunc/CorfuncPerspective.py
@@ -134,9 +134,9 @@ class CorfuncWindow(QtWidgets.QDialog, Ui_CorfuncDialog, Perspective):
             show_warning = False
 
         if show_warning:
-            self.textBackground.setStyleSheet("QLineEdit { background-color: rgb(255,255,0) }")
+            self.txtBackground.setStyleSheet("QLineEdit { background-color: rgb(255,255,0) }")
         else:
-            self.textBackground.setStyleSheet("")
+            self.txtBackground.setStyleSheet("")
 
     def isSerializable(self):
         """
@@ -147,16 +147,16 @@ class CorfuncWindow(QtWidgets.QDialog, Ui_CorfuncDialog, Perspective):
     def setup_slots(self):
         """Connect the buttons to their appropriate slots."""
 
-        self.buttonGo.clicked.connect(self._run)
-        self.buttonGo.setEnabled(False)
+        self.cmdGo.clicked.connect(self._run)
+        self.cmdGo.setEnabled(False)
 
-        self.buttonExportTransformed.clicked.connect(self.on_save_transformed)
-        self.buttonExportTransformed.setEnabled(False)
+        self.cmdExportTransformed.clicked.connect(self.on_save_transformed)
+        self.cmdExportTransformed.setEnabled(False)
 
-        self.buttonExportExtrapolated.clicked.connect(self.on_save_extrapolation)
-        self.buttonExportExtrapolated.setEnabled(False)
+        self.cmdExportExtrapolated.clicked.connect(self.on_save_extrapolation)
+        self.cmdExportExtrapolated.setEnabled(False)
 
-        self.buttonHelp.clicked.connect(self.showHelp)
+        self.cmdHelp.clicked.connect(self.showHelp)
 
         self.model.itemChanged.connect(self.model_changed)
 
@@ -169,24 +169,24 @@ class CorfuncWindow(QtWidgets.QDialog, Ui_CorfuncDialog, Perspective):
         self.set_text_enable(False)
 
         # Calculation Options
-        self.radTangentAuto.clicked.connect(self.set_tangent_method(None))
-        self.radTangentInflection.clicked.connect(self.set_tangent_method(TangentMethod.INFLECTION))
-        self.radTangentMidpoint.clicked.connect(self.set_tangent_method(TangentMethod.HALF_MIN))
+        self.rbTangentAuto.clicked.connect(self.set_tangent_method(None))
+        self.rbTangentInflection.clicked.connect(self.set_tangent_method(TangentMethod.INFLECTION))
+        self.rbTangentMidpoint.clicked.connect(self.set_tangent_method(TangentMethod.HALF_MIN))
 
-        self.radLongPeriodAuto.clicked.connect(self.set_long_period_method(None))
-        self.radLongPeriodMax.clicked.connect(self.set_long_period_method(LongPeriodMethod.MAX))
-        self.radLongPeriodDouble.clicked.connect(self.set_long_period_method(LongPeriodMethod.DOUBLE_MIN))
+        self.rbLongPeriodAuto.clicked.connect(self.set_long_period_method(None))
+        self.rbLongPeriodMax.clicked.connect(self.set_long_period_method(LongPeriodMethod.MAX))
+        self.rbLongPeriodDouble.clicked.connect(self.set_long_period_method(LongPeriodMethod.DOUBLE_MIN))
 
         # Slider values
         self.slider.valueEdited.connect(self.on_extrapolation_slider_changed)
         self.slider.valueEditing.connect(self.on_extrapolation_slider_changing)
 
         # Validators for other text fields
-        self.textBackground.setValidator(QDoubleValidator())
-        self.textGuinierA.setValidator(QDoubleValidator())
-        self.textGuinierB.setValidator(QDoubleValidator())
-        self.textPorodK.setValidator(QDoubleValidator())
-        self.textPorodSigma.setValidator(QDoubleValidator())
+        self.txtBackground.setValidator(QDoubleValidator())
+        self.txtGuinierA.setValidator(QDoubleValidator())
+        self.txtGuinierB.setValidator(QDoubleValidator())
+        self.txtPorodK.setValidator(QDoubleValidator())
+        self.txtPorodSigma.setValidator(QDoubleValidator())
 
     def set_text_enable(self, state: bool):
         self.txtLowerQMax.setEnabled(state)
@@ -285,8 +285,8 @@ class CorfuncWindow(QtWidgets.QDialog, Ui_CorfuncDialog, Perspective):
             return
 
         self._running = True
-        self.buttonGo.setText("Calculating...")
-        self.buttonGo.repaint()
+        self.cmdGo.setText("Calculating...")
+        self.cmdGo.repaint()
 
         # Set up calculator
 
@@ -296,23 +296,23 @@ class CorfuncWindow(QtWidgets.QDialog, Ui_CorfuncDialog, Perspective):
             tangent_method=self._tangent_method,
             long_period_method=self._long_period_method)
 
-        calculator.fit_background = self.checkboxFitBackground.isChecked()
-        calculator.fit_guinier = self.checkboxFitGuinier.isChecked()
-        calculator.fit_porod = self.checkboxFitPorod.isChecked()
+        calculator.fit_background = self.chkFitBackground.isChecked()
+        calculator.fit_guinier = self.chkFitGuinier.isChecked()
+        calculator.fit_porod = self.chkFitPorod.isChecked()
 
 
         if not calculator.fit_background:
-            calculator.background = safe_float(self.textBackground.text())
+            calculator.background = safe_float(self.txtBackground.text())
 
         if not calculator.fit_guinier:
-            guinier = GuinierData(A=safe_float(self.textGuinierA.text()),
-                                  B=safe_float(self.textGuinierB.text()))
+            guinier = GuinierData(A=safe_float(self.txtGuinierA.text()),
+                                  B=safe_float(self.txtGuinierB.text()))
 
             calculator.guinier = guinier
 
         if not calculator.fit_porod:
-            porod = PorodData(K=safe_float(self.textPorodK.text()),
-                              sigma=safe_float(self.textPorodSigma.text()))
+            porod = PorodData(K=safe_float(self.txtPorodK.text()),
+                              sigma=safe_float(self.txtPorodSigma.text()))
 
             calculator.porod = porod
 
@@ -370,17 +370,17 @@ class CorfuncWindow(QtWidgets.QDialog, Ui_CorfuncDialog, Perspective):
                 self.model.setItem(WIDGETS.W_POLY_STRIBECK, QtGui.QStandardItem("{:.3g}".format(lamellar.polydispersity_stribeck)))
                 self.model.setItem(WIDGETS.W_PERIOD, QtGui.QStandardItem("{:.3g}".format(lamellar.long_period)))
 
-            self.buttonExportTransformed.setEnabled(True)
-            self.buttonExportExtrapolated.setEnabled(True)
+            self.cmdExportTransformed.setEnabled(True)
+            self.cmdExportExtrapolated.setEnabled(True)
 
         except ValueError as e:
             logging.error(repr(e))
-            self.buttonExportTransformed.setEnabled(False)
-            self.buttonExportExtrapolated.setEnabled(False)
+            self.cmdExportTransformed.setEnabled(False)
+            self.cmdExportExtrapolated.setEnabled(False)
             self.set_background_warning()
 
-        self.buttonGo.setText("Go")
-        self.buttonGo.repaint()
+        self.cmdGo.setText("Go")
+        self.cmdGo.repaint()
 
         self._running = False
 
@@ -394,24 +394,24 @@ class CorfuncWindow(QtWidgets.QDialog, Ui_CorfuncDialog, Perspective):
         self.mapper.addMapping(self.txtLowerQMax, WIDGETS.W_QMIN)
         self.mapper.addMapping(self.txtUpperQMin, WIDGETS.W_QMAX)
         self.mapper.addMapping(self.txtUpperQMax, WIDGETS.W_QCUTOFF)
-        self.mapper.addMapping(self.textBackground, WIDGETS.W_BACKGROUND)
+        self.mapper.addMapping(self.txtBackground, WIDGETS.W_BACKGROUND)
         #self.mapper.addMapping(self.transformCombo, W.W_TRANSFORM)
 
-        self.mapper.addMapping(self.textGuinierA, WIDGETS.W_GUINIERA)
-        self.mapper.addMapping(self.textGuinierB, WIDGETS.W_GUINIERB)
-        self.mapper.addMapping(self.textPorodK, WIDGETS.W_PORODK)
-        self.mapper.addMapping(self.textPorodSigma, WIDGETS.W_PORODSIGMA)
+        self.mapper.addMapping(self.txtGuinierA, WIDGETS.W_GUINIERA)
+        self.mapper.addMapping(self.txtGuinierB, WIDGETS.W_GUINIERB)
+        self.mapper.addMapping(self.txtPorodK, WIDGETS.W_PORODK)
+        self.mapper.addMapping(self.txtPorodSigma, WIDGETS.W_PORODSIGMA)
 
-        self.mapper.addMapping(self.textAvgCoreThick, WIDGETS.W_CORETHICK)
-        self.mapper.addMapping(self.textAvgIntThick, WIDGETS.W_INTTHICK)
-        self.mapper.addMapping(self.textAvgHardBlock, WIDGETS.W_HARDBLOCK)
-        self.mapper.addMapping(self.textAvgSoftBlock, WIDGETS.W_SOFTBLOCK)
-        self.mapper.addMapping(self.textPolyRyan, WIDGETS.W_POLY_RYAN)
-        self.mapper.addMapping(self.textPolyStribeck, WIDGETS.W_POLY_STRIBECK)
+        self.mapper.addMapping(self.txtAvgCoreThick, WIDGETS.W_CORETHICK)
+        self.mapper.addMapping(self.txtAvgIntThick, WIDGETS.W_INTTHICK)
+        self.mapper.addMapping(self.txtAvgHardBlock, WIDGETS.W_HARDBLOCK)
+        self.mapper.addMapping(self.txtAvgSoftBlock, WIDGETS.W_SOFTBLOCK)
+        self.mapper.addMapping(self.txtPolyRyan, WIDGETS.W_POLY_RYAN)
+        self.mapper.addMapping(self.txtPolyStribeck, WIDGETS.W_POLY_STRIBECK)
         self.mapper.addMapping(self.txtLongPeriod, WIDGETS.W_PERIOD)
         self.mapper.addMapping(self.txtLocalCrystal, WIDGETS.W_CRYSTAL)
 
-        self.mapper.addMapping(self.textFilename, WIDGETS.W_FILENAME)
+        self.mapper.addMapping(self.txtFilename, WIDGETS.W_FILENAME)
 
         self.mapper.toFirst()
 
@@ -492,7 +492,7 @@ class CorfuncWindow(QtWidgets.QDialog, Ui_CorfuncDialog, Perspective):
         log_data_min = math.log(min(self.data.x))
         log_data_max = math.log(max(self.data.x))
 
-        self.buttonGo.setEnabled(True)
+        self.cmdGo.setEnabled(True)
 
         def fractional_position(f):
             return math.exp(f*log_data_max + (1-f)*log_data_min)
@@ -735,22 +735,22 @@ class CorfuncWindow(QtWidgets.QDialog, Ui_CorfuncDialog, Perspective):
         :return: {name: value}
         """
         return {
-            'guinier_a': self.textGuinierA.text(),
-            'guinier_b': self.textGuinierB.text(),
-            'porod_k': self.textPorodK.text(),
-            'porod_sigma': self.textPorodSigma.text(),
-            'avg_core_thick': self.textAvgCoreThick.text(),
-            'avg_inter_thick': self.textAvgIntThick.text(),
-            'avg_hard_block_thick': self.textAvgHardBlock.text(),
-            'avg_soft_block_thick': self.textAvgSoftBlock.text(),
+            'guinier_a': self.txtGuinierA.text(),
+            'guinier_b': self.txtGuinierB.text(),
+            'porod_k': self.txtPorodK.text(),
+            'porod_sigma': self.txtPorodSigma.text(),
+            'avg_core_thick': self.txtAvgCoreThick.text(),
+            'avg_inter_thick': self.txtAvgIntThick.text(),
+            'avg_hard_block_thick': self.txtAvgHardBlock.text(),
+            'avg_soft_block_thick': self.txtAvgSoftBlock.text(),
             'local_crystalinity': self.txtLocalCrystal.text(),
-            'polydispersity': self.textPolyRyan.text(),
-            'polydispersity_stribeck': self.textPolyStribeck.text(),
+            'polydispersity': self.txtPolyRyan.text(),
+            'polydispersity_stribeck': self.txtPolyStribeck.text(),
             'long_period': self.txtLongPeriod.text(),
             'lower_q_max': self.txtLowerQMax.text(),
             'upper_q_min': self.txtUpperQMin.text(),
             'upper_q_max': self.txtUpperQMax.text(),
-            'background': self.textBackground.text(),
+            'background': self.txtBackground.text(),
         }
 
     def updateFromParameters(self, params):
@@ -803,8 +803,8 @@ class CorfuncWindow(QtWidgets.QDialog, Ui_CorfuncDialog, Perspective):
             params.get('background', '0')))
         # reconnect model
         self.model.itemChanged.connect(self.model_changed)
-        self.buttonExportTransformed.setEnabled(params.get('guinier_a', '0.0') != '0.0')
-        self.buttonGo.setEnabled(params.get('long_period', '0') != '0')
+        self.cmdExportTransformed.setEnabled(params.get('guinier_a', '0.0') != '0.0')
+        self.cmdGo.setEnabled(params.get('long_period', '0') != '0')
 
     @property
     def real_space_figure(self):

--- a/src/sas/qtgui/Perspectives/Corfunc/CorfuncPerspective.py
+++ b/src/sas/qtgui/Perspectives/Corfunc/CorfuncPerspective.py
@@ -107,7 +107,7 @@ class CorfuncWindow(QtWidgets.QDialog, Ui_CorfuncDialog, Perspective):
         # Things to make the corfunc panel behave
         self.horizontalLayout_3.setStretch(0, 0)
         self.horizontalLayout_3.setStretch(1, 1)
-        self.scrollArea.setFixedWidth(600)
+        self.scrollAreaCorfunc.setFixedWidth(600)
         self.adjustSize()
 
         # Connect buttons to slots.
@@ -134,9 +134,9 @@ class CorfuncWindow(QtWidgets.QDialog, Ui_CorfuncDialog, Perspective):
             show_warning = False
 
         if show_warning:
-            self.txtBackground.setStyleSheet("QLineEdit { background-color: rgb(255,255,0) }")
+            self.textBackground.setStyleSheet("QLineEdit { background-color: rgb(255,255,0) }")
         else:
-            self.txtBackground.setStyleSheet("")
+            self.textBackground.setStyleSheet("")
 
     def isSerializable(self):
         """
@@ -147,16 +147,16 @@ class CorfuncWindow(QtWidgets.QDialog, Ui_CorfuncDialog, Perspective):
     def setup_slots(self):
         """Connect the buttons to their appropriate slots."""
 
-        self.cmdExtract.clicked.connect(self._run)
-        self.cmdExtract.setEnabled(False)
+        self.buttonGo.clicked.connect(self._run)
+        self.buttonGo.setEnabled(False)
 
-        self.cmdSave.clicked.connect(self.on_save_transformed)
-        self.cmdSave.setEnabled(False)
+        self.buttonExportTransformed.clicked.connect(self.on_save_transformed)
+        self.buttonExportTransformed.setEnabled(False)
 
-        self.cmdSaveExtrapolation.clicked.connect(self.on_save_extrapolation)
-        self.cmdSaveExtrapolation.setEnabled(False)
+        self.buttonExportExtrapolated.clicked.connect(self.on_save_extrapolation)
+        self.buttonExportExtrapolated.setEnabled(False)
 
-        self.cmdHelp.clicked.connect(self.showHelp)
+        self.buttonHelp.clicked.connect(self.showHelp)
 
         self.model.itemChanged.connect(self.model_changed)
 
@@ -182,11 +182,11 @@ class CorfuncWindow(QtWidgets.QDialog, Ui_CorfuncDialog, Perspective):
         self.slider.valueEditing.connect(self.on_extrapolation_slider_changing)
 
         # Validators for other text fields
-        self.txtBackground.setValidator(QDoubleValidator())
-        self.txtGuinierA.setValidator(QDoubleValidator())
-        self.txtGuinierB.setValidator(QDoubleValidator())
-        self.txtPorodK.setValidator(QDoubleValidator())
-        self.txtPorodSigma.setValidator(QDoubleValidator())
+        self.textBackground.setValidator(QDoubleValidator())
+        self.textGuinierA.setValidator(QDoubleValidator())
+        self.textGuinierB.setValidator(QDoubleValidator())
+        self.textPorodK.setValidator(QDoubleValidator())
+        self.textPorodSigma.setValidator(QDoubleValidator())
 
     def set_text_enable(self, state: bool):
         self.txtLowerQMax.setEnabled(state)
@@ -285,8 +285,8 @@ class CorfuncWindow(QtWidgets.QDialog, Ui_CorfuncDialog, Perspective):
             return
 
         self._running = True
-        self.cmdExtract.setText("Calculating...")
-        self.cmdExtract.repaint()
+        self.buttonGo.setText("Calculating...")
+        self.buttonGo.repaint()
 
         # Set up calculator
 
@@ -296,23 +296,23 @@ class CorfuncWindow(QtWidgets.QDialog, Ui_CorfuncDialog, Perspective):
             tangent_method=self._tangent_method,
             long_period_method=self._long_period_method)
 
-        calculator.fit_background = self.fitBackground.isChecked()
-        calculator.fit_guinier = self.fitGuinier.isChecked()
-        calculator.fit_porod = self.fitPorod.isChecked()
+        calculator.fit_background = self.checkboxFitBackground.isChecked()
+        calculator.fit_guinier = self.checkboxFitGuinier.isChecked()
+        calculator.fit_porod = self.checkboxFitPorod.isChecked()
 
 
         if not calculator.fit_background:
-            calculator.background = safe_float(self.txtBackground.text())
+            calculator.background = safe_float(self.textBackground.text())
 
         if not calculator.fit_guinier:
-            guinier = GuinierData(A=safe_float(self.txtGuinierA.text()),
-                                  B=safe_float(self.txtGuinierB.text()))
+            guinier = GuinierData(A=safe_float(self.textGuinierA.text()),
+                                  B=safe_float(self.textGuinierB.text()))
 
             calculator.guinier = guinier
 
         if not calculator.fit_porod:
-            porod = PorodData(K=safe_float(self.txtPorodK.text()),
-                              sigma=safe_float(self.txtPorodSigma.text()))
+            porod = PorodData(K=safe_float(self.textPorodK.text()),
+                              sigma=safe_float(self.textPorodSigma.text()))
 
             calculator.porod = porod
 
@@ -370,17 +370,17 @@ class CorfuncWindow(QtWidgets.QDialog, Ui_CorfuncDialog, Perspective):
                 self.model.setItem(WIDGETS.W_POLY_STRIBECK, QtGui.QStandardItem("{:.3g}".format(lamellar.polydispersity_stribeck)))
                 self.model.setItem(WIDGETS.W_PERIOD, QtGui.QStandardItem("{:.3g}".format(lamellar.long_period)))
 
-            self.cmdSave.setEnabled(True)
-            self.cmdSaveExtrapolation.setEnabled(True)
+            self.buttonExportTransformed.setEnabled(True)
+            self.buttonExportExtrapolated.setEnabled(True)
 
         except ValueError as e:
             logging.error(repr(e))
-            self.cmdSave.setEnabled(False)
-            self.cmdSaveExtrapolation.setEnabled(False)
+            self.buttonExportTransformed.setEnabled(False)
+            self.buttonExportExtrapolated.setEnabled(False)
             self.set_background_warning()
 
-        self.cmdExtract.setText("Go")
-        self.cmdExtract.repaint()
+        self.buttonGo.setText("Go")
+        self.buttonGo.repaint()
 
         self._running = False
 
@@ -394,24 +394,24 @@ class CorfuncWindow(QtWidgets.QDialog, Ui_CorfuncDialog, Perspective):
         self.mapper.addMapping(self.txtLowerQMax, WIDGETS.W_QMIN)
         self.mapper.addMapping(self.txtUpperQMin, WIDGETS.W_QMAX)
         self.mapper.addMapping(self.txtUpperQMax, WIDGETS.W_QCUTOFF)
-        self.mapper.addMapping(self.txtBackground, WIDGETS.W_BACKGROUND)
+        self.mapper.addMapping(self.textBackground, WIDGETS.W_BACKGROUND)
         #self.mapper.addMapping(self.transformCombo, W.W_TRANSFORM)
 
-        self.mapper.addMapping(self.txtGuinierA, WIDGETS.W_GUINIERA)
-        self.mapper.addMapping(self.txtGuinierB, WIDGETS.W_GUINIERB)
-        self.mapper.addMapping(self.txtPorodK, WIDGETS.W_PORODK)
-        self.mapper.addMapping(self.txtPorodSigma, WIDGETS.W_PORODSIGMA)
+        self.mapper.addMapping(self.textGuinierA, WIDGETS.W_GUINIERA)
+        self.mapper.addMapping(self.textGuinierB, WIDGETS.W_GUINIERB)
+        self.mapper.addMapping(self.textPorodK, WIDGETS.W_PORODK)
+        self.mapper.addMapping(self.textPorodSigma, WIDGETS.W_PORODSIGMA)
 
-        self.mapper.addMapping(self.txtAvgCoreThick, WIDGETS.W_CORETHICK)
-        self.mapper.addMapping(self.txtAvgIntThick, WIDGETS.W_INTTHICK)
-        self.mapper.addMapping(self.txtAvgHardBlock, WIDGETS.W_HARDBLOCK)
-        self.mapper.addMapping(self.txtAvgSoftBlock, WIDGETS.W_SOFTBLOCK)
-        self.mapper.addMapping(self.txtPolyRyan, WIDGETS.W_POLY_RYAN)
-        self.mapper.addMapping(self.txtPolyStribeck, WIDGETS.W_POLY_STRIBECK)
+        self.mapper.addMapping(self.textAvgCoreThick, WIDGETS.W_CORETHICK)
+        self.mapper.addMapping(self.textAvgIntThick, WIDGETS.W_INTTHICK)
+        self.mapper.addMapping(self.textAvgHardBlock, WIDGETS.W_HARDBLOCK)
+        self.mapper.addMapping(self.textAvgSoftBlock, WIDGETS.W_SOFTBLOCK)
+        self.mapper.addMapping(self.textPolyRyan, WIDGETS.W_POLY_RYAN)
+        self.mapper.addMapping(self.textPolyStribeck, WIDGETS.W_POLY_STRIBECK)
         self.mapper.addMapping(self.txtLongPeriod, WIDGETS.W_PERIOD)
         self.mapper.addMapping(self.txtLocalCrystal, WIDGETS.W_CRYSTAL)
 
-        self.mapper.addMapping(self.txtFilename, WIDGETS.W_FILENAME)
+        self.mapper.addMapping(self.textFilename, WIDGETS.W_FILENAME)
 
         self.mapper.toFirst()
 
@@ -492,7 +492,7 @@ class CorfuncWindow(QtWidgets.QDialog, Ui_CorfuncDialog, Perspective):
         log_data_min = math.log(min(self.data.x))
         log_data_max = math.log(max(self.data.x))
 
-        self.cmdExtract.setEnabled(True)
+        self.buttonGo.setEnabled(True)
 
         def fractional_position(f):
             return math.exp(f*log_data_max + (1-f)*log_data_min)
@@ -735,22 +735,22 @@ class CorfuncWindow(QtWidgets.QDialog, Ui_CorfuncDialog, Perspective):
         :return: {name: value}
         """
         return {
-            'guinier_a': self.txtGuinierA.text(),
-            'guinier_b': self.txtGuinierB.text(),
-            'porod_k': self.txtPorodK.text(),
-            'porod_sigma': self.txtPorodSigma.text(),
-            'avg_core_thick': self.txtAvgCoreThick.text(),
-            'avg_inter_thick': self.txtAvgIntThick.text(),
-            'avg_hard_block_thick': self.txtAvgHardBlock.text(),
-            'avg_soft_block_thick': self.txtAvgSoftBlock.text(),
+            'guinier_a': self.textGuinierA.text(),
+            'guinier_b': self.textGuinierB.text(),
+            'porod_k': self.textPorodK.text(),
+            'porod_sigma': self.textPorodSigma.text(),
+            'avg_core_thick': self.textAvgCoreThick.text(),
+            'avg_inter_thick': self.textAvgIntThick.text(),
+            'avg_hard_block_thick': self.textAvgHardBlock.text(),
+            'avg_soft_block_thick': self.textAvgSoftBlock.text(),
             'local_crystalinity': self.txtLocalCrystal.text(),
-            'polydispersity': self.txtPolyRyan.text(),
-            'polydispersity_stribeck': self.txtPolyStribeck.text(),
+            'polydispersity': self.textPolyRyan.text(),
+            'polydispersity_stribeck': self.textPolyStribeck.text(),
             'long_period': self.txtLongPeriod.text(),
             'lower_q_max': self.txtLowerQMax.text(),
             'upper_q_min': self.txtUpperQMin.text(),
             'upper_q_max': self.txtUpperQMax.text(),
-            'background': self.txtBackground.text(),
+            'background': self.textBackground.text(),
         }
 
     def updateFromParameters(self, params):
@@ -803,8 +803,8 @@ class CorfuncWindow(QtWidgets.QDialog, Ui_CorfuncDialog, Perspective):
             params.get('background', '0')))
         # reconnect model
         self.model.itemChanged.connect(self.model_changed)
-        self.cmdSave.setEnabled(params.get('guinier_a', '0.0') != '0.0')
-        self.cmdExtract.setEnabled(params.get('long_period', '0') != '0')
+        self.buttonExportTransformed.setEnabled(params.get('guinier_a', '0.0') != '0.0')
+        self.buttonGo.setEnabled(params.get('long_period', '0') != '0')
 
     @property
     def real_space_figure(self):

--- a/src/sas/qtgui/Perspectives/Corfunc/CorfuncPerspective.py
+++ b/src/sas/qtgui/Perspectives/Corfunc/CorfuncPerspective.py
@@ -107,7 +107,7 @@ class CorfuncWindow(QtWidgets.QDialog, Ui_CorfuncDialog, Perspective):
         # Things to make the corfunc panel behave
         self.horizontalLayout_3.setStretch(0, 0)
         self.horizontalLayout_3.setStretch(1, 1)
-        self.scrollAreaCorfunc.setFixedWidth(600)
+        self.scrollArea.setFixedWidth(600)
         self.adjustSize()
 
         # Connect buttons to slots.

--- a/src/sas/qtgui/Perspectives/Corfunc/SaveExtrapolatedPopup.py
+++ b/src/sas/qtgui/Perspectives/Corfunc/SaveExtrapolatedPopup.py
@@ -33,13 +33,13 @@ class SaveExtrapolatedPopup(QDialog, Ui_SaveExtrapolatedPanel):
 
         self.setWindowTitle("Save extrapolated data")
 
-        self.cmdOK.clicked.connect(self.on_ok)
-        self.cmdCancel.clicked.connect(self.on_cancel)
+        self.buttonOK.clicked.connect(self.on_ok)
+        self.buttonCancel.clicked.connect(self.on_cancel)
 
         # Default values from input qs
-        self.spnLow.setValue(input_qs[0])
-        self.spnHigh.setValue(input_qs[-1])
-        self.spnDelta.setValue(np.mean(input_qs[1:] - input_qs[:-1]))
+        self.spinBoxLow.setValue(input_qs[0])
+        self.spinBoxHigh.setValue(input_qs[-1])
+        self.spinBoxDelta.setValue(np.mean(input_qs[1:] - input_qs[:-1]))
 
 
     def on_ok(self):
@@ -48,9 +48,9 @@ class SaveExtrapolatedPopup(QDialog, Ui_SaveExtrapolatedPanel):
             self._input_validation()
 
             q = np.arange(
-                self.spnLow.value(),
-                self.spnHigh.value(),
-                self.spnDelta.value())
+                self.spinBoxLow.value(),
+                self.spinBoxHigh.value(),
+                self.spinBoxDelta.value())
 
             intensity = self.interpolation_function(q)
 
@@ -69,10 +69,10 @@ class SaveExtrapolatedPopup(QDialog, Ui_SaveExtrapolatedPanel):
         """ Check input is valid, notify user if not"""
 
         # Range values
-        if self.spnLow.value() >= self.spnHigh.value():
+        if self.spinBoxLow.value() >= self.spinBoxHigh.value():
             raise UserInputInvalid("High Q value should be greater than low Q value.")
 
-        if self.spnDelta.value() <= 0:
+        if self.spinBoxDelta.value() <= 0:
             raise UserInputInvalid("Delta Q (sampling interval) should be a positive number.")
 
         return

--- a/src/sas/qtgui/Perspectives/Corfunc/SaveExtrapolatedPopup.py
+++ b/src/sas/qtgui/Perspectives/Corfunc/SaveExtrapolatedPopup.py
@@ -33,13 +33,13 @@ class SaveExtrapolatedPopup(QDialog, Ui_SaveExtrapolatedPanel):
 
         self.setWindowTitle("Save extrapolated data")
 
-        self.buttonOK.clicked.connect(self.on_ok)
-        self.buttonCancel.clicked.connect(self.on_cancel)
+        self.cmdOK.clicked.connect(self.on_ok)
+        self.cmdCancel.clicked.connect(self.on_cancel)
 
         # Default values from input qs
-        self.spinBoxLow.setValue(input_qs[0])
-        self.spinBoxHigh.setValue(input_qs[-1])
-        self.spinBoxDelta.setValue(np.mean(input_qs[1:] - input_qs[:-1]))
+        self.doubleSpinBoxLow.setValue(input_qs[0])
+        self.doubleSpinBoxHigh.setValue(input_qs[-1])
+        self.doubleSpinBoxDelta.setValue(np.mean(input_qs[1:] - input_qs[:-1]))
 
 
     def on_ok(self):
@@ -48,9 +48,9 @@ class SaveExtrapolatedPopup(QDialog, Ui_SaveExtrapolatedPanel):
             self._input_validation()
 
             q = np.arange(
-                self.spinBoxLow.value(),
-                self.spinBoxHigh.value(),
-                self.spinBoxDelta.value())
+                self.doubleSpinBoxLow.value(),
+                self.doubleSpinBoxHigh.value(),
+                self.doubleSpinBoxDelta.value())
 
             intensity = self.interpolation_function(q)
 
@@ -69,10 +69,10 @@ class SaveExtrapolatedPopup(QDialog, Ui_SaveExtrapolatedPanel):
         """ Check input is valid, notify user if not"""
 
         # Range values
-        if self.spinBoxLow.value() >= self.spinBoxHigh.value():
+        if self.doubleSpinBoxLow.value() >= self.doubleSpinBoxHigh.value():
             raise UserInputInvalid("High Q value should be greater than low Q value.")
 
-        if self.spinBoxDelta.value() <= 0:
+        if self.doubleSpinBoxDelta.value() <= 0:
             raise UserInputInvalid("Delta Q (sampling interval) should be a positive number.")
 
         return

--- a/src/sas/qtgui/Perspectives/Corfunc/UI/CorfuncPanel.ui
+++ b/src/sas/qtgui/Perspectives/Corfunc/UI/CorfuncPanel.ui
@@ -21,7 +21,7 @@
   </property>
   <layout class="QHBoxLayout" name="horizontalLayout_3">
    <item>
-    <widget class="QScrollArea" name="scrollAreaCorfunc">
+    <widget class="QScrollArea" name="scrollArea">
      <property name="frameShape">
       <enum>QFrame::NoFrame</enum>
      </property>
@@ -87,7 +87,7 @@
            <number>0</number>
           </property>
           <item>
-           <layout class="QVBoxLayout" name="verticalLayout_Input_Left">
+           <layout class="QVBoxLayout" name="verticalLayout_3">
             <property name="sizeConstraint">
              <enum>QLayout::SetDefaultConstraint</enum>
             </property>
@@ -95,7 +95,7 @@
              <number>0</number>
             </property>
             <item>
-             <widget class="QGroupBox" name="groupBox_1_Input_Left">
+             <widget class="QGroupBox" name="groupBox">
               <property name="sizePolicy">
                <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
                 <horstretch>0</horstretch>
@@ -107,7 +107,7 @@
               </property>
               <layout class="QGridLayout" name="gridLayout_6">
                <item row="4" column="0">
-                <widget class="QFrame" name="frame_Input">
+                <widget class="QFrame" name="frame_5">
                  <layout class="QGridLayout" name="gridLayout_7">
                   <item row="1" column="0">
                    <widget class="QLabel" name="lblTangentMethod">
@@ -160,7 +160,7 @@
                    </widget>
                   </item>
                   <item row="0" column="1">
-                   <widget class="QCheckBox" name="checkboxFitBackground">
+                   <widget class="QCheckBox" name="chkFitBackground">
                     <property name="text">
                      <string>Fit Background</string>
                     </property>
@@ -436,7 +436,7 @@
              </widget>
             </item>
             <item>
-             <widget class="QGroupBox" name="groupBox_2_Extrapolation_Parameters">
+             <widget class="QGroupBox" name="groupBox_4">
               <property name="sizePolicy">
                <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
                 <horstretch>0</horstretch>
@@ -448,7 +448,7 @@
               </property>
               <layout class="QVBoxLayout" name="backgroundLayout">
                <item>
-                <layout class="QGridLayout" name="gridLayout_Extrapolation_Parameters_1">
+                <layout class="QGridLayout" name="gridLayout_4">
                  <item row="0" column="1">
                   <widget class="QLineEdit" name="txtBackground">
                    <property name="sizePolicy">
@@ -482,9 +482,9 @@
                 </layout>
                </item>
                <item>
-                <layout class="QGridLayout" name="gridLayout_Extrapolation_Parameters_2">
+                <layout class="QGridLayout" name="gridLayout_2">
                  <item row="5" column="0" colspan="2">
-                  <layout class="QGridLayout" name="gridLayout_Extrapolation_Parameters_bottom">
+                  <layout class="QGridLayout" name="gridLayout_5">
                    <property name="bottomMargin">
                     <number>0</number>
                    </property>
@@ -578,7 +578,7 @@
              </widget>
             </item>
             <item>
-             <widget class="QGroupBox" name="groupBox_3_Lamellar_Parameters">
+             <widget class="QGroupBox" name="groupBox_3">
               <property name="sizePolicy">
                <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
                 <horstretch>0</horstretch>
@@ -590,7 +590,7 @@
               </property>
               <layout class="QGridLayout" name="gridLayout_3">
                <item row="1" column="0">
-                <layout class="QGridLayout" name="gridLayout_Lamellar_Parameters">
+                <layout class="QGridLayout" name="gridLayout_8">
                  <property name="sizeConstraint">
                   <enum>QLayout::SetDefaultConstraint</enum>
                  </property>
@@ -937,7 +937,7 @@
              </widget>
             </item>
             <item>
-             <widget class="QGroupBox" name="groupBox_4_Export">
+             <widget class="QGroupBox" name="groupBox_2">
               <property name="sizePolicy">
                <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
                 <horstretch>0</horstretch>
@@ -1004,7 +1004,7 @@
              </spacer>
             </item>
             <item>
-             <layout class="QHBoxLayout" name="horizontalLayout_5_bottom">
+             <layout class="QHBoxLayout" name="horizontalLayout_5">
               <item>
                <spacer name="horizontalSpacer">
                 <property name="orientation">
@@ -1109,7 +1109,7 @@
   <tabstop>txtLowerQMax</tabstop>
   <tabstop>txtUpperQMin</tabstop>
   <tabstop>txtUpperQMax</tabstop>
-  <tabstop>checkboxFitBackground</tabstop>
+  <tabstop>chkFitBackground</tabstop>
   <tabstop>chkFitGuinier</tabstop>
   <tabstop>chkFitPorod</tabstop>
   <tabstop>rbTangentInflection</tabstop>
@@ -1135,13 +1135,13 @@
   <tabstop>cmdExportTransformed</tabstop>
   <tabstop>cmdHelp</tabstop>
   <tabstop>tabWidget</tabstop>
-  <tabstop>scrollAreaCorfunc</tabstop>
+  <tabstop>scrollArea</tabstop>
   <tabstop>txtFilename</tabstop>
  </tabstops>
  <resources/>
  <connections/>
  <buttongroups>
-  <buttongroup name="buttonGroup_2"/>
   <buttongroup name="buttonGroup"/>
+  <buttongroup name="buttonGroup_2"/>
  </buttongroups>
 </ui>

--- a/src/sas/qtgui/Perspectives/Corfunc/UI/CorfuncPanel.ui
+++ b/src/sas/qtgui/Perspectives/Corfunc/UI/CorfuncPanel.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>1113</width>
-    <height>746</height>
+    <width>1157</width>
+    <height>885</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -43,7 +43,7 @@
         <x>0</x>
         <y>0</y>
         <width>581</width>
-        <height>728</height>
+        <height>867</height>
        </rect>
       </property>
       <layout class="QVBoxLayout" name="verticalLayout">
@@ -1141,7 +1141,7 @@
  <resources/>
  <connections/>
  <buttongroups>
-  <buttongroup name="buttonGroup_2"/>
   <buttongroup name="buttonGroup"/>
+  <buttongroup name="buttonGroup_2"/>
  </buttongroups>
 </ui>

--- a/src/sas/qtgui/Perspectives/Corfunc/UI/CorfuncPanel.ui
+++ b/src/sas/qtgui/Perspectives/Corfunc/UI/CorfuncPanel.ui
@@ -110,7 +110,7 @@
                 <widget class="QFrame" name="frame_Input">
                  <layout class="QGridLayout" name="gridLayout_7">
                   <item row="1" column="0">
-                   <widget class="QLabel" name="label_TangentMethod">
+                   <widget class="QLabel" name="lblTangentMethod">
                     <property name="text">
                      <string>Tangent Method:  </string>
                     </property>
@@ -120,7 +120,7 @@
                    </widget>
                   </item>
                   <item row="0" column="0">
-                   <widget class="QLabel" name="label_Fitting">
+                   <widget class="QLabel" name="lblFitting">
                     <property name="text">
                      <string>Fitting:  </string>
                     </property>
@@ -130,7 +130,7 @@
                    </widget>
                   </item>
                   <item row="2" column="0">
-                   <widget class="QLabel" name="label_LongPeriodMethod">
+                   <widget class="QLabel" name="lblLongPeriodMethod">
                     <property name="text">
                      <string>Long Period Method:  </string>
                     </property>
@@ -140,7 +140,7 @@
                    </widget>
                   </item>
                   <item row="1" column="1">
-                   <widget class="QRadioButton" name="radTangentInflection">
+                   <widget class="QRadioButton" name="rbTangentInflection">
                     <property name="text">
                      <string>Use Inflection Point</string>
                     </property>
@@ -150,7 +150,7 @@
                    </widget>
                   </item>
                   <item row="0" column="3">
-                   <widget class="QCheckBox" name="checkboxFitPorod">
+                   <widget class="QCheckBox" name="chkFitPorod">
                     <property name="text">
                      <string>Fit Porod</string>
                     </property>
@@ -170,7 +170,7 @@
                    </widget>
                   </item>
                   <item row="1" column="2">
-                   <widget class="QRadioButton" name="radTangentMidpoint">
+                   <widget class="QRadioButton" name="rbTangentMidpoint">
                     <property name="text">
                      <string>Use Halfway Point</string>
                     </property>
@@ -180,7 +180,7 @@
                    </widget>
                   </item>
                   <item row="2" column="3">
-                   <widget class="QRadioButton" name="radLongPeriodAuto">
+                   <widget class="QRadioButton" name="rbLongPeriodAuto">
                     <property name="text">
                      <string>Automatic</string>
                     </property>
@@ -193,7 +193,7 @@
                    </widget>
                   </item>
                   <item row="1" column="3">
-                   <widget class="QRadioButton" name="radTangentAuto">
+                   <widget class="QRadioButton" name="rbTangentAuto">
                     <property name="text">
                      <string>Automatic</string>
                     </property>
@@ -206,7 +206,7 @@
                    </widget>
                   </item>
                   <item row="2" column="2">
-                   <widget class="QRadioButton" name="radLongPeriodDouble">
+                   <widget class="QRadioButton" name="rbLongPeriodDouble">
                     <property name="text">
                      <string>Use 2x Minimum</string>
                     </property>
@@ -216,7 +216,7 @@
                    </widget>
                   </item>
                   <item row="0" column="2">
-                   <widget class="QCheckBox" name="checkboxFitGuinier">
+                   <widget class="QCheckBox" name="chkFitGuinier">
                     <property name="text">
                      <string>Fit Guinier</string>
                     </property>
@@ -226,7 +226,7 @@
                    </widget>
                   </item>
                   <item row="2" column="1">
-                   <widget class="QRadioButton" name="radLongPeriodMax">
+                   <widget class="QRadioButton" name="rbLongPeriodMax">
                     <property name="text">
                      <string>Use Maximum</string>
                     </property>
@@ -241,14 +241,14 @@
                <item row="0" column="0">
                 <layout class="QHBoxLayout" name="horizontalLayout_4">
                  <item>
-                  <widget class="QLabel" name="labelName">
+                  <widget class="QLabel" name="lblName">
                    <property name="text">
                     <string>Name:</string>
                    </property>
                   </widget>
                  </item>
                  <item>
-                  <widget class="QLineEdit" name="textFilename">
+                  <widget class="QLineEdit" name="txtFilename">
                    <property name="enabled">
                     <bool>false</bool>
                    </property>
@@ -373,7 +373,7 @@
                   </spacer>
                  </item>
                  <item>
-                  <widget class="QPushButton" name="buttonGo">
+                  <widget class="QPushButton" name="cmdGo">
                    <property name="sizePolicy">
                     <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                      <horstretch>0</horstretch>
@@ -424,7 +424,7 @@
                   <number>10</number>
                  </property>
                  <item>
-                  <widget class="QLabel" name="label_Adjust">
+                  <widget class="QLabel" name="lblAdjust">
                    <property name="text">
                     <string>Adjust:</string>
                    </property>
@@ -450,7 +450,7 @@
                <item>
                 <layout class="QGridLayout" name="gridLayout_Extrapolation_Parameters_1">
                  <item row="0" column="1">
-                  <widget class="QLineEdit" name="textBackground">
+                  <widget class="QLineEdit" name="txtBackground">
                    <property name="sizePolicy">
                     <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
                      <horstretch>0</horstretch>
@@ -460,7 +460,7 @@
                   </widget>
                  </item>
                  <item row="0" column="0">
-                  <widget class="QLabel" name="label_Background">
+                  <widget class="QLabel" name="lblBackground">
                    <property name="text">
                     <string>Background:</string>
                    </property>
@@ -489,14 +489,14 @@
                     <number>0</number>
                    </property>
                    <item row="3" column="4">
-                    <widget class="QLineEdit" name="textGuinierB">
+                    <widget class="QLineEdit" name="txtGuinierB">
                      <property name="readOnly">
                       <bool>false</bool>
                      </property>
                     </widget>
                    </item>
                    <item row="3" column="0">
-                    <widget class="QLabel" name="label_Guinier">
+                    <widget class="QLabel" name="lblGuinier">
                      <property name="text">
                       <string>Guinier</string>
                      </property>
@@ -506,7 +506,7 @@
                     </widget>
                    </item>
                    <item row="3" column="3">
-                    <widget class="QLabel" name="label_Guinier_B">
+                    <widget class="QLabel" name="lblGuinierB">
                      <property name="text">
                       <string>     B:</string>
                      </property>
@@ -516,35 +516,35 @@
                     </widget>
                    </item>
                    <item row="4" column="1">
-                    <widget class="QLabel" name="label_Porod_K">
+                    <widget class="QLabel" name="lblPorodK">
                      <property name="text">
                       <string>K:</string>
                      </property>
                     </widget>
                    </item>
                    <item row="4" column="2">
-                    <widget class="QLineEdit" name="textPorodK">
+                    <widget class="QLineEdit" name="txtPorodK">
                      <property name="readOnly">
                       <bool>false</bool>
                      </property>
                     </widget>
                    </item>
                    <item row="3" column="1">
-                    <widget class="QLabel" name="label_Guinier_A">
+                    <widget class="QLabel" name="lblGuinierA">
                      <property name="text">
                       <string>A:</string>
                      </property>
                     </widget>
                    </item>
                    <item row="3" column="2">
-                    <widget class="QLineEdit" name="textGuinierA">
+                    <widget class="QLineEdit" name="txtGuinierA">
                      <property name="readOnly">
                       <bool>false</bool>
                      </property>
                     </widget>
                    </item>
                    <item row="4" column="0">
-                    <widget class="QLabel" name="label_Porod">
+                    <widget class="QLabel" name="lblPorod">
                      <property name="text">
                       <string>Porod</string>
                      </property>
@@ -554,14 +554,14 @@
                     </widget>
                    </item>
                    <item row="4" column="4">
-                    <widget class="QLineEdit" name="textPorodSigma">
+                    <widget class="QLineEdit" name="txtPorodSigma">
                      <property name="readOnly">
                       <bool>false</bool>
                      </property>
                     </widget>
                    </item>
                    <item row="4" column="3">
-                    <widget class="QLabel" name="label_Porod_sigma">
+                    <widget class="QLabel" name="lblPorodSigma">
                      <property name="text">
                       <string>σ:</string>
                      </property>
@@ -601,7 +601,7 @@
                   <number>10</number>
                  </property>
                  <item row="2" column="3">
-                  <widget class="QLabel" name="label_Stribeck">
+                  <widget class="QLabel" name="lblStribeck">
                    <property name="sizePolicy">
                     <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
                      <horstretch>0</horstretch>
@@ -617,14 +617,14 @@
                   </widget>
                  </item>
                  <item row="2" column="2">
-                  <widget class="QLineEdit" name="textPolyRyan">
+                  <widget class="QLineEdit" name="txtPolyRyan">
                    <property name="readOnly">
                     <bool>true</bool>
                    </property>
                   </widget>
                  </item>
                  <item row="0" column="2">
-                  <widget class="QLineEdit" name="textAvgHardBlock">
+                  <widget class="QLineEdit" name="txtAvgHardBlock">
                    <property name="sizePolicy">
                     <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
                      <horstretch>0</horstretch>
@@ -643,7 +643,7 @@
                   </widget>
                  </item>
                  <item row="2" column="1">
-                  <widget class="QLabel" name="label_Eekhaut">
+                  <widget class="QLabel" name="lblEekhaut">
                    <property name="sizePolicy">
                     <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
                      <horstretch>0</horstretch>
@@ -659,14 +659,14 @@
                   </widget>
                  </item>
                  <item row="2" column="4">
-                  <widget class="QLineEdit" name="textPolyStribeck">
+                  <widget class="QLineEdit" name="txtPolyStribeck">
                    <property name="readOnly">
                     <bool>true</bool>
                    </property>
                   </widget>
                  </item>
                  <item row="0" column="1">
-                  <widget class="QLabel" name="label_HardBlock">
+                  <widget class="QLabel" name="lblHardBlock">
                    <property name="sizePolicy">
                     <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
                      <horstretch>0</horstretch>
@@ -688,7 +688,7 @@
                   </widget>
                  </item>
                  <item row="0" column="0">
-                  <widget class="QLabel" name="label_AvgThicknesses">
+                  <widget class="QLabel" name="lblAvgThicknesses">
                    <property name="sizePolicy">
                     <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
                      <horstretch>0</horstretch>
@@ -704,7 +704,7 @@
                   </widget>
                  </item>
                  <item row="0" column="3">
-                  <widget class="QLabel" name="label_SoftBlock">
+                  <widget class="QLabel" name="lblSoftBlock">
                    <property name="sizePolicy">
                     <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
                      <horstretch>0</horstretch>
@@ -726,7 +726,7 @@
                   </widget>
                  </item>
                  <item row="0" column="4">
-                  <widget class="QLineEdit" name="textAvgSoftBlock">
+                  <widget class="QLineEdit" name="txtAvgSoftBlock">
                    <property name="sizePolicy">
                     <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
                      <horstretch>0</horstretch>
@@ -745,7 +745,7 @@
                   </widget>
                  </item>
                  <item row="2" column="0">
-                  <widget class="QLabel" name="label_Polydispersity">
+                  <widget class="QLabel" name="lblPolydispersity">
                    <property name="sizePolicy">
                     <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
                      <horstretch>0</horstretch>
@@ -761,7 +761,7 @@
                   </widget>
                  </item>
                  <item row="1" column="1">
-                  <widget class="QLabel" name="label_Interface">
+                  <widget class="QLabel" name="lblInterface">
                    <property name="sizePolicy">
                     <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
                      <horstretch>0</horstretch>
@@ -783,7 +783,7 @@
                   </widget>
                  </item>
                  <item row="1" column="3">
-                  <widget class="QLabel" name="label_Core">
+                  <widget class="QLabel" name="lblCore">
                    <property name="sizePolicy">
                     <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
                      <horstretch>0</horstretch>
@@ -805,7 +805,7 @@
                   </widget>
                  </item>
                  <item row="1" column="2">
-                  <widget class="QLineEdit" name="textAvgIntThick">
+                  <widget class="QLineEdit" name="txtAvgIntThick">
                    <property name="sizePolicy">
                     <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
                      <horstretch>0</horstretch>
@@ -824,7 +824,7 @@
                   </widget>
                  </item>
                  <item row="1" column="4">
-                  <widget class="QLineEdit" name="textAvgCoreThick">
+                  <widget class="QLineEdit" name="txtAvgCoreThick">
                    <property name="sizePolicy">
                     <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
                      <horstretch>0</horstretch>
@@ -850,7 +850,7 @@
                   <number>0</number>
                  </property>
                  <item row="0" column="0">
-                  <widget class="QLabel" name="label_14">
+                  <widget class="QLabel" name="lblLongPeriod">
                    <property name="sizePolicy">
                     <sizepolicy hsizetype="MinimumExpanding" vsizetype="MinimumExpanding">
                      <horstretch>0</horstretch>
@@ -891,7 +891,7 @@
                   </widget>
                  </item>
                  <item row="0" column="2">
-                  <widget class="QLabel" name="label_19">
+                  <widget class="QLabel" name="lblLocalCrystallinity">
                    <property name="sizePolicy">
                     <sizepolicy hsizetype="MinimumExpanding" vsizetype="MinimumExpanding">
                      <horstretch>0</horstretch>
@@ -949,7 +949,7 @@
               </property>
               <layout class="QHBoxLayout" name="horizontalLayout_2">
                <item>
-                <widget class="QPushButton" name="buttonExportExtrapolated">
+                <widget class="QPushButton" name="cmdExportExtrapolated">
                  <property name="toolTip">
                   <string>Save the extrapolated data (non-transformed)</string>
                  </property>
@@ -959,7 +959,7 @@
                 </widget>
                </item>
                <item>
-                <widget class="QPushButton" name="buttonExportTransformed">
+                <widget class="QPushButton" name="cmdExportTransformed">
                  <property name="sizePolicy">
                   <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
                    <horstretch>0</horstretch>
@@ -1019,7 +1019,7 @@
                </spacer>
               </item>
               <item>
-               <widget class="QPushButton" name="buttonHelp">
+               <widget class="QPushButton" name="cmdHelp">
                 <property name="text">
                  <string>Help</string>
                 </property>
@@ -1105,43 +1105,43 @@
   </layout>
  </widget>
  <tabstops>
-  <tabstop>buttonGo</tabstop>
+  <tabstop>cmdGo</tabstop>
   <tabstop>txtLowerQMax</tabstop>
   <tabstop>txtUpperQMin</tabstop>
   <tabstop>txtUpperQMax</tabstop>
   <tabstop>checkboxFitBackground</tabstop>
-  <tabstop>checkboxFitGuinier</tabstop>
-  <tabstop>checkboxFitPorod</tabstop>
-  <tabstop>radTangentInflection</tabstop>
-  <tabstop>radTangentMidpoint</tabstop>
-  <tabstop>radTangentAuto</tabstop>
-  <tabstop>radLongPeriodMax</tabstop>
-  <tabstop>radLongPeriodDouble</tabstop>
-  <tabstop>radLongPeriodAuto</tabstop>
-  <tabstop>textBackground</tabstop>
-  <tabstop>textGuinierA</tabstop>
-  <tabstop>textGuinierB</tabstop>
-  <tabstop>textPorodK</tabstop>
-  <tabstop>textPorodSigma</tabstop>
-  <tabstop>textAvgHardBlock</tabstop>
-  <tabstop>textAvgSoftBlock</tabstop>
-  <tabstop>textAvgIntThick</tabstop>
-  <tabstop>textAvgCoreThick</tabstop>
-  <tabstop>textPolyRyan</tabstop>
-  <tabstop>textPolyStribeck</tabstop>
+  <tabstop>chkFitGuinier</tabstop>
+  <tabstop>chkFitPorod</tabstop>
+  <tabstop>rbTangentInflection</tabstop>
+  <tabstop>rbTangentMidpoint</tabstop>
+  <tabstop>rbTangentAuto</tabstop>
+  <tabstop>rbLongPeriodMax</tabstop>
+  <tabstop>rbLongPeriodDouble</tabstop>
+  <tabstop>rbLongPeriodAuto</tabstop>
+  <tabstop>txtBackground</tabstop>
+  <tabstop>txtGuinierA</tabstop>
+  <tabstop>txtGuinierB</tabstop>
+  <tabstop>txtPorodK</tabstop>
+  <tabstop>txtPorodSigma</tabstop>
+  <tabstop>txtAvgHardBlock</tabstop>
+  <tabstop>txtAvgSoftBlock</tabstop>
+  <tabstop>txtAvgIntThick</tabstop>
+  <tabstop>txtAvgCoreThick</tabstop>
+  <tabstop>txtPolyRyan</tabstop>
+  <tabstop>txtPolyStribeck</tabstop>
   <tabstop>txtLongPeriod</tabstop>
   <tabstop>txtLocalCrystal</tabstop>
-  <tabstop>buttonExportExtrapolated</tabstop>
-  <tabstop>buttonExportTransformed</tabstop>
-  <tabstop>buttonHelp</tabstop>
+  <tabstop>cmdExportExtrapolated</tabstop>
+  <tabstop>cmdExportTransformed</tabstop>
+  <tabstop>cmdHelp</tabstop>
   <tabstop>tabWidget</tabstop>
   <tabstop>scrollAreaCorfunc</tabstop>
-  <tabstop>textFilename</tabstop>
+  <tabstop>txtFilename</tabstop>
  </tabstops>
  <resources/>
  <connections/>
  <buttongroups>
-  <buttongroup name="buttonGroup"/>
   <buttongroup name="buttonGroup_2"/>
+  <buttongroup name="buttonGroup"/>
  </buttongroups>
 </ui>

--- a/src/sas/qtgui/Perspectives/Corfunc/UI/CorfuncPanel.ui
+++ b/src/sas/qtgui/Perspectives/Corfunc/UI/CorfuncPanel.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>1157</width>
-    <height>885</height>
+    <width>1113</width>
+    <height>746</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -21,7 +21,7 @@
   </property>
   <layout class="QHBoxLayout" name="horizontalLayout_3">
    <item>
-    <widget class="QScrollArea" name="scrollArea">
+    <widget class="QScrollArea" name="scrollAreaCorfunc">
      <property name="frameShape">
       <enum>QFrame::NoFrame</enum>
      </property>
@@ -43,7 +43,7 @@
         <x>0</x>
         <y>0</y>
         <width>581</width>
-        <height>871</height>
+        <height>728</height>
        </rect>
       </property>
       <layout class="QVBoxLayout" name="verticalLayout">
@@ -87,7 +87,7 @@
            <number>0</number>
           </property>
           <item>
-           <layout class="QVBoxLayout" name="verticalLayout_3">
+           <layout class="QVBoxLayout" name="verticalLayout_Input_Left">
             <property name="sizeConstraint">
              <enum>QLayout::SetDefaultConstraint</enum>
             </property>
@@ -95,7 +95,7 @@
              <number>0</number>
             </property>
             <item>
-             <widget class="QGroupBox" name="groupBox">
+             <widget class="QGroupBox" name="groupBox_1_Input_Left">
               <property name="sizePolicy">
                <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
                 <horstretch>0</horstretch>
@@ -107,10 +107,10 @@
               </property>
               <layout class="QGridLayout" name="gridLayout_6">
                <item row="4" column="0">
-                <widget class="QFrame" name="frame_5">
+                <widget class="QFrame" name="frame_Input">
                  <layout class="QGridLayout" name="gridLayout_7">
                   <item row="1" column="0">
-                   <widget class="QLabel" name="label_20">
+                   <widget class="QLabel" name="label_TangentMethod">
                     <property name="text">
                      <string>Tangent Method:  </string>
                     </property>
@@ -120,7 +120,7 @@
                    </widget>
                   </item>
                   <item row="0" column="0">
-                   <widget class="QLabel" name="label_18">
+                   <widget class="QLabel" name="label_Fitting">
                     <property name="text">
                      <string>Fitting:  </string>
                     </property>
@@ -130,7 +130,7 @@
                    </widget>
                   </item>
                   <item row="2" column="0">
-                   <widget class="QLabel" name="label_21">
+                   <widget class="QLabel" name="label_LongPeriodMethod">
                     <property name="text">
                      <string>Long Period Method:  </string>
                     </property>
@@ -150,7 +150,7 @@
                    </widget>
                   </item>
                   <item row="0" column="3">
-                   <widget class="QCheckBox" name="fitPorod">
+                   <widget class="QCheckBox" name="checkboxFitPorod">
                     <property name="text">
                      <string>Fit Porod</string>
                     </property>
@@ -160,7 +160,7 @@
                    </widget>
                   </item>
                   <item row="0" column="1">
-                   <widget class="QCheckBox" name="fitBackground">
+                   <widget class="QCheckBox" name="checkboxFitBackground">
                     <property name="text">
                      <string>Fit Background</string>
                     </property>
@@ -216,7 +216,7 @@
                    </widget>
                   </item>
                   <item row="0" column="2">
-                   <widget class="QCheckBox" name="fitGuinier">
+                   <widget class="QCheckBox" name="checkboxFitGuinier">
                     <property name="text">
                      <string>Fit Guinier</string>
                     </property>
@@ -241,14 +241,14 @@
                <item row="0" column="0">
                 <layout class="QHBoxLayout" name="horizontalLayout_4">
                  <item>
-                  <widget class="QLabel" name="lblName">
+                  <widget class="QLabel" name="labelName">
                    <property name="text">
                     <string>Name:</string>
                    </property>
                   </widget>
                  </item>
                  <item>
-                  <widget class="QLineEdit" name="txtFilename">
+                  <widget class="QLineEdit" name="textFilename">
                    <property name="enabled">
                     <bool>false</bool>
                    </property>
@@ -373,7 +373,7 @@
                   </spacer>
                  </item>
                  <item>
-                  <widget class="QPushButton" name="cmdExtract">
+                  <widget class="QPushButton" name="buttonGo">
                    <property name="sizePolicy">
                     <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                      <horstretch>0</horstretch>
@@ -424,7 +424,7 @@
                   <number>10</number>
                  </property>
                  <item>
-                  <widget class="QLabel" name="label_3">
+                  <widget class="QLabel" name="label_Adjust">
                    <property name="text">
                     <string>Adjust:</string>
                    </property>
@@ -436,7 +436,7 @@
              </widget>
             </item>
             <item>
-             <widget class="QGroupBox" name="groupBox_4">
+             <widget class="QGroupBox" name="groupBox_2_Extrapolation_Parameters">
               <property name="sizePolicy">
                <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
                 <horstretch>0</horstretch>
@@ -448,9 +448,9 @@
               </property>
               <layout class="QVBoxLayout" name="backgroundLayout">
                <item>
-                <layout class="QGridLayout" name="gridLayout_4">
+                <layout class="QGridLayout" name="gridLayout_Extrapolation_Parameters_1">
                  <item row="0" column="1">
-                  <widget class="QLineEdit" name="txtBackground">
+                  <widget class="QLineEdit" name="textBackground">
                    <property name="sizePolicy">
                     <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
                      <horstretch>0</horstretch>
@@ -460,7 +460,7 @@
                   </widget>
                  </item>
                  <item row="0" column="0">
-                  <widget class="QLabel" name="label">
+                  <widget class="QLabel" name="label_Background">
                    <property name="text">
                     <string>Background:</string>
                    </property>
@@ -482,21 +482,21 @@
                 </layout>
                </item>
                <item>
-                <layout class="QGridLayout" name="gridLayout_2">
+                <layout class="QGridLayout" name="gridLayout_Extrapolation_Parameters_2">
                  <item row="5" column="0" colspan="2">
-                  <layout class="QGridLayout" name="gridLayout_5">
+                  <layout class="QGridLayout" name="gridLayout_Extrapolation_Parameters_bottom">
                    <property name="bottomMargin">
                     <number>0</number>
                    </property>
                    <item row="3" column="4">
-                    <widget class="QLineEdit" name="txtGuinierB">
+                    <widget class="QLineEdit" name="textGuinierB">
                      <property name="readOnly">
                       <bool>false</bool>
                      </property>
                     </widget>
                    </item>
                    <item row="3" column="0">
-                    <widget class="QLabel" name="label_8">
+                    <widget class="QLabel" name="label_Guinier">
                      <property name="text">
                       <string>Guinier</string>
                      </property>
@@ -506,7 +506,7 @@
                     </widget>
                    </item>
                    <item row="3" column="3">
-                    <widget class="QLabel" name="label_7">
+                    <widget class="QLabel" name="label_Guinier_B">
                      <property name="text">
                       <string>     B:</string>
                      </property>
@@ -516,35 +516,35 @@
                     </widget>
                    </item>
                    <item row="4" column="1">
-                    <widget class="QLabel" name="label_10">
+                    <widget class="QLabel" name="label_Porod_K">
                      <property name="text">
                       <string>K:</string>
                      </property>
                     </widget>
                    </item>
                    <item row="4" column="2">
-                    <widget class="QLineEdit" name="txtPorodK">
+                    <widget class="QLineEdit" name="textPorodK">
                      <property name="readOnly">
                       <bool>false</bool>
                      </property>
                     </widget>
                    </item>
                    <item row="3" column="1">
-                    <widget class="QLabel" name="label_6">
+                    <widget class="QLabel" name="label_Guinier_A">
                      <property name="text">
                       <string>A:</string>
                      </property>
                     </widget>
                    </item>
                    <item row="3" column="2">
-                    <widget class="QLineEdit" name="txtGuinierA">
+                    <widget class="QLineEdit" name="textGuinierA">
                      <property name="readOnly">
                       <bool>false</bool>
                      </property>
                     </widget>
                    </item>
                    <item row="4" column="0">
-                    <widget class="QLabel" name="label_9">
+                    <widget class="QLabel" name="label_Porod">
                      <property name="text">
                       <string>Porod</string>
                      </property>
@@ -554,14 +554,14 @@
                     </widget>
                    </item>
                    <item row="4" column="4">
-                    <widget class="QLineEdit" name="txtPorodSigma">
+                    <widget class="QLineEdit" name="textPorodSigma">
                      <property name="readOnly">
                       <bool>false</bool>
                      </property>
                     </widget>
                    </item>
                    <item row="4" column="3">
-                    <widget class="QLabel" name="label_11">
+                    <widget class="QLabel" name="label_Porod_sigma">
                      <property name="text">
                       <string>σ:</string>
                      </property>
@@ -578,7 +578,7 @@
              </widget>
             </item>
             <item>
-             <widget class="QGroupBox" name="groupBox_3">
+             <widget class="QGroupBox" name="groupBox_3_Lamellar_Parameters">
               <property name="sizePolicy">
                <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
                 <horstretch>0</horstretch>
@@ -590,7 +590,7 @@
               </property>
               <layout class="QGridLayout" name="gridLayout_3">
                <item row="1" column="0">
-                <layout class="QGridLayout" name="gridLayout_8">
+                <layout class="QGridLayout" name="gridLayout_Lamellar_Parameters">
                  <property name="sizeConstraint">
                   <enum>QLayout::SetDefaultConstraint</enum>
                  </property>
@@ -601,7 +601,7 @@
                   <number>10</number>
                  </property>
                  <item row="2" column="3">
-                  <widget class="QLabel" name="label_13">
+                  <widget class="QLabel" name="label_Stribeck">
                    <property name="sizePolicy">
                     <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
                      <horstretch>0</horstretch>
@@ -617,14 +617,14 @@
                   </widget>
                  </item>
                  <item row="2" column="2">
-                  <widget class="QLineEdit" name="txtPolyRyan">
+                  <widget class="QLineEdit" name="textPolyRyan">
                    <property name="readOnly">
                     <bool>true</bool>
                    </property>
                   </widget>
                  </item>
                  <item row="0" column="2">
-                  <widget class="QLineEdit" name="txtAvgHardBlock">
+                  <widget class="QLineEdit" name="textAvgHardBlock">
                    <property name="sizePolicy">
                     <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
                      <horstretch>0</horstretch>
@@ -643,7 +643,7 @@
                   </widget>
                  </item>
                  <item row="2" column="1">
-                  <widget class="QLabel" name="label_12">
+                  <widget class="QLabel" name="label_Eekhaut">
                    <property name="sizePolicy">
                     <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
                      <horstretch>0</horstretch>
@@ -659,14 +659,14 @@
                   </widget>
                  </item>
                  <item row="2" column="4">
-                  <widget class="QLineEdit" name="txtPolyStribeck">
+                  <widget class="QLineEdit" name="textPolyStribeck">
                    <property name="readOnly">
                     <bool>true</bool>
                    </property>
                   </widget>
                  </item>
                  <item row="0" column="1">
-                  <widget class="QLabel" name="label_16">
+                  <widget class="QLabel" name="label_HardBlock">
                    <property name="sizePolicy">
                     <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
                      <horstretch>0</horstretch>
@@ -688,7 +688,7 @@
                   </widget>
                  </item>
                  <item row="0" column="0">
-                  <widget class="QLabel" name="label_4">
+                  <widget class="QLabel" name="label_AvgThicknesses">
                    <property name="sizePolicy">
                     <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
                      <horstretch>0</horstretch>
@@ -704,7 +704,7 @@
                   </widget>
                  </item>
                  <item row="0" column="3">
-                  <widget class="QLabel" name="label_2">
+                  <widget class="QLabel" name="label_SoftBlock">
                    <property name="sizePolicy">
                     <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
                      <horstretch>0</horstretch>
@@ -726,7 +726,7 @@
                   </widget>
                  </item>
                  <item row="0" column="4">
-                  <widget class="QLineEdit" name="txtAvgSoftBlock">
+                  <widget class="QLineEdit" name="textAvgSoftBlock">
                    <property name="sizePolicy">
                     <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
                      <horstretch>0</horstretch>
@@ -745,7 +745,7 @@
                   </widget>
                  </item>
                  <item row="2" column="0">
-                  <widget class="QLabel" name="label_5">
+                  <widget class="QLabel" name="label_Polydispersity">
                    <property name="sizePolicy">
                     <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
                      <horstretch>0</horstretch>
@@ -761,7 +761,7 @@
                   </widget>
                  </item>
                  <item row="1" column="1">
-                  <widget class="QLabel" name="label_15">
+                  <widget class="QLabel" name="label_Interface">
                    <property name="sizePolicy">
                     <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
                      <horstretch>0</horstretch>
@@ -783,7 +783,7 @@
                   </widget>
                  </item>
                  <item row="1" column="3">
-                  <widget class="QLabel" name="label_17">
+                  <widget class="QLabel" name="label_Core">
                    <property name="sizePolicy">
                     <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
                      <horstretch>0</horstretch>
@@ -805,7 +805,7 @@
                   </widget>
                  </item>
                  <item row="1" column="2">
-                  <widget class="QLineEdit" name="txtAvgIntThick">
+                  <widget class="QLineEdit" name="textAvgIntThick">
                    <property name="sizePolicy">
                     <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
                      <horstretch>0</horstretch>
@@ -824,7 +824,7 @@
                   </widget>
                  </item>
                  <item row="1" column="4">
-                  <widget class="QLineEdit" name="txtAvgCoreThick">
+                  <widget class="QLineEdit" name="textAvgCoreThick">
                    <property name="sizePolicy">
                     <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
                      <horstretch>0</horstretch>
@@ -937,7 +937,7 @@
              </widget>
             </item>
             <item>
-             <widget class="QGroupBox" name="groupBox_2">
+             <widget class="QGroupBox" name="groupBox_4_Export">
               <property name="sizePolicy">
                <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
                 <horstretch>0</horstretch>
@@ -949,7 +949,7 @@
               </property>
               <layout class="QHBoxLayout" name="horizontalLayout_2">
                <item>
-                <widget class="QPushButton" name="cmdSaveExtrapolation">
+                <widget class="QPushButton" name="buttonExportExtrapolated">
                  <property name="toolTip">
                   <string>Save the extrapolated data (non-transformed)</string>
                  </property>
@@ -959,7 +959,7 @@
                 </widget>
                </item>
                <item>
-                <widget class="QPushButton" name="cmdSave">
+                <widget class="QPushButton" name="buttonExportTransformed">
                  <property name="sizePolicy">
                   <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
                    <horstretch>0</horstretch>
@@ -1004,7 +1004,7 @@
              </spacer>
             </item>
             <item>
-             <layout class="QHBoxLayout" name="horizontalLayout_5">
+             <layout class="QHBoxLayout" name="horizontalLayout_5_bottom">
               <item>
                <spacer name="horizontalSpacer">
                 <property name="orientation">
@@ -1019,7 +1019,7 @@
                </spacer>
               </item>
               <item>
-               <widget class="QPushButton" name="cmdHelp">
+               <widget class="QPushButton" name="buttonHelp">
                 <property name="text">
                  <string>Help</string>
                 </property>
@@ -1058,7 +1058,7 @@
       </sizepolicy>
      </property>
      <property name="currentIndex">
-      <number>2</number>
+      <number>3</number>
      </property>
      <widget class="QWidget" name="tab">
       <attribute name="title">
@@ -1105,38 +1105,38 @@
   </layout>
  </widget>
  <tabstops>
-  <tabstop>cmdExtract</tabstop>
+  <tabstop>buttonGo</tabstop>
   <tabstop>txtLowerQMax</tabstop>
   <tabstop>txtUpperQMin</tabstop>
   <tabstop>txtUpperQMax</tabstop>
-  <tabstop>fitBackground</tabstop>
-  <tabstop>fitGuinier</tabstop>
-  <tabstop>fitPorod</tabstop>
+  <tabstop>checkboxFitBackground</tabstop>
+  <tabstop>checkboxFitGuinier</tabstop>
+  <tabstop>checkboxFitPorod</tabstop>
   <tabstop>radTangentInflection</tabstop>
   <tabstop>radTangentMidpoint</tabstop>
   <tabstop>radTangentAuto</tabstop>
   <tabstop>radLongPeriodMax</tabstop>
   <tabstop>radLongPeriodDouble</tabstop>
   <tabstop>radLongPeriodAuto</tabstop>
-  <tabstop>txtBackground</tabstop>
-  <tabstop>txtGuinierA</tabstop>
-  <tabstop>txtGuinierB</tabstop>
-  <tabstop>txtPorodK</tabstop>
-  <tabstop>txtPorodSigma</tabstop>
-  <tabstop>txtAvgHardBlock</tabstop>
-  <tabstop>txtAvgSoftBlock</tabstop>
-  <tabstop>txtAvgIntThick</tabstop>
-  <tabstop>txtAvgCoreThick</tabstop>
-  <tabstop>txtPolyRyan</tabstop>
-  <tabstop>txtPolyStribeck</tabstop>
+  <tabstop>textBackground</tabstop>
+  <tabstop>textGuinierA</tabstop>
+  <tabstop>textGuinierB</tabstop>
+  <tabstop>textPorodK</tabstop>
+  <tabstop>textPorodSigma</tabstop>
+  <tabstop>textAvgHardBlock</tabstop>
+  <tabstop>textAvgSoftBlock</tabstop>
+  <tabstop>textAvgIntThick</tabstop>
+  <tabstop>textAvgCoreThick</tabstop>
+  <tabstop>textPolyRyan</tabstop>
+  <tabstop>textPolyStribeck</tabstop>
   <tabstop>txtLongPeriod</tabstop>
   <tabstop>txtLocalCrystal</tabstop>
-  <tabstop>cmdSaveExtrapolation</tabstop>
-  <tabstop>cmdSave</tabstop>
-  <tabstop>cmdHelp</tabstop>
+  <tabstop>buttonExportExtrapolated</tabstop>
+  <tabstop>buttonExportTransformed</tabstop>
+  <tabstop>buttonHelp</tabstop>
   <tabstop>tabWidget</tabstop>
-  <tabstop>scrollArea</tabstop>
-  <tabstop>txtFilename</tabstop>
+  <tabstop>scrollAreaCorfunc</tabstop>
+  <tabstop>textFilename</tabstop>
  </tabstops>
  <resources/>
  <connections/>

--- a/src/sas/qtgui/Perspectives/Corfunc/UI/SaveExtrapolated.ui
+++ b/src/sas/qtgui/Perspectives/Corfunc/UI/SaveExtrapolated.ui
@@ -13,7 +13,7 @@
   <property name="windowTitle">
    <string>Dialog</string>
   </property>
-  <widget class="QDoubleSpinBox" name="spinBoxLow">
+  <widget class="QDoubleSpinBox" name="doubleSpinBoxLow">
    <property name="geometry">
     <rect>
      <x>90</x>
@@ -32,7 +32,7 @@
     <double>100.000000000000000</double>
    </property>
   </widget>
-  <widget class="QDoubleSpinBox" name="spinBoxHigh">
+  <widget class="QDoubleSpinBox" name="doubleSpinBoxHigh">
    <property name="geometry">
     <rect>
      <x>90</x>
@@ -54,7 +54,7 @@
     <double>1.000000000000000</double>
    </property>
   </widget>
-  <widget class="QDoubleSpinBox" name="spinBoxDelta">
+  <widget class="QDoubleSpinBox" name="doubleSpinBoxDelta">
    <property name="geometry">
     <rect>
      <x>90</x>
@@ -160,7 +160,7 @@
     <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Å&lt;span style=&quot; vertical-align:super;&quot;&gt;-1&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
    </property>
   </widget>
-  <widget class="QPushButton" name="buttonOK">
+  <widget class="QPushButton" name="cmdOK">
    <property name="geometry">
     <rect>
      <x>20</x>
@@ -173,7 +173,7 @@
     <string>OK</string>
    </property>
   </widget>
-  <widget class="QPushButton" name="buttonCancel">
+  <widget class="QPushButton" name="cmdCancel">
    <property name="geometry">
     <rect>
      <x>130</x>

--- a/src/sas/qtgui/Perspectives/Corfunc/UI/SaveExtrapolated.ui
+++ b/src/sas/qtgui/Perspectives/Corfunc/UI/SaveExtrapolated.ui
@@ -13,7 +13,7 @@
   <property name="windowTitle">
    <string>Dialog</string>
   </property>
-  <widget class="QDoubleSpinBox" name="spnLow">
+  <widget class="QDoubleSpinBox" name="spinBoxLow">
    <property name="geometry">
     <rect>
      <x>90</x>
@@ -32,7 +32,7 @@
     <double>100.000000000000000</double>
    </property>
   </widget>
-  <widget class="QDoubleSpinBox" name="spnHigh">
+  <widget class="QDoubleSpinBox" name="spinBoxHigh">
    <property name="geometry">
     <rect>
      <x>90</x>
@@ -54,7 +54,7 @@
     <double>1.000000000000000</double>
    </property>
   </widget>
-  <widget class="QDoubleSpinBox" name="spnDelta">
+  <widget class="QDoubleSpinBox" name="spinBoxDelta">
    <property name="geometry">
     <rect>
      <x>90</x>
@@ -160,7 +160,7 @@
     <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Å&lt;span style=&quot; vertical-align:super;&quot;&gt;-1&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
    </property>
   </widget>
-  <widget class="QPushButton" name="cmdOK">
+  <widget class="QPushButton" name="buttonOK">
    <property name="geometry">
     <rect>
      <x>20</x>
@@ -173,7 +173,7 @@
     <string>OK</string>
    </property>
   </widget>
-  <widget class="QPushButton" name="cmdCancel">
+  <widget class="QPushButton" name="buttonCancel">
    <property name="geometry">
     <rect>
      <x>130</x>

--- a/src/sas/qtgui/Perspectives/Fitting/ComplexConstraint.py
+++ b/src/sas/qtgui/Perspectives/Fitting/ComplexConstraint.py
@@ -40,14 +40,14 @@ class ComplexConstraint(QtWidgets.QDialog, Ui_ComplexConstraintUI):
         self.parent = parent
         self.redefining_warning = ""
 
-        self.warning = self.lblWarning.text()
+        self.warning = self.labelWarning.text()
         self.setupData()
         self.setupSignals()
         self.setupWidgets()
         self.setupTooltip()
 
         # Default focus is on OK
-        self.cmdOK.setFocus()
+        self.buttonOK.setFocus()
 
     def setupData(self):
         """
@@ -60,27 +60,27 @@ class ComplexConstraint(QtWidgets.QDialog, Ui_ComplexConstraintUI):
         """
         Signals from various elements
         """
-        self.cmdOK.clicked.connect(self.onApply)
-        self.cmdHelp.clicked.connect(self.onHelp)
-        self.cmdAddAll.clicked.connect(self.onSetAll)
+        self.buttonOK.clicked.connect(self.onApply)
+        self.buttonHelp.clicked.connect(self.onHelp)
+        self.buttonAddAll.clicked.connect(self.onSetAll)
 
-        self.txtConstraint.editingFinished.connect(self.validateFormula)
-        self.cbModel1.currentIndexChanged.connect(self.onModelIndexChange)
-        self.cbModel2.currentIndexChanged.connect(self.onModelIndexChange)
+        self.textComplexConstraint.editingFinished.connect(self.validateFormula)
+        self.comboboxModel1.currentIndexChanged.connect(self.onModelIndexChange)
+        self.comboboxModel2.currentIndexChanged.connect(self.onModelIndexChange)
 
-        self.cbParam1.currentIndexChanged.connect(self.onParamIndexChange)
-        self.cbParam2.currentIndexChanged.connect(self.onParamIndexChange)
-        self.cbOperator.currentIndexChanged.connect(self.onOperatorChange)
+        self.comboboxParam1.currentIndexChanged.connect(self.onParamIndexChange)
+        self.comboboxParam2.currentIndexChanged.connect(self.onParamIndexChange)
+        self.comboboxOperator.currentIndexChanged.connect(self.onOperatorChange)
 
     def setupWidgets(self):
         """
         Setup widgets based on current parameters
         """
-        self.cbModel1.insertItems(0, self.tab_names)
+        self.comboboxModel1.insertItems(0, self.tab_names)
         # add an `All` option in the lhs if there are more than 3 tabs
         if len(self.tab_names) > 2:
-            self.cbModel1.addItem("All")
-        self.cbModel2.insertItems(0, self.tab_names)
+            self.comboboxModel1.addItem("All")
+        self.comboboxModel2.insertItems(0, self.tab_names)
 
         self.setupParamWidgets()
 
@@ -88,10 +88,10 @@ class ComplexConstraint(QtWidgets.QDialog, Ui_ComplexConstraintUI):
 
     def setupMenu(self):
         # Show Add All button, if necessary
-        if self.cbModel1.currentText() ==self.cbModel2.currentText():
-            self.cmdAddAll.setVisible(False)
+        if self.comboboxModel1.currentText() ==self.comboboxModel2.currentText():
+            self.buttonAddAll.setVisible(False)
         else:
-            self.cmdAddAll.setVisible(True)
+            self.buttonAddAll.setVisible(True)
         return
 
     def setupParamWidgets(self):
@@ -99,72 +99,72 @@ class ComplexConstraint(QtWidgets.QDialog, Ui_ComplexConstraintUI):
         Fill out comboboxes and set labels with non-constrained parameters
         """
         # Store previously select parameter
-        previous_param1 = self.cbParam1.currentText()
+        previous_param1 = self.comboboxParam1.currentText()
         # Clear the combobox
-        self.cbParam1.clear()
+        self.comboboxParam1.clear()
         # Populate the left combobox parameter arbitrarily with the parameters
         # from the first tab if `All` option is selected
-        if self.cbModel1.currentText() == "All":
+        if self.comboboxModel1.currentText() == "All":
             items1 = self.tabs[1].main_params_to_fit + self.tabs[1].poly_params_to_fit
         else:
-            tab_index1 = self.cbModel1.currentIndex()
+            tab_index1 = self.comboboxModel1.currentIndex()
             items1 = self.tabs[tab_index1].main_params_to_fit + self.tabs[tab_index1].poly_params_to_fit
-        self.cbParam1.addItems(items1)
+        self.comboboxParam1.addItems(items1)
         # Show the previously selected parameter if available
         if previous_param1 in items1:
-            index1 = self.cbParam1.findText(previous_param1)
-            self.cbParam1.setCurrentIndex(index1)
+            index1 = self.comboboxParam1.findText(previous_param1)
+            self.comboboxParam1.setCurrentIndex(index1)
 
         # Store previously select parameter
-        previous_param2 = self.cbParam2.currentText()
-        self.cbParam2.clear()
-        tab_index2 = self.cbModel2.currentIndex()
+        previous_param2 = self.comboboxParam2.currentText()
+        self.comboboxParam2.clear()
+        tab_index2 = self.comboboxModel2.currentIndex()
         items2 = [param for param in self.params[tab_index2]]
         # The following can be used if it is judged preferable that constrained
         # parameters are not used in the definition of a new constraint
         #items2 = [param for param in self.params[tab_index2] if not self.tabs[tab_index2].paramHasConstraint(param)]
 
-        self.cbParam2.addItems(items2)
+        self.comboboxParam2.addItems(items2)
         # Show the previously selected parameter if available
         if previous_param2 in items2:
-            index2 = self.cbParam2.findText(previous_param2)
-            self.cbParam2.setCurrentIndex(index2)
+            index2 = self.comboboxParam2.findText(previous_param2)
+            self.comboboxParam2.setCurrentIndex(index2)
 
-        self.txtParam.setText(self.cbModel1.currentText() + ":"
-                              + self.cbParam1.currentText())
+        self.textParamComplexConstraint.setText(self.comboboxModel1.currentText() + ":"
+                              + self.comboboxParam1.currentText())
 
-        self.cbOperator.clear()
-        self.cbOperator.addItems(ALLOWED_OPERATORS)
-        self.txtOperator.setText(self.cbOperator.currentText())
+        self.comboboxOperator.clear()
+        self.comboboxOperator.addItems(ALLOWED_OPERATORS)
+        self.labelOperatorComplexConstraint.setText(self.comboboxOperator.currentText())
 
-        self.txtConstraint.setText(self.tab_names[tab_index2]+"."+self.cbParam2.currentText())
+        self.textComplexConstraint.setText(self.tab_names[tab_index2]+"."+self.comboboxParam2.currentText())
 
         # disable Apply if no parameters available
         if len(items1)==0:
-            self.cmdOK.setEnabled(False)
-            self.cmdAddAll.setEnabled(False)
+            self.buttonOK.setEnabled(False)
+            self.buttonAddAll.setEnabled(False)
             txt = "No parameters in model "+self.tab_names[0] +\
                 " are available for constraining.\n"+\
                 "Please select at least one parameter for fitting when adding a constraint."
         else:
             txt = self.redefining_warning
-            self.cmdOK.setEnabled(True)
-            self.cmdAddAll.setEnabled(True)
-        self.lblWarning.setText(txt)
+            self.buttonOK.setEnabled(True)
+            self.buttonAddAll.setEnabled(True)
+        self.labelWarning.setText(txt)
 
         # disable Aplly all if `All` option on lhs has been selected
-        if self.cbModel1.currentText() == "All":
-            self.cmdAddAll.setEnabled(False)
+        if self.comboboxModel1.currentText() == "All":
+            self.buttonAddAll.setEnabled(False)
         else:
-            self.cmdAddAll.setEnabled(True)
+            self.buttonAddAll.setEnabled(True)
 
     def setupTooltip(self):
         """
-        Tooltip for txtConstraint
+        Tooltip for textComplexConstraint
         """
         tooltip = "E.g. M1:scale = 2.0 * M2.scale\n"
         tooltip += "M1:scale = sqrt(M2.scale) + 5"
-        self.txtConstraint.setToolTip(tooltip)
+        self.textComplexConstraint.setToolTip(tooltip)
 
     def onParamIndexChange(self, index):
         """
@@ -172,12 +172,12 @@ class ComplexConstraint(QtWidgets.QDialog, Ui_ComplexConstraintUI):
         """
         # Find out the signal source
         source = self.sender().objectName()
-        param1 = self.cbParam1.currentText()
-        param2 = self.cbParam2.currentText()
-        if source == "cbParam1":
-            self.txtParam.setText(self.cbModel1.currentText() + ":" + param1)
+        param1 = self.comboboxParam1.currentText()
+        param2 = self.comboboxParam2.currentText()
+        if source == "comboboxParam1":
+            self.textParamComplexConstraint.setText(self.comboboxModel1.currentText() + ":" + param1)
         else:
-            self.txtConstraint.setText(self.cbModel2.currentText() + "." + param2)
+            self.textComplexConstraint.setText(self.comboboxModel2.currentText() + "." + param2)
         # Check if any of the parameters are polydisperse
         params_list = [param1, param2]
         all_pars = [tab.model_parameters for tab in self.tabs]
@@ -187,7 +187,7 @@ class ComplexConstraint(QtWidgets.QDialog, Ui_ComplexConstraintUI):
             if any([FittingUtilities.isParamPolydisperse(p, pars, is2D) for p in params_list]):
                 # no parameters are pd - reset the text to not show the warning
                 txt = self.warning
-        self.lblWarning.setText(txt)
+        self.labelWarning.setText(txt)
 
     def onModelIndexChange(self, index):
         """
@@ -202,7 +202,7 @@ class ComplexConstraint(QtWidgets.QDialog, Ui_ComplexConstraintUI):
         """
         Respond to operator combo box changes
         """
-        self.txtOperator.setText(self.cbOperator.currentText())
+        self.labelOperatorComplexConstraint.setText(self.comboboxOperator.currentText())
 
     def validateFormula(self):
         """
@@ -211,15 +211,15 @@ class ComplexConstraint(QtWidgets.QDialog, Ui_ComplexConstraintUI):
         # temporarily disable validation, as not yet fully operational
         return
 
-        formula_is_valid = self.validateConstraint(self.txtConstraint.text())
+        formula_is_valid = self.validateConstraint(self.textComplexConstraint.text())
         if not formula_is_valid:
-            self.cmdOK.setEnabled(False)
-            self.cmdAddAll.setEnabled(False)
-            self.txtConstraint.setStyleSheet("QLineEdit {background-color: red;}")
+            self.buttonOK.setEnabled(False)
+            self.buttonAddAll.setEnabled(False)
+            self.textComplexConstraint.setStyleSheet("QLineEdit {background-color: red;}")
         else:
-            self.cmdOK.setEnabled(True)
-            self.cmdAddAll.setEnabled(True)
-            self.txtConstraint.setStyleSheet("QLineEdit {background-color: white;}")
+            self.buttonOK.setEnabled(True)
+            self.buttonAddAll.setEnabled(True)
+            self.textComplexConstraint.setStyleSheet("QLineEdit {background-color: white;}")
 
     def validateConstraint(self, constraint_text):
         """
@@ -230,9 +230,9 @@ class ComplexConstraint(QtWidgets.QDialog, Ui_ComplexConstraintUI):
             return False
 
         # M1.scale --> model_str='M1', constraint_text='scale'
-        param_str = self.cbParam2.currentText()
+        param_str = self.comboboxParam2.currentText()
         constraint_text = constraint_text.strip()
-        model_str = self.cbModel2.currentText()
+        model_str = self.comboboxModel2.currentText()
 
         # 0. Has to contain the model name
         if model_str != model_str:
@@ -267,13 +267,13 @@ class ComplexConstraint(QtWidgets.QDialog, Ui_ComplexConstraintUI):
         """
         Return the generated constraint
         """
-        param = self.cbParam1.currentText()
-        value = self.cbParam2.currentText()
-        func = self.txtConstraint.text()
-        value_ex = (self.cbModel1.currentText() + "."
-                    + self.cbParam1.currentText())
-        model1 = self.cbModel1.currentText()
-        operator = self.cbOperator.currentText()
+        param = self.comboboxParam1.currentText()
+        value = self.comboboxParam2.currentText()
+        func = self.textComplexConstraint.text()
+        value_ex = (self.comboboxModel1.currentText() + "."
+                    + self.comboboxParam1.currentText())
+        model1 = self.comboboxModel1.currentText()
+        operator = self.comboboxOperator.currentText()
 
         con = Constraint(self,
                          param=param,
@@ -291,7 +291,7 @@ class ComplexConstraint(QtWidgets.QDialog, Ui_ComplexConstraintUI):
         # get the the parameter that is being redefined
         param = cons_tuple[1].param
         # get a list of all constrained parameters
-        tab_index1 = self.cbModel1.currentIndex()
+        tab_index1 = self.comboboxModel1.currentIndex()
         items = [param for param in self.params[tab_index1] if self.tabs[tab_index1].paramHasConstraint(param)]
         # loop over the list of constrained parameters to check for redefinition
         for item in items:
@@ -306,12 +306,12 @@ class ComplexConstraint(QtWidgets.QDialog, Ui_ComplexConstraintUI):
         """
         # if the combobox is set to `All` just call `applyAcrossTabs` and
         # return
-        if self.cbModel1.currentText() == "All":
+        if self.comboboxModel1.currentText() == "All":
             # exclude the tab on the lhs
             tabs = [tab for tab in self.tabs if
-                    tab.kernel_module.name != self.cbModel2.currentText()]
-            self.applyAcrossTabs(tabs, self.cbParam1.currentText(),
-                                 self.txtConstraint.text())
+                    tab.kernel_module.name != self.comboboxModel2.currentText()]
+            self.applyAcrossTabs(tabs, self.comboboxParam1.currentText(),
+                                 self.textComplexConstraint.text())
             self.setupParamWidgets()
             return
 
@@ -355,8 +355,8 @@ class ComplexConstraint(QtWidgets.QDialog, Ui_ComplexConstraintUI):
         Set constraints on all identically named parameters between two fitpages
         """
         # loop over parameters in constrained model
-        index1 = self.cbModel1.currentIndex()
-        index2 = self.cbModel2.currentIndex()
+        index1 = self.comboboxModel1.currentIndex()
+        index2 = self.comboboxModel2.currentIndex()
         items1 = self.tabs[index1].main_params_to_fit + self.tabs[index1].poly_params_to_fit
         items2 = self.tabs[index2].main_params_to_fit + self.tabs[index2].poly_params_to_fit
         # create an empty list to store redefined constraints
@@ -365,10 +365,10 @@ class ComplexConstraint(QtWidgets.QDialog, Ui_ComplexConstraintUI):
             if item not in items2: continue
             param = item
             value = item
-            func = self.cbModel2.currentText() + "." + param
-            value_ex = self.cbModel1.currentText() + "." + param
-            model1 = self.cbModel1.currentText()
-            operator = self.cbOperator.currentText()
+            func = self.comboboxModel2.currentText() + "." + param
+            value_ex = self.comboboxModel1.currentText() + "." + param
+            model1 = self.comboboxModel1.currentText()
+            operator = self.comboboxOperator.currentText()
 
             con = Constraint(self,
                              param=param,

--- a/src/sas/qtgui/Perspectives/Fitting/ComplexConstraint.py
+++ b/src/sas/qtgui/Perspectives/Fitting/ComplexConstraint.py
@@ -40,14 +40,14 @@ class ComplexConstraint(QtWidgets.QDialog, Ui_ComplexConstraintUI):
         self.parent = parent
         self.redefining_warning = ""
 
-        self.warning = self.labelWarning.text()
+        self.warning = self.lblWarning.text()
         self.setupData()
         self.setupSignals()
         self.setupWidgets()
         self.setupTooltip()
 
         # Default focus is on OK
-        self.buttonOK.setFocus()
+        self.cmdOK.setFocus()
 
     def setupData(self):
         """
@@ -60,27 +60,27 @@ class ComplexConstraint(QtWidgets.QDialog, Ui_ComplexConstraintUI):
         """
         Signals from various elements
         """
-        self.buttonOK.clicked.connect(self.onApply)
-        self.buttonHelp.clicked.connect(self.onHelp)
-        self.buttonAddAll.clicked.connect(self.onSetAll)
+        self.cmdOK.clicked.connect(self.onApply)
+        self.cmdHelp.clicked.connect(self.onHelp)
+        self.cmdAddAll.clicked.connect(self.onSetAll)
 
-        self.textComplexConstraint.editingFinished.connect(self.validateFormula)
-        self.comboboxModel1.currentIndexChanged.connect(self.onModelIndexChange)
-        self.comboboxModel2.currentIndexChanged.connect(self.onModelIndexChange)
+        self.txtComplexConstraint.editingFinished.connect(self.validateFormula)
+        self.cbModel1.currentIndexChanged.connect(self.onModelIndexChange)
+        self.cbModel2.currentIndexChanged.connect(self.onModelIndexChange)
 
-        self.comboboxParam1.currentIndexChanged.connect(self.onParamIndexChange)
-        self.comboboxParam2.currentIndexChanged.connect(self.onParamIndexChange)
-        self.comboboxOperator.currentIndexChanged.connect(self.onOperatorChange)
+        self.cbParam1.currentIndexChanged.connect(self.onParamIndexChange)
+        self.cbParam2.currentIndexChanged.connect(self.onParamIndexChange)
+        self.cbOperator.currentIndexChanged.connect(self.onOperatorChange)
 
     def setupWidgets(self):
         """
         Setup widgets based on current parameters
         """
-        self.comboboxModel1.insertItems(0, self.tab_names)
+        self.cbModel1.insertItems(0, self.tab_names)
         # add an `All` option in the lhs if there are more than 3 tabs
         if len(self.tab_names) > 2:
-            self.comboboxModel1.addItem("All")
-        self.comboboxModel2.insertItems(0, self.tab_names)
+            self.cbModel1.addItem("All")
+        self.cbModel2.insertItems(0, self.tab_names)
 
         self.setupParamWidgets()
 
@@ -88,10 +88,10 @@ class ComplexConstraint(QtWidgets.QDialog, Ui_ComplexConstraintUI):
 
     def setupMenu(self):
         # Show Add All button, if necessary
-        if self.comboboxModel1.currentText() ==self.comboboxModel2.currentText():
-            self.buttonAddAll.setVisible(False)
+        if self.cbModel1.currentText() ==self.cbModel2.currentText():
+            self.cmdAddAll.setVisible(False)
         else:
-            self.buttonAddAll.setVisible(True)
+            self.cmdAddAll.setVisible(True)
         return
 
     def setupParamWidgets(self):
@@ -99,72 +99,72 @@ class ComplexConstraint(QtWidgets.QDialog, Ui_ComplexConstraintUI):
         Fill out comboboxes and set labels with non-constrained parameters
         """
         # Store previously select parameter
-        previous_param1 = self.comboboxParam1.currentText()
+        previous_param1 = self.cbParam1.currentText()
         # Clear the combobox
-        self.comboboxParam1.clear()
+        self.cbParam1.clear()
         # Populate the left combobox parameter arbitrarily with the parameters
         # from the first tab if `All` option is selected
-        if self.comboboxModel1.currentText() == "All":
+        if self.cbModel1.currentText() == "All":
             items1 = self.tabs[1].main_params_to_fit + self.tabs[1].poly_params_to_fit
         else:
-            tab_index1 = self.comboboxModel1.currentIndex()
+            tab_index1 = self.cbModel1.currentIndex()
             items1 = self.tabs[tab_index1].main_params_to_fit + self.tabs[tab_index1].poly_params_to_fit
-        self.comboboxParam1.addItems(items1)
+        self.cbParam1.addItems(items1)
         # Show the previously selected parameter if available
         if previous_param1 in items1:
-            index1 = self.comboboxParam1.findText(previous_param1)
-            self.comboboxParam1.setCurrentIndex(index1)
+            index1 = self.cbParam1.findText(previous_param1)
+            self.cbParam1.setCurrentIndex(index1)
 
         # Store previously select parameter
-        previous_param2 = self.comboboxParam2.currentText()
-        self.comboboxParam2.clear()
-        tab_index2 = self.comboboxModel2.currentIndex()
+        previous_param2 = self.cbParam2.currentText()
+        self.cbParam2.clear()
+        tab_index2 = self.cbModel2.currentIndex()
         items2 = [param for param in self.params[tab_index2]]
         # The following can be used if it is judged preferable that constrained
         # parameters are not used in the definition of a new constraint
         #items2 = [param for param in self.params[tab_index2] if not self.tabs[tab_index2].paramHasConstraint(param)]
 
-        self.comboboxParam2.addItems(items2)
+        self.cbParam2.addItems(items2)
         # Show the previously selected parameter if available
         if previous_param2 in items2:
-            index2 = self.comboboxParam2.findText(previous_param2)
-            self.comboboxParam2.setCurrentIndex(index2)
+            index2 = self.cbParam2.findText(previous_param2)
+            self.cbParam2.setCurrentIndex(index2)
 
-        self.textParamComplexConstraint.setText(self.comboboxModel1.currentText() + ":"
-                              + self.comboboxParam1.currentText())
+        self.txtParamComplexConstraint.setText(self.cbModel1.currentText() + ":"
+                              + self.cbParam1.currentText())
 
-        self.comboboxOperator.clear()
-        self.comboboxOperator.addItems(ALLOWED_OPERATORS)
-        self.labelOperatorComplexConstraint.setText(self.comboboxOperator.currentText())
+        self.cbOperator.clear()
+        self.cbOperator.addItems(ALLOWED_OPERATORS)
+        self.lblOperatorComplexConstraint.setText(self.cbOperator.currentText())
 
-        self.textComplexConstraint.setText(self.tab_names[tab_index2]+"."+self.comboboxParam2.currentText())
+        self.txtComplexConstraint.setText(self.tab_names[tab_index2]+"."+self.cbParam2.currentText())
 
         # disable Apply if no parameters available
         if len(items1)==0:
-            self.buttonOK.setEnabled(False)
-            self.buttonAddAll.setEnabled(False)
+            self.cmdOK.setEnabled(False)
+            self.cmdAddAll.setEnabled(False)
             txt = "No parameters in model "+self.tab_names[0] +\
                 " are available for constraining.\n"+\
                 "Please select at least one parameter for fitting when adding a constraint."
         else:
             txt = self.redefining_warning
-            self.buttonOK.setEnabled(True)
-            self.buttonAddAll.setEnabled(True)
-        self.labelWarning.setText(txt)
+            self.cmdOK.setEnabled(True)
+            self.cmdAddAll.setEnabled(True)
+        self.lblWarning.setText(txt)
 
         # disable Aplly all if `All` option on lhs has been selected
-        if self.comboboxModel1.currentText() == "All":
-            self.buttonAddAll.setEnabled(False)
+        if self.cbModel1.currentText() == "All":
+            self.cmdAddAll.setEnabled(False)
         else:
-            self.buttonAddAll.setEnabled(True)
+            self.cmdAddAll.setEnabled(True)
 
     def setupTooltip(self):
         """
-        Tooltip for textComplexConstraint
+        Tooltip for txtComplexConstraint
         """
         tooltip = "E.g. M1:scale = 2.0 * M2.scale\n"
         tooltip += "M1:scale = sqrt(M2.scale) + 5"
-        self.textComplexConstraint.setToolTip(tooltip)
+        self.txtComplexConstraint.setToolTip(tooltip)
 
     def onParamIndexChange(self, index):
         """
@@ -172,12 +172,12 @@ class ComplexConstraint(QtWidgets.QDialog, Ui_ComplexConstraintUI):
         """
         # Find out the signal source
         source = self.sender().objectName()
-        param1 = self.comboboxParam1.currentText()
-        param2 = self.comboboxParam2.currentText()
-        if source == "comboboxParam1":
-            self.textParamComplexConstraint.setText(self.comboboxModel1.currentText() + ":" + param1)
+        param1 = self.cbParam1.currentText()
+        param2 = self.cbParam2.currentText()
+        if source == "cbParam1":
+            self.txtParamComplexConstraint.setText(self.cbModel1.currentText() + ":" + param1)
         else:
-            self.textComplexConstraint.setText(self.comboboxModel2.currentText() + "." + param2)
+            self.txtComplexConstraint.setText(self.cbModel2.currentText() + "." + param2)
         # Check if any of the parameters are polydisperse
         params_list = [param1, param2]
         all_pars = [tab.model_parameters for tab in self.tabs]
@@ -187,7 +187,7 @@ class ComplexConstraint(QtWidgets.QDialog, Ui_ComplexConstraintUI):
             if any([FittingUtilities.isParamPolydisperse(p, pars, is2D) for p in params_list]):
                 # no parameters are pd - reset the text to not show the warning
                 txt = self.warning
-        self.labelWarning.setText(txt)
+        self.lblWarning.setText(txt)
 
     def onModelIndexChange(self, index):
         """
@@ -202,7 +202,7 @@ class ComplexConstraint(QtWidgets.QDialog, Ui_ComplexConstraintUI):
         """
         Respond to operator combo box changes
         """
-        self.labelOperatorComplexConstraint.setText(self.comboboxOperator.currentText())
+        self.lblOperatorComplexConstraint.setText(self.cbOperator.currentText())
 
     def validateFormula(self):
         """
@@ -211,15 +211,15 @@ class ComplexConstraint(QtWidgets.QDialog, Ui_ComplexConstraintUI):
         # temporarily disable validation, as not yet fully operational
         return
 
-        formula_is_valid = self.validateConstraint(self.textComplexConstraint.text())
+        formula_is_valid = self.validateConstraint(self.txtComplexConstraint.text())
         if not formula_is_valid:
-            self.buttonOK.setEnabled(False)
-            self.buttonAddAll.setEnabled(False)
-            self.textComplexConstraint.setStyleSheet("QLineEdit {background-color: red;}")
+            self.cmdOK.setEnabled(False)
+            self.cmdAddAll.setEnabled(False)
+            self.txtComplexConstraint.setStyleSheet("QLineEdit {background-color: red;}")
         else:
-            self.buttonOK.setEnabled(True)
-            self.buttonAddAll.setEnabled(True)
-            self.textComplexConstraint.setStyleSheet("QLineEdit {background-color: white;}")
+            self.cmdOK.setEnabled(True)
+            self.cmdAddAll.setEnabled(True)
+            self.txtComplexConstraint.setStyleSheet("QLineEdit {background-color: white;}")
 
     def validateConstraint(self, constraint_text):
         """
@@ -230,9 +230,9 @@ class ComplexConstraint(QtWidgets.QDialog, Ui_ComplexConstraintUI):
             return False
 
         # M1.scale --> model_str='M1', constraint_text='scale'
-        param_str = self.comboboxParam2.currentText()
+        param_str = self.cbParam2.currentText()
         constraint_text = constraint_text.strip()
-        model_str = self.comboboxModel2.currentText()
+        model_str = self.cbModel2.currentText()
 
         # 0. Has to contain the model name
         if model_str != model_str:
@@ -267,13 +267,13 @@ class ComplexConstraint(QtWidgets.QDialog, Ui_ComplexConstraintUI):
         """
         Return the generated constraint
         """
-        param = self.comboboxParam1.currentText()
-        value = self.comboboxParam2.currentText()
-        func = self.textComplexConstraint.text()
-        value_ex = (self.comboboxModel1.currentText() + "."
-                    + self.comboboxParam1.currentText())
-        model1 = self.comboboxModel1.currentText()
-        operator = self.comboboxOperator.currentText()
+        param = self.cbParam1.currentText()
+        value = self.cbParam2.currentText()
+        func = self.txtComplexConstraint.text()
+        value_ex = (self.cbModel1.currentText() + "."
+                    + self.cbParam1.currentText())
+        model1 = self.cbModel1.currentText()
+        operator = self.cbOperator.currentText()
 
         con = Constraint(self,
                          param=param,
@@ -291,7 +291,7 @@ class ComplexConstraint(QtWidgets.QDialog, Ui_ComplexConstraintUI):
         # get the the parameter that is being redefined
         param = cons_tuple[1].param
         # get a list of all constrained parameters
-        tab_index1 = self.comboboxModel1.currentIndex()
+        tab_index1 = self.cbModel1.currentIndex()
         items = [param for param in self.params[tab_index1] if self.tabs[tab_index1].paramHasConstraint(param)]
         # loop over the list of constrained parameters to check for redefinition
         for item in items:
@@ -306,12 +306,12 @@ class ComplexConstraint(QtWidgets.QDialog, Ui_ComplexConstraintUI):
         """
         # if the combobox is set to `All` just call `applyAcrossTabs` and
         # return
-        if self.comboboxModel1.currentText() == "All":
+        if self.cbModel1.currentText() == "All":
             # exclude the tab on the lhs
             tabs = [tab for tab in self.tabs if
-                    tab.kernel_module.name != self.comboboxModel2.currentText()]
-            self.applyAcrossTabs(tabs, self.comboboxParam1.currentText(),
-                                 self.textComplexConstraint.text())
+                    tab.kernel_module.name != self.cbModel2.currentText()]
+            self.applyAcrossTabs(tabs, self.cbParam1.currentText(),
+                                 self.txtComplexConstraint.text())
             self.setupParamWidgets()
             return
 
@@ -355,8 +355,8 @@ class ComplexConstraint(QtWidgets.QDialog, Ui_ComplexConstraintUI):
         Set constraints on all identically named parameters between two fitpages
         """
         # loop over parameters in constrained model
-        index1 = self.comboboxModel1.currentIndex()
-        index2 = self.comboboxModel2.currentIndex()
+        index1 = self.cbModel1.currentIndex()
+        index2 = self.cbModel2.currentIndex()
         items1 = self.tabs[index1].main_params_to_fit + self.tabs[index1].poly_params_to_fit
         items2 = self.tabs[index2].main_params_to_fit + self.tabs[index2].poly_params_to_fit
         # create an empty list to store redefined constraints
@@ -365,10 +365,10 @@ class ComplexConstraint(QtWidgets.QDialog, Ui_ComplexConstraintUI):
             if item not in items2: continue
             param = item
             value = item
-            func = self.comboboxModel2.currentText() + "." + param
-            value_ex = self.comboboxModel1.currentText() + "." + param
-            model1 = self.comboboxModel1.currentText()
-            operator = self.comboboxOperator.currentText()
+            func = self.cbModel2.currentText() + "." + param
+            value_ex = self.cbModel1.currentText() + "." + param
+            model1 = self.cbModel1.currentText()
+            operator = self.cbOperator.currentText()
 
             con = Constraint(self,
                              param=param,

--- a/src/sas/qtgui/Perspectives/Fitting/ConstraintWidget.py
+++ b/src/sas/qtgui/Perspectives/Fitting/ConstraintWidget.py
@@ -169,8 +169,8 @@ class ConstraintWidget(QtWidgets.QWidget, Ui_ConstraintWidgetUI):
         Set up various widget states
         """
         # disable special cases until properly defined
-        self.label.setVisible(False)
-        self.comboboxSpecialCases.setVisible(False)
+        self.lblSpecialCases.setVisible(False)
+        self.cbSpecialCases.setVisible(False)
 
         self.sim_fit_labels = ['FitPage', 'Model', 'Data', 'Mnemonic']
         # tab widget - headers
@@ -188,7 +188,7 @@ class ConstraintWidget(QtWidgets.QWidget, Ui_ConstraintWidgetUI):
         self.tblTabList.customContextMenuRequested.connect(self.showModelContextMenu)
 
         # Single Fit is the default, so disable chainfit
-        self.checkBoxChainedFit.setVisible(False)
+        self.cbChainedFit.setVisible(False)
 
         # disabled constraint
         labels = ['Constraint']
@@ -207,14 +207,14 @@ class ConstraintWidget(QtWidgets.QWidget, Ui_ConstraintWidgetUI):
         Set up signals/slots for this widget
         """
         # simple widgets
-        self.radioButtonSingle.toggled.connect(self.onFitTypeChange)
-        self.radioButtonBatch.toggled.connect(self.onFitTypeChange)
-        self.comboboxSpecialCases.currentIndexChanged.connect(self.onSpecialCaseChange)
-        self.buttonFit.clicked.connect(self.onFit)
-        self.buttonHelp.clicked.connect(self.onHelp)
-        self.buttonAddConstraints.clicked.connect(self.showMultiConstraint)
-        self.checkBoxChainedFit.toggled.connect(self.onChainFit)
-        self.checkBoxWeight.toggled.connect(self.onWeightModify)
+        self.rbSingleFits.toggled.connect(self.onFitTypeChange)
+        self.rbBatchFits.toggled.connect(self.onFitTypeChange)
+        self.cbSpecialCases.currentIndexChanged.connect(self.onSpecialCaseChange)
+        self.cmdFit.clicked.connect(self.onFit)
+        self.cmdHelp.clicked.connect(self.onHelp)
+        self.cmdAddConstraints.clicked.connect(self.showMultiConstraint)
+        self.cbChainedFit.toggled.connect(self.onChainFit)
+        self.cbWeight.toggled.connect(self.onWeightModify)
 
         # QTableWidgets
         self.tblTabList.cellChanged.connect(self.onTabCellEdit)
@@ -270,9 +270,9 @@ class ConstraintWidget(QtWidgets.QWidget, Ui_ConstraintWidgetUI):
         single fit/batch fit
         """
         source = self.sender().objectName()
-        self.currentType = "BatchPage" if source == "radioButtonBatch" else "FitPage"
-        self.checkBoxChainedFit.setVisible(source=="radioButtonBatch")
-        self.checkBoxWeight.setVisible(source!="radioButtonBatch")
+        self.currentType = "BatchPage" if source == "rbBatchFits" else "FitPage"
+        self.cbChainedFit.setVisible(source=="rbBatchFits")
+        self.cbWeight.setVisible(source!="rbBatchFits")
         self.initializeFitList()
 
     def onSpecialCaseChange(self, index):
@@ -309,8 +309,8 @@ class ConstraintWidget(QtWidgets.QWidget, Ui_ConstraintWidgetUI):
         if self.is_running:
             self.is_running = False
             #re-enable the Fit button
-            self.buttonFit.setStyleSheet('QPushButton {color: black;}')
-            self.buttonFit.setText("Fit")
+            self.cmdFit.setStyleSheet('QPushButton {color: black;}')
+            self.cmdFit.setText("Fit")
             # stop the fitpages
             self.calc_fit.stop()
             return
@@ -402,8 +402,8 @@ class ConstraintWidget(QtWidgets.QWidget, Ui_ConstraintWidgetUI):
             self.calc_fit.ready(2.5)
 
         # modify the Fit button
-        self.buttonFit.setStyleSheet('QPushButton {color: red;}')
-        self.buttonFit.setText('Stop fit')
+        self.cmdFit.setStyleSheet('QPushButton {color: red;}')
+        self.cmdFit.setText('Stop fit')
         self.parent.communicate.statusBarUpdateSignal.emit('Fitting started...')
         self.is_running = True
 
@@ -445,7 +445,7 @@ class ConstraintWidget(QtWidgets.QWidget, Ui_ConstraintWidgetUI):
             tab_name = item.text()
             self.tabs_for_fitting[tab_name] = (item.checkState() == QtCore.Qt.Checked)
             # Enable fitting only when there are models to fit
-            self.buttonFit.setEnabled(any(self.tabs_for_fitting.values()))
+            self.cmdFit.setEnabled(any(self.tabs_for_fitting.values()))
             return
 
         elif column == self.sim_fit_labels.index('Mnemonic'):
@@ -457,7 +457,7 @@ class ConstraintWidget(QtWidgets.QWidget, Ui_ConstraintWidgetUI):
                 self.tblTabList.blockSignals(True)
                 item.setBackground(QtCore.Qt.red)
                 self.tblTabList.blockSignals(False)
-                self.buttonFit.setEnabled(False)
+                self.cmdFit.setEnabled(False)
                 if new_moniker == "":
                     msg = "Please use a non-empty name."
                 else:
@@ -469,7 +469,7 @@ class ConstraintWidget(QtWidgets.QWidget, Ui_ConstraintWidgetUI):
             self.tblTabList.blockSignals(True)
             item.setBackground(QtCore.Qt.white)
             self.tblTabList.blockSignals(False)
-            self.buttonFit.setEnabled(True)
+            self.cmdFit.setEnabled(True)
             item.setToolTip("")
             msg = "Fitpage name changed to {}.".format(new_moniker)
             self.parent.communicate.statusBarUpdateSignal.emit(msg)
@@ -502,7 +502,7 @@ class ConstraintWidget(QtWidgets.QWidget, Ui_ConstraintWidgetUI):
                 self.tblTabList.blockSignals(True)
                 item.setBackground(QtCore.Qt.red)
                 self.tblTabList.blockSignals(False)
-                self.buttonFit.setEnabled(False)
+                self.cmdFit.setEnabled(False)
                 msg = "Weighting must be a numerical value (integer or float)."
                 self.parent.communicate.statusBarUpdateSignal.emit(msg)
                 item.setToolTip(msg)
@@ -512,7 +512,7 @@ class ConstraintWidget(QtWidgets.QWidget, Ui_ConstraintWidgetUI):
             self.tblTabList.blockSignals(True)
             item.setBackground(QtCore.Qt.white)
             self.tblTabList.blockSignals(False)
-            self.buttonFit.setEnabled(True)
+            self.cmdFit.setEnabled(True)
             fit_page_column = self.sim_fit_labels.index('FitPage')
             self.weighting_ratios[self.tblTabList.item(row, fit_page_column).data(0)] = new_weighting
 
@@ -650,8 +650,8 @@ class ConstraintWidget(QtWidgets.QWidget, Ui_ConstraintWidgetUI):
         Respond to the successful fit complete signal
         """
         #re-enable the Fit button
-        self.buttonFit.setStyleSheet('QPushButton {color: black;}')
-        self.buttonFit.setText("Fit")
+        self.cmdFit.setStyleSheet('QPushButton {color: black;}')
+        self.cmdFit.setText("Fit")
         self.is_running = False
 
         # Notify the parent about completed fitting
@@ -710,8 +710,8 @@ class ConstraintWidget(QtWidgets.QWidget, Ui_ConstraintWidgetUI):
         Respond to the successful batch fit complete signal
         """
         #re-enable the Fit button
-        self.buttonFit.setStyleSheet('QPushButton {color: black;}')
-        self.buttonFit.setText("Fit")
+        self.cmdFit.setStyleSheet('QPushButton {color: black;}')
+        self.cmdFit.setText("Fit")
         self.is_running = False
 
         # Notify the parent about completed fitting
@@ -757,8 +757,8 @@ class ConstraintWidget(QtWidgets.QWidget, Ui_ConstraintWidgetUI):
         Respond to fitting failure.
         """
         #re-enable the Fit button
-        self.buttonFit.setStyleSheet('QPushButton {color: black;}')
-        self.buttonFit.setText("Fit")
+        self.cmdFit.setStyleSheet('QPushButton {color: black;}')
+        self.cmdFit.setText("Fit")
         self.is_running = False
 
         # Notify the parent about completed fitting
@@ -1037,16 +1037,16 @@ class ConstraintWidget(QtWidgets.QWidget, Ui_ConstraintWidgetUI):
         self.tblConstraints.setRowCount(0)
 
         # Fit disabled
-        self.buttonFit.setEnabled(False)
+        self.cmdFit.setEnabled(False)
 
         if not objects:
             return
 
         tabs = [tab for tab in ObjectLibrary.listObjects() if self.isTabImportable(tab)]
         if len(tabs) < 1:
-            self.buttonAddConstraints.setEnabled(False)
+            self.cmdAddConstraints.setEnabled(False)
         else:
-            self.buttonAddConstraints.setEnabled(True)
+            self.cmdAddConstraints.setEnabled(True)
 
         if not self._row_order:
             # Initialize tab order list
@@ -1059,7 +1059,7 @@ class ConstraintWidget(QtWidgets.QWidget, Ui_ConstraintWidgetUI):
             self.updateFitLine(tab, model_key=model_key)
             self.updateSignalsFromTab(tab)
             # We have at least 1 fit page, allow fitting
-            self.buttonFit.setEnabled(True)
+            self.cmdFit.setEnabled(True)
 
     def orderedSublist(self, order_list, target_list):
         """
@@ -1157,7 +1157,7 @@ class ConstraintWidget(QtWidgets.QWidget, Ui_ConstraintWidgetUI):
         param_list.append(['data_id', "cs_tab"+str(self.page_id)])
         param_list.append(['current_type', self.currentType])
         param_list.append(['is_chain_fitting', str(self.is_chain_fitting)])
-        param_list.append(['special_case', self.comboboxSpecialCases.currentText()])
+        param_list.append(['special_case', self.cbSpecialCases.currentText()])
 
         return param_list
 
@@ -1221,12 +1221,12 @@ class ConstraintWidget(QtWidgets.QWidget, Ui_ConstraintWidgetUI):
         # fit/batch radio
         isBatch = parameters['current_type'][0] == 'BatchPage'
         if isBatch:
-            self.radioButtonBatch.toggle()
+            self.rbBatchFits.toggle()
 
         # chain
         is_chain = parameters['is_chain_fitting'][0] == 'True'
         if isBatch:
-            self.checkBoxChainedFit.setChecked(is_chain)
+            self.cbChainedFit.setChecked(is_chain)
 
     def getReport(self):
         """

--- a/src/sas/qtgui/Perspectives/Fitting/ConstraintWidget.py
+++ b/src/sas/qtgui/Perspectives/Fitting/ConstraintWidget.py
@@ -170,7 +170,7 @@ class ConstraintWidget(QtWidgets.QWidget, Ui_ConstraintWidgetUI):
         """
         # disable special cases until properly defined
         self.label.setVisible(False)
-        self.cbCases.setVisible(False)
+        self.comboboxSpecialCases.setVisible(False)
 
         self.sim_fit_labels = ['FitPage', 'Model', 'Data', 'Mnemonic']
         # tab widget - headers
@@ -188,7 +188,7 @@ class ConstraintWidget(QtWidgets.QWidget, Ui_ConstraintWidgetUI):
         self.tblTabList.customContextMenuRequested.connect(self.showModelContextMenu)
 
         # Single Fit is the default, so disable chainfit
-        self.chkChain.setVisible(False)
+        self.checkBoxChainedFit.setVisible(False)
 
         # disabled constraint
         labels = ['Constraint']
@@ -207,14 +207,14 @@ class ConstraintWidget(QtWidgets.QWidget, Ui_ConstraintWidgetUI):
         Set up signals/slots for this widget
         """
         # simple widgets
-        self.btnSingle.toggled.connect(self.onFitTypeChange)
-        self.btnBatch.toggled.connect(self.onFitTypeChange)
-        self.cbCases.currentIndexChanged.connect(self.onSpecialCaseChange)
-        self.cmdFit.clicked.connect(self.onFit)
-        self.cmdHelp.clicked.connect(self.onHelp)
-        self.cmdAdd.clicked.connect(self.showMultiConstraint)
-        self.chkChain.toggled.connect(self.onChainFit)
-        self.chkWeight.toggled.connect(self.onWeightModify)
+        self.radioButtonSingle.toggled.connect(self.onFitTypeChange)
+        self.radioButtonBatch.toggled.connect(self.onFitTypeChange)
+        self.comboboxSpecialCases.currentIndexChanged.connect(self.onSpecialCaseChange)
+        self.buttonFit.clicked.connect(self.onFit)
+        self.buttonHelp.clicked.connect(self.onHelp)
+        self.buttonAddConstraints.clicked.connect(self.showMultiConstraint)
+        self.checkBoxChainedFit.toggled.connect(self.onChainFit)
+        self.checkBoxWeight.toggled.connect(self.onWeightModify)
 
         # QTableWidgets
         self.tblTabList.cellChanged.connect(self.onTabCellEdit)
@@ -270,9 +270,9 @@ class ConstraintWidget(QtWidgets.QWidget, Ui_ConstraintWidgetUI):
         single fit/batch fit
         """
         source = self.sender().objectName()
-        self.currentType = "BatchPage" if source == "btnBatch" else "FitPage"
-        self.chkChain.setVisible(source=="btnBatch")
-        self.chkWeight.setVisible(source!="btnBatch")
+        self.currentType = "BatchPage" if source == "radioButtonBatch" else "FitPage"
+        self.checkBoxChainedFit.setVisible(source=="radioButtonBatch")
+        self.checkBoxWeight.setVisible(source!="radioButtonBatch")
         self.initializeFitList()
 
     def onSpecialCaseChange(self, index):
@@ -309,8 +309,8 @@ class ConstraintWidget(QtWidgets.QWidget, Ui_ConstraintWidgetUI):
         if self.is_running:
             self.is_running = False
             #re-enable the Fit button
-            self.cmdFit.setStyleSheet('QPushButton {color: black;}')
-            self.cmdFit.setText("Fit")
+            self.buttonFit.setStyleSheet('QPushButton {color: black;}')
+            self.buttonFit.setText("Fit")
             # stop the fitpages
             self.calc_fit.stop()
             return
@@ -402,8 +402,8 @@ class ConstraintWidget(QtWidgets.QWidget, Ui_ConstraintWidgetUI):
             self.calc_fit.ready(2.5)
 
         # modify the Fit button
-        self.cmdFit.setStyleSheet('QPushButton {color: red;}')
-        self.cmdFit.setText('Stop fit')
+        self.buttonFit.setStyleSheet('QPushButton {color: red;}')
+        self.buttonFit.setText('Stop fit')
         self.parent.communicate.statusBarUpdateSignal.emit('Fitting started...')
         self.is_running = True
 
@@ -445,7 +445,7 @@ class ConstraintWidget(QtWidgets.QWidget, Ui_ConstraintWidgetUI):
             tab_name = item.text()
             self.tabs_for_fitting[tab_name] = (item.checkState() == QtCore.Qt.Checked)
             # Enable fitting only when there are models to fit
-            self.cmdFit.setEnabled(any(self.tabs_for_fitting.values()))
+            self.buttonFit.setEnabled(any(self.tabs_for_fitting.values()))
             return
 
         elif column == self.sim_fit_labels.index('Mnemonic'):
@@ -457,7 +457,7 @@ class ConstraintWidget(QtWidgets.QWidget, Ui_ConstraintWidgetUI):
                 self.tblTabList.blockSignals(True)
                 item.setBackground(QtCore.Qt.red)
                 self.tblTabList.blockSignals(False)
-                self.cmdFit.setEnabled(False)
+                self.buttonFit.setEnabled(False)
                 if new_moniker == "":
                     msg = "Please use a non-empty name."
                 else:
@@ -469,7 +469,7 @@ class ConstraintWidget(QtWidgets.QWidget, Ui_ConstraintWidgetUI):
             self.tblTabList.blockSignals(True)
             item.setBackground(QtCore.Qt.white)
             self.tblTabList.blockSignals(False)
-            self.cmdFit.setEnabled(True)
+            self.buttonFit.setEnabled(True)
             item.setToolTip("")
             msg = "Fitpage name changed to {}.".format(new_moniker)
             self.parent.communicate.statusBarUpdateSignal.emit(msg)
@@ -502,7 +502,7 @@ class ConstraintWidget(QtWidgets.QWidget, Ui_ConstraintWidgetUI):
                 self.tblTabList.blockSignals(True)
                 item.setBackground(QtCore.Qt.red)
                 self.tblTabList.blockSignals(False)
-                self.cmdFit.setEnabled(False)
+                self.buttonFit.setEnabled(False)
                 msg = "Weighting must be a numerical value (integer or float)."
                 self.parent.communicate.statusBarUpdateSignal.emit(msg)
                 item.setToolTip(msg)
@@ -512,7 +512,7 @@ class ConstraintWidget(QtWidgets.QWidget, Ui_ConstraintWidgetUI):
             self.tblTabList.blockSignals(True)
             item.setBackground(QtCore.Qt.white)
             self.tblTabList.blockSignals(False)
-            self.cmdFit.setEnabled(True)
+            self.buttonFit.setEnabled(True)
             fit_page_column = self.sim_fit_labels.index('FitPage')
             self.weighting_ratios[self.tblTabList.item(row, fit_page_column).data(0)] = new_weighting
 
@@ -650,8 +650,8 @@ class ConstraintWidget(QtWidgets.QWidget, Ui_ConstraintWidgetUI):
         Respond to the successful fit complete signal
         """
         #re-enable the Fit button
-        self.cmdFit.setStyleSheet('QPushButton {color: black;}')
-        self.cmdFit.setText("Fit")
+        self.buttonFit.setStyleSheet('QPushButton {color: black;}')
+        self.buttonFit.setText("Fit")
         self.is_running = False
 
         # Notify the parent about completed fitting
@@ -710,8 +710,8 @@ class ConstraintWidget(QtWidgets.QWidget, Ui_ConstraintWidgetUI):
         Respond to the successful batch fit complete signal
         """
         #re-enable the Fit button
-        self.cmdFit.setStyleSheet('QPushButton {color: black;}')
-        self.cmdFit.setText("Fit")
+        self.buttonFit.setStyleSheet('QPushButton {color: black;}')
+        self.buttonFit.setText("Fit")
         self.is_running = False
 
         # Notify the parent about completed fitting
@@ -757,8 +757,8 @@ class ConstraintWidget(QtWidgets.QWidget, Ui_ConstraintWidgetUI):
         Respond to fitting failure.
         """
         #re-enable the Fit button
-        self.cmdFit.setStyleSheet('QPushButton {color: black;}')
-        self.cmdFit.setText("Fit")
+        self.buttonFit.setStyleSheet('QPushButton {color: black;}')
+        self.buttonFit.setText("Fit")
         self.is_running = False
 
         # Notify the parent about completed fitting
@@ -1037,16 +1037,16 @@ class ConstraintWidget(QtWidgets.QWidget, Ui_ConstraintWidgetUI):
         self.tblConstraints.setRowCount(0)
 
         # Fit disabled
-        self.cmdFit.setEnabled(False)
+        self.buttonFit.setEnabled(False)
 
         if not objects:
             return
 
         tabs = [tab for tab in ObjectLibrary.listObjects() if self.isTabImportable(tab)]
         if len(tabs) < 1:
-            self.cmdAdd.setEnabled(False)
+            self.buttonAddConstraints.setEnabled(False)
         else:
-            self.cmdAdd.setEnabled(True)
+            self.buttonAddConstraints.setEnabled(True)
 
         if not self._row_order:
             # Initialize tab order list
@@ -1059,7 +1059,7 @@ class ConstraintWidget(QtWidgets.QWidget, Ui_ConstraintWidgetUI):
             self.updateFitLine(tab, model_key=model_key)
             self.updateSignalsFromTab(tab)
             # We have at least 1 fit page, allow fitting
-            self.cmdFit.setEnabled(True)
+            self.buttonFit.setEnabled(True)
 
     def orderedSublist(self, order_list, target_list):
         """
@@ -1157,7 +1157,7 @@ class ConstraintWidget(QtWidgets.QWidget, Ui_ConstraintWidgetUI):
         param_list.append(['data_id', "cs_tab"+str(self.page_id)])
         param_list.append(['current_type', self.currentType])
         param_list.append(['is_chain_fitting', str(self.is_chain_fitting)])
-        param_list.append(['special_case', self.cbCases.currentText()])
+        param_list.append(['special_case', self.comboboxSpecialCases.currentText()])
 
         return param_list
 
@@ -1221,12 +1221,12 @@ class ConstraintWidget(QtWidgets.QWidget, Ui_ConstraintWidgetUI):
         # fit/batch radio
         isBatch = parameters['current_type'][0] == 'BatchPage'
         if isBatch:
-            self.btnBatch.toggle()
+            self.radioButtonBatch.toggle()
 
         # chain
         is_chain = parameters['is_chain_fitting'][0] == 'True'
         if isBatch:
-            self.chkChain.setChecked(is_chain)
+            self.checkBoxChainedFit.setChecked(is_chain)
 
     def getReport(self):
         """

--- a/src/sas/qtgui/Perspectives/Fitting/ConstraintWidget.py
+++ b/src/sas/qtgui/Perspectives/Fitting/ConstraintWidget.py
@@ -188,7 +188,7 @@ class ConstraintWidget(QtWidgets.QWidget, Ui_ConstraintWidgetUI):
         self.tblTabList.customContextMenuRequested.connect(self.showModelContextMenu)
 
         # Single Fit is the default, so disable chainfit
-        self.cbChainedFit.setVisible(False)
+        self.chkChainedFit.setVisible(False)
 
         # disabled constraint
         labels = ['Constraint']
@@ -213,8 +213,8 @@ class ConstraintWidget(QtWidgets.QWidget, Ui_ConstraintWidgetUI):
         self.cmdFit.clicked.connect(self.onFit)
         self.cmdHelp.clicked.connect(self.onHelp)
         self.cmdAddConstraints.clicked.connect(self.showMultiConstraint)
-        self.cbChainedFit.toggled.connect(self.onChainFit)
-        self.cbWeight.toggled.connect(self.onWeightModify)
+        self.chkChainedFit.toggled.connect(self.onChainFit)
+        self.chkWeight.toggled.connect(self.onWeightModify)
 
         # QTableWidgets
         self.tblTabList.cellChanged.connect(self.onTabCellEdit)
@@ -271,8 +271,8 @@ class ConstraintWidget(QtWidgets.QWidget, Ui_ConstraintWidgetUI):
         """
         source = self.sender().objectName()
         self.currentType = "BatchPage" if source == "rbBatchFits" else "FitPage"
-        self.cbChainedFit.setVisible(source=="rbBatchFits")
-        self.cbWeight.setVisible(source!="rbBatchFits")
+        self.chkChainedFit.setVisible(source=="rbBatchFits")
+        self.chkWeight.setVisible(source!="rbBatchFits")
         self.initializeFitList()
 
     def onSpecialCaseChange(self, index):
@@ -1226,7 +1226,7 @@ class ConstraintWidget(QtWidgets.QWidget, Ui_ConstraintWidgetUI):
         # chain
         is_chain = parameters['is_chain_fitting'][0] == 'True'
         if isBatch:
-            self.cbChainedFit.setChecked(is_chain)
+            self.chkChainedFit.setChecked(is_chain)
 
     def getReport(self):
         """

--- a/src/sas/qtgui/Perspectives/Fitting/FittingOptions.py
+++ b/src/sas/qtgui/Perspectives/Fitting/FittingOptions.py
@@ -50,15 +50,15 @@ class FittingOptions(PreferencesWidget, Ui_FittingOptions):
 
         # Fill up the algorithm combo, based on what BUMPS says is available
         self.active_fitters = [n.name for n in fitters.FITTERS if n.id in fitters.FIT_ACTIVE_IDS and 'least' not in n.id]
-        self.comboboxFitAlgorithms.addItems(self.active_fitters)
-        self.comboboxDefaultFitAlgorithm.addItems(self.active_fitters)
+        self.cbFitAlgorithms.addItems(self.active_fitters)
+        self.cbDefaultFitAlgorithm.addItems(self.active_fitters)
 
         # Set the default index
         self.current_fitter_id = getattr(sasview_config, 'FITTING_DEFAULT_OPTIMIZER', fitters.FIT_DEFAULT_ID)
         default_name = [n.name for n in fitters.FITTERS if n.id == self.current_fitter_id][0]
-        default_index = self.comboboxFitAlgorithms.findText(default_name)
-        self.comboboxDefaultFitAlgorithm.setCurrentIndex(default_index)
-        self.comboboxFitAlgorithms.setCurrentIndex(default_index)
+        default_index = self.cbFitAlgorithms.findText(default_name)
+        self.cbDefaultFitAlgorithm.setCurrentIndex(default_index)
+        self.cbFitAlgorithms.setCurrentIndex(default_index)
         self._algorithm_change(default_index)
         # previous algorithm choice
         self.previous_index = default_index
@@ -67,8 +67,8 @@ class FittingOptions(PreferencesWidget, Ui_FittingOptions):
         self.assignValidators()
 
         # To prevent errors related to parent, connect the combo box changes once the widget is instantiated
-        self.comboboxFitAlgorithms.currentIndexChanged.connect(self.onAlgorithmChange)
-        self.comboboxDefaultFitAlgorithm.currentIndexChanged.connect(self.onDefaultAlgorithmChange)
+        self.cbFitAlgorithms.currentIndexChanged.connect(self.onAlgorithmChange)
+        self.cbDefaultFitAlgorithm.currentIndexChanged.connect(self.onDefaultAlgorithmChange)
 
     #
     # Preference Widget required methods
@@ -77,16 +77,16 @@ class FittingOptions(PreferencesWidget, Ui_FittingOptions):
         pass
 
     def _toggleBlockAllSignaling(self, toggle: bool):
-        self.comboboxFitAlgorithms.blockSignals(toggle)
-        self.comboboxDefaultFitAlgorithm.blockSignals(toggle)
+        self.cbFitAlgorithms.blockSignals(toggle)
+        self.cbDefaultFitAlgorithm.blockSignals(toggle)
 
     def _restoreFromConfig(self):
         optimizer_key = sasview_config.FITTING_DEFAULT_OPTIMIZER
         optimizer_name = bumps.options.FIT_CONFIG.names[optimizer_key]
-        self.comboboxDefaultFitAlgorithm.setCurrentIndex(self.comboboxDefaultFitAlgorithm.findText(optimizer_name))
+        self.cbDefaultFitAlgorithm.setCurrentIndex(self.cbDefaultFitAlgorithm.findText(optimizer_name))
         name = [n.name for n in fitters.FITTERS if n.id == self.current_fitter_id][0]
-        self.comboboxFitAlgorithms.setCurrentIndex(self.comboboxFitAlgorithms.findText(name))
-        self._algorithm_change(self.comboboxFitAlgorithms.currentIndex())
+        self.cbFitAlgorithms.setCurrentIndex(self.cbFitAlgorithms.findText(name))
+        self._algorithm_change(self.cbFitAlgorithms.currentIndex())
 
     def assignValidators(self):
         """
@@ -118,8 +118,8 @@ class FittingOptions(PreferencesWidget, Ui_FittingOptions):
         sender.setStyleSheet('QLineEdit { background-color: %s }' % color)
 
     def onDefaultAlgorithmChange(self):
-        text = self.comboboxDefaultFitAlgorithm.currentText()
-        self.comboboxFitAlgorithms.setCurrentIndex(self.comboboxFitAlgorithms.findText(text))
+        text = self.cbDefaultFitAlgorithm.currentText()
+        self.cbFitAlgorithms.setCurrentIndex(self.cbFitAlgorithms.findText(text))
         id = dict((new_val, new_k) for new_k, new_val in bumps.options.FIT_CONFIG.names.items()).get(text)
         self._stageChange('FITTING_DEFAULT_OPTIMIZER', id)
 
@@ -134,7 +134,7 @@ class FittingOptions(PreferencesWidget, Ui_FittingOptions):
         """
         # Find the algorithm ID from name
         fitter_id = \
-            [n.id for n in fitters.FITTERS if n.name == str(self.comboboxFitAlgorithms.currentText())][0]
+            [n.id for n in fitters.FITTERS if n.name == str(self.cbFitAlgorithms.currentText())][0]
 
         # find the right stacked widget
         widget_name = "self.page_"+str(fitter_id)
@@ -152,7 +152,7 @@ class FittingOptions(PreferencesWidget, Ui_FittingOptions):
                                         msg,
                                         QtWidgets.QMessageBox.Ok)
             # Move the index to previous position
-            self.comboboxFitAlgorithms.setCurrentIndex(self.previous_index)
+            self.cbFitAlgorithms.setCurrentIndex(self.previous_index)
             return
 
         index_for_this_id = self.stackedWidgetFitAlgorithms.indexOf(widget_to_activate)
@@ -169,7 +169,7 @@ class FittingOptions(PreferencesWidget, Ui_FittingOptions):
 
     def applyNonConfigValues(self):
         """Applies values that aren't stored in config. Only widgets that require this need to override this method."""
-        self.current_fitter_id = [n.id for n in fitters.FITTERS if n.name == str(self.comboboxFitAlgorithms.currentText())][0]
+        self.current_fitter_id = [n.id for n in fitters.FITTERS if n.name == str(self.cbFitAlgorithms.currentText())][0]
         options = self.config.values[self.current_fitter_id]
         for option in options.keys():
             # Find the widget name of the option
@@ -191,7 +191,7 @@ class FittingOptions(PreferencesWidget, Ui_FittingOptions):
                 return
 
         # Notify the perspective, so the window title is updated
-        self.fit_option_changed.emit(self.comboboxFitAlgorithms.currentText())
+        self.fit_option_changed.emit(self.cbFitAlgorithms.currentText())
 
         def bumpsUpdate(option):
             """
@@ -247,7 +247,7 @@ class FittingOptions(PreferencesWidget, Ui_FittingOptions):
         """
         Sends back the current choice of parameters
         """
-        algorithm = self.comboboxFitAlgorithms.currentText()
+        algorithm = self.cbFitAlgorithms.currentText()
         return algorithm
 
     def updateWidgetFromBumps(self, fitter_id):

--- a/src/sas/qtgui/Perspectives/Fitting/FittingOptions.py
+++ b/src/sas/qtgui/Perspectives/Fitting/FittingOptions.py
@@ -50,15 +50,15 @@ class FittingOptions(PreferencesWidget, Ui_FittingOptions):
 
         # Fill up the algorithm combo, based on what BUMPS says is available
         self.active_fitters = [n.name for n in fitters.FITTERS if n.id in fitters.FIT_ACTIVE_IDS and 'least' not in n.id]
-        self.cbAlgorithm.addItems(self.active_fitters)
-        self.cbAlgorithmDefault.addItems(self.active_fitters)
+        self.comboboxFitAlgorithms.addItems(self.active_fitters)
+        self.comboboxDefaultFitAlgorithm.addItems(self.active_fitters)
 
         # Set the default index
         self.current_fitter_id = getattr(sasview_config, 'FITTING_DEFAULT_OPTIMIZER', fitters.FIT_DEFAULT_ID)
         default_name = [n.name for n in fitters.FITTERS if n.id == self.current_fitter_id][0]
-        default_index = self.cbAlgorithm.findText(default_name)
-        self.cbAlgorithmDefault.setCurrentIndex(default_index)
-        self.cbAlgorithm.setCurrentIndex(default_index)
+        default_index = self.comboboxFitAlgorithms.findText(default_name)
+        self.comboboxDefaultFitAlgorithm.setCurrentIndex(default_index)
+        self.comboboxFitAlgorithms.setCurrentIndex(default_index)
         self._algorithm_change(default_index)
         # previous algorithm choice
         self.previous_index = default_index
@@ -67,8 +67,8 @@ class FittingOptions(PreferencesWidget, Ui_FittingOptions):
         self.assignValidators()
 
         # To prevent errors related to parent, connect the combo box changes once the widget is instantiated
-        self.cbAlgorithm.currentIndexChanged.connect(self.onAlgorithmChange)
-        self.cbAlgorithmDefault.currentIndexChanged.connect(self.onDefaultAlgorithmChange)
+        self.comboboxFitAlgorithms.currentIndexChanged.connect(self.onAlgorithmChange)
+        self.comboboxDefaultFitAlgorithm.currentIndexChanged.connect(self.onDefaultAlgorithmChange)
 
     #
     # Preference Widget required methods
@@ -77,16 +77,16 @@ class FittingOptions(PreferencesWidget, Ui_FittingOptions):
         pass
 
     def _toggleBlockAllSignaling(self, toggle: bool):
-        self.cbAlgorithm.blockSignals(toggle)
-        self.cbAlgorithmDefault.blockSignals(toggle)
+        self.comboboxFitAlgorithms.blockSignals(toggle)
+        self.comboboxDefaultFitAlgorithm.blockSignals(toggle)
 
     def _restoreFromConfig(self):
         optimizer_key = sasview_config.FITTING_DEFAULT_OPTIMIZER
         optimizer_name = bumps.options.FIT_CONFIG.names[optimizer_key]
-        self.cbAlgorithmDefault.setCurrentIndex(self.cbAlgorithmDefault.findText(optimizer_name))
+        self.comboboxDefaultFitAlgorithm.setCurrentIndex(self.comboboxDefaultFitAlgorithm.findText(optimizer_name))
         name = [n.name for n in fitters.FITTERS if n.id == self.current_fitter_id][0]
-        self.cbAlgorithm.setCurrentIndex(self.cbAlgorithm.findText(name))
-        self._algorithm_change(self.cbAlgorithm.currentIndex())
+        self.comboboxFitAlgorithms.setCurrentIndex(self.comboboxFitAlgorithms.findText(name))
+        self._algorithm_change(self.comboboxFitAlgorithms.currentIndex())
 
     def assignValidators(self):
         """
@@ -118,8 +118,8 @@ class FittingOptions(PreferencesWidget, Ui_FittingOptions):
         sender.setStyleSheet('QLineEdit { background-color: %s }' % color)
 
     def onDefaultAlgorithmChange(self):
-        text = self.cbAlgorithmDefault.currentText()
-        self.cbAlgorithm.setCurrentIndex(self.cbAlgorithm.findText(text))
+        text = self.comboboxDefaultFitAlgorithm.currentText()
+        self.comboboxFitAlgorithms.setCurrentIndex(self.comboboxFitAlgorithms.findText(text))
         id = dict((new_val, new_k) for new_k, new_val in bumps.options.FIT_CONFIG.names.items()).get(text)
         self._stageChange('FITTING_DEFAULT_OPTIMIZER', id)
 
@@ -134,7 +134,7 @@ class FittingOptions(PreferencesWidget, Ui_FittingOptions):
         """
         # Find the algorithm ID from name
         fitter_id = \
-            [n.id for n in fitters.FITTERS if n.name == str(self.cbAlgorithm.currentText())][0]
+            [n.id for n in fitters.FITTERS if n.name == str(self.comboboxFitAlgorithms.currentText())][0]
 
         # find the right stacked widget
         widget_name = "self.page_"+str(fitter_id)
@@ -152,13 +152,13 @@ class FittingOptions(PreferencesWidget, Ui_FittingOptions):
                                         msg,
                                         QtWidgets.QMessageBox.Ok)
             # Move the index to previous position
-            self.cbAlgorithm.setCurrentIndex(self.previous_index)
+            self.comboboxFitAlgorithms.setCurrentIndex(self.previous_index)
             return
 
-        index_for_this_id = self.stackedWidget.indexOf(widget_to_activate)
+        index_for_this_id = self.stackedWidgetFitAlgorithms.indexOf(widget_to_activate)
 
         # Select the requested widget
-        self.stackedWidget.setCurrentIndex(index_for_this_id)
+        self.stackedWidgetFitAlgorithms.setCurrentIndex(index_for_this_id)
 
         self.updateWidgetFromBumps(fitter_id)
 
@@ -169,7 +169,7 @@ class FittingOptions(PreferencesWidget, Ui_FittingOptions):
 
     def applyNonConfigValues(self):
         """Applies values that aren't stored in config. Only widgets that require this need to override this method."""
-        self.current_fitter_id = [n.id for n in fitters.FITTERS if n.name == str(self.cbAlgorithm.currentText())][0]
+        self.current_fitter_id = [n.id for n in fitters.FITTERS if n.name == str(self.comboboxFitAlgorithms.currentText())][0]
         options = self.config.values[self.current_fitter_id]
         for option in options.keys():
             # Find the widget name of the option
@@ -191,7 +191,7 @@ class FittingOptions(PreferencesWidget, Ui_FittingOptions):
                 return
 
         # Notify the perspective, so the window title is updated
-        self.fit_option_changed.emit(self.cbAlgorithm.currentText())
+        self.fit_option_changed.emit(self.comboboxFitAlgorithms.currentText())
 
         def bumpsUpdate(option):
             """
@@ -247,7 +247,7 @@ class FittingOptions(PreferencesWidget, Ui_FittingOptions):
         """
         Sends back the current choice of parameters
         """
-        algorithm = self.cbAlgorithm.currentText()
+        algorithm = self.comboboxFitAlgorithms.currentText()
         return algorithm
 
     def updateWidgetFromBumps(self, fitter_id):

--- a/src/sas/qtgui/Perspectives/Fitting/FittingWidget.py
+++ b/src/sas/qtgui/Perspectives/Fitting/FittingWidget.py
@@ -389,28 +389,28 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         self.model_dict["poly"] = self._poly_model
         self.model_dict["magnet"] = self._magnet_model
 
-        self.lst_dict["standard"] = self.listModelParameters
-        self.lst_dict["poly"] = self.listPolydispersity
-        self.lst_dict["magnet"] = self.listPolarisation_Magnetic_Scattering
+        self.lst_dict["standard"] = self.lstModelParameters
+        self.lst_dict["poly"] = self.lstPolydispersity
+        self.lst_dict["magnet"] = self.lstPolarisation_Magnetic_Scattering
 
-        self.tabToList[0] = self.listModelParameters
-        self.tabToList[3] = self.listPolydispersity
-        self.tabToList[4] = self.listPolarisation_Magnetic_Scattering
+        self.tabToList[0] = self.lstModelParameters
+        self.tabToList[3] = self.lstPolydispersity
+        self.tabToList[4] = self.lstPolarisation_Magnetic_Scattering
 
         self.tabToKey[0] = "standard"
         self.tabToKey[3] = "poly"
         self.tabToKey[4] = "magnet"
 
         # Param model displayed in param list
-        self.listModelParameters.setModel(self._model_model)
+        self.lstModelParameters.setModel(self._model_model)
         self.readCategoryInfo()
 
         self.model_parameters = None
 
         # Delegates for custom editing and display
-        self.listModelParameters.setItemDelegate(ModelViewDelegate(self))
+        self.lstModelParameters.setItemDelegate(ModelViewDelegate(self))
 
-        self.listModelParameters.setAlternatingRowColors(True)
+        self.lstModelParameters.setAlternatingRowColors(True)
         stylesheet = """
 
             QTreeView {
@@ -439,33 +439,33 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
                 background: qlineargradient(x1: 0, y1: 0, x2: 0, y2: 1, stop: 0 #6b9be8, stop: 1 #577fbf);
             }
            """
-        self.listModelParameters.setStyleSheet(stylesheet)
-        self.listModelParameters.setContextMenuPolicy(QtCore.Qt.CustomContextMenu)
-        self.listModelParameters.customContextMenuRequested.connect(self.showModelContextMenu)
-        self.listModelParameters.setAttribute(QtCore.Qt.WA_MacShowFocusRect, False)
+        self.lstModelParameters.setStyleSheet(stylesheet)
+        self.lstModelParameters.setContextMenuPolicy(QtCore.Qt.CustomContextMenu)
+        self.lstModelParameters.customContextMenuRequested.connect(self.showModelContextMenu)
+        self.lstModelParameters.setAttribute(QtCore.Qt.WA_MacShowFocusRect, False)
         # Column resize signals
-        self.listModelParameters.header().sectionResized.connect(self.onColumnWidthUpdate)
+        self.lstModelParameters.header().sectionResized.connect(self.onColumnWidthUpdate)
 
         # Poly model displayed in poly list
-        self.listPolydispersity.setModel(self._poly_model)
+        self.lstPolydispersity.setModel(self._poly_model)
         self.setPolyModel()
-        self.setTableProperties(self.listPolydispersity)
+        self.setTableProperties(self.lstPolydispersity)
         # Delegates for custom editing and display
-        self.listPolydispersity.setItemDelegate(PolyViewDelegate(self))
+        self.lstPolydispersity.setItemDelegate(PolyViewDelegate(self))
         # Polydispersity function combo response
-        self.listPolydispersity.itemDelegate().combo_updated.connect(self.onPolyComboIndexChange)
-        self.listPolydispersity.itemDelegate().filename_updated.connect(self.onPolyFilenameChange)
+        self.lstPolydispersity.itemDelegate().combo_updated.connect(self.onPolyComboIndexChange)
+        self.lstPolydispersity.itemDelegate().filename_updated.connect(self.onPolyFilenameChange)
 
-        self.listPolydispersity.setContextMenuPolicy(QtCore.Qt.CustomContextMenu)
-        self.listPolydispersity.customContextMenuRequested.connect(self.showModelContextMenu)
-        self.listPolydispersity.setAttribute(QtCore.Qt.WA_MacShowFocusRect, False)
+        self.lstPolydispersity.setContextMenuPolicy(QtCore.Qt.CustomContextMenu)
+        self.lstPolydispersity.customContextMenuRequested.connect(self.showModelContextMenu)
+        self.lstPolydispersity.setAttribute(QtCore.Qt.WA_MacShowFocusRect, False)
 
         # Magnetism model displayed in magnetism list
-        self.listPolarisation_Magnetic_Scattering.setModel(self._magnet_model)
+        self.lstPolarisation_Magnetic_Scattering.setModel(self._magnet_model)
         self.setMagneticModel()
-        self.setTableProperties(self.listPolarisation_Magnetic_Scattering)
+        self.setTableProperties(self.lstPolarisation_Magnetic_Scattering)
         # Delegates for custom editing and display
-        self.listPolarisation_Magnetic_Scattering.setItemDelegate(MagnetismViewDelegate(self))
+        self.lstPolarisation_Magnetic_Scattering.setItemDelegate(MagnetismViewDelegate(self))
         # Initial status of the ordering tab - invisible
         self.tabOverviewFitting.removeTab(TAB_ORDERING)
 
@@ -474,11 +474,11 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         Model category combo setup
         """
         category_list = sorted(self.master_category_dict.keys())
-        self.comboboxCategory.addItem(CATEGORY_DEFAULT)
-        self.comboboxCategory.addItems(category_list)
+        self.cbCategory.addItem(CATEGORY_DEFAULT)
+        self.cbCategory.addItems(category_list)
         if CATEGORY_STRUCTURE not in category_list:
-            self.comboboxCategory.addItem(CATEGORY_STRUCTURE)
-        self.comboboxCategory.setCurrentIndex(0)
+            self.cbCategory.addItem(CATEGORY_STRUCTURE)
+        self.cbCategory.setCurrentIndex(0)
 
     def setEnablementOnDataLoad(self):
         """
@@ -492,21 +492,21 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
             self.labelFilenameRight.setText(self.logic.data.filename)
         self.updateQRange()
         # Switch off Data2D control
-        self.checkbox2DView.setEnabled(False)
-        self.checkbox2DView.setVisible(False)
-        self.checkboxMagnetism.setEnabled(False)
-        self.tabOverviewFitting.setTabEnabled(TAB_MAGNETISM, self.checkboxMagnetism.isChecked())
+        self.chk2DView.setEnabled(False)
+        self.chk2DView.setVisible(False)
+        self.chkMagnetism.setEnabled(False)
+        self.tabOverviewFitting.setTabEnabled(TAB_MAGNETISM, self.chkMagnetism.isChecked())
         # Combo box or label for file name"
         if self.is_batch_fitting:
             self.labelFilenameRight.setVisible(False)
             for dataitem in self.all_data:
                 name = GuiUtils.dataFromItem(dataitem).name
-                self.comboboxFileNames.addItem(name)
-            self.comboboxFileNames.setVisible(True)
-            self.checkboxChainFit.setEnabled(True)
-            self.checkboxChainFit.setVisible(True)
+                self.self.cmdHelp.addItem(name)
+            self.self.cmdHelp.setVisible(True)
+            self.chkChainFit.setEnabled(True)
+            self.chkChainFit.setVisible(True)
             # This panel is not designed to view individual fits, so disable plotting
-            self.buttonPlot.setVisible(False)
+            self.cmdPlot.setVisible(False)
         # Similarly on other tabs
         self.options_widget.setEnablementOnDataLoad()
         self.onSelectModel()
@@ -519,19 +519,19 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
 
     def disableModelCombo(self):
         """ Disable the combobox """
-        self.comboboxModel.setEnabled(False)
+        self.cbModel.setEnabled(False)
         self.labelModel.setEnabled(False)
         self.enabled_cbmodel = False
 
     def enableModelCombo(self):
         """ Enable the combobox """
-        self.comboboxModel.setEnabled(True)
+        self.cbModel.setEnabled(True)
         self.labelModel.setEnabled(True)
         self.enabled_cbmodel = True
 
     def disableStructureCombo(self):
         """ Disable the combobox """
-        self.comboboxStructureFactor.setEnabled(False)
+        self.cbStructureFactor.setEnabled(False)
         self.labelStructure.setEnabled(False)
         self.enabled_sfmodel = False
 
@@ -553,7 +553,7 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
 
     def enableStructureCombo(self):
         """ Enable the combobox """
-        self.comboboxStructureFactor.setEnabled(True)
+        self.cbStructureFactor.setEnabled(True)
         self.labelStructure.setEnabled(True)
         self.enabled_sfmodel = True
 
@@ -561,7 +561,7 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         """ Enable/disable the polydispersity tab """
         self.tabOverviewFitting.setTabEnabled(TAB_POLY, isChecked)
         # Check if any parameters are ready for fitting
-        self.buttonFit.setEnabled(self.haveParamsToFit())
+        self.cmdFit.setEnabled(self.haveParamsToFit())
         # Set sasmodel polydispersity to 0 if polydispersity is unchecked, if not use Qmodel values
         if self._poly_model.rowCount() > 0:
             for key, value in self.poly_params.items():
@@ -572,7 +572,7 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         """ Enable/disable the magnetism tab """
         self.tabOverviewFitting.setTabEnabled(TAB_MAGNETISM, isChecked)
         # Check if any parameters are ready for fitting
-        self.buttonFit.setEnabled(self.haveParamsToFit())
+        self.cmdFit.setEnabled(self.haveParamsToFit())
 
     def toggleChainFit(self, isChecked):
         """ Enable/disable chain fitting """
@@ -585,7 +585,7 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
 
     def toggle2D(self, isChecked):
         """ Enable/disable the controls dependent on 1D/2D data instance """
-        self.checkboxMagnetism.setEnabled(isChecked)
+        self.chkMagnetism.setEnabled(isChecked)
         self.is2D = isChecked
         # Reload the current model
         if self.kernel_module:
@@ -604,17 +604,17 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         """
         Set initial control enablement
         """
-        self.comboboxFileNames.setVisible(False)
-        self.buttonFit.setEnabled(False)
-        self.buttonPlot.setEnabled(False)
-        self.checkboxPolydispersity.setEnabled(False)
-        self.checkboxPolydispersity.setChecked(False)
-        self.checkbox2DView.setEnabled(True)
-        self.checkbox2DView.setChecked(False)
-        self.checkboxMagnetism.setEnabled(False)
-        self.checkboxMagnetism.setChecked(False)
-        self.checkboxChainFit.setEnabled(False)
-        self.checkboxChainFit.setVisible(False)
+        self.self.cmdHelp.setVisible(False)
+        self.cmdFit.setEnabled(False)
+        self.cmdPlot.setEnabled(False)
+        self.chkPolydispersity.setEnabled(False)
+        self.chkPolydispersity.setChecked(False)
+        self.chk2DView.setEnabled(True)
+        self.chk2DView.setChecked(False)
+        self.chkMagnetism.setEnabled(False)
+        self.chkMagnetism.setChecked(False)
+        self.chkChainFit.setEnabled(False)
+        self.chkChainFit.setVisible(False)
         # Tabs
         self.tabOverviewFitting.setTabEnabled(TAB_POLY, False)
         self.tabOverviewFitting.setTabEnabled(TAB_MAGNETISM, False)
@@ -629,30 +629,30 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         Connect GUI element signals
         """
         # Comboboxes
-        self.comboboxStructureFactor.currentIndexChanged.connect(self.onSelectStructureFactor)
-        self.comboboxCategory.currentIndexChanged.connect(self.onSelectCategory)
-        self.comboboxModel.currentIndexChanged.connect(self.onSelectModel)
-        self.comboboxFileNames.currentIndexChanged.connect(self.onSelectBatchFilename)
+        self.cbStructureFactor.currentIndexChanged.connect(self.onSelectStructureFactor)
+        self.cbCategory.currentIndexChanged.connect(self.onSelectCategory)
+        self.cbModel.currentIndexChanged.connect(self.onSelectModel)
+        self.cmdHelp.currentIndexChanged.connect(self.onSelectBatchFilename)
         # Checkboxes
-        self.checkbox2DView.toggled.connect(self.toggle2D)
-        self.checkboxPolydispersity.toggled.connect(self.togglePoly)
-        self.checkboxMagnetism.toggled.connect(self.toggleMagnetism)
-        self.checkboxChainFit.toggled.connect(self.toggleChainFit)
+        self.chk2DView.toggled.connect(self.toggle2D)
+        self.chkPolydispersity.toggled.connect(self.togglePoly)
+        self.chkMagnetism.toggled.connect(self.toggleMagnetism)
+        self.chkChainFit.toggled.connect(self.toggleChainFit)
         # Buttons
-        self.buttonFit.clicked.connect(self.onFit)
-        self.buttonPlot.clicked.connect(self.onPlot)
-        self.buttonHelp.clicked.connect(self.onHelp)
-        self.buttonDisplayMagneticAngles.clicked.connect(self.onDisplayMagneticAngles)
+        self.cmdFit.clicked.connect(self.onFit)
+        self.cmdPlot.clicked.connect(self.onPlot)
+        self.cmdHelp.clicked.connect(self.onHelp)
+        self.cmdDisplayMagneticAngles.clicked.connect(self.onDisplayMagneticAngles)
 
         # Respond to change in parameters from the UI
         self._model_model.dataChanged.connect(self.onMainParamsChange)
         self._poly_model.dataChanged.connect(self.onPolyModelChange)
         self._magnet_model.dataChanged.connect(self.onMagnetModelChange)
-        self.listModelParameters.selectionModel().selectionChanged.connect(self.onSelectionChanged)
-        self.listModelParameters.installEventFilter(self)
-        self.listPolydispersity.installEventFilter(self)
-        self.listPolarisation_Magnetic_Scattering.installEventFilter(self)
-        self.listPolydispersity.selectionModel().selectionChanged.connect(self.onSelectionChanged)
+        self.lstModelParameters.selectionModel().selectionChanged.connect(self.onSelectionChanged)
+        self.lstModelParameters.installEventFilter(self)
+        self.lstPolydispersity.installEventFilter(self)
+        self.lstPolarisation_Magnetic_Scattering.installEventFilter(self)
+        self.lstPolydispersity.selectionModel().selectionChanged.connect(self.onSelectionChanged)
 
         # Local signals
         self.batchFittingFinishedSignal.connect(self.batchFitComplete)
@@ -682,7 +682,7 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
 
     def eventFilter(self, obj, event):
         # Catch enter key presses when editing model params
-        if obj in [self.listModelParameters, self.listPolydispersity, self.listPolarisation_Magnetic_Scattering]:
+        if obj in [self.lstModelParameters, self.lstPolydispersity, self.lstPolarisation_Magnetic_Scattering]:
             if event.type() == QtCore.QEvent.KeyPress and event.key() in [QtCore.Qt.Key_Return, QtCore.Qt.Key_Enter]:
                 self.onKey(event)
                 return True
@@ -793,7 +793,7 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         Show the constraint widget and receive the expression
         """
         if current_list is None:
-            current_list = self.listModelParameters
+            current_list = self.lstModelParameters
         model = current_list.model()
         for key, val in self.model_dict.items():
             if val == model:
@@ -810,7 +810,7 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         # Check if any of the parameters are polydisperse
         if not np.any([FittingUtilities.isParamPolydisperse(p, self.model_parameters, is2D=self.is2D) for p in params_list]):
             # no parameters are pd - reset the text to not show the warning
-            mc_widget.labelWarning.setText("")
+            mc_widget.lblWarning.setText("")
         if mc_widget.exec_() != QtWidgets.QDialog.Accepted:
             return
 
@@ -891,11 +891,11 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         """
         Return list of polydisperse parameters for the current model
         """
-        if not self.checkboxPolydispersity.isChecked():
+        if not self.chkPolydispersity.isChecked():
             return []
         poly_model_params = [self.polyNameToParam(self._poly_model.item(row).text())
                              for row in range(self._poly_model.rowCount())
-                             if self.checkboxPolydispersity.isChecked() and
+                             if self.chkPolydispersity.isChecked() and
                              self.isCheckable(row, model_key="poly")]
         return poly_model_params
 
@@ -903,7 +903,7 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         """
         Return list of magnetic parameters for the current model
         """
-        if not self.checkboxMagnetism.isChecked():
+        if not self.chkMagnetism.isChecked():
             return []
         magnetic_model_params = [self._magnet_model.item(row).text()
                             for row in range(self._magnet_model.rowCount())
@@ -1032,8 +1032,8 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         """
         model_key = self.tabToKey[self.tabOverviewFitting.currentIndex()]
         model = self.model_dict[model_key]
-        min_col = self.listModelParameters.itemDelegate().param_min
-        max_col = self.listModelParameters.itemDelegate().param_max
+        min_col = self.lstModelParameters.itemDelegate().param_min
+        max_col = self.lstModelParameters.itemDelegate().param_max
         for row in self.selectedParameters(model_key=model_key):
             param = model.item(row, 0).text()
             value = model.item(row, 1).text()
@@ -1265,7 +1265,7 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         status = QtCore.Qt.Checked
         model_key = self.tabToKey[self.tabOverviewFitting.currentIndex()]
         model = self.model_dict[model_key]
-        item = model.itemFromIndex(self.listModelParameters.currentIndex())
+        item = model.itemFromIndex(self.lstModelParameters.currentIndex())
         self.setParameterSelection(status, item=item, model_key=model_key)
 
     def deselectParameters(self):
@@ -1275,7 +1275,7 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         status = QtCore.Qt.Unchecked
         model_key = self.tabToKey[self.tabOverviewFitting.currentIndex()]
         model = self.model_dict[model_key]
-        item = model.itemFromIndex(self.listModelParameters.currentIndex())
+        item = model.itemFromIndex(self.lstModelParameters.currentIndex())
         self.setParameterSelection(status, item=item, model_key=model_key)
 
     def selectedParameters(self, model_key="standard"):
@@ -1465,32 +1465,32 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         """
         Respond to select Model from list event
         """
-        model = self.comboboxModel.currentText()
+        model = self.cbModel.currentText()
 
         if model == MODEL_DEFAULT:
             # if the previous category was not the default, keep it.
             # Otherwise, just return
             if self._previous_model_index != 0:
                 # We need to block signals, or else state changes on perceived unchanged conditions
-                self.comboboxModel.blockSignals(True)
-                self.comboboxModel.setCurrentIndex(self._previous_model_index)
-                self.comboboxModel.blockSignals(False)
+                self.cbModel.blockSignals(True)
+                self.cbModel.setCurrentIndex(self._previous_model_index)
+                self.cbModel.blockSignals(False)
             return
         if self.model_data is not None:
             # Store any old parameters before switching to a new model
             self.page_parameters = self.getParameterDict()
 
         # Assure the control is active
-        if not self.comboboxModel.isEnabled():
+        if not self.cbModel.isEnabled():
             return
         # Empty combobox forced to be read
         if not model:
             return
 
-        self.checkboxMagnetism.setEnabled(self.canHaveMagnetism())
-        self.checkboxMagnetism.setEnabled(self.canHaveMagnetism())
-        self.tabOverviewFitting.setTabEnabled(TAB_MAGNETISM, self.checkboxMagnetism.isChecked() and self.canHaveMagnetism())
-        self._previous_model_index = self.comboboxModel.currentIndex()
+        self.chkMagnetism.setEnabled(self.canHaveMagnetism())
+        self.chkMagnetism.setEnabled(self.canHaveMagnetism())
+        self.tabOverviewFitting.setTabEnabled(TAB_MAGNETISM, self.chkMagnetism.isChecked() and self.canHaveMagnetism())
+        self._previous_model_index = self.cbModel.currentIndex()
 
         # Reset parameters to fit
         self.resetParametersToFit()
@@ -1498,8 +1498,8 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         self.has_poly_error_column = False
 
         structure = None
-        if self.comboboxStructureFactor.isEnabled():
-            structure = str(self.comboboxStructureFactor.currentText())
+        if self.cbStructureFactor.isEnabled():
+            structure = str(self.cbStructureFactor.currentText())
         self.respondToModelStructure(model=model, structure_factor=structure)
 
         # paste parameters from previous state
@@ -1508,11 +1508,11 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
 
         # disable polydispersity if the model does not support it
         has_poly = self._poly_model.rowCount() != 0
-        self.checkboxPolydispersity.setEnabled(has_poly)
+        self.chkPolydispersity.setEnabled(has_poly)
         self.tabOverviewFitting.setTabEnabled(TAB_POLY, has_poly)
 
         # set focus so it doesn't move up
-        self.comboboxModel.setFocus()
+        self.cbModel.setFocus()
 
     def onSelectBatchFilename(self, data_index):
         """
@@ -1525,9 +1525,9 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         """
         Select Structure Factor from list
         """
-        model = str(self.comboboxModel.currentText())
-        category = str(self.comboboxCategory.currentText())
-        structure = str(self.comboboxStructureFactor.currentText())
+        model = str(self.cbModel.currentText())
+        category = str(self.cbCategory.currentText())
+        structure = str(self.cbStructureFactor.currentText())
         if category == CATEGORY_STRUCTURE:
             model = None
         # copy original clipboard
@@ -1566,19 +1566,19 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         self.onCategoriesChanged()
 
         # See if we need to update the combo in-place
-        if self.comboboxCategory.currentText() != CATEGORY_CUSTOM: return
+        if self.cbCategory.currentText() != CATEGORY_CUSTOM: return
 
-        current_text = self.comboboxModel.currentText()
-        self.comboboxModel.clear()
+        current_text = self.cbModel.currentText()
+        self.cbModel.clear()
         self.enableModelCombo()
         self.disableStructureCombo()
         # Retrieve the list of models
         model_list = self.master_category_dict[CATEGORY_CUSTOM]
         # Populate the models combobox
-        self.comboboxModel.addItems(sorted([model for (model, _) in model_list]))
-        new_index = self.comboboxModel.findText(current_text)
+        self.cbModel.addItems(sorted([model for (model, _) in model_list]))
+        new_index = self.cbModel.findText(current_text)
         if new_index != -1:
-            self.comboboxModel.setCurrentIndex(self.comboboxModel.findText(current_text))
+            self.cbModel.setCurrentIndex(self.cbModel.findText(current_text))
 
     def onSelectionChanged(self):
         """
@@ -1658,28 +1658,28 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         """
         # Update the chart
         if self.data_is_loaded:
-            self.buttonPlot.setText("Compute/Plot")
+            self.cmdPlot.setText("Compute/Plot")
             self.calculateQGridForModel()
         else:
-            self.buttonPlot.setText("Calculate")
+            self.cmdPlot.setText("Calculate")
             # Create default datasets if no data passed
             self.createDefaultDataset()
             self.theory_item = None # ensure theory is recalc. before plot, see showTheoryPlot()
 
     def respondToModelStructure(self, model=None, structure_factor=None):
         # Set enablement on calculate/plot
-        self.buttonPlot.setEnabled(True)
+        self.cmdPlot.setEnabled(True)
 
         # kernel parameters -> model_model
         self.SASModelToQModel(model, structure_factor)
 
         # Enable magnetism checkbox for selected models
-        self.checkboxMagnetism.setEnabled(self.canHaveMagnetism())
-        self.tabOverviewFitting.setTabEnabled(TAB_MAGNETISM, self.checkboxMagnetism.isChecked() and self.canHaveMagnetism())
+        self.chkMagnetism.setEnabled(self.canHaveMagnetism())
+        self.tabOverviewFitting.setTabEnabled(TAB_MAGNETISM, self.chkMagnetism.isChecked() and self.canHaveMagnetism())
 
         # Update column widths
         for column, width in self.lstParamHeaderSizes.items():
-            self.listModelParameters.setColumnWidth(column, width)
+            self.lstModelParameters.setColumnWidth(column, width)
 
         # disable background for SESANS data
         # this should be forced to 0 in sasmodels but this tells the user it is enforced to 0 and disables the box
@@ -1700,23 +1700,23 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         """
         Select Category from list
         """
-        category = self.comboboxCategory.currentText()
+        category = self.cbCategory.currentText()
         # Check if the user chose "Choose category entry"
         if category == CATEGORY_DEFAULT:
             # if the previous category was not the default, keep it.
             # Otherwise, just return
             if self._previous_category_index != 0:
                 # We need to block signals, or else state changes on perceived unchanged conditions
-                self.comboboxCategory.blockSignals(True)
-                self.comboboxCategory.setCurrentIndex(self._previous_category_index)
-                self.comboboxCategory.blockSignals(False)
+                self.cbCategory.blockSignals(True)
+                self.cbCategory.setCurrentIndex(self._previous_category_index)
+                self.cbCategory.blockSignals(False)
             return
 
         if category == CATEGORY_STRUCTURE:
             self.disableModelCombo()
             self.enableStructureCombo()
             # set the index to 0
-            self.comboboxStructureFactor.setCurrentIndex(0)
+            self.cbStructureFactor.setCurrentIndex(0)
             self.model_parameters = None
             self._model_model.clear()
             return
@@ -1727,22 +1727,22 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         # Wipe out the parameter model
         self._model_model.clear()
         # Safely clear and enable the model combo
-        self.comboboxModel.blockSignals(True)
-        self.comboboxModel.clear()
-        self.comboboxModel.blockSignals(False)
+        self.cbModel.blockSignals(True)
+        self.cbModel.clear()
+        self.cbModel.blockSignals(False)
         self.enableModelCombo()
         self.disableStructureCombo()
         self.kernel_module = None
 
-        self._previous_category_index = self.comboboxCategory.currentIndex()
+        self._previous_category_index = self.cbCategory.currentIndex()
         # Retrieve the list of models
         model_list = self.master_category_dict[category]
         # Populate the models combobox
-        self.comboboxModel.blockSignals(True)
-        self.comboboxModel.addItem(MODEL_DEFAULT)
+        self.cbModel.blockSignals(True)
+        self.cbModel.addItem(MODEL_DEFAULT)
         models_to_show = [m[0] for m in model_list if m[0] != 'rpa' and m[1]]
-        self.comboboxModel.addItems(sorted(models_to_show))
-        self.comboboxModel.blockSignals(False)
+        self.cbModel.addItems(sorted(models_to_show))
+        self.cbModel.blockSignals(False)
 
     def onPolyModelChange(self, top, bottom):
         """
@@ -1759,7 +1759,7 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         # corresponding values in FitPage
         parameter_name = parameter_name.rsplit()[-1]
 
-        delegate = self.listPolydispersity.itemDelegate()
+        delegate = self.lstPolydispersity.itemDelegate()
 
         # Extract changed value.
         if model_column == delegate.poly_parameter:
@@ -1771,7 +1771,7 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
             else:
                 if parameter_name_w in self.poly_params_to_fit:
                     self.poly_params_to_fit.remove(parameter_name_w)
-            self.buttonFit.setEnabled(self.haveParamsToFit())
+            self.cmdFit.setEnabled(self.haveParamsToFit())
             # Update state stack
             self.updateUndo()
 
@@ -1838,7 +1838,7 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
             else:
                 if parameter_name in self.magnet_params_to_fit:
                     self.magnet_params_to_fit.remove(parameter_name)
-            self.buttonFit.setEnabled(self.haveParamsToFit())
+            self.cmdFit.setEnabled(self.haveParamsToFit())
             # Update state stack
             self.updateUndo()
             return
@@ -1849,7 +1849,7 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         except TypeError:
             # Unparsable field
             return
-        delegate = self.listPolarisation_Magnetic_Scattering.itemDelegate()
+        delegate = self.lstPolarisation_Magnetic_Scattering.itemDelegate()
 
         if model_column > 1:
             if model_column == delegate.mag_min:
@@ -2148,13 +2148,13 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         qmax = self.q_range_max
 
         params_to_fit = copy.deepcopy(self.main_params_to_fit)
-        if self.checkboxPolydispersity.isChecked():
+        if self.chkPolydispersity.isChecked():
             for p in self.poly_params_to_fit:
                 if "Distribution of" in p:
                     params_to_fit += [self.polyNameToParam(p)]
                 else:
                     params_to_fit += [p]
-        if self.checkboxMagnetism.isChecked() and self.canHaveMagnetism():
+        if self.chkMagnetism.isChecked() and self.canHaveMagnetism():
             params_to_fit += self.magnet_params_to_fit
         if not params_to_fit:
             raise ValueError('Fitting requires at least one parameter to optimize.')
@@ -2287,7 +2287,7 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         #if not self.has_error_column:
             # create top-level error column
         error_column = []
-        self.listModelParameters.itemDelegate().addErrorColumn()
+        self.lstModelParameters.itemDelegate().addErrorColumn()
         self.iterateOverModel(createErrorColumn)
 
         self._model_model.insertColumn(2, error_column)
@@ -2362,7 +2362,7 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         if self.has_poly_error_column:
             self._poly_model.removeColumn(2)
 
-        self.listPolydispersity.itemDelegate().addErrorColumn()
+        self.lstPolydispersity.itemDelegate().addErrorColumn()
         error_column = []
         self.iterateOverPolyModel(createErrorColumn)
 
@@ -2426,7 +2426,7 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         if self.has_magnet_error_column:
             self._magnet_model.removeColumn(2)
 
-        self.listPolarisation_Magnetic_Scattering.itemDelegate().addErrorColumn()
+        self.lstPolarisation_Magnetic_Scattering.itemDelegate().addErrorColumn()
         error_column = []
         self.iterateOverMagnetModel(createErrorColumn)
 
@@ -2441,7 +2441,7 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         Plot the current set of data
         """
         # Regardless of previous state, this should now be `plot show` functionality only
-        self.buttonPlot.setText("Compute/Plot")
+        self.cmdPlot.setText("Compute/Plot")
         # Force data recalculation so existing charts are updated
         if not self.data_is_loaded:
             self.showTheoryPlot()
@@ -2463,7 +2463,7 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         self.calculateQGridForModel()
 
     def onKey(self, event):
-        if event.key() in [QtCore.Qt.Key_Enter, QtCore.Qt.Key_Return] and self.buttonPlot.isEnabled():
+        if event.key() in [QtCore.Qt.Key_Enter, QtCore.Qt.Key_Return] and self.cmdPlot.isEnabled():
             self.onPlot()
 
     def recalculatePlotData(self):
@@ -2532,8 +2532,8 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         structure_factor_list = self.master_category_dict.pop(CATEGORY_STRUCTURE)
         factors = [factor[0] for factor in structure_factor_list]
         factors.insert(0, STRUCTURE_DEFAULT)
-        self.comboboxStructureFactor.clear()
-        self.comboboxStructureFactor.addItems(sorted(factors))
+        self.cbStructureFactor.clear()
+        self.cbStructureFactor.addItems(sorted(factors))
 
     def createDefaultDataset(self):
         """
@@ -2690,8 +2690,8 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
             self.enableStructureFactorControl(structure_factor)
 
             # Add S(Q)
-            if self.comboboxStructureFactor.isEnabled():
-                structure_factor = self.comboboxStructureFactor.currentText()
+            if self.cbStructureFactor.isEnabled():
+                structure_factor = self.cbStructureFactor.currentText()
                 self.fromStructureFactorToQModel(structure_factor)
 
             # Add polydispersity to the model
@@ -2710,7 +2710,7 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
 
         # (Re)-create headers
         FittingUtilities.addHeadersToModel(self._model_model)
-        self.listModelParameters.header().setFont(self.boldFont)
+        self.lstModelParameters.header().setFont(self.boldFont)
 
     def fromModelToQModel(self, model_name):
         """
@@ -2718,7 +2718,7 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         """
         name = model_name
         kernel_module = None
-        if self.comboboxCategory.currentText() == CATEGORY_CUSTOM:
+        if self.cbCategory.currentText() == CATEGORY_CUSTOM:
             # custom kernel load requires full path
             name = os.path.join(models.find_plugins_dir(), model_name+".py")
         try:
@@ -2784,7 +2784,7 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
                 self.kernel_module,
                 self.is2D,
                 self._model_model,
-                self.listModelParameters)
+                self.lstModelParameters)
 
     def fromStructureFactorToQModel(self, structure_factor):
         """
@@ -2815,7 +2815,7 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
                 is2D=self.is2D,
                 parameters_original=None,
                 model=self._model_model,
-                view=self.listModelParameters)
+                view=self.lstModelParameters)
 
         # Insert product-only params into QModel
         if product_params:
@@ -2824,7 +2824,7 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
                     is2D=self.is2D,
                     parameters_original=None,
                     model=self._model_model,
-                    view=self.listModelParameters,
+                    view=self.lstModelParameters,
                     row_num=2)
 
             # Since this all happens after shells are dealt with and we've inserted rows, fix this counter
@@ -2884,9 +2884,9 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
             return False
         if self.main_params_to_fit:
             return True
-        if self.checkboxPolydispersity.isChecked() and self.poly_params_to_fit:
+        if self.chkPolydispersity.isChecked() and self.poly_params_to_fit:
             return True
-        if self.checkboxMagnetism.isChecked() and self.canHaveMagnetism() and self.magnet_params_to_fit:
+        if self.chkMagnetism.isChecked() and self.canHaveMagnetism() and self.magnet_params_to_fit:
             return True
         return False
 
@@ -2900,7 +2900,7 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
 
         if model_column == 0:
             self.checkboxSelected(item, model_key="standard")
-            self.buttonFit.setEnabled(self.haveParamsToFit())
+            self.cmdFit.setEnabled(self.haveParamsToFit())
             # Update state stack
             self.updateUndo()
             return
@@ -2923,9 +2923,9 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
             parameter_name = str(self._model_model.data(name_index))
 
         # Update the parameter value - note: this supports +/-inf as well
-        param_column = self.listModelParameters.itemDelegate().param_value
-        min_column = self.listModelParameters.itemDelegate().param_min
-        max_column = self.listModelParameters.itemDelegate().param_max
+        param_column = self.lstModelParameters.itemDelegate().param_value
+        min_column = self.lstModelParameters.itemDelegate().param_min
+        max_column = self.lstModelParameters.itemDelegate().param_max
         if model_column == param_column:
             # don't try to update multiplicity counters if they aren't there.
             # Note that this will fail for proper bad update where the model
@@ -3146,11 +3146,11 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         if not hasattr(model, 'setParam'): return
 
         # add polydisperse parameters if asked
-        if self.checkboxPolydispersity.isChecked() and self._poly_model.rowCount() > 0:
+        if self.chkPolydispersity.isChecked() and self._poly_model.rowCount() > 0:
             for key, value in self.poly_params.items():
                 model.setParam(key, value)
         # add magnetic params if asked
-        if self.checkboxMagnetism.isChecked() and self.canHaveMagnetism() and self._magnet_model.rowCount() > 0:
+        if self.chkMagnetism.isChecked() and self.canHaveMagnetism() and self._magnet_model.rowCount() > 0:
             for key, value in self.magnet_params.items():
                 model.setParam(key, value)
 
@@ -3399,26 +3399,26 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
             Reload the category/model comboboxes
             """
             # Store the current combo indices
-            current_cat = self.comboboxCategory.currentText()
-            current_model = self.comboboxModel.currentText()
+            current_cat = self.cbCategory.currentText()
+            current_model = self.cbModel.currentText()
 
             # reread the category file and repopulate the combo
-            self.comboboxCategory.blockSignals(True)
-            self.comboboxCategory.clear()
+            self.cbCategory.blockSignals(True)
+            self.cbCategory.clear()
             self.readCategoryInfo()
             self.initializeCategoryCombo()
 
             # Scroll back to the original index in Categories
-            new_index = self.comboboxCategory.findText(current_cat)
+            new_index = self.cbCategory.findText(current_cat)
             if new_index != -1:
-                self.comboboxCategory.setCurrentIndex(new_index)
-            self.comboboxCategory.blockSignals(False)
+                self.cbCategory.setCurrentIndex(new_index)
+            self.cbCategory.blockSignals(False)
             # ...and in the Models
-            self.comboboxModel.blockSignals(True)
-            new_index = self.comboboxModel.findText(current_model)
+            self.cbModel.blockSignals(True)
+            new_index = self.cbModel.findText(current_model)
             if new_index != -1:
-                self.comboboxModel.setCurrentIndex(new_index)
-            self.comboboxModel.blockSignals(False)
+                self.cbModel.setCurrentIndex(new_index)
+            self.cbModel.blockSignals(False)
 
             return
 
@@ -3521,8 +3521,8 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         func.addItems([str(name_disp) for name_disp in POLYDISPERSITY_MODELS.keys()])
         # Set the default index
         func.setCurrentIndex(func.findText(DEFAULT_POLYDISP_FUNCTION))
-        ind = self._poly_model.index(i,self.listPolydispersity.itemDelegate().poly_function)
-        self.listPolydispersity.setIndexWidget(ind, func)
+        ind = self._poly_model.index(i,self.lstPolydispersity.itemDelegate().poly_function)
+        self.lstPolydispersity.setIndexWidget(ind, func)
         func.currentIndexChanged.connect(lambda: self.onPolyComboIndexChange(str(func.currentText()), i))
 
     def onPolyFilenameChange(self, row_index):
@@ -3533,12 +3533,12 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         array_caption = 'array'
 
         # Get the combo box reference
-        ind = self._poly_model.index(row_index, self.listPolydispersity.itemDelegate().poly_function)
-        widget = self.listPolydispersity.indexWidget(ind)
+        ind = self._poly_model.index(row_index, self.lstPolydispersity.itemDelegate().poly_function)
+        widget = self.lstPolydispersity.indexWidget(ind)
 
         # Update the combo box so it displays "array"
         widget.blockSignals(True)
-        widget.setCurrentIndex(self.listPolydispersity.itemDelegate().POLYDISPERSE_FUNCTIONS.index(array_caption))
+        widget.setCurrentIndex(self.lstPolydispersity.itemDelegate().POLYDISPERSE_FUNCTIONS.index(array_caption))
         widget.blockSignals(False)
 
         # Invoke the file reader
@@ -3550,8 +3550,8 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         """
         # Get npts/nsigs for current selection
         param = self.model_parameters.form_volume_parameters[row_index]
-        file_index = self._poly_model.index(row_index, self.listPolydispersity.itemDelegate().poly_function)
-        combo_box = self.listPolydispersity.indexWidget(file_index)
+        file_index = self._poly_model.index(row_index, self.lstPolydispersity.itemDelegate().poly_function)
+        combo_box = self.lstPolydispersity.indexWidget(file_index)
         try:
             self.disp_model = POLYDISPERSITY_MODELS[combo_string]()
         except IndexError:
@@ -3588,8 +3588,8 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
                 # uncheck the parameter
                 self._poly_model.item(row_index, 0).setCheckState(QtCore.Qt.Unchecked)
                 # disable the row
-                lo = self.listPolydispersity.itemDelegate().poly_parameter
-                hi = self.listPolydispersity.itemDelegate().poly_function
+                lo = self.lstPolydispersity.itemDelegate().poly_parameter
+                hi = self.lstPolydispersity.itemDelegate().poly_function
                 self._poly_model.blockSignals(True)
                 [self._poly_model.item(row_index, i).setEnabled(False) for i in range(lo, hi)]
                 self._poly_model.blockSignals(False)
@@ -3603,14 +3603,14 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
 
         # Enable the row in case it was disabled by Array
         self._poly_model.blockSignals(True)
-        max_range = self.listPolydispersity.itemDelegate().poly_filename
+        max_range = self.lstPolydispersity.itemDelegate().poly_filename
         [self._poly_model.item(row_index, i).setEnabled(True) for i in range(7)]
-        file_index = self._poly_model.index(row_index, self.listPolydispersity.itemDelegate().poly_filename)
+        file_index = self._poly_model.index(row_index, self.lstPolydispersity.itemDelegate().poly_filename)
         self._poly_model.setData(file_index, "")
         self._poly_model.blockSignals(False)
 
-        npts_index = self._poly_model.index(row_index, self.listPolydispersity.itemDelegate().poly_npts)
-        nsigs_index = self._poly_model.index(row_index, self.listPolydispersity.itemDelegate().poly_nsigs)
+        npts_index = self._poly_model.index(row_index, self.lstPolydispersity.itemDelegate().poly_npts)
+        nsigs_index = self._poly_model.index(row_index, self.lstPolydispersity.itemDelegate().poly_nsigs)
 
         npts = POLYDISPERSITY_MODELS[str(combo_string)].default['npts']
         nsigs = POLYDISPERSITY_MODELS[str(combo_string)].default['nsigmas']
@@ -3655,7 +3655,7 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         self.disp_model.set_weights(np.array(values), np.array(weights))
         # + update the cell with filename
         fname = os.path.basename(str(datafile))
-        fname_index = self._poly_model.index(row_index, self.listPolydispersity.itemDelegate().poly_filename)
+        fname_index = self._poly_model.index(row_index, self.lstPolydispersity.itemDelegate().poly_filename)
         self._poly_model.setData(fname_index, fname)
 
     def onColumnWidthUpdate(self, index, old_size, new_size):
@@ -3775,8 +3775,8 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         shell_index = self._model_model.index(shell_row-1, 1)
         button_index = self._model_model.index(shell_row-1, 4)
 
-        self.listModelParameters.setIndexWidget(shell_index, func)
-        self.listModelParameters.setIndexWidget(button_index, button)
+        self.lstModelParameters.setIndexWidget(shell_index, func)
+        self.lstModelParameters.setIndexWidget(button_index, button)
         self._n_shells_row = shell_row - 1
 
         # Get the default number of shells for the model
@@ -3853,7 +3853,7 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
                 self._model_model,
                 index,
                 first_row,
-                self.listModelParameters)
+                self.lstModelParameters)
 
         self._num_shell_params = len(new_rows)
         self.current_shell_displayed = index
@@ -3916,21 +3916,21 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         """
         assert isinstance(enabled, bool)
 
-        self.listModelParameters.setEnabled(enabled)
-        self.listPolydispersity.setEnabled(enabled)
-        self.listPolarisation_Magnetic_Scattering.setEnabled(enabled)
+        self.lstModelParameters.setEnabled(enabled)
+        self.lstPolydispersity.setEnabled(enabled)
+        self.lstPolarisation_Magnetic_Scattering.setEnabled(enabled)
 
-        self.comboboxCategory.setEnabled(enabled)
+        self.cbCategory.setEnabled(enabled)
 
         if enabled:
             # worry about original enablement of model and SF
-            self.comboboxModel.setEnabled(self.enabled_cbmodel)
-            self.comboboxStructureFactor.setEnabled(self.enabled_sfmodel)
+            self.cbModel.setEnabled(self.enabled_cbmodel)
+            self.cbStructureFactor.setEnabled(self.enabled_sfmodel)
         else:
-            self.comboboxModel.setEnabled(enabled)
-            self.comboboxStructureFactor.setEnabled(enabled)
+            self.cbModel.setEnabled(enabled)
+            self.cbStructureFactor.setEnabled(enabled)
 
-        self.buttonPlot.setEnabled(enabled)
+        self.cmdPlot.setEnabled(enabled)
 
     def enableInteractiveElements(self):
         """
@@ -3938,8 +3938,8 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         Enable the param table(s)
         """
         # Notify the user that fitting is available
-        self.buttonFit.setStyleSheet('QPushButton {color: black;}')
-        self.buttonFit.setText("Fit")
+        self.cmdFit.setStyleSheet('QPushButton {color: black;}')
+        self.cmdFit.setText("Fit")
         self.fit_started = False
         self.setInteractiveElements(True)
 
@@ -3950,8 +3950,8 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         """
         # Notify the user that fitting is being run
         # Allow for stopping the job
-        self.buttonFit.setStyleSheet('QPushButton {color: red;}')
-        self.buttonFit.setText('Stop fit')
+        self.cmdFit.setStyleSheet('QPushButton {color: red;}')
+        self.cmdFit.setText('Stop fit')
         self.setInteractiveElements(False)
 
     def disableInteractiveElementsOnCalculate(self):
@@ -3961,8 +3961,8 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         """
         # Notify the user that fitting is being run
         # Allow for stopping the job
-        self.buttonFit.setStyleSheet('QPushButton {color: red;}')
-        self.buttonFit.setText('Running...')
+        self.cmdFit.setStyleSheet('QPushButton {color: red;}')
+        self.cmdFit.setText('Running...')
         self.setInteractiveElements(False)
 
     def readFitPage(self, fp):
@@ -3973,15 +3973,15 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         # Main tab info
         self.logic.data.name = fp.name
         self.data_is_loaded = fp.data_is_loaded
-        self.checkboxPolydispersity.setChecked(fp.is_polydisperse)
-        self.checkboxMagnetism.setChecked(fp.is_magnetic)
-        self.checkbox2DView.setChecked(fp.is2D)
+        self.chkPolydispersity.setChecked(fp.is_polydisperse)
+        self.chkMagnetism.setChecked(fp.is_magnetic)
+        self.chk2DView.setChecked(fp.is2D)
 
         # Update the comboboxes
-        self.comboboxCategory.setCurrentIndex(self.comboboxCategory.findText(fp.current_category))
-        self.comboboxModel.setCurrentIndex(self.comboboxModel.findText(fp.current_model))
+        self.cbCategory.setCurrentIndex(self.cbCategory.findText(fp.current_category))
+        self.cbModel.setCurrentIndex(self.cbModel.findText(fp.current_model))
         if fp.current_factor:
-            self.comboboxStructureFactor.setCurrentIndex(self.comboboxStructureFactor.findText(fp.current_factor))
+            self.cbStructureFactor.setCurrentIndex(self.cbStructureFactor.findText(fp.current_factor))
 
         self.chi2 = fp.chi2
 
@@ -4015,9 +4015,9 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         # Main tab info
         fp.name = self.logic.data.name
         fp.data_is_loaded = self.data_is_loaded
-        fp.is_polydisperse = self.checkboxPolydispersity.isChecked()
-        fp.is_magnetic = self.checkboxMagnetism.isChecked()
-        fp.is2D = self.checkbox2DView.isChecked()
+        fp.is_polydisperse = self.chkPolydispersity.isChecked()
+        fp.is_magnetic = self.chkMagnetism.isChecked()
+        fp.is2D = self.chk2DView.isChecked()
         fp.data = self.data
 
         # Use current models - they contain all the required parameters
@@ -4025,12 +4025,12 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         fp.poly_model = self._poly_model
         fp.magnetism_model = self._magnet_model
 
-        if self.comboboxCategory.currentIndex() != 0:
-            fp.current_category = str(self.comboboxCategory.currentText())
-            fp.current_model = str(self.comboboxModel.currentText())
+        if self.cbCategory.currentIndex() != 0:
+            fp.current_category = str(self.cbCategory.currentText())
+            fp.current_model = str(self.cbModel.currentText())
 
-        if self.comboboxStructureFactor.isEnabled() and self.comboboxStructureFactor.currentIndex() != 0:
-            fp.current_factor = str(self.comboboxStructureFactor.currentText())
+        if self.cbStructureFactor.isEnabled() and self.cbStructureFactor.currentIndex() != 0:
+            fp.current_factor = str(self.cbStructureFactor.currentText())
         else:
             fp.current_factor = ''
 
@@ -4101,9 +4101,9 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         params = FittingUtilities.getStandardParam(self._model_model)
         poly_params = []
         magnet_params = []
-        if self.checkboxPolydispersity.isChecked() and self._poly_model.rowCount() > 0:
+        if self.chkPolydispersity.isChecked() and self._poly_model.rowCount() > 0:
             poly_params = FittingUtilities.getStandardParam(self._poly_model)
-        if self.checkboxMagnetism.isChecked() and self.canHaveMagnetism() and self._magnet_model.rowCount() > 0:
+        if self.chkMagnetism.isChecked() and self.canHaveMagnetism() and self._magnet_model.rowCount() > 0:
             magnet_params = FittingUtilities.getStandardParam(self._magnet_model)
         report_logic = ReportPageLogic(self,
                                        kernel_module=self.kernel_module,
@@ -4264,9 +4264,9 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         serializes combobox state
         """
         param_list = []
-        model = str(self.comboboxModel.currentText())
-        category = str(self.comboboxCategory.currentText())
-        structure = str(self.comboboxStructureFactor.currentText())
+        model = str(self.cbModel.currentText())
+        category = str(self.cbCategory.currentText())
+        structure = str(self.cbStructureFactor.currentText())
         param_list.append(['fitpage_category', category])
         param_list.append(['fitpage_model', model])
         param_list.append(['fitpage_structure', structure])
@@ -4307,16 +4307,16 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
 
         # resolution
         smearing, accuracy, smearing_min, smearing_max = self.smearing_widget.state()
-        index = self.smearing_widget.comboBoxInstrumentalSmearing.currentIndex()
+        index = self.smearing_widget.cbInstrumentalSmearing.currentIndex()
         param_list.append(['smearing', str(index)])
         param_list.append(['smearing_min', str(smearing_min)])
         param_list.append(['smearing_max', str(smearing_max)])
 
         # checkboxes, if required
-        has_polydisp = self.checkboxPolydispersity.isChecked()
-        has_magnetism = self.checkboxMagnetism.isChecked()
-        has_chain = self.checkboxChainFit.isChecked()
-        has_2D = self.checkbox2DView.isChecked()
+        has_polydisp = self.chkPolydispersity.isChecked()
+        has_magnetism = self.chkMagnetism.isChecked()
+        has_chain = self.chkChainFit.isChecked()
+        has_2D = self.chk2DView.isChecked()
         param_list.append(['polydisperse_params', str(has_polydisp)])
         param_list.append(['magnetic_params', str(has_magnetism)])
         param_list.append(['chainfit_params', str(has_chain)])
@@ -4332,7 +4332,7 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         if self.kernel_module is None:
             return param_list
 
-        param_list.append(['model_name', str(self.comboboxModel.currentText())])
+        param_list.append(['model_name', str(self.cbModel.currentText())])
 
         def gatherParams(row):
             """
@@ -4406,7 +4406,7 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
             param_nsigs = str(self._poly_model.item(row, 5+column_offset).text())
             param_fun   = str(self._poly_model.item(row, 6+column_offset).text()).rstrip()
             index = self._poly_model.index(row, 6+column_offset)
-            widget = self.listPolydispersity.indexWidget(index)
+            widget = self.lstPolydispersity.indexWidget(index)
             if widget is not None and isinstance(widget, QtWidgets.QComboBox):
                 param_fun = widget.currentText()
             # width
@@ -4432,9 +4432,9 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
                                param_error, param_min, param_max])
 
         self.iterateOverModel(gatherParams)
-        if self.checkboxPolydispersity.isChecked():
+        if self.chkPolydispersity.isChecked():
             self.iterateOverPolyModel(gatherPolyParams)
-        if self.checkboxMagnetism.isChecked() and self.canHaveMagnetism():
+        if self.chkMagnetism.isChecked() and self.canHaveMagnetism():
             self.iterateOverMagnetModel(gatherMagnetParams)
 
         if self.kernel_module.is_multiplicity_model:
@@ -4448,11 +4448,11 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         and fills it up with sent parameters
         """
         if 'fitpage_category' in line_dict:
-            self.comboboxCategory.setCurrentIndex(self.comboboxCategory.findText(line_dict['fitpage_category'][0]))
+            self.cbCategory.setCurrentIndex(self.cbCategory.findText(line_dict['fitpage_category'][0]))
         if 'fitpage_model' in line_dict:
-            self.comboboxModel.setCurrentIndex(self.comboboxModel.findText(line_dict['fitpage_model'][0]))
+            self.cbModel.setCurrentIndex(self.cbModel.findText(line_dict['fitpage_model'][0]))
         if 'fitpage_structure' in line_dict:
-            self.comboboxStructureFactor.setCurrentIndex(self.comboboxStructureFactor.findText(line_dict['fitpage_structure'][0]))
+            self.cbStructureFactor.setCurrentIndex(self.cbStructureFactor.findText(line_dict['fitpage_structure'][0]))
 
         # Now that the page is ready for parameters, fill it up
         self.updatePageWithParameters(line_dict)
@@ -4476,13 +4476,13 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         if 'tab_name' in line_dict.keys() and self.kernel_module is not None:
             self.kernel_module.name = line_dict['tab_name'][0]
         if 'polydisperse_params' in line_dict.keys():
-            self.checkboxPolydispersity.setChecked(line_dict['polydisperse_params'][0]=='True')
+            self.chkPolydispersity.setChecked(line_dict['polydisperse_params'][0]=='True')
         if 'magnetic_params' in line_dict.keys():
-            self.checkboxMagnetism.setChecked(line_dict['magnetic_params'][0]=='True')
+            self.chkMagnetism.setChecked(line_dict['magnetic_params'][0]=='True')
         if 'chainfit_params' in line_dict.keys():
-            self.checkboxChainFit.setChecked(line_dict['chainfit_params'][0]=='True')
+            self.chkChainFit.setChecked(line_dict['chainfit_params'][0]=='True')
         if '2D_params' in line_dict.keys():
-            self.checkbox2DView.setChecked(line_dict['2D_params'][0]=='True')
+            self.chk2DView.setChecked(line_dict['2D_params'][0]=='True')
 
         # Create the context dictionary for parameters
         context['model_name'] = model
@@ -4490,7 +4490,7 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
             if len(value) > 2:
                 context[key] = value
 
-        if warn_user and str(self.comboboxModel.currentText()) != str(context['model_name']):
+        if warn_user and str(self.cbModel.currentText()) != str(context['model_name']):
             msg = QtWidgets.QMessageBox()
             msg.setIcon(QtWidgets.QMessageBox.Information)
             msg.setText("The model in the clipboard is not the same as the currently loaded model. \
@@ -4505,7 +4505,7 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         if 'smearing' in line_dict.keys():
             try:
                 index = int(line_dict['smearing'][0])
-                self.smearing_widget.comboBoxInstrumentalSmearing.setCurrentIndex(index)
+                self.smearing_widget.cbInstrumentalSmearing.setCurrentIndex(index)
             except ValueError:
                 pass
         if 'smearing_min' in line_dict.keys():
@@ -4545,7 +4545,7 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         Find and update the multiplicity combobox
         """
         index = self._model_model.index(self._n_shells_row, 1)
-        widget = self.listModelParameters.indexWidget(index)
+        widget = self.lstModelParameters.indexWidget(index)
         if widget is not None and isinstance(widget, QtWidgets.QComboBox):
             widget.setCurrentIndex(widget.findText(str(multip)))
         self.current_shell_displayed = multip
@@ -4574,7 +4574,7 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
                     # quietly pass
                     return
                 index = self._model_model.index(row, 1)
-                widget = self.listModelParameters.indexWidget(index)
+                widget = self.lstModelParameters.indexWidget(index)
                 if widget is not None and isinstance(widget, QtWidgets.QComboBox):
                     #widget.setCurrentIndex(combo_index)
                     return
@@ -4585,7 +4585,7 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
             # parameter value can be either just a value or text on the combobox
             param_text = param_dict[param_name][1]
             index = self._model_model.index(row, 1)
-            widget = self.listModelParameters.indexWidget(index)
+            widget = self.lstModelParameters.indexWidget(index)
             if widget is not None and isinstance(widget, QtWidgets.QComboBox):
                 # Find the right index based on text
                 combo_index = int(param_text, 0)
@@ -4715,10 +4715,10 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         Store current state for fit_page
         """
         # Comboboxes
-        state.categorycombobox = self.comboboxCategory.currentText()
-        state.formfactorcombobox = self.comboboxModel.currentText()
-        if self.comboboxStructureFactor.isEnabled():
-            state.structurecombobox = self.comboboxStructureFactor.currentText()
+        state.categorycombobox = self.cbCategory.currentText()
+        state.formfactorcombobox = self.cbModel.currentText()
+        if self.cbStructureFactor.isEnabled():
+            state.structurecombobox = self.cbStructureFactor.currentText()
         state.tcChi = self.chi2
 
         state.enable2D = self.is2D

--- a/src/sas/qtgui/Perspectives/Fitting/FittingWidget.py
+++ b/src/sas/qtgui/Perspectives/Fitting/FittingWidget.py
@@ -170,8 +170,8 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
 
         # New font to display angstrom symbol
         new_font = 'font-family: -apple-system, "Helvetica Neue", "Ubuntu";'
-        self.labelAngstromLetterUp.setStyleSheet(new_font)
-        self.labelAngstromLetterDown.setStyleSheet(new_font)
+        self.lblAngstromLetterUp.setStyleSheet(new_font)
+        self.lblAngstromLetterDown.setStyleSheet(new_font)
 
     def info(self, type, value, tb):
         logger.error("".join(traceback.format_exception(type, value, tb)))
@@ -363,9 +363,9 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         self.boldFont.setBold(True)
 
         # Set data label
-        self.labelFilenameLeft.setFont(self.boldFont)
-        self.labelFilenameLeft.setText("No data loaded")
-        self.labelFilenameRight.setText("")
+        self.lblFilenameLeft.setFont(self.boldFont)
+        self.lblFilenameLeft.setText("No data loaded")
+        self.lblFilenameRight.setText("")
 
         # Magnetic angles explained in one picture
         self.magneticAnglesWidget = QtWidgets.QWidget()
@@ -485,11 +485,11 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         Enable/disable various UI elements based on data loaded
         """
         # Tag along functionality
-        self.labelFilenameLeft.setText("Data loaded from: ")
+        self.lblFilenameLeft.setText("Data loaded from: ")
         if self.logic.data.name:
-            self.labelFilenameRight.setText(self.logic.data.name)
+            self.lblFilenameRight.setText(self.logic.data.name)
         else:
-            self.labelFilenameRight.setText(self.logic.data.filename)
+            self.lblFilenameRight.setText(self.logic.data.filename)
         self.updateQRange()
         # Switch off Data2D control
         self.chk2DView.setEnabled(False)
@@ -498,11 +498,11 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         self.tabOverviewFitting.setTabEnabled(TAB_MAGNETISM, self.chkMagnetism.isChecked())
         # Combo box or label for file name"
         if self.is_batch_fitting:
-            self.labelFilenameRight.setVisible(False)
+            self.lblFilenameRight.setVisible(False)
             for dataitem in self.all_data:
                 name = GuiUtils.dataFromItem(dataitem).name
-                self.self.cmdHelp.addItem(name)
-            self.self.cmdHelp.setVisible(True)
+                self.cmdHelp.addItem(name)
+            self.cmdHelp.setVisible(True)
             self.chkChainFit.setEnabled(True)
             self.chkChainFit.setVisible(True)
             # This panel is not designed to view individual fits, so disable plotting
@@ -520,19 +520,19 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
     def disableModelCombo(self):
         """ Disable the combobox """
         self.cbModel.setEnabled(False)
-        self.labelModel.setEnabled(False)
+        self.lblModel.setEnabled(False)
         self.enabled_cbmodel = False
 
     def enableModelCombo(self):
         """ Enable the combobox """
         self.cbModel.setEnabled(True)
-        self.labelModel.setEnabled(True)
+        self.lblModel.setEnabled(True)
         self.enabled_cbmodel = True
 
     def disableStructureCombo(self):
         """ Disable the combobox """
         self.cbStructureFactor.setEnabled(False)
-        self.labelStructure.setEnabled(False)
+        self.lblStructure.setEnabled(False)
         self.enabled_sfmodel = False
 
     def enableBackgroundParameter(self, set_value: Optional[float] = None):
@@ -554,7 +554,7 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
     def enableStructureCombo(self):
         """ Enable the combobox """
         self.cbStructureFactor.setEnabled(True)
-        self.labelStructure.setEnabled(True)
+        self.lblStructure.setEnabled(True)
         self.enabled_sfmodel = True
 
     def togglePoly(self, isChecked):
@@ -604,7 +604,7 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         """
         Set initial control enablement
         """
-        self.self.cmdHelp.setVisible(False)
+        self.cmdHelp.setVisible(False)
         self.cmdFit.setEnabled(False)
         self.cmdPlot.setEnabled(False)
         self.chkPolydispersity.setEnabled(False)
@@ -618,7 +618,7 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         # Tabs
         self.tabOverviewFitting.setTabEnabled(TAB_POLY, False)
         self.tabOverviewFitting.setTabEnabled(TAB_MAGNETISM, False)
-        self.labelChiSquaredValue.setText("---")
+        self.lblChiSquaredValue.setText("---")
         # Smearing tab
         self.smearing_widget.updateData(self.data)
         # Line edits in the option tab
@@ -632,7 +632,7 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         self.cbStructureFactor.currentIndexChanged.connect(self.onSelectStructureFactor)
         self.cbCategory.currentIndexChanged.connect(self.onSelectCategory)
         self.cbModel.currentIndexChanged.connect(self.onSelectModel)
-        self.cmdHelp.currentIndexChanged.connect(self.onSelectBatchFilename)
+        self.cbFileNames.currentIndexChanged.connect(self.onSelectBatchFilename)
         # Checkboxes
         self.chk2DView.toggled.connect(self.toggle2D)
         self.chkPolydispersity.toggled.connect(self.togglePoly)
@@ -1613,21 +1613,21 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         Updates the fitting widget format when SESANS data is loaded.
         """
         # update the units in the 'Fitting details' box of the Model tab on the Fit Panel
-        self.labelAngstromLetterUp.setText("Å")
-        self.labelAngstromLetterDown.setText("Å")
+        self.lblAngstromLetterUp.setText("Å")
+        self.lblAngstromLetterDown.setText("Å")
         # disable the background parameter and set at 0 for sesans
         self.disableBackgroundParameter(set_value=0.0)
         # update options defaults and settings for SESANS data
         self.options_widget.updateQRange(1, 100000, self.options_widget.NPTS_DEFAULT)
         # update the units in the 'Fitting details' box of the Fit Options tab on the Fit Panel
-        self.options_widget.labelAngstromInvMinRange.setText("Å")
-        self.options_widget.labelAngstromInvMaxRange.setText("Å")
+        self.options_widget.lblAngstromInvMinRange.setText("Å")
+        self.options_widget.lblAngstromInvMaxRange.setText("Å")
         # update the smearing drop down box to indicate a Hankel Transform is being used instead of resolution
         self.smearing_widget.onIndexChange(1)
         # update the Weighting box of the Fit Options tab on the Fit Panel
-        self.options_widget.radioButtonWeightingUsedIData.setText("Use dP Data")
-        self.options_widget.radioButtonWeightingUseAbsSqrtIData.setText("Use |sqrt(P Data)|")
-        self.options_widget.radioButtonWeightingUseAbsIData.setText("Use |P Data|")
+        self.options_widget.rbWeightingUsedIData.setText("Use dP Data")
+        self.options_widget.rbWeightingUseAbsSqrtIData.setText("Use |sqrt(P Data)|")
+        self.options_widget.rbWeightingUseAbsIData.setText("Use |P Data|")
 
     def replaceConstraintName(self, old_name, new_name=""):
         """
@@ -2131,7 +2131,7 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
 
         # Read only value - we can get away by just printing it here
         chi2_repr = GuiUtils.formatNumber(self.chi2, high=True)
-        self.labelChiSquaredValue.setText(chi2_repr)
+        self.lblChiSquaredValue.setText(chi2_repr)
 
 
     def prepareFitters(self, fitter=None, fit_id=0, weight_increase=1):
@@ -2459,7 +2459,7 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         """
         # update display
         smearing, accuracy, smearing_min, smearing_max = self.smearing_widget.state()
-        self.labelSmearingValue.setText(smearing)
+        self.lblSmearingValue.setText(smearing)
         self.calculateQGridForModel()
 
     def onKey(self, event):
@@ -2521,8 +2521,8 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         self.q_range_min, self.q_range_max, self.npts, self.log_points, self.weighting = \
             self.options_widget.state()
         # set Q range labels on the main tab
-        self.labelMinRangeValue.setText(GuiUtils.formatNumber(self.q_range_min, high=True))
-        self.labelMaxRangeValue.setText(GuiUtils.formatNumber(self.q_range_max, high=True))
+        self.lblMinRangeValue.setText(GuiUtils.formatNumber(self.q_range_min, high=True))
+        self.lblMaxRangeValue.setText(GuiUtils.formatNumber(self.q_range_max, high=True))
         self.recalculatePlotData()
 
     def setDefaultStructureCombo(self):
@@ -2659,8 +2659,8 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         if self.data_is_loaded:
             self.q_range_min, self.q_range_max, self.npts = self.logic.computeDataRange()
         # set Q range labels on the main tab
-        self.labelMinRangeValue.setText(GuiUtils.formatNumber(self.q_range_min, high=True))
-        self.labelMaxRangeValue.setText(GuiUtils.formatNumber(self.q_range_max, high=True))
+        self.lblMinRangeValue.setText(GuiUtils.formatNumber(self.q_range_min, high=True))
+        self.lblMaxRangeValue.setText(GuiUtils.formatNumber(self.q_range_max, high=True))
 
         # set Q range labels on the options tab
         self.options_widget.updateQRange(self.q_range_min, self.q_range_max, self.npts)
@@ -3383,7 +3383,7 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
             self.chi2 = FittingUtilities.calculateChi2(weighted_data, self.data, weights)
             # Update the control
             chi2_repr = "---" if self.chi2 is None else GuiUtils.formatNumber(self.chi2, high=True)
-            self.labelChiSquaredValue.setText(chi2_repr)
+            self.lblChiSquaredValue.setText(chi2_repr)
         self.fitResults = False
 
         residuals_plot = FittingUtilities.plotResiduals(self.data, fitted_data, weights)

--- a/src/sas/qtgui/Perspectives/Fitting/FittingWidget.py
+++ b/src/sas/qtgui/Perspectives/Fitting/FittingWidget.py
@@ -467,7 +467,7 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         # Delegates for custom editing and display
         self.lstPolarisation_Magnetic_Scattering.setItemDelegate(MagnetismViewDelegate(self))
         # Initial status of the ordering tab - invisible
-        self.tabOverviewFitting.removeTab(TAB_ORDERING)
+        self.tabFitting.removeTab(TAB_ORDERING)
 
     def initializeCategoryCombo(self):
         """
@@ -495,14 +495,14 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         self.chk2DView.setEnabled(False)
         self.chk2DView.setVisible(False)
         self.chkMagnetism.setEnabled(False)
-        self.tabOverviewFitting.setTabEnabled(TAB_MAGNETISM, self.chkMagnetism.isChecked())
+        self.tabFitting.setTabEnabled(TAB_MAGNETISM, self.chkMagnetism.isChecked())
         # Combo box or label for file name"
         if self.is_batch_fitting:
             self.lblFilenameRight.setVisible(False)
             for dataitem in self.all_data:
                 name = GuiUtils.dataFromItem(dataitem).name
-                self.cmdHelp.addItem(name)
-            self.cmdHelp.setVisible(True)
+                self.cbFileNames.addItem(name)
+            self.cbFileNames.setVisible(True)
             self.chkChainFit.setEnabled(True)
             self.chkChainFit.setVisible(True)
             # This panel is not designed to view individual fits, so disable plotting
@@ -559,7 +559,7 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
 
     def togglePoly(self, isChecked):
         """ Enable/disable the polydispersity tab """
-        self.tabOverviewFitting.setTabEnabled(TAB_POLY, isChecked)
+        self.tabFitting.setTabEnabled(TAB_POLY, isChecked)
         # Check if any parameters are ready for fitting
         self.cmdFit.setEnabled(self.haveParamsToFit())
         # Set sasmodel polydispersity to 0 if polydispersity is unchecked, if not use Qmodel values
@@ -570,7 +570,7 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
 
     def toggleMagnetism(self, isChecked):
         """ Enable/disable the magnetism tab """
-        self.tabOverviewFitting.setTabEnabled(TAB_MAGNETISM, isChecked)
+        self.tabFitting.setTabEnabled(TAB_MAGNETISM, isChecked)
         # Check if any parameters are ready for fitting
         self.cmdFit.setEnabled(self.haveParamsToFit())
 
@@ -579,9 +579,9 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         self.is_chain_fitting = isChecked
         # show/hide the ordering tab
         if isChecked:
-            self.tabOverviewFitting.insertTab(TAB_ORDERING, self.tabOrder, "Order")
+            self.tabFitting.insertTab(TAB_ORDERING, self.tabOrder, "Order")
         else:
-            self.tabOverviewFitting.removeTab(TAB_ORDERING)
+            self.tabFitting.removeTab(TAB_ORDERING)
 
     def toggle2D(self, isChecked):
         """ Enable/disable the controls dependent on 1D/2D data instance """
@@ -604,7 +604,7 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         """
         Set initial control enablement
         """
-        self.cmdHelp.setVisible(False)
+        self.cbFileNames.setVisible(False)
         self.cmdFit.setEnabled(False)
         self.cmdPlot.setEnabled(False)
         self.chkPolydispersity.setEnabled(False)
@@ -616,9 +616,9 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         self.chkChainFit.setEnabled(False)
         self.chkChainFit.setVisible(False)
         # Tabs
-        self.tabOverviewFitting.setTabEnabled(TAB_POLY, False)
-        self.tabOverviewFitting.setTabEnabled(TAB_MAGNETISM, False)
-        self.lblChiSquaredValue.setText("---")
+        self.tabFitting.setTabEnabled(TAB_POLY, False)
+        self.tabFitting.setTabEnabled(TAB_MAGNETISM, False)
+        self.lblChi2Value.setText("---")
         # Smearing tab
         self.smearing_widget.updateData(self.data)
         # Line edits in the option tab
@@ -710,7 +710,7 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         When clicked on white space: model description
         """
         # See which model we're dealing with by looking at the tab id
-        current_list = self.tabToList[self.tabOverviewFitting.currentIndex()]
+        current_list = self.tabToList[self.tabFitting.currentIndex()]
         rows = [s.row() for s in current_list.selectionModel().selectedRows()
                 if self.isCheckable(s.row())]
 
@@ -729,8 +729,8 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         num_rows = len(rows)
         if num_rows < 1:
             return menu
-        current_list = self.tabToList[self.tabOverviewFitting.currentIndex()]
-        model_key = self.tabToKey[self.tabOverviewFitting.currentIndex()]
+        current_list = self.tabToList[self.tabFitting.currentIndex()]
+        model_key = self.tabToKey[self.tabFitting.currentIndex()]
         # Select for fitting
         param_string = "parameter " if num_rows == 1 else "parameters "
         to_string = "to its current value" if num_rows == 1 else "to their current values"
@@ -815,7 +815,7 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
             return
 
         constraint = Constraint()
-        c_text = mc_widget.textConstraint.text()
+        c_text = mc_widget.txtConstraint.text()
 
         # widget.params[0] is the parameter we're constraining
         constraint.param = mc_widget.params[0]
@@ -1030,7 +1030,7 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         """
         Adds a constraint on a single parameter.
         """
-        model_key = self.tabToKey[self.tabOverviewFitting.currentIndex()]
+        model_key = self.tabToKey[self.tabFitting.currentIndex()]
         model = self.model_dict[model_key]
         min_col = self.lstModelParameters.itemDelegate().param_min
         max_col = self.lstModelParameters.itemDelegate().param_max
@@ -1066,8 +1066,8 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         """
         Edit constraints for selected parameters.
         """
-        current_list = self.tabToList[self.tabOverviewFitting.currentIndex()]
-        model_key = self.tabToKey[self.tabOverviewFitting.currentIndex()]
+        current_list = self.tabToList[self.tabFitting.currentIndex()]
+        model_key = self.tabToKey[self.tabFitting.currentIndex()]
 
         params_list = [s.data() for s in current_list.selectionModel().selectedRows()
                    if self.isCheckable(s.row(), model_key=model_key)]
@@ -1079,12 +1079,12 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         # Check if any of the parameters are polydisperse
         if not np.any([FittingUtilities.isParamPolydisperse(p, self.model_parameters, is2D=self.is2D) for p in params_list]):
             # no parameters are pd - reset the text to not show the warning
-            mc_widget.labelWarning.setText("")
+            mc_widget.lblWarning.setText("")
         if mc_widget.exec_() != QtWidgets.QDialog.Accepted:
             return
 
         constraint = Constraint()
-        c_text = mc_widget.textConstraint.text()
+        c_text = mc_widget.txtConstraint.text()
 
         # widget.params[0] is the parameter we're constraining
         constraint.param = mc_widget.params[0]
@@ -1113,8 +1113,8 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         """
         Delete constraints from selected parameters.
         """
-        current_list = self.tabToList[self.tabOverviewFitting.currentIndex()]
-        model_key = self.tabToKey[self.tabOverviewFitting.currentIndex()]
+        current_list = self.tabToList[self.tabFitting.currentIndex()]
+        model_key = self.tabToKey[self.tabFitting.currentIndex()]
         params = [s.data() for s in current_list.selectionModel().selectedRows()
                    if self.isCheckable(s.row(), model_key=model_key)]
         for param in params:
@@ -1263,7 +1263,7 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         Selected parameter is chosen for fitting
         """
         status = QtCore.Qt.Checked
-        model_key = self.tabToKey[self.tabOverviewFitting.currentIndex()]
+        model_key = self.tabToKey[self.tabFitting.currentIndex()]
         model = self.model_dict[model_key]
         item = model.itemFromIndex(self.lstModelParameters.currentIndex())
         self.setParameterSelection(status, item=item, model_key=model_key)
@@ -1273,7 +1273,7 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         Selected parameters are removed for fitting
         """
         status = QtCore.Qt.Unchecked
-        model_key = self.tabToKey[self.tabOverviewFitting.currentIndex()]
+        model_key = self.tabToKey[self.tabFitting.currentIndex()]
         model = self.model_dict[model_key]
         item = model.itemFromIndex(self.lstModelParameters.currentIndex())
         self.setParameterSelection(status, item=item, model_key=model_key)
@@ -1489,7 +1489,7 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
 
         self.chkMagnetism.setEnabled(self.canHaveMagnetism())
         self.chkMagnetism.setEnabled(self.canHaveMagnetism())
-        self.tabOverviewFitting.setTabEnabled(TAB_MAGNETISM, self.chkMagnetism.isChecked() and self.canHaveMagnetism())
+        self.tabFitting.setTabEnabled(TAB_MAGNETISM, self.chkMagnetism.isChecked() and self.canHaveMagnetism())
         self._previous_model_index = self.cbModel.currentIndex()
 
         # Reset parameters to fit
@@ -1509,7 +1509,7 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         # disable polydispersity if the model does not support it
         has_poly = self._poly_model.rowCount() != 0
         self.chkPolydispersity.setEnabled(has_poly)
-        self.tabOverviewFitting.setTabEnabled(TAB_POLY, has_poly)
+        self.tabFitting.setTabEnabled(TAB_POLY, has_poly)
 
         # set focus so it doesn't move up
         self.cbModel.setFocus()
@@ -1584,8 +1584,8 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         """
         React to parameter selection
         """
-        current_list = self.tabToList[self.tabOverviewFitting.currentIndex()]
-        model_key = self.tabToKey[self.tabOverviewFitting.currentIndex()]
+        current_list = self.tabToList[self.tabFitting.currentIndex()]
+        model_key = self.tabToKey[self.tabFitting.currentIndex()]
 
         rows = current_list.selectionModel().selectedRows()
         # Clean previous messages
@@ -1675,7 +1675,7 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
 
         # Enable magnetism checkbox for selected models
         self.chkMagnetism.setEnabled(self.canHaveMagnetism())
-        self.tabOverviewFitting.setTabEnabled(TAB_MAGNETISM, self.chkMagnetism.isChecked() and self.canHaveMagnetism())
+        self.tabFitting.setTabEnabled(TAB_MAGNETISM, self.chkMagnetism.isChecked() and self.canHaveMagnetism())
 
         # Update column widths
         for column, width in self.lstParamHeaderSizes.items():
@@ -1882,7 +1882,7 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
 
     def getHelpLocation(self, tree_base) -> Path:
         # Actual file will depend on the current tab
-        tab_id = self.tabOverviewFitting.currentIndex()
+        tab_id = self.tabFitting.currentIndex()
         tree_location = tree_base / "user" / "qtgui" / "Perspectives" / "Fitting"
 
         match tab_id:
@@ -2131,7 +2131,7 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
 
         # Read only value - we can get away by just printing it here
         chi2_repr = GuiUtils.formatNumber(self.chi2, high=True)
-        self.lblChiSquaredValue.setText(chi2_repr)
+        self.lblChi2ValueValue.setText(chi2_repr)
 
 
     def prepareFitters(self, fitter=None, fit_id=0, weight_increase=1):
@@ -3383,7 +3383,7 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
             self.chi2 = FittingUtilities.calculateChi2(weighted_data, self.data, weights)
             # Update the control
             chi2_repr = "---" if self.chi2 is None else GuiUtils.formatNumber(self.chi2, high=True)
-            self.lblChiSquaredValue.setText(chi2_repr)
+            self.lblChi2ValueValue.setText(chi2_repr)
         self.fitResults = False
 
         residuals_plot = FittingUtilities.plotResiduals(self.data, fitted_data, weights)
@@ -4339,7 +4339,7 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
             Create list of main parameters based on _model_model
             """
             param_name = str(self._model_model.item(row, 0).text())
-            current_list = self.tabToList[self.tabOverviewFitting.currentIndex()]
+            current_list = self.tabToList[self.tabFitting.currentIndex()]
             model = self._model_model
             if model.item(row, 0) is None:
                 return

--- a/src/sas/qtgui/Perspectives/Fitting/FittingWidget.py
+++ b/src/sas/qtgui/Perspectives/Fitting/FittingWidget.py
@@ -170,8 +170,8 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
 
         # New font to display angstrom symbol
         new_font = 'font-family: -apple-system, "Helvetica Neue", "Ubuntu";'
-        self.label_17.setStyleSheet(new_font)
-        self.label_19.setStyleSheet(new_font)
+        self.labelAngstromLetterUp.setStyleSheet(new_font)
+        self.labelAngstromLetterDown.setStyleSheet(new_font)
 
     def info(self, type, value, tb):
         logger.error("".join(traceback.format_exception(type, value, tb)))
@@ -363,9 +363,9 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         self.boldFont.setBold(True)
 
         # Set data label
-        self.label.setFont(self.boldFont)
-        self.label.setText("No data loaded")
-        self.lblFilename.setText("")
+        self.labelFilenameLeft.setFont(self.boldFont)
+        self.labelFilenameLeft.setText("No data loaded")
+        self.labelFilenameRight.setText("")
 
         # Magnetic angles explained in one picture
         self.magneticAnglesWidget = QtWidgets.QWidget()
@@ -389,28 +389,28 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         self.model_dict["poly"] = self._poly_model
         self.model_dict["magnet"] = self._magnet_model
 
-        self.lst_dict["standard"] = self.lstParams
-        self.lst_dict["poly"] = self.lstPoly
-        self.lst_dict["magnet"] = self.lstMagnetic
+        self.lst_dict["standard"] = self.listModelParameters
+        self.lst_dict["poly"] = self.listPolydispersity
+        self.lst_dict["magnet"] = self.listPolarisation_Magnetic_Scattering
 
-        self.tabToList[0] = self.lstParams
-        self.tabToList[3] = self.lstPoly
-        self.tabToList[4] = self.lstMagnetic
+        self.tabToList[0] = self.listModelParameters
+        self.tabToList[3] = self.listPolydispersity
+        self.tabToList[4] = self.listPolarisation_Magnetic_Scattering
 
         self.tabToKey[0] = "standard"
         self.tabToKey[3] = "poly"
         self.tabToKey[4] = "magnet"
 
         # Param model displayed in param list
-        self.lstParams.setModel(self._model_model)
+        self.listModelParameters.setModel(self._model_model)
         self.readCategoryInfo()
 
         self.model_parameters = None
 
         # Delegates for custom editing and display
-        self.lstParams.setItemDelegate(ModelViewDelegate(self))
+        self.listModelParameters.setItemDelegate(ModelViewDelegate(self))
 
-        self.lstParams.setAlternatingRowColors(True)
+        self.listModelParameters.setAlternatingRowColors(True)
         stylesheet = """
 
             QTreeView {
@@ -439,74 +439,74 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
                 background: qlineargradient(x1: 0, y1: 0, x2: 0, y2: 1, stop: 0 #6b9be8, stop: 1 #577fbf);
             }
            """
-        self.lstParams.setStyleSheet(stylesheet)
-        self.lstParams.setContextMenuPolicy(QtCore.Qt.CustomContextMenu)
-        self.lstParams.customContextMenuRequested.connect(self.showModelContextMenu)
-        self.lstParams.setAttribute(QtCore.Qt.WA_MacShowFocusRect, False)
+        self.listModelParameters.setStyleSheet(stylesheet)
+        self.listModelParameters.setContextMenuPolicy(QtCore.Qt.CustomContextMenu)
+        self.listModelParameters.customContextMenuRequested.connect(self.showModelContextMenu)
+        self.listModelParameters.setAttribute(QtCore.Qt.WA_MacShowFocusRect, False)
         # Column resize signals
-        self.lstParams.header().sectionResized.connect(self.onColumnWidthUpdate)
+        self.listModelParameters.header().sectionResized.connect(self.onColumnWidthUpdate)
 
         # Poly model displayed in poly list
-        self.lstPoly.setModel(self._poly_model)
+        self.listPolydispersity.setModel(self._poly_model)
         self.setPolyModel()
-        self.setTableProperties(self.lstPoly)
+        self.setTableProperties(self.listPolydispersity)
         # Delegates for custom editing and display
-        self.lstPoly.setItemDelegate(PolyViewDelegate(self))
+        self.listPolydispersity.setItemDelegate(PolyViewDelegate(self))
         # Polydispersity function combo response
-        self.lstPoly.itemDelegate().combo_updated.connect(self.onPolyComboIndexChange)
-        self.lstPoly.itemDelegate().filename_updated.connect(self.onPolyFilenameChange)
+        self.listPolydispersity.itemDelegate().combo_updated.connect(self.onPolyComboIndexChange)
+        self.listPolydispersity.itemDelegate().filename_updated.connect(self.onPolyFilenameChange)
 
-        self.lstPoly.setContextMenuPolicy(QtCore.Qt.CustomContextMenu)
-        self.lstPoly.customContextMenuRequested.connect(self.showModelContextMenu)
-        self.lstPoly.setAttribute(QtCore.Qt.WA_MacShowFocusRect, False)
+        self.listPolydispersity.setContextMenuPolicy(QtCore.Qt.CustomContextMenu)
+        self.listPolydispersity.customContextMenuRequested.connect(self.showModelContextMenu)
+        self.listPolydispersity.setAttribute(QtCore.Qt.WA_MacShowFocusRect, False)
 
         # Magnetism model displayed in magnetism list
-        self.lstMagnetic.setModel(self._magnet_model)
+        self.listPolarisation_Magnetic_Scattering.setModel(self._magnet_model)
         self.setMagneticModel()
-        self.setTableProperties(self.lstMagnetic)
+        self.setTableProperties(self.listPolarisation_Magnetic_Scattering)
         # Delegates for custom editing and display
-        self.lstMagnetic.setItemDelegate(MagnetismViewDelegate(self))
+        self.listPolarisation_Magnetic_Scattering.setItemDelegate(MagnetismViewDelegate(self))
         # Initial status of the ordering tab - invisible
-        self.tabFitting.removeTab(TAB_ORDERING)
+        self.tabOverviewFitting.removeTab(TAB_ORDERING)
 
     def initializeCategoryCombo(self):
         """
         Model category combo setup
         """
         category_list = sorted(self.master_category_dict.keys())
-        self.cbCategory.addItem(CATEGORY_DEFAULT)
-        self.cbCategory.addItems(category_list)
+        self.comboboxCategory.addItem(CATEGORY_DEFAULT)
+        self.comboboxCategory.addItems(category_list)
         if CATEGORY_STRUCTURE not in category_list:
-            self.cbCategory.addItem(CATEGORY_STRUCTURE)
-        self.cbCategory.setCurrentIndex(0)
+            self.comboboxCategory.addItem(CATEGORY_STRUCTURE)
+        self.comboboxCategory.setCurrentIndex(0)
 
     def setEnablementOnDataLoad(self):
         """
         Enable/disable various UI elements based on data loaded
         """
         # Tag along functionality
-        self.label.setText("Data loaded from: ")
+        self.labelFilenameLeft.setText("Data loaded from: ")
         if self.logic.data.name:
-            self.lblFilename.setText(self.logic.data.name)
+            self.labelFilenameRight.setText(self.logic.data.name)
         else:
-            self.lblFilename.setText(self.logic.data.filename)
+            self.labelFilenameRight.setText(self.logic.data.filename)
         self.updateQRange()
         # Switch off Data2D control
-        self.chk2DView.setEnabled(False)
-        self.chk2DView.setVisible(False)
-        self.chkMagnetism.setEnabled(False)
-        self.tabFitting.setTabEnabled(TAB_MAGNETISM, self.chkMagnetism.isChecked())
+        self.checkbox2DView.setEnabled(False)
+        self.checkbox2DView.setVisible(False)
+        self.checkboxMagnetism.setEnabled(False)
+        self.tabOverviewFitting.setTabEnabled(TAB_MAGNETISM, self.checkboxMagnetism.isChecked())
         # Combo box or label for file name"
         if self.is_batch_fitting:
-            self.lblFilename.setVisible(False)
+            self.labelFilenameRight.setVisible(False)
             for dataitem in self.all_data:
                 name = GuiUtils.dataFromItem(dataitem).name
-                self.cbFileNames.addItem(name)
-            self.cbFileNames.setVisible(True)
-            self.chkChainFit.setEnabled(True)
-            self.chkChainFit.setVisible(True)
+                self.comboboxFileNames.addItem(name)
+            self.comboboxFileNames.setVisible(True)
+            self.checkboxChainFit.setEnabled(True)
+            self.checkboxChainFit.setVisible(True)
             # This panel is not designed to view individual fits, so disable plotting
-            self.cmdPlot.setVisible(False)
+            self.buttonPlot.setVisible(False)
         # Similarly on other tabs
         self.options_widget.setEnablementOnDataLoad()
         self.onSelectModel()
@@ -519,20 +519,20 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
 
     def disableModelCombo(self):
         """ Disable the combobox """
-        self.cbModel.setEnabled(False)
-        self.lblModel.setEnabled(False)
+        self.comboboxModel.setEnabled(False)
+        self.labelModel.setEnabled(False)
         self.enabled_cbmodel = False
 
     def enableModelCombo(self):
         """ Enable the combobox """
-        self.cbModel.setEnabled(True)
-        self.lblModel.setEnabled(True)
+        self.comboboxModel.setEnabled(True)
+        self.labelModel.setEnabled(True)
         self.enabled_cbmodel = True
 
     def disableStructureCombo(self):
         """ Disable the combobox """
-        self.cbStructureFactor.setEnabled(False)
-        self.lblStructure.setEnabled(False)
+        self.comboboxStructureFactor.setEnabled(False)
+        self.labelStructure.setEnabled(False)
         self.enabled_sfmodel = False
 
     def enableBackgroundParameter(self, set_value: Optional[float] = None):
@@ -553,15 +553,15 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
 
     def enableStructureCombo(self):
         """ Enable the combobox """
-        self.cbStructureFactor.setEnabled(True)
-        self.lblStructure.setEnabled(True)
+        self.comboboxStructureFactor.setEnabled(True)
+        self.labelStructure.setEnabled(True)
         self.enabled_sfmodel = True
 
     def togglePoly(self, isChecked):
         """ Enable/disable the polydispersity tab """
-        self.tabFitting.setTabEnabled(TAB_POLY, isChecked)
+        self.tabOverviewFitting.setTabEnabled(TAB_POLY, isChecked)
         # Check if any parameters are ready for fitting
-        self.cmdFit.setEnabled(self.haveParamsToFit())
+        self.buttonFit.setEnabled(self.haveParamsToFit())
         # Set sasmodel polydispersity to 0 if polydispersity is unchecked, if not use Qmodel values
         if self._poly_model.rowCount() > 0:
             for key, value in self.poly_params.items():
@@ -570,22 +570,22 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
 
     def toggleMagnetism(self, isChecked):
         """ Enable/disable the magnetism tab """
-        self.tabFitting.setTabEnabled(TAB_MAGNETISM, isChecked)
+        self.tabOverviewFitting.setTabEnabled(TAB_MAGNETISM, isChecked)
         # Check if any parameters are ready for fitting
-        self.cmdFit.setEnabled(self.haveParamsToFit())
+        self.buttonFit.setEnabled(self.haveParamsToFit())
 
     def toggleChainFit(self, isChecked):
         """ Enable/disable chain fitting """
         self.is_chain_fitting = isChecked
         # show/hide the ordering tab
         if isChecked:
-            self.tabFitting.insertTab(TAB_ORDERING, self.tabOrder, "Order")
+            self.tabOverviewFitting.insertTab(TAB_ORDERING, self.tabOrder, "Order")
         else:
-            self.tabFitting.removeTab(TAB_ORDERING)
+            self.tabOverviewFitting.removeTab(TAB_ORDERING)
 
     def toggle2D(self, isChecked):
         """ Enable/disable the controls dependent on 1D/2D data instance """
-        self.chkMagnetism.setEnabled(isChecked)
+        self.checkboxMagnetism.setEnabled(isChecked)
         self.is2D = isChecked
         # Reload the current model
         if self.kernel_module:
@@ -604,21 +604,21 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         """
         Set initial control enablement
         """
-        self.cbFileNames.setVisible(False)
-        self.cmdFit.setEnabled(False)
-        self.cmdPlot.setEnabled(False)
-        self.chkPolydispersity.setEnabled(False)
-        self.chkPolydispersity.setChecked(False)
-        self.chk2DView.setEnabled(True)
-        self.chk2DView.setChecked(False)
-        self.chkMagnetism.setEnabled(False)
-        self.chkMagnetism.setChecked(False)
-        self.chkChainFit.setEnabled(False)
-        self.chkChainFit.setVisible(False)
+        self.comboboxFileNames.setVisible(False)
+        self.buttonFit.setEnabled(False)
+        self.buttonPlot.setEnabled(False)
+        self.checkboxPolydispersity.setEnabled(False)
+        self.checkboxPolydispersity.setChecked(False)
+        self.checkbox2DView.setEnabled(True)
+        self.checkbox2DView.setChecked(False)
+        self.checkboxMagnetism.setEnabled(False)
+        self.checkboxMagnetism.setChecked(False)
+        self.checkboxChainFit.setEnabled(False)
+        self.checkboxChainFit.setVisible(False)
         # Tabs
-        self.tabFitting.setTabEnabled(TAB_POLY, False)
-        self.tabFitting.setTabEnabled(TAB_MAGNETISM, False)
-        self.lblChi2Value.setText("---")
+        self.tabOverviewFitting.setTabEnabled(TAB_POLY, False)
+        self.tabOverviewFitting.setTabEnabled(TAB_MAGNETISM, False)
+        self.labelChiSquaredValue.setText("---")
         # Smearing tab
         self.smearing_widget.updateData(self.data)
         # Line edits in the option tab
@@ -629,30 +629,30 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         Connect GUI element signals
         """
         # Comboboxes
-        self.cbStructureFactor.currentIndexChanged.connect(self.onSelectStructureFactor)
-        self.cbCategory.currentIndexChanged.connect(self.onSelectCategory)
-        self.cbModel.currentIndexChanged.connect(self.onSelectModel)
-        self.cbFileNames.currentIndexChanged.connect(self.onSelectBatchFilename)
+        self.comboboxStructureFactor.currentIndexChanged.connect(self.onSelectStructureFactor)
+        self.comboboxCategory.currentIndexChanged.connect(self.onSelectCategory)
+        self.comboboxModel.currentIndexChanged.connect(self.onSelectModel)
+        self.comboboxFileNames.currentIndexChanged.connect(self.onSelectBatchFilename)
         # Checkboxes
-        self.chk2DView.toggled.connect(self.toggle2D)
-        self.chkPolydispersity.toggled.connect(self.togglePoly)
-        self.chkMagnetism.toggled.connect(self.toggleMagnetism)
-        self.chkChainFit.toggled.connect(self.toggleChainFit)
+        self.checkbox2DView.toggled.connect(self.toggle2D)
+        self.checkboxPolydispersity.toggled.connect(self.togglePoly)
+        self.checkboxMagnetism.toggled.connect(self.toggleMagnetism)
+        self.checkboxChainFit.toggled.connect(self.toggleChainFit)
         # Buttons
-        self.cmdFit.clicked.connect(self.onFit)
-        self.cmdPlot.clicked.connect(self.onPlot)
-        self.cmdHelp.clicked.connect(self.onHelp)
-        self.cmdMagneticDisplay.clicked.connect(self.onDisplayMagneticAngles)
+        self.buttonFit.clicked.connect(self.onFit)
+        self.buttonPlot.clicked.connect(self.onPlot)
+        self.buttonHelp.clicked.connect(self.onHelp)
+        self.buttonDisplayMagneticAngles.clicked.connect(self.onDisplayMagneticAngles)
 
         # Respond to change in parameters from the UI
         self._model_model.dataChanged.connect(self.onMainParamsChange)
         self._poly_model.dataChanged.connect(self.onPolyModelChange)
         self._magnet_model.dataChanged.connect(self.onMagnetModelChange)
-        self.lstParams.selectionModel().selectionChanged.connect(self.onSelectionChanged)
-        self.lstParams.installEventFilter(self)
-        self.lstPoly.installEventFilter(self)
-        self.lstMagnetic.installEventFilter(self)
-        self.lstPoly.selectionModel().selectionChanged.connect(self.onSelectionChanged)
+        self.listModelParameters.selectionModel().selectionChanged.connect(self.onSelectionChanged)
+        self.listModelParameters.installEventFilter(self)
+        self.listPolydispersity.installEventFilter(self)
+        self.listPolarisation_Magnetic_Scattering.installEventFilter(self)
+        self.listPolydispersity.selectionModel().selectionChanged.connect(self.onSelectionChanged)
 
         # Local signals
         self.batchFittingFinishedSignal.connect(self.batchFitComplete)
@@ -682,7 +682,7 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
 
     def eventFilter(self, obj, event):
         # Catch enter key presses when editing model params
-        if obj in [self.lstParams, self.lstPoly, self.lstMagnetic]:
+        if obj in [self.listModelParameters, self.listPolydispersity, self.listPolarisation_Magnetic_Scattering]:
             if event.type() == QtCore.QEvent.KeyPress and event.key() in [QtCore.Qt.Key_Return, QtCore.Qt.Key_Enter]:
                 self.onKey(event)
                 return True
@@ -710,7 +710,7 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         When clicked on white space: model description
         """
         # See which model we're dealing with by looking at the tab id
-        current_list = self.tabToList[self.tabFitting.currentIndex()]
+        current_list = self.tabToList[self.tabOverviewFitting.currentIndex()]
         rows = [s.row() for s in current_list.selectionModel().selectedRows()
                 if self.isCheckable(s.row())]
 
@@ -729,8 +729,8 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         num_rows = len(rows)
         if num_rows < 1:
             return menu
-        current_list = self.tabToList[self.tabFitting.currentIndex()]
-        model_key = self.tabToKey[self.tabFitting.currentIndex()]
+        current_list = self.tabToList[self.tabOverviewFitting.currentIndex()]
+        model_key = self.tabToKey[self.tabOverviewFitting.currentIndex()]
         # Select for fitting
         param_string = "parameter " if num_rows == 1 else "parameters "
         to_string = "to its current value" if num_rows == 1 else "to their current values"
@@ -793,7 +793,7 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         Show the constraint widget and receive the expression
         """
         if current_list is None:
-            current_list = self.lstParams
+            current_list = self.listModelParameters
         model = current_list.model()
         for key, val in self.model_dict.items():
             if val == model:
@@ -810,12 +810,12 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         # Check if any of the parameters are polydisperse
         if not np.any([FittingUtilities.isParamPolydisperse(p, self.model_parameters, is2D=self.is2D) for p in params_list]):
             # no parameters are pd - reset the text to not show the warning
-            mc_widget.lblWarning.setText("")
+            mc_widget.labelWarning.setText("")
         if mc_widget.exec_() != QtWidgets.QDialog.Accepted:
             return
 
         constraint = Constraint()
-        c_text = mc_widget.txtConstraint.text()
+        c_text = mc_widget.textConstraint.text()
 
         # widget.params[0] is the parameter we're constraining
         constraint.param = mc_widget.params[0]
@@ -891,11 +891,11 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         """
         Return list of polydisperse parameters for the current model
         """
-        if not self.chkPolydispersity.isChecked():
+        if not self.checkboxPolydispersity.isChecked():
             return []
         poly_model_params = [self.polyNameToParam(self._poly_model.item(row).text())
                              for row in range(self._poly_model.rowCount())
-                             if self.chkPolydispersity.isChecked() and
+                             if self.checkboxPolydispersity.isChecked() and
                              self.isCheckable(row, model_key="poly")]
         return poly_model_params
 
@@ -903,7 +903,7 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         """
         Return list of magnetic parameters for the current model
         """
-        if not self.chkMagnetism.isChecked():
+        if not self.checkboxMagnetism.isChecked():
             return []
         magnetic_model_params = [self._magnet_model.item(row).text()
                             for row in range(self._magnet_model.rowCount())
@@ -1030,10 +1030,10 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         """
         Adds a constraint on a single parameter.
         """
-        model_key = self.tabToKey[self.tabFitting.currentIndex()]
+        model_key = self.tabToKey[self.tabOverviewFitting.currentIndex()]
         model = self.model_dict[model_key]
-        min_col = self.lstParams.itemDelegate().param_min
-        max_col = self.lstParams.itemDelegate().param_max
+        min_col = self.listModelParameters.itemDelegate().param_min
+        max_col = self.listModelParameters.itemDelegate().param_max
         for row in self.selectedParameters(model_key=model_key):
             param = model.item(row, 0).text()
             value = model.item(row, 1).text()
@@ -1066,8 +1066,8 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         """
         Edit constraints for selected parameters.
         """
-        current_list = self.tabToList[self.tabFitting.currentIndex()]
-        model_key = self.tabToKey[self.tabFitting.currentIndex()]
+        current_list = self.tabToList[self.tabOverviewFitting.currentIndex()]
+        model_key = self.tabToKey[self.tabOverviewFitting.currentIndex()]
 
         params_list = [s.data() for s in current_list.selectionModel().selectedRows()
                    if self.isCheckable(s.row(), model_key=model_key)]
@@ -1079,12 +1079,12 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         # Check if any of the parameters are polydisperse
         if not np.any([FittingUtilities.isParamPolydisperse(p, self.model_parameters, is2D=self.is2D) for p in params_list]):
             # no parameters are pd - reset the text to not show the warning
-            mc_widget.lblWarning.setText("")
+            mc_widget.labelWarning.setText("")
         if mc_widget.exec_() != QtWidgets.QDialog.Accepted:
             return
 
         constraint = Constraint()
-        c_text = mc_widget.txtConstraint.text()
+        c_text = mc_widget.textConstraint.text()
 
         # widget.params[0] is the parameter we're constraining
         constraint.param = mc_widget.params[0]
@@ -1113,8 +1113,8 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         """
         Delete constraints from selected parameters.
         """
-        current_list = self.tabToList[self.tabFitting.currentIndex()]
-        model_key = self.tabToKey[self.tabFitting.currentIndex()]
+        current_list = self.tabToList[self.tabOverviewFitting.currentIndex()]
+        model_key = self.tabToKey[self.tabOverviewFitting.currentIndex()]
         params = [s.data() for s in current_list.selectionModel().selectedRows()
                    if self.isCheckable(s.row(), model_key=model_key)]
         for param in params:
@@ -1263,9 +1263,9 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         Selected parameter is chosen for fitting
         """
         status = QtCore.Qt.Checked
-        model_key = self.tabToKey[self.tabFitting.currentIndex()]
+        model_key = self.tabToKey[self.tabOverviewFitting.currentIndex()]
         model = self.model_dict[model_key]
-        item = model.itemFromIndex(self.lstParams.currentIndex())
+        item = model.itemFromIndex(self.listModelParameters.currentIndex())
         self.setParameterSelection(status, item=item, model_key=model_key)
 
     def deselectParameters(self):
@@ -1273,9 +1273,9 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         Selected parameters are removed for fitting
         """
         status = QtCore.Qt.Unchecked
-        model_key = self.tabToKey[self.tabFitting.currentIndex()]
+        model_key = self.tabToKey[self.tabOverviewFitting.currentIndex()]
         model = self.model_dict[model_key]
-        item = model.itemFromIndex(self.lstParams.currentIndex())
+        item = model.itemFromIndex(self.listModelParameters.currentIndex())
         self.setParameterSelection(status, item=item, model_key=model_key)
 
     def selectedParameters(self, model_key="standard"):
@@ -1465,32 +1465,32 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         """
         Respond to select Model from list event
         """
-        model = self.cbModel.currentText()
+        model = self.comboboxModel.currentText()
 
         if model == MODEL_DEFAULT:
             # if the previous category was not the default, keep it.
             # Otherwise, just return
             if self._previous_model_index != 0:
                 # We need to block signals, or else state changes on perceived unchanged conditions
-                self.cbModel.blockSignals(True)
-                self.cbModel.setCurrentIndex(self._previous_model_index)
-                self.cbModel.blockSignals(False)
+                self.comboboxModel.blockSignals(True)
+                self.comboboxModel.setCurrentIndex(self._previous_model_index)
+                self.comboboxModel.blockSignals(False)
             return
         if self.model_data is not None:
             # Store any old parameters before switching to a new model
             self.page_parameters = self.getParameterDict()
 
         # Assure the control is active
-        if not self.cbModel.isEnabled():
+        if not self.comboboxModel.isEnabled():
             return
         # Empty combobox forced to be read
         if not model:
             return
 
-        self.chkMagnetism.setEnabled(self.canHaveMagnetism())
-        self.chkMagnetism.setEnabled(self.canHaveMagnetism())
-        self.tabFitting.setTabEnabled(TAB_MAGNETISM, self.chkMagnetism.isChecked() and self.canHaveMagnetism())
-        self._previous_model_index = self.cbModel.currentIndex()
+        self.checkboxMagnetism.setEnabled(self.canHaveMagnetism())
+        self.checkboxMagnetism.setEnabled(self.canHaveMagnetism())
+        self.tabOverviewFitting.setTabEnabled(TAB_MAGNETISM, self.checkboxMagnetism.isChecked() and self.canHaveMagnetism())
+        self._previous_model_index = self.comboboxModel.currentIndex()
 
         # Reset parameters to fit
         self.resetParametersToFit()
@@ -1498,8 +1498,8 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         self.has_poly_error_column = False
 
         structure = None
-        if self.cbStructureFactor.isEnabled():
-            structure = str(self.cbStructureFactor.currentText())
+        if self.comboboxStructureFactor.isEnabled():
+            structure = str(self.comboboxStructureFactor.currentText())
         self.respondToModelStructure(model=model, structure_factor=structure)
 
         # paste parameters from previous state
@@ -1508,11 +1508,11 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
 
         # disable polydispersity if the model does not support it
         has_poly = self._poly_model.rowCount() != 0
-        self.chkPolydispersity.setEnabled(has_poly)
-        self.tabFitting.setTabEnabled(TAB_POLY, has_poly)
+        self.checkboxPolydispersity.setEnabled(has_poly)
+        self.tabOverviewFitting.setTabEnabled(TAB_POLY, has_poly)
 
         # set focus so it doesn't move up
-        self.cbModel.setFocus()
+        self.comboboxModel.setFocus()
 
     def onSelectBatchFilename(self, data_index):
         """
@@ -1525,9 +1525,9 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         """
         Select Structure Factor from list
         """
-        model = str(self.cbModel.currentText())
-        category = str(self.cbCategory.currentText())
-        structure = str(self.cbStructureFactor.currentText())
+        model = str(self.comboboxModel.currentText())
+        category = str(self.comboboxCategory.currentText())
+        structure = str(self.comboboxStructureFactor.currentText())
         if category == CATEGORY_STRUCTURE:
             model = None
         # copy original clipboard
@@ -1566,26 +1566,26 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         self.onCategoriesChanged()
 
         # See if we need to update the combo in-place
-        if self.cbCategory.currentText() != CATEGORY_CUSTOM: return
+        if self.comboboxCategory.currentText() != CATEGORY_CUSTOM: return
 
-        current_text = self.cbModel.currentText()
-        self.cbModel.clear()
+        current_text = self.comboboxModel.currentText()
+        self.comboboxModel.clear()
         self.enableModelCombo()
         self.disableStructureCombo()
         # Retrieve the list of models
         model_list = self.master_category_dict[CATEGORY_CUSTOM]
         # Populate the models combobox
-        self.cbModel.addItems(sorted([model for (model, _) in model_list]))
-        new_index = self.cbModel.findText(current_text)
+        self.comboboxModel.addItems(sorted([model for (model, _) in model_list]))
+        new_index = self.comboboxModel.findText(current_text)
         if new_index != -1:
-            self.cbModel.setCurrentIndex(self.cbModel.findText(current_text))
+            self.comboboxModel.setCurrentIndex(self.comboboxModel.findText(current_text))
 
     def onSelectionChanged(self):
         """
         React to parameter selection
         """
-        current_list = self.tabToList[self.tabFitting.currentIndex()]
-        model_key = self.tabToKey[self.tabFitting.currentIndex()]
+        current_list = self.tabToList[self.tabOverviewFitting.currentIndex()]
+        model_key = self.tabToKey[self.tabOverviewFitting.currentIndex()]
 
         rows = current_list.selectionModel().selectedRows()
         # Clean previous messages
@@ -1613,21 +1613,21 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         Updates the fitting widget format when SESANS data is loaded.
         """
         # update the units in the 'Fitting details' box of the Model tab on the Fit Panel
-        self.label_17.setText("Å")
-        self.label_19.setText("Å")
+        self.labelAngstromLetterUp.setText("Å")
+        self.labelAngstromLetterDown.setText("Å")
         # disable the background parameter and set at 0 for sesans
         self.disableBackgroundParameter(set_value=0.0)
         # update options defaults and settings for SESANS data
         self.options_widget.updateQRange(1, 100000, self.options_widget.NPTS_DEFAULT)
         # update the units in the 'Fitting details' box of the Fit Options tab on the Fit Panel
-        self.options_widget.label_13.setText("Å")
-        self.options_widget.label_15.setText("Å")
+        self.options_widget.labelAngstromInvMinRange.setText("Å")
+        self.options_widget.labelAngstromInvMaxRange.setText("Å")
         # update the smearing drop down box to indicate a Hankel Transform is being used instead of resolution
         self.smearing_widget.onIndexChange(1)
         # update the Weighting box of the Fit Options tab on the Fit Panel
-        self.options_widget.rbWeighting2.setText("Use dP Data")
-        self.options_widget.rbWeighting3.setText("Use |sqrt(P Data)|")
-        self.options_widget.rbWeighting4.setText("Use |P Data|")
+        self.options_widget.radioButtonWeightingUsedIData.setText("Use dP Data")
+        self.options_widget.radioButtonWeightingUseAbsSqrtIData.setText("Use |sqrt(P Data)|")
+        self.options_widget.radioButtonWeightingUseAbsIData.setText("Use |P Data|")
 
     def replaceConstraintName(self, old_name, new_name=""):
         """
@@ -1658,28 +1658,28 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         """
         # Update the chart
         if self.data_is_loaded:
-            self.cmdPlot.setText("Compute/Plot")
+            self.buttonPlot.setText("Compute/Plot")
             self.calculateQGridForModel()
         else:
-            self.cmdPlot.setText("Calculate")
+            self.buttonPlot.setText("Calculate")
             # Create default datasets if no data passed
             self.createDefaultDataset()
             self.theory_item = None # ensure theory is recalc. before plot, see showTheoryPlot()
 
     def respondToModelStructure(self, model=None, structure_factor=None):
         # Set enablement on calculate/plot
-        self.cmdPlot.setEnabled(True)
+        self.buttonPlot.setEnabled(True)
 
         # kernel parameters -> model_model
         self.SASModelToQModel(model, structure_factor)
 
         # Enable magnetism checkbox for selected models
-        self.chkMagnetism.setEnabled(self.canHaveMagnetism())
-        self.tabFitting.setTabEnabled(TAB_MAGNETISM, self.chkMagnetism.isChecked() and self.canHaveMagnetism())
+        self.checkboxMagnetism.setEnabled(self.canHaveMagnetism())
+        self.tabOverviewFitting.setTabEnabled(TAB_MAGNETISM, self.checkboxMagnetism.isChecked() and self.canHaveMagnetism())
 
         # Update column widths
         for column, width in self.lstParamHeaderSizes.items():
-            self.lstParams.setColumnWidth(column, width)
+            self.listModelParameters.setColumnWidth(column, width)
 
         # disable background for SESANS data
         # this should be forced to 0 in sasmodels but this tells the user it is enforced to 0 and disables the box
@@ -1700,23 +1700,23 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         """
         Select Category from list
         """
-        category = self.cbCategory.currentText()
+        category = self.comboboxCategory.currentText()
         # Check if the user chose "Choose category entry"
         if category == CATEGORY_DEFAULT:
             # if the previous category was not the default, keep it.
             # Otherwise, just return
             if self._previous_category_index != 0:
                 # We need to block signals, or else state changes on perceived unchanged conditions
-                self.cbCategory.blockSignals(True)
-                self.cbCategory.setCurrentIndex(self._previous_category_index)
-                self.cbCategory.blockSignals(False)
+                self.comboboxCategory.blockSignals(True)
+                self.comboboxCategory.setCurrentIndex(self._previous_category_index)
+                self.comboboxCategory.blockSignals(False)
             return
 
         if category == CATEGORY_STRUCTURE:
             self.disableModelCombo()
             self.enableStructureCombo()
             # set the index to 0
-            self.cbStructureFactor.setCurrentIndex(0)
+            self.comboboxStructureFactor.setCurrentIndex(0)
             self.model_parameters = None
             self._model_model.clear()
             return
@@ -1727,22 +1727,22 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         # Wipe out the parameter model
         self._model_model.clear()
         # Safely clear and enable the model combo
-        self.cbModel.blockSignals(True)
-        self.cbModel.clear()
-        self.cbModel.blockSignals(False)
+        self.comboboxModel.blockSignals(True)
+        self.comboboxModel.clear()
+        self.comboboxModel.blockSignals(False)
         self.enableModelCombo()
         self.disableStructureCombo()
         self.kernel_module = None
 
-        self._previous_category_index = self.cbCategory.currentIndex()
+        self._previous_category_index = self.comboboxCategory.currentIndex()
         # Retrieve the list of models
         model_list = self.master_category_dict[category]
         # Populate the models combobox
-        self.cbModel.blockSignals(True)
-        self.cbModel.addItem(MODEL_DEFAULT)
+        self.comboboxModel.blockSignals(True)
+        self.comboboxModel.addItem(MODEL_DEFAULT)
         models_to_show = [m[0] for m in model_list if m[0] != 'rpa' and m[1]]
-        self.cbModel.addItems(sorted(models_to_show))
-        self.cbModel.blockSignals(False)
+        self.comboboxModel.addItems(sorted(models_to_show))
+        self.comboboxModel.blockSignals(False)
 
     def onPolyModelChange(self, top, bottom):
         """
@@ -1759,7 +1759,7 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         # corresponding values in FitPage
         parameter_name = parameter_name.rsplit()[-1]
 
-        delegate = self.lstPoly.itemDelegate()
+        delegate = self.listPolydispersity.itemDelegate()
 
         # Extract changed value.
         if model_column == delegate.poly_parameter:
@@ -1771,7 +1771,7 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
             else:
                 if parameter_name_w in self.poly_params_to_fit:
                     self.poly_params_to_fit.remove(parameter_name_w)
-            self.cmdFit.setEnabled(self.haveParamsToFit())
+            self.buttonFit.setEnabled(self.haveParamsToFit())
             # Update state stack
             self.updateUndo()
 
@@ -1838,7 +1838,7 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
             else:
                 if parameter_name in self.magnet_params_to_fit:
                     self.magnet_params_to_fit.remove(parameter_name)
-            self.cmdFit.setEnabled(self.haveParamsToFit())
+            self.buttonFit.setEnabled(self.haveParamsToFit())
             # Update state stack
             self.updateUndo()
             return
@@ -1849,7 +1849,7 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         except TypeError:
             # Unparsable field
             return
-        delegate = self.lstMagnetic.itemDelegate()
+        delegate = self.listPolarisation_Magnetic_Scattering.itemDelegate()
 
         if model_column > 1:
             if model_column == delegate.mag_min:
@@ -1882,7 +1882,7 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
 
     def getHelpLocation(self, tree_base) -> Path:
         # Actual file will depend on the current tab
-        tab_id = self.tabFitting.currentIndex()
+        tab_id = self.tabOverviewFitting.currentIndex()
         tree_location = tree_base / "user" / "qtgui" / "Perspectives" / "Fitting"
 
         match tab_id:
@@ -2131,7 +2131,7 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
 
         # Read only value - we can get away by just printing it here
         chi2_repr = GuiUtils.formatNumber(self.chi2, high=True)
-        self.lblChi2Value.setText(chi2_repr)
+        self.labelChiSquaredValue.setText(chi2_repr)
 
 
     def prepareFitters(self, fitter=None, fit_id=0, weight_increase=1):
@@ -2148,13 +2148,13 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         qmax = self.q_range_max
 
         params_to_fit = copy.deepcopy(self.main_params_to_fit)
-        if self.chkPolydispersity.isChecked():
+        if self.checkboxPolydispersity.isChecked():
             for p in self.poly_params_to_fit:
                 if "Distribution of" in p:
                     params_to_fit += [self.polyNameToParam(p)]
                 else:
                     params_to_fit += [p]
-        if self.chkMagnetism.isChecked() and self.canHaveMagnetism():
+        if self.checkboxMagnetism.isChecked() and self.canHaveMagnetism():
             params_to_fit += self.magnet_params_to_fit
         if not params_to_fit:
             raise ValueError('Fitting requires at least one parameter to optimize.')
@@ -2287,7 +2287,7 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         #if not self.has_error_column:
             # create top-level error column
         error_column = []
-        self.lstParams.itemDelegate().addErrorColumn()
+        self.listModelParameters.itemDelegate().addErrorColumn()
         self.iterateOverModel(createErrorColumn)
 
         self._model_model.insertColumn(2, error_column)
@@ -2362,7 +2362,7 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         if self.has_poly_error_column:
             self._poly_model.removeColumn(2)
 
-        self.lstPoly.itemDelegate().addErrorColumn()
+        self.listPolydispersity.itemDelegate().addErrorColumn()
         error_column = []
         self.iterateOverPolyModel(createErrorColumn)
 
@@ -2426,7 +2426,7 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         if self.has_magnet_error_column:
             self._magnet_model.removeColumn(2)
 
-        self.lstMagnetic.itemDelegate().addErrorColumn()
+        self.listPolarisation_Magnetic_Scattering.itemDelegate().addErrorColumn()
         error_column = []
         self.iterateOverMagnetModel(createErrorColumn)
 
@@ -2441,7 +2441,7 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         Plot the current set of data
         """
         # Regardless of previous state, this should now be `plot show` functionality only
-        self.cmdPlot.setText("Compute/Plot")
+        self.buttonPlot.setText("Compute/Plot")
         # Force data recalculation so existing charts are updated
         if not self.data_is_loaded:
             self.showTheoryPlot()
@@ -2459,11 +2459,11 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         """
         # update display
         smearing, accuracy, smearing_min, smearing_max = self.smearing_widget.state()
-        self.lblCurrentSmearing.setText(smearing)
+        self.labelSmearingValue.setText(smearing)
         self.calculateQGridForModel()
 
     def onKey(self, event):
-        if event.key() in [QtCore.Qt.Key_Enter, QtCore.Qt.Key_Return] and self.cmdPlot.isEnabled():
+        if event.key() in [QtCore.Qt.Key_Enter, QtCore.Qt.Key_Return] and self.buttonPlot.isEnabled():
             self.onPlot()
 
     def recalculatePlotData(self):
@@ -2521,8 +2521,8 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         self.q_range_min, self.q_range_max, self.npts, self.log_points, self.weighting = \
             self.options_widget.state()
         # set Q range labels on the main tab
-        self.lblMinRangeDef.setText(GuiUtils.formatNumber(self.q_range_min, high=True))
-        self.lblMaxRangeDef.setText(GuiUtils.formatNumber(self.q_range_max, high=True))
+        self.labelMinRangeValue.setText(GuiUtils.formatNumber(self.q_range_min, high=True))
+        self.labelMaxRangeValue.setText(GuiUtils.formatNumber(self.q_range_max, high=True))
         self.recalculatePlotData()
 
     def setDefaultStructureCombo(self):
@@ -2532,8 +2532,8 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         structure_factor_list = self.master_category_dict.pop(CATEGORY_STRUCTURE)
         factors = [factor[0] for factor in structure_factor_list]
         factors.insert(0, STRUCTURE_DEFAULT)
-        self.cbStructureFactor.clear()
-        self.cbStructureFactor.addItems(sorted(factors))
+        self.comboboxStructureFactor.clear()
+        self.comboboxStructureFactor.addItems(sorted(factors))
 
     def createDefaultDataset(self):
         """
@@ -2659,8 +2659,8 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         if self.data_is_loaded:
             self.q_range_min, self.q_range_max, self.npts = self.logic.computeDataRange()
         # set Q range labels on the main tab
-        self.lblMinRangeDef.setText(GuiUtils.formatNumber(self.q_range_min, high=True))
-        self.lblMaxRangeDef.setText(GuiUtils.formatNumber(self.q_range_max, high=True))
+        self.labelMinRangeValue.setText(GuiUtils.formatNumber(self.q_range_min, high=True))
+        self.labelMaxRangeValue.setText(GuiUtils.formatNumber(self.q_range_max, high=True))
 
         # set Q range labels on the options tab
         self.options_widget.updateQRange(self.q_range_min, self.q_range_max, self.npts)
@@ -2690,8 +2690,8 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
             self.enableStructureFactorControl(structure_factor)
 
             # Add S(Q)
-            if self.cbStructureFactor.isEnabled():
-                structure_factor = self.cbStructureFactor.currentText()
+            if self.comboboxStructureFactor.isEnabled():
+                structure_factor = self.comboboxStructureFactor.currentText()
                 self.fromStructureFactorToQModel(structure_factor)
 
             # Add polydispersity to the model
@@ -2710,7 +2710,7 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
 
         # (Re)-create headers
         FittingUtilities.addHeadersToModel(self._model_model)
-        self.lstParams.header().setFont(self.boldFont)
+        self.listModelParameters.header().setFont(self.boldFont)
 
     def fromModelToQModel(self, model_name):
         """
@@ -2718,7 +2718,7 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         """
         name = model_name
         kernel_module = None
-        if self.cbCategory.currentText() == CATEGORY_CUSTOM:
+        if self.comboboxCategory.currentText() == CATEGORY_CUSTOM:
             # custom kernel load requires full path
             name = os.path.join(models.find_plugins_dir(), model_name+".py")
         try:
@@ -2784,7 +2784,7 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
                 self.kernel_module,
                 self.is2D,
                 self._model_model,
-                self.lstParams)
+                self.listModelParameters)
 
     def fromStructureFactorToQModel(self, structure_factor):
         """
@@ -2815,7 +2815,7 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
                 is2D=self.is2D,
                 parameters_original=None,
                 model=self._model_model,
-                view=self.lstParams)
+                view=self.listModelParameters)
 
         # Insert product-only params into QModel
         if product_params:
@@ -2824,7 +2824,7 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
                     is2D=self.is2D,
                     parameters_original=None,
                     model=self._model_model,
-                    view=self.lstParams,
+                    view=self.listModelParameters,
                     row_num=2)
 
             # Since this all happens after shells are dealt with and we've inserted rows, fix this counter
@@ -2884,9 +2884,9 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
             return False
         if self.main_params_to_fit:
             return True
-        if self.chkPolydispersity.isChecked() and self.poly_params_to_fit:
+        if self.checkboxPolydispersity.isChecked() and self.poly_params_to_fit:
             return True
-        if self.chkMagnetism.isChecked() and self.canHaveMagnetism() and self.magnet_params_to_fit:
+        if self.checkboxMagnetism.isChecked() and self.canHaveMagnetism() and self.magnet_params_to_fit:
             return True
         return False
 
@@ -2900,7 +2900,7 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
 
         if model_column == 0:
             self.checkboxSelected(item, model_key="standard")
-            self.cmdFit.setEnabled(self.haveParamsToFit())
+            self.buttonFit.setEnabled(self.haveParamsToFit())
             # Update state stack
             self.updateUndo()
             return
@@ -2923,9 +2923,9 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
             parameter_name = str(self._model_model.data(name_index))
 
         # Update the parameter value - note: this supports +/-inf as well
-        param_column = self.lstParams.itemDelegate().param_value
-        min_column = self.lstParams.itemDelegate().param_min
-        max_column = self.lstParams.itemDelegate().param_max
+        param_column = self.listModelParameters.itemDelegate().param_value
+        min_column = self.listModelParameters.itemDelegate().param_min
+        max_column = self.listModelParameters.itemDelegate().param_max
         if model_column == param_column:
             # don't try to update multiplicity counters if they aren't there.
             # Note that this will fail for proper bad update where the model
@@ -3146,11 +3146,11 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         if not hasattr(model, 'setParam'): return
 
         # add polydisperse parameters if asked
-        if self.chkPolydispersity.isChecked() and self._poly_model.rowCount() > 0:
+        if self.checkboxPolydispersity.isChecked() and self._poly_model.rowCount() > 0:
             for key, value in self.poly_params.items():
                 model.setParam(key, value)
         # add magnetic params if asked
-        if self.chkMagnetism.isChecked() and self.canHaveMagnetism() and self._magnet_model.rowCount() > 0:
+        if self.checkboxMagnetism.isChecked() and self.canHaveMagnetism() and self._magnet_model.rowCount() > 0:
             for key, value in self.magnet_params.items():
                 model.setParam(key, value)
 
@@ -3383,7 +3383,7 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
             self.chi2 = FittingUtilities.calculateChi2(weighted_data, self.data, weights)
             # Update the control
             chi2_repr = "---" if self.chi2 is None else GuiUtils.formatNumber(self.chi2, high=True)
-            self.lblChi2Value.setText(chi2_repr)
+            self.labelChiSquaredValue.setText(chi2_repr)
         self.fitResults = False
 
         residuals_plot = FittingUtilities.plotResiduals(self.data, fitted_data, weights)
@@ -3399,26 +3399,26 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
             Reload the category/model comboboxes
             """
             # Store the current combo indices
-            current_cat = self.cbCategory.currentText()
-            current_model = self.cbModel.currentText()
+            current_cat = self.comboboxCategory.currentText()
+            current_model = self.comboboxModel.currentText()
 
             # reread the category file and repopulate the combo
-            self.cbCategory.blockSignals(True)
-            self.cbCategory.clear()
+            self.comboboxCategory.blockSignals(True)
+            self.comboboxCategory.clear()
             self.readCategoryInfo()
             self.initializeCategoryCombo()
 
             # Scroll back to the original index in Categories
-            new_index = self.cbCategory.findText(current_cat)
+            new_index = self.comboboxCategory.findText(current_cat)
             if new_index != -1:
-                self.cbCategory.setCurrentIndex(new_index)
-            self.cbCategory.blockSignals(False)
+                self.comboboxCategory.setCurrentIndex(new_index)
+            self.comboboxCategory.blockSignals(False)
             # ...and in the Models
-            self.cbModel.blockSignals(True)
-            new_index = self.cbModel.findText(current_model)
+            self.comboboxModel.blockSignals(True)
+            new_index = self.comboboxModel.findText(current_model)
             if new_index != -1:
-                self.cbModel.setCurrentIndex(new_index)
-            self.cbModel.blockSignals(False)
+                self.comboboxModel.setCurrentIndex(new_index)
+            self.comboboxModel.blockSignals(False)
 
             return
 
@@ -3521,8 +3521,8 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         func.addItems([str(name_disp) for name_disp in POLYDISPERSITY_MODELS.keys()])
         # Set the default index
         func.setCurrentIndex(func.findText(DEFAULT_POLYDISP_FUNCTION))
-        ind = self._poly_model.index(i,self.lstPoly.itemDelegate().poly_function)
-        self.lstPoly.setIndexWidget(ind, func)
+        ind = self._poly_model.index(i,self.listPolydispersity.itemDelegate().poly_function)
+        self.listPolydispersity.setIndexWidget(ind, func)
         func.currentIndexChanged.connect(lambda: self.onPolyComboIndexChange(str(func.currentText()), i))
 
     def onPolyFilenameChange(self, row_index):
@@ -3533,12 +3533,12 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         array_caption = 'array'
 
         # Get the combo box reference
-        ind = self._poly_model.index(row_index, self.lstPoly.itemDelegate().poly_function)
-        widget = self.lstPoly.indexWidget(ind)
+        ind = self._poly_model.index(row_index, self.listPolydispersity.itemDelegate().poly_function)
+        widget = self.listPolydispersity.indexWidget(ind)
 
         # Update the combo box so it displays "array"
         widget.blockSignals(True)
-        widget.setCurrentIndex(self.lstPoly.itemDelegate().POLYDISPERSE_FUNCTIONS.index(array_caption))
+        widget.setCurrentIndex(self.listPolydispersity.itemDelegate().POLYDISPERSE_FUNCTIONS.index(array_caption))
         widget.blockSignals(False)
 
         # Invoke the file reader
@@ -3550,8 +3550,8 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         """
         # Get npts/nsigs for current selection
         param = self.model_parameters.form_volume_parameters[row_index]
-        file_index = self._poly_model.index(row_index, self.lstPoly.itemDelegate().poly_function)
-        combo_box = self.lstPoly.indexWidget(file_index)
+        file_index = self._poly_model.index(row_index, self.listPolydispersity.itemDelegate().poly_function)
+        combo_box = self.listPolydispersity.indexWidget(file_index)
         try:
             self.disp_model = POLYDISPERSITY_MODELS[combo_string]()
         except IndexError:
@@ -3588,8 +3588,8 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
                 # uncheck the parameter
                 self._poly_model.item(row_index, 0).setCheckState(QtCore.Qt.Unchecked)
                 # disable the row
-                lo = self.lstPoly.itemDelegate().poly_parameter
-                hi = self.lstPoly.itemDelegate().poly_function
+                lo = self.listPolydispersity.itemDelegate().poly_parameter
+                hi = self.listPolydispersity.itemDelegate().poly_function
                 self._poly_model.blockSignals(True)
                 [self._poly_model.item(row_index, i).setEnabled(False) for i in range(lo, hi)]
                 self._poly_model.blockSignals(False)
@@ -3603,14 +3603,14 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
 
         # Enable the row in case it was disabled by Array
         self._poly_model.blockSignals(True)
-        max_range = self.lstPoly.itemDelegate().poly_filename
+        max_range = self.listPolydispersity.itemDelegate().poly_filename
         [self._poly_model.item(row_index, i).setEnabled(True) for i in range(7)]
-        file_index = self._poly_model.index(row_index, self.lstPoly.itemDelegate().poly_filename)
+        file_index = self._poly_model.index(row_index, self.listPolydispersity.itemDelegate().poly_filename)
         self._poly_model.setData(file_index, "")
         self._poly_model.blockSignals(False)
 
-        npts_index = self._poly_model.index(row_index, self.lstPoly.itemDelegate().poly_npts)
-        nsigs_index = self._poly_model.index(row_index, self.lstPoly.itemDelegate().poly_nsigs)
+        npts_index = self._poly_model.index(row_index, self.listPolydispersity.itemDelegate().poly_npts)
+        nsigs_index = self._poly_model.index(row_index, self.listPolydispersity.itemDelegate().poly_nsigs)
 
         npts = POLYDISPERSITY_MODELS[str(combo_string)].default['npts']
         nsigs = POLYDISPERSITY_MODELS[str(combo_string)].default['nsigmas']
@@ -3655,7 +3655,7 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         self.disp_model.set_weights(np.array(values), np.array(weights))
         # + update the cell with filename
         fname = os.path.basename(str(datafile))
-        fname_index = self._poly_model.index(row_index, self.lstPoly.itemDelegate().poly_filename)
+        fname_index = self._poly_model.index(row_index, self.listPolydispersity.itemDelegate().poly_filename)
         self._poly_model.setData(fname_index, fname)
 
     def onColumnWidthUpdate(self, index, old_size, new_size):
@@ -3775,8 +3775,8 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         shell_index = self._model_model.index(shell_row-1, 1)
         button_index = self._model_model.index(shell_row-1, 4)
 
-        self.lstParams.setIndexWidget(shell_index, func)
-        self.lstParams.setIndexWidget(button_index, button)
+        self.listModelParameters.setIndexWidget(shell_index, func)
+        self.listModelParameters.setIndexWidget(button_index, button)
         self._n_shells_row = shell_row - 1
 
         # Get the default number of shells for the model
@@ -3853,7 +3853,7 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
                 self._model_model,
                 index,
                 first_row,
-                self.lstParams)
+                self.listModelParameters)
 
         self._num_shell_params = len(new_rows)
         self.current_shell_displayed = index
@@ -3916,21 +3916,21 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         """
         assert isinstance(enabled, bool)
 
-        self.lstParams.setEnabled(enabled)
-        self.lstPoly.setEnabled(enabled)
-        self.lstMagnetic.setEnabled(enabled)
+        self.listModelParameters.setEnabled(enabled)
+        self.listPolydispersity.setEnabled(enabled)
+        self.listPolarisation_Magnetic_Scattering.setEnabled(enabled)
 
-        self.cbCategory.setEnabled(enabled)
+        self.comboboxCategory.setEnabled(enabled)
 
         if enabled:
             # worry about original enablement of model and SF
-            self.cbModel.setEnabled(self.enabled_cbmodel)
-            self.cbStructureFactor.setEnabled(self.enabled_sfmodel)
+            self.comboboxModel.setEnabled(self.enabled_cbmodel)
+            self.comboboxStructureFactor.setEnabled(self.enabled_sfmodel)
         else:
-            self.cbModel.setEnabled(enabled)
-            self.cbStructureFactor.setEnabled(enabled)
+            self.comboboxModel.setEnabled(enabled)
+            self.comboboxStructureFactor.setEnabled(enabled)
 
-        self.cmdPlot.setEnabled(enabled)
+        self.buttonPlot.setEnabled(enabled)
 
     def enableInteractiveElements(self):
         """
@@ -3938,8 +3938,8 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         Enable the param table(s)
         """
         # Notify the user that fitting is available
-        self.cmdFit.setStyleSheet('QPushButton {color: black;}')
-        self.cmdFit.setText("Fit")
+        self.buttonFit.setStyleSheet('QPushButton {color: black;}')
+        self.buttonFit.setText("Fit")
         self.fit_started = False
         self.setInteractiveElements(True)
 
@@ -3950,8 +3950,8 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         """
         # Notify the user that fitting is being run
         # Allow for stopping the job
-        self.cmdFit.setStyleSheet('QPushButton {color: red;}')
-        self.cmdFit.setText('Stop fit')
+        self.buttonFit.setStyleSheet('QPushButton {color: red;}')
+        self.buttonFit.setText('Stop fit')
         self.setInteractiveElements(False)
 
     def disableInteractiveElementsOnCalculate(self):
@@ -3961,8 +3961,8 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         """
         # Notify the user that fitting is being run
         # Allow for stopping the job
-        self.cmdFit.setStyleSheet('QPushButton {color: red;}')
-        self.cmdFit.setText('Running...')
+        self.buttonFit.setStyleSheet('QPushButton {color: red;}')
+        self.buttonFit.setText('Running...')
         self.setInteractiveElements(False)
 
     def readFitPage(self, fp):
@@ -3973,15 +3973,15 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         # Main tab info
         self.logic.data.name = fp.name
         self.data_is_loaded = fp.data_is_loaded
-        self.chkPolydispersity.setChecked(fp.is_polydisperse)
-        self.chkMagnetism.setChecked(fp.is_magnetic)
-        self.chk2DView.setChecked(fp.is2D)
+        self.checkboxPolydispersity.setChecked(fp.is_polydisperse)
+        self.checkboxMagnetism.setChecked(fp.is_magnetic)
+        self.checkbox2DView.setChecked(fp.is2D)
 
         # Update the comboboxes
-        self.cbCategory.setCurrentIndex(self.cbCategory.findText(fp.current_category))
-        self.cbModel.setCurrentIndex(self.cbModel.findText(fp.current_model))
+        self.comboboxCategory.setCurrentIndex(self.comboboxCategory.findText(fp.current_category))
+        self.comboboxModel.setCurrentIndex(self.comboboxModel.findText(fp.current_model))
         if fp.current_factor:
-            self.cbStructureFactor.setCurrentIndex(self.cbStructureFactor.findText(fp.current_factor))
+            self.comboboxStructureFactor.setCurrentIndex(self.comboboxStructureFactor.findText(fp.current_factor))
 
         self.chi2 = fp.chi2
 
@@ -4015,9 +4015,9 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         # Main tab info
         fp.name = self.logic.data.name
         fp.data_is_loaded = self.data_is_loaded
-        fp.is_polydisperse = self.chkPolydispersity.isChecked()
-        fp.is_magnetic = self.chkMagnetism.isChecked()
-        fp.is2D = self.chk2DView.isChecked()
+        fp.is_polydisperse = self.checkboxPolydispersity.isChecked()
+        fp.is_magnetic = self.checkboxMagnetism.isChecked()
+        fp.is2D = self.checkbox2DView.isChecked()
         fp.data = self.data
 
         # Use current models - they contain all the required parameters
@@ -4025,12 +4025,12 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         fp.poly_model = self._poly_model
         fp.magnetism_model = self._magnet_model
 
-        if self.cbCategory.currentIndex() != 0:
-            fp.current_category = str(self.cbCategory.currentText())
-            fp.current_model = str(self.cbModel.currentText())
+        if self.comboboxCategory.currentIndex() != 0:
+            fp.current_category = str(self.comboboxCategory.currentText())
+            fp.current_model = str(self.comboboxModel.currentText())
 
-        if self.cbStructureFactor.isEnabled() and self.cbStructureFactor.currentIndex() != 0:
-            fp.current_factor = str(self.cbStructureFactor.currentText())
+        if self.comboboxStructureFactor.isEnabled() and self.comboboxStructureFactor.currentIndex() != 0:
+            fp.current_factor = str(self.comboboxStructureFactor.currentText())
         else:
             fp.current_factor = ''
 
@@ -4101,9 +4101,9 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         params = FittingUtilities.getStandardParam(self._model_model)
         poly_params = []
         magnet_params = []
-        if self.chkPolydispersity.isChecked() and self._poly_model.rowCount() > 0:
+        if self.checkboxPolydispersity.isChecked() and self._poly_model.rowCount() > 0:
             poly_params = FittingUtilities.getStandardParam(self._poly_model)
-        if self.chkMagnetism.isChecked() and self.canHaveMagnetism() and self._magnet_model.rowCount() > 0:
+        if self.checkboxMagnetism.isChecked() and self.canHaveMagnetism() and self._magnet_model.rowCount() > 0:
             magnet_params = FittingUtilities.getStandardParam(self._magnet_model)
         report_logic = ReportPageLogic(self,
                                        kernel_module=self.kernel_module,
@@ -4264,9 +4264,9 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         serializes combobox state
         """
         param_list = []
-        model = str(self.cbModel.currentText())
-        category = str(self.cbCategory.currentText())
-        structure = str(self.cbStructureFactor.currentText())
+        model = str(self.comboboxModel.currentText())
+        category = str(self.comboboxCategory.currentText())
+        structure = str(self.comboboxStructureFactor.currentText())
         param_list.append(['fitpage_category', category])
         param_list.append(['fitpage_model', model])
         param_list.append(['fitpage_structure', structure])
@@ -4307,16 +4307,16 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
 
         # resolution
         smearing, accuracy, smearing_min, smearing_max = self.smearing_widget.state()
-        index = self.smearing_widget.cbSmearing.currentIndex()
+        index = self.smearing_widget.comboBoxInstrumentalSmearing.currentIndex()
         param_list.append(['smearing', str(index)])
         param_list.append(['smearing_min', str(smearing_min)])
         param_list.append(['smearing_max', str(smearing_max)])
 
         # checkboxes, if required
-        has_polydisp = self.chkPolydispersity.isChecked()
-        has_magnetism = self.chkMagnetism.isChecked()
-        has_chain = self.chkChainFit.isChecked()
-        has_2D = self.chk2DView.isChecked()
+        has_polydisp = self.checkboxPolydispersity.isChecked()
+        has_magnetism = self.checkboxMagnetism.isChecked()
+        has_chain = self.checkboxChainFit.isChecked()
+        has_2D = self.checkbox2DView.isChecked()
         param_list.append(['polydisperse_params', str(has_polydisp)])
         param_list.append(['magnetic_params', str(has_magnetism)])
         param_list.append(['chainfit_params', str(has_chain)])
@@ -4332,14 +4332,14 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         if self.kernel_module is None:
             return param_list
 
-        param_list.append(['model_name', str(self.cbModel.currentText())])
+        param_list.append(['model_name', str(self.comboboxModel.currentText())])
 
         def gatherParams(row):
             """
             Create list of main parameters based on _model_model
             """
             param_name = str(self._model_model.item(row, 0).text())
-            current_list = self.tabToList[self.tabFitting.currentIndex()]
+            current_list = self.tabToList[self.tabOverviewFitting.currentIndex()]
             model = self._model_model
             if model.item(row, 0) is None:
                 return
@@ -4406,7 +4406,7 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
             param_nsigs = str(self._poly_model.item(row, 5+column_offset).text())
             param_fun   = str(self._poly_model.item(row, 6+column_offset).text()).rstrip()
             index = self._poly_model.index(row, 6+column_offset)
-            widget = self.lstPoly.indexWidget(index)
+            widget = self.listPolydispersity.indexWidget(index)
             if widget is not None and isinstance(widget, QtWidgets.QComboBox):
                 param_fun = widget.currentText()
             # width
@@ -4432,9 +4432,9 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
                                param_error, param_min, param_max])
 
         self.iterateOverModel(gatherParams)
-        if self.chkPolydispersity.isChecked():
+        if self.checkboxPolydispersity.isChecked():
             self.iterateOverPolyModel(gatherPolyParams)
-        if self.chkMagnetism.isChecked() and self.canHaveMagnetism():
+        if self.checkboxMagnetism.isChecked() and self.canHaveMagnetism():
             self.iterateOverMagnetModel(gatherMagnetParams)
 
         if self.kernel_module.is_multiplicity_model:
@@ -4448,11 +4448,11 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         and fills it up with sent parameters
         """
         if 'fitpage_category' in line_dict:
-            self.cbCategory.setCurrentIndex(self.cbCategory.findText(line_dict['fitpage_category'][0]))
+            self.comboboxCategory.setCurrentIndex(self.comboboxCategory.findText(line_dict['fitpage_category'][0]))
         if 'fitpage_model' in line_dict:
-            self.cbModel.setCurrentIndex(self.cbModel.findText(line_dict['fitpage_model'][0]))
+            self.comboboxModel.setCurrentIndex(self.comboboxModel.findText(line_dict['fitpage_model'][0]))
         if 'fitpage_structure' in line_dict:
-            self.cbStructureFactor.setCurrentIndex(self.cbStructureFactor.findText(line_dict['fitpage_structure'][0]))
+            self.comboboxStructureFactor.setCurrentIndex(self.comboboxStructureFactor.findText(line_dict['fitpage_structure'][0]))
 
         # Now that the page is ready for parameters, fill it up
         self.updatePageWithParameters(line_dict)
@@ -4476,13 +4476,13 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         if 'tab_name' in line_dict.keys() and self.kernel_module is not None:
             self.kernel_module.name = line_dict['tab_name'][0]
         if 'polydisperse_params' in line_dict.keys():
-            self.chkPolydispersity.setChecked(line_dict['polydisperse_params'][0]=='True')
+            self.checkboxPolydispersity.setChecked(line_dict['polydisperse_params'][0]=='True')
         if 'magnetic_params' in line_dict.keys():
-            self.chkMagnetism.setChecked(line_dict['magnetic_params'][0]=='True')
+            self.checkboxMagnetism.setChecked(line_dict['magnetic_params'][0]=='True')
         if 'chainfit_params' in line_dict.keys():
-            self.chkChainFit.setChecked(line_dict['chainfit_params'][0]=='True')
+            self.checkboxChainFit.setChecked(line_dict['chainfit_params'][0]=='True')
         if '2D_params' in line_dict.keys():
-            self.chk2DView.setChecked(line_dict['2D_params'][0]=='True')
+            self.checkbox2DView.setChecked(line_dict['2D_params'][0]=='True')
 
         # Create the context dictionary for parameters
         context['model_name'] = model
@@ -4490,7 +4490,7 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
             if len(value) > 2:
                 context[key] = value
 
-        if warn_user and str(self.cbModel.currentText()) != str(context['model_name']):
+        if warn_user and str(self.comboboxModel.currentText()) != str(context['model_name']):
             msg = QtWidgets.QMessageBox()
             msg.setIcon(QtWidgets.QMessageBox.Information)
             msg.setText("The model in the clipboard is not the same as the currently loaded model. \
@@ -4505,7 +4505,7 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         if 'smearing' in line_dict.keys():
             try:
                 index = int(line_dict['smearing'][0])
-                self.smearing_widget.cbSmearing.setCurrentIndex(index)
+                self.smearing_widget.comboBoxInstrumentalSmearing.setCurrentIndex(index)
             except ValueError:
                 pass
         if 'smearing_min' in line_dict.keys():
@@ -4545,7 +4545,7 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         Find and update the multiplicity combobox
         """
         index = self._model_model.index(self._n_shells_row, 1)
-        widget = self.lstParams.indexWidget(index)
+        widget = self.listModelParameters.indexWidget(index)
         if widget is not None and isinstance(widget, QtWidgets.QComboBox):
             widget.setCurrentIndex(widget.findText(str(multip)))
         self.current_shell_displayed = multip
@@ -4574,7 +4574,7 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
                     # quietly pass
                     return
                 index = self._model_model.index(row, 1)
-                widget = self.lstParams.indexWidget(index)
+                widget = self.listModelParameters.indexWidget(index)
                 if widget is not None and isinstance(widget, QtWidgets.QComboBox):
                     #widget.setCurrentIndex(combo_index)
                     return
@@ -4585,7 +4585,7 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
             # parameter value can be either just a value or text on the combobox
             param_text = param_dict[param_name][1]
             index = self._model_model.index(row, 1)
-            widget = self.lstParams.indexWidget(index)
+            widget = self.listModelParameters.indexWidget(index)
             if widget is not None and isinstance(widget, QtWidgets.QComboBox):
                 # Find the right index based on text
                 combo_index = int(param_text, 0)
@@ -4715,10 +4715,10 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         Store current state for fit_page
         """
         # Comboboxes
-        state.categorycombobox = self.cbCategory.currentText()
-        state.formfactorcombobox = self.cbModel.currentText()
-        if self.cbStructureFactor.isEnabled():
-            state.structurecombobox = self.cbStructureFactor.currentText()
+        state.categorycombobox = self.comboboxCategory.currentText()
+        state.formfactorcombobox = self.comboboxModel.currentText()
+        if self.comboboxStructureFactor.isEnabled():
+            state.structurecombobox = self.comboboxStructureFactor.currentText()
         state.tcChi = self.chi2
 
         state.enable2D = self.is2D

--- a/src/sas/qtgui/Perspectives/Fitting/GPUOptions.py
+++ b/src/sas/qtgui/Perspectives/Fitting/GPUOptions.py
@@ -59,8 +59,8 @@ class GPUOptions(PreferencesWidget, Ui_GPUOptions):
         self.progressBar.setVisible(False)
         self.progressBar.setFormat(" Test %v / %m")
 
-        self.cmdTest.clicked.connect(self.cmdTestClicked)
-        self.cmdHelp.clicked.connect(self.cmdHelpClicked)
+        self.cmdTest.clicked.connect(self.testButtonClicked)
+        self.cmdHelp.clicked.connect(self.helpButtonClicked)
         self.testingDoneSignal.connect(self.testCompleted)
         self.testingFailedSignal.connect(self.testFailed)
 

--- a/src/sas/qtgui/Perspectives/Fitting/GPUOptions.py
+++ b/src/sas/qtgui/Perspectives/Fitting/GPUOptions.py
@@ -59,8 +59,8 @@ class GPUOptions(PreferencesWidget, Ui_GPUOptions):
         self.progressBar.setVisible(False)
         self.progressBar.setFormat(" Test %v / %m")
 
-        self.testButton.clicked.connect(self.testButtonClicked)
-        self.helpButton.clicked.connect(self.helpButtonClicked)
+        self.cmdTest.clicked.connect(self.cmdTestClicked)
+        self.cmdHelp.clicked.connect(self.cmdHelpClicked)
         self.testingDoneSignal.connect(self.testCompleted)
         self.testingFailedSignal.connect(self.testFailed)
 
@@ -142,7 +142,7 @@ class GPUOptions(PreferencesWidget, Ui_GPUOptions):
         self.progressBar.setMinimum(0)
         self.progressBar.setMaximum(number_of_tests)
         self.progressBar.setVisible(True)
-        self.testButton.setEnabled(False)
+        self.cmdTest.setEnabled(False)
         no_opencl_msg = self.set_sas_open_cl()
 
         test_thread = threads.deferToThread(self.testThread, no_opencl_msg)
@@ -255,7 +255,7 @@ class GPUOptions(PreferencesWidget, Ui_GPUOptions):
         Testing failed: log the reason
         """
         self.progressBar.setVisible(False)
-        self.testButton.setEnabled(True)
+        self.cmdTest.setEnabled(True)
 
         logging.error(str(msg))
 
@@ -264,7 +264,7 @@ class GPUOptions(PreferencesWidget, Ui_GPUOptions):
         Respond to successful test completion
         """
         self.progressBar.setVisible(False)
-        self.testButton.setEnabled(True)
+        self.cmdTest.setEnabled(True)
 
         GPUTestResults(self, msg)
 

--- a/src/sas/qtgui/Perspectives/Fitting/MultiConstraint.py
+++ b/src/sas/qtgui/Perspectives/Fitting/MultiConstraint.py
@@ -53,13 +53,13 @@ class MultiConstraint(QtWidgets.QDialog, Ui_MultiConstraintUI):
 
         # Set param text control to the second parameter passed
         if self.input_constraint is None:
-            self.textConstraint.setText(self.params[1])
+            self.txtConstraint.setText(self.params[1])
         else:
-            self.textConstraint.setText(self.function)
+            self.txtConstraint.setText(self.function)
         self.cmdOK.clicked.connect(self.accept)
         self.cmdHelp.clicked.connect(self.onHelp)
         self.cmdSwap.clicked.connect(self.revert)
-        self.textConstraint.editingFinished.connect(self.validateFormula)
+        self.txtConstraint.editingFinished.connect(self.validateFormula)
 
         # Default focus is on OK
         self.cmdOK.setFocus()
@@ -73,9 +73,9 @@ class MultiConstraint(QtWidgets.QDialog, Ui_MultiConstraintUI):
         # change fully qualified param name (e.g. M1.sld -> M1.sld_solvent)
         self.model_name = self.model_name.replace(self.params[0], self.params[1])
         # Try to swap parameter names in the line edit
-        current_text = self.textConstraint.text()
+        current_text = self.txtConstraint.text()
         new_text = current_text.replace(self.params[0], self.params[1])
-        self.textConstraint.setText(new_text)
+        self.txtConstraint.setText(new_text)
         # Update labels and tooltips
         self.setupLabels()
         self.setupTooltip()
@@ -96,7 +96,7 @@ class MultiConstraint(QtWidgets.QDialog, Ui_MultiConstraintUI):
         """
         tooltip = "E.g.\n%s = 2.0 * (%s)\n" %(self.params[0], self.params[1])
         tooltip += "%s = sqrt(%s) + 5"%(self.params[0], self.params[1])
-        self.textConstraint.setToolTip(tooltip)
+        self.txtConstraint.setToolTip(tooltip)
 
     def validateFormula(self):
         """

--- a/src/sas/qtgui/Perspectives/Fitting/MultiConstraint.py
+++ b/src/sas/qtgui/Perspectives/Fitting/MultiConstraint.py
@@ -53,16 +53,16 @@ class MultiConstraint(QtWidgets.QDialog, Ui_MultiConstraintUI):
 
         # Set param text control to the second parameter passed
         if self.input_constraint is None:
-            self.txtConstraint.setText(self.params[1])
+            self.textConstraint.setText(self.params[1])
         else:
-            self.txtConstraint.setText(self.function)
-        self.cmdOK.clicked.connect(self.accept)
-        self.cmdHelp.clicked.connect(self.onHelp)
-        self.cmdRevert.clicked.connect(self.revert)
-        self.txtConstraint.editingFinished.connect(self.validateFormula)
+            self.textConstraint.setText(self.function)
+        self.buttonOK.clicked.connect(self.accept)
+        self.buttonHelp.clicked.connect(self.onHelp)
+        self.buttonSwap.clicked.connect(self.revert)
+        self.textConstraint.editingFinished.connect(self.validateFormula)
 
         # Default focus is on OK
-        self.cmdOK.setFocus()
+        self.buttonOK.setFocus()
 
     def revert(self):
         """
@@ -73,9 +73,9 @@ class MultiConstraint(QtWidgets.QDialog, Ui_MultiConstraintUI):
         # change fully qualified param name (e.g. M1.sld -> M1.sld_solvent)
         self.model_name = self.model_name.replace(self.params[0], self.params[1])
         # Try to swap parameter names in the line edit
-        current_text = self.txtConstraint.text()
+        current_text = self.textConstraint.text()
         new_text = current_text.replace(self.params[0], self.params[1])
-        self.txtConstraint.setText(new_text)
+        self.textConstraint.setText(new_text)
         # Update labels and tooltips
         self.setupLabels()
         self.setupTooltip()
@@ -86,9 +86,9 @@ class MultiConstraint(QtWidgets.QDialog, Ui_MultiConstraintUI):
         """
         l1 = str(self.params[0])
         l2 = str(self.params[1])
-        self.txtParam1.setText(l1)
-        self.txtParam1_2.setText(l1)
-        self.txtParam2.setText(l2)
+        self.label_Parameter1_SwapBox.setText(l1)
+        self.label_Parameter1_TextBox.setText(l1)
+        self.label_Parameter2_SwapBox.setText(l2)
 
     def setupTooltip(self):
         """
@@ -96,7 +96,7 @@ class MultiConstraint(QtWidgets.QDialog, Ui_MultiConstraintUI):
         """
         tooltip = "E.g.\n%s = 2.0 * (%s)\n" %(self.params[0], self.params[1])
         tooltip += "%s = sqrt(%s) + 5"%(self.params[0], self.params[1])
-        self.txtConstraint.setToolTip(tooltip)
+        self.textConstraint.setToolTip(tooltip)
 
     def validateFormula(self):
         """

--- a/src/sas/qtgui/Perspectives/Fitting/MultiConstraint.py
+++ b/src/sas/qtgui/Perspectives/Fitting/MultiConstraint.py
@@ -56,13 +56,13 @@ class MultiConstraint(QtWidgets.QDialog, Ui_MultiConstraintUI):
             self.textConstraint.setText(self.params[1])
         else:
             self.textConstraint.setText(self.function)
-        self.buttonOK.clicked.connect(self.accept)
-        self.buttonHelp.clicked.connect(self.onHelp)
-        self.buttonSwap.clicked.connect(self.revert)
+        self.cmdOK.clicked.connect(self.accept)
+        self.cmdHelp.clicked.connect(self.onHelp)
+        self.cmdSwap.clicked.connect(self.revert)
         self.textConstraint.editingFinished.connect(self.validateFormula)
 
         # Default focus is on OK
-        self.buttonOK.setFocus()
+        self.cmdOK.setFocus()
 
     def revert(self):
         """
@@ -86,9 +86,9 @@ class MultiConstraint(QtWidgets.QDialog, Ui_MultiConstraintUI):
         """
         l1 = str(self.params[0])
         l2 = str(self.params[1])
-        self.label_Parameter1_SwapBox.setText(l1)
-        self.label_Parameter1_TextBox.setText(l1)
-        self.label_Parameter2_SwapBox.setText(l2)
+        self.lbl_Parameter1_SwapBox.setText(l1)
+        self.lbl_Parameter1_TextBox.setText(l1)
+        self.lbl_Parameter2_SwapBox.setText(l2)
 
     def setupTooltip(self):
         """

--- a/src/sas/qtgui/Perspectives/Fitting/OptionsWidget.py
+++ b/src/sas/qtgui/Perspectives/Fitting/OptionsWidget.py
@@ -57,12 +57,12 @@ class OptionsWidget(QtWidgets.QWidget, Ui_tabOptions):
 
         # Group boxes
         self.boxWeighting.setEnabled(False)
-        self.buttonMaskEdit.setEnabled(False)
+        self.cmdMaskEdit.setEnabled(False)
         # Button groups
-        self.weightingGroup.addButton(self.radioButtonWeightingNone)
-        self.weightingGroup.addButton(self.radioButtonWeightingUsedIData)
-        self.weightingGroup.addButton(self.radioButtonWeightingUseAbsSqrtIData)
-        self.weightingGroup.addButton(self.radioButtonWeightingUseAbsIData)
+        self.weightingGroup.addButton(self.rbWeightingNone)
+        self.weightingGroup.addButton(self.rbWeightingUsedIData)
+        self.weightingGroup.addButton(self.rbWeightingUseAbsSqrtIData)
+        self.weightingGroup.addButton(self.rbWeightingUseAbsIData)
 
         # Let only floats in the range edits
         self.txtMinRange.setValidator(GuiUtils.DoubleValidator())
@@ -74,9 +74,9 @@ class OptionsWidget(QtWidgets.QWidget, Ui_tabOptions):
         self.txtNptsFit.setEnabled(False)
 
         # Attach slots
-        self.buttonReset.clicked.connect(self.onRangeReset)
-        self.buttonMaskEdit.clicked.connect(self.onMaskEdit)
-        self.checkBoxLogSpacedPoints.stateChanged.connect(self.toggleLogData)
+        self.cmdReset.clicked.connect(self.onRangeReset)
+        self.cmdMaskEdit.clicked.connect(self.onMaskEdit)
+        self.chkLogSpacedPoints.stateChanged.connect(self.toggleLogData)
         # Button groups
         self.weightingGroup.buttonClicked.connect(self.onWeightingChoice)
 
@@ -98,8 +98,8 @@ class OptionsWidget(QtWidgets.QWidget, Ui_tabOptions):
         self.model.blockSignals(False)
 
         new_font = 'font-family: -apple-system, "Helvetica Neue", "Ubuntu";'
-        self.labelAngstromInvMinRange.setStyleSheet(new_font)
-        self.labelAngstromInvMaxRange.setStyleSheet(new_font)
+        self.lblAngstromInvMinRange.setStyleSheet(new_font)
+        self.lblAngstromInvMaxRange.setStyleSheet(new_font)
 
     def initModel(self):
         """
@@ -128,7 +128,7 @@ class OptionsWidget(QtWidgets.QWidget, Ui_tabOptions):
         self.mapper.toFirst()
 
     def setLogScale(self, log_scale):
-        self.checkBoxLogSpacedPoints.setChecked(log_scale)
+        self.chkLogSpacedPoints.setChecked(log_scale)
 
     def toggleLogData(self, isChecked):
         """ Toggles between log and linear data sets """
@@ -206,19 +206,19 @@ class OptionsWidget(QtWidgets.QWidget, Ui_tabOptions):
         """
         is2Ddata = isinstance(self.logic.data, Data2D)
         self.boxWeighting.setEnabled(True)
-        self.buttonMaskEdit.setEnabled(is2Ddata)
+        self.cmdMaskEdit.setEnabled(is2Ddata)
         # Switch off txtNpts related controls
         self.txtNpts.setEnabled(False)
-        self.checkBoxLogSpacedPoints.setEnabled(False)
+        self.chkLogSpacedPoints.setEnabled(False)
         # Weighting controls
         if self.logic.di_flag:
-            self.radioButtonWeightingUsedIData.setEnabled(True)
-            self.radioButtonWeightingUsedIData.setChecked(True)
-            self.onWeightingChoice(self.radioButtonWeightingUsedIData)
+            self.rbWeightingUsedIData.setEnabled(True)
+            self.rbWeightingUsedIData.setChecked(True)
+            self.onWeightingChoice(self.rbWeightingUsedIData)
         else:
-            self.radioButtonWeightingUsedIData.setEnabled(False)
-            self.radioButtonWeightingNone.setChecked(True)
-            self.onWeightingChoice(self.radioButtonWeightingNone)
+            self.rbWeightingUsedIData.setEnabled(False)
+            self.rbWeightingNone.setChecked(True)
+            self.onWeightingChoice(self.rbWeightingNone)
 
     def updateMinQ(self, q_min=None):
         if q_min and (isinstance(q_min, (float, str))):
@@ -257,7 +257,7 @@ class OptionsWidget(QtWidgets.QWidget, Ui_tabOptions):
         q_range_max = float(self.model.item(self.MODEL.index('MAX_RANGE')).text())
         npts = int(self.model.item(self.MODEL.index('NPTS')).text())
         npts_fit = int(self.model.item(self.MODEL.index('NPTS_FIT')).text())
-        log_points = self.checkBoxLogSpacedPoints.isChecked()
+        log_points = self.chkLogSpacedPoints.isChecked()
         return (q_range_min, q_range_max, npts, log_points, self.weighting)
 
     def npts2fit(self, data=None, qmin=None, qmax=None, npts=None):

--- a/src/sas/qtgui/Perspectives/Fitting/OptionsWidget.py
+++ b/src/sas/qtgui/Perspectives/Fitting/OptionsWidget.py
@@ -57,12 +57,12 @@ class OptionsWidget(QtWidgets.QWidget, Ui_tabOptions):
 
         # Group boxes
         self.boxWeighting.setEnabled(False)
-        self.cmdMaskEdit.setEnabled(False)
+        self.buttonMaskEdit.setEnabled(False)
         # Button groups
-        self.weightingGroup.addButton(self.rbWeighting1)
-        self.weightingGroup.addButton(self.rbWeighting2)
-        self.weightingGroup.addButton(self.rbWeighting3)
-        self.weightingGroup.addButton(self.rbWeighting4)
+        self.weightingGroup.addButton(self.radioButtonWeightingNone)
+        self.weightingGroup.addButton(self.radioButtonWeightingUsedIData)
+        self.weightingGroup.addButton(self.radioButtonWeightingUseAbsSqrtIData)
+        self.weightingGroup.addButton(self.radioButtonWeightingUseAbsIData)
 
         # Let only floats in the range edits
         self.txtMinRange.setValidator(GuiUtils.DoubleValidator())
@@ -74,9 +74,9 @@ class OptionsWidget(QtWidgets.QWidget, Ui_tabOptions):
         self.txtNptsFit.setEnabled(False)
 
         # Attach slots
-        self.cmdReset.clicked.connect(self.onRangeReset)
-        self.cmdMaskEdit.clicked.connect(self.onMaskEdit)
-        self.chkLogData.stateChanged.connect(self.toggleLogData)
+        self.buttonReset.clicked.connect(self.onRangeReset)
+        self.buttonMaskEdit.clicked.connect(self.onMaskEdit)
+        self.checkBoxLogSpacedPoints.stateChanged.connect(self.toggleLogData)
         # Button groups
         self.weightingGroup.buttonClicked.connect(self.onWeightingChoice)
 
@@ -98,8 +98,8 @@ class OptionsWidget(QtWidgets.QWidget, Ui_tabOptions):
         self.model.blockSignals(False)
 
         new_font = 'font-family: -apple-system, "Helvetica Neue", "Ubuntu";'
-        self.label_13.setStyleSheet(new_font)
-        self.label_15.setStyleSheet(new_font)
+        self.labelAngstromInvMinRange.setStyleSheet(new_font)
+        self.labelAngstromInvMaxRange.setStyleSheet(new_font)
 
     def initModel(self):
         """
@@ -128,7 +128,7 @@ class OptionsWidget(QtWidgets.QWidget, Ui_tabOptions):
         self.mapper.toFirst()
 
     def setLogScale(self, log_scale):
-        self.chkLogData.setChecked(log_scale)
+        self.checkBoxLogSpacedPoints.setChecked(log_scale)
 
     def toggleLogData(self, isChecked):
         """ Toggles between log and linear data sets """
@@ -206,19 +206,19 @@ class OptionsWidget(QtWidgets.QWidget, Ui_tabOptions):
         """
         is2Ddata = isinstance(self.logic.data, Data2D)
         self.boxWeighting.setEnabled(True)
-        self.cmdMaskEdit.setEnabled(is2Ddata)
+        self.buttonMaskEdit.setEnabled(is2Ddata)
         # Switch off txtNpts related controls
         self.txtNpts.setEnabled(False)
-        self.chkLogData.setEnabled(False)
+        self.checkBoxLogSpacedPoints.setEnabled(False)
         # Weighting controls
         if self.logic.di_flag:
-            self.rbWeighting2.setEnabled(True)
-            self.rbWeighting2.setChecked(True)
-            self.onWeightingChoice(self.rbWeighting2)
+            self.radioButtonWeightingUsedIData.setEnabled(True)
+            self.radioButtonWeightingUsedIData.setChecked(True)
+            self.onWeightingChoice(self.radioButtonWeightingUsedIData)
         else:
-            self.rbWeighting2.setEnabled(False)
-            self.rbWeighting1.setChecked(True)
-            self.onWeightingChoice(self.rbWeighting1)
+            self.radioButtonWeightingUsedIData.setEnabled(False)
+            self.radioButtonWeightingNone.setChecked(True)
+            self.onWeightingChoice(self.radioButtonWeightingNone)
 
     def updateMinQ(self, q_min=None):
         if q_min and (isinstance(q_min, (float, str))):
@@ -257,7 +257,7 @@ class OptionsWidget(QtWidgets.QWidget, Ui_tabOptions):
         q_range_max = float(self.model.item(self.MODEL.index('MAX_RANGE')).text())
         npts = int(self.model.item(self.MODEL.index('NPTS')).text())
         npts_fit = int(self.model.item(self.MODEL.index('NPTS_FIT')).text())
-        log_points = self.chkLogData.isChecked()
+        log_points = self.checkBoxLogSpacedPoints.isChecked()
         return (q_range_min, q_range_max, npts, log_points, self.weighting)
 
     def npts2fit(self, data=None, qmin=None, qmax=None, npts=None):

--- a/src/sas/qtgui/Perspectives/Fitting/OrderWidget.py
+++ b/src/sas/qtgui/Perspectives/Fitting/OrderWidget.py
@@ -23,7 +23,7 @@ class OrderWidget(QtWidgets.QWidget, Ui_OrderWidgetUI):
         Read in new datasets and update the view
         """
         self.all_data = all_data
-        self.lstOrder.clear()
+        self.listDataOrder.clear()
         self.setupTable()
 
     def setupTable(self):
@@ -37,15 +37,15 @@ class OrderWidget(QtWidgets.QWidget, Ui_OrderWidgetUI):
             if dataset is None: continue
             dataset_name = dataset.name
             self.order[dataset_name] = item
-            self.lstOrder.addItem(dataset_name)
+            self.listDataOrder.addItem(dataset_name)
 
     def ordering(self):
         """
         Returns the current ordering of the datasets
         """
         order = []
-        for row in range(self.lstOrder.count()):
-            item_name = self.lstOrder.item(row).text()
+        for row in range(self.listDataOrder.count()):
+            item_name = self.listDataOrder.item(row).text()
             order.append(self.order[item_name])
         return order
 

--- a/src/sas/qtgui/Perspectives/Fitting/OrderWidget.py
+++ b/src/sas/qtgui/Perspectives/Fitting/OrderWidget.py
@@ -23,7 +23,7 @@ class OrderWidget(QtWidgets.QWidget, Ui_OrderWidgetUI):
         Read in new datasets and update the view
         """
         self.all_data = all_data
-        self.listDataOrder.clear()
+        self.lstDataOrder.clear()
         self.setupTable()
 
     def setupTable(self):
@@ -37,15 +37,15 @@ class OrderWidget(QtWidgets.QWidget, Ui_OrderWidgetUI):
             if dataset is None: continue
             dataset_name = dataset.name
             self.order[dataset_name] = item
-            self.listDataOrder.addItem(dataset_name)
+            self.lstDataOrder.addItem(dataset_name)
 
     def ordering(self):
         """
         Returns the current ordering of the datasets
         """
         order = []
-        for row in range(self.listDataOrder.count()):
-            item_name = self.listDataOrder.item(row).text()
+        for row in range(self.lstDataOrder.count()):
+            item_name = self.lstDataOrder.item(row).text()
             order.append(self.order[item_name])
         return order
 

--- a/src/sas/qtgui/Perspectives/Fitting/SmearingWidget.py
+++ b/src/sas/qtgui/Perspectives/Fitting/SmearingWidget.py
@@ -86,8 +86,8 @@ class SmearingWidget(QtWidgets.QWidget, Ui_SmearingWidgetUI):
         self.txt_dQ_low.setValidator(GuiUtils.DoubleValidator())
 
         # Attach slots
-        self.comboBoxInstrumentalSmearing.currentIndexChanged.connect(self.onIndexChange)
-        self.comboBoxInstrumentalSmearing.setCurrentIndex(0)
+        self.cbInstrumentalSmearing.currentIndexChanged.connect(self.onIndexChange)
+        self.cbInstrumentalSmearing.setCurrentIndex(0)
         self.txt_dQ_low.setText(str(DEFAULT_PINHOLE_UP))
         self.txt_dQ_high.setText(str(DEFAULT_PINHOLE_DOWN))
 
@@ -115,7 +115,7 @@ class SmearingWidget(QtWidgets.QWidget, Ui_SmearingWidgetUI):
 
         self.mapper.addMapping(self.txt_dQ_low,   MODEL.index('PINHOLE_MIN'))
         self.mapper.addMapping(self.txt_dQ_high, MODEL.index('PINHOLE_MAX'))
-        self.mapper.addMapping(self.comboBoxAccuracy,   MODEL.index('ACCURACY'))
+        self.mapper.addMapping(self.cbAccuracy,   MODEL.index('ACCURACY'))
 
         self.mapper.toFirst()
 
@@ -124,9 +124,9 @@ class SmearingWidget(QtWidgets.QWidget, Ui_SmearingWidgetUI):
         Update control elements based on data and model passed
         """
         # retain the combobox index
-        old_index = self.comboBoxInstrumentalSmearing.currentIndex()
-        self.comboBoxInstrumentalSmearing.clear()
-        self.comboBoxInstrumentalSmearing.addItem("None")
+        old_index = self.cbInstrumentalSmearing.currentIndex()
+        self.cbInstrumentalSmearing.clear()
+        self.cbInstrumentalSmearing.addItem("None")
         self.groupBoxAccuracy.setVisible(False)
         self.data = data
         if data is None:
@@ -139,14 +139,14 @@ class SmearingWidget(QtWidgets.QWidget, Ui_SmearingWidgetUI):
         Update the model
         """
         self.kernel_model = kernel_model
-        # keep the original comboBoxInstrumentalSmearing value, if already set
-        index_to_show = self.comboBoxInstrumentalSmearing.currentIndex()
+        # keep the original cbInstrumentalSmearing value, if already set
+        index_to_show = self.cbInstrumentalSmearing.currentIndex()
         if old_index is not None:
             index_to_show = old_index
 
-        self.comboBoxInstrumentalSmearing.blockSignals(True)
-        self.comboBoxInstrumentalSmearing.clear()
-        self.comboBoxInstrumentalSmearing.addItem("None")
+        self.cbInstrumentalSmearing.blockSignals(True)
+        self.cbInstrumentalSmearing.clear()
+        self.cbInstrumentalSmearing.addItem("None")
         if self.data is None:
             self.setElementsVisibility(False)
             return
@@ -154,25 +154,25 @@ class SmearingWidget(QtWidgets.QWidget, Ui_SmearingWidgetUI):
         self.current_smearer = smear_selection(self.data, self.kernel_model)
         self.setSmearInfo()
         if self.smear_type == "Hankel Transform":
-            self.comboBoxInstrumentalSmearing.addItem(SMEARING_SESANS)
+            self.cbInstrumentalSmearing.addItem(SMEARING_SESANS)
             index_to_show = 1
         elif self.smear_type is not None:
-            self.comboBoxInstrumentalSmearing.addItem(SMEARING_QD)
+            self.cbInstrumentalSmearing.addItem(SMEARING_QD)
             index_to_show = 1 if keep_order else index_to_show
 
         if self.kernel_model is None:
             # No model definend yet - just use data file smearing, if any
-            self.comboBoxInstrumentalSmearing.blockSignals(False)
-            self.comboBoxInstrumentalSmearing.setCurrentIndex(index_to_show)
+            self.cbInstrumentalSmearing.blockSignals(False)
+            self.cbInstrumentalSmearing.setCurrentIndex(index_to_show)
             return
 
         if isinstance(self.data, Data1D):
-            self.comboBoxInstrumentalSmearing.addItems(SMEARING_1D)
+            self.cbInstrumentalSmearing.addItems(SMEARING_1D)
         else:
-            self.comboBoxInstrumentalSmearing.addItems(SMEARING_2D)
-        self.comboBoxInstrumentalSmearing.blockSignals(False)
+            self.cbInstrumentalSmearing.addItems(SMEARING_2D)
+        self.cbInstrumentalSmearing.blockSignals(False)
 
-        self.comboBoxInstrumentalSmearing.setCurrentIndex(index_to_show)
+        self.cbInstrumentalSmearing.setCurrentIndex(index_to_show)
 
     def smearer(self):
         """ Returns the current smearer """
@@ -182,7 +182,7 @@ class SmearingWidget(QtWidgets.QWidget, Ui_SmearingWidgetUI):
         """
         Callback for smearing combobox index change
         """
-        text = self.comboBoxInstrumentalSmearing.currentText()
+        text = self.cbInstrumentalSmearing.currentText()
         if text == 'None':
             self.setElementsVisibility(False)
             self.current_smearer = None
@@ -200,7 +200,7 @@ class SmearingWidget(QtWidgets.QWidget, Ui_SmearingWidgetUI):
             self.onSlitSmear()
         elif text == "Hankel Transform":
             self.setElementsVisibility(False)
-            self.comboBoxInstrumentalSmearing.setEnabled(False)  # turn off ability to change smearing; no other options for sesans
+            self.cbInstrumentalSmearing.setEnabled(False)  # turn off ability to change smearing; no other options for sesans
         self.smearingChangedSignal.emit()
 
     def onModelChange(self):
@@ -208,7 +208,7 @@ class SmearingWidget(QtWidgets.QWidget, Ui_SmearingWidgetUI):
         Respond to model change by notifying any listeners
         """
         # Recalculate the smearing
-        index = self.comboBoxInstrumentalSmearing.currentIndex()
+        index = self.cbInstrumentalSmearing.currentIndex()
         # update the backup values based on model choice
         smearing, accuracy, d_down, d_up = self.state()
         # don't save the state if dQ Data
@@ -230,19 +230,19 @@ class SmearingWidget(QtWidgets.QWidget, Ui_SmearingWidgetUI):
         """
         Labels and linedits visibility control
         """
-        self.label_Smearing_dQ_high.setVisible(visible)
-        self.label_Smearing_dQ_low.setVisible(visible)
+        self.lbl_Smearing_dQ_high.setVisible(visible)
+        self.lbl_Smearing_dQ_low.setVisible(visible)
         self.txt_dQ_high.setVisible(visible)
         self.txt_dQ_low.setVisible(visible)
-        self.labelInvAngstrom_dQ_low.setVisible(visible)
-        self.labelInvAngstrom_dQ_high.setVisible(visible)
+        self.lblInvAngstrom_dQ_low.setVisible(visible)
+        self.lblInvAngstrom_dQ_high.setVisible(visible)
         self.setAccuracyVisibility()
 
     def setAccuracyVisibility(self):
         """
         Accuracy combobox visibility
         """
-        if isinstance(self.data, Data2D) and self.comboBoxInstrumentalSmearing.currentIndex() >= 1:
+        if isinstance(self.data, Data2D) and self.cbInstrumentalSmearing.currentIndex() >= 1:
             self.groupBoxAccuracy.setVisible(True)
         else:
             self.groupBoxAccuracy.setVisible(False)
@@ -252,10 +252,10 @@ class SmearingWidget(QtWidgets.QWidget, Ui_SmearingWidgetUI):
         Use pinhole labels
         """
         self.txt_dQ_high.setVisible(False)
-        self.label_Smearing_dQ_high.setText('')
-        self.labelInvAngstrom_dQ_high.setText('')
-        self.label_Smearing_dQ_low.setText('<html><head/><body><p>dQ/Q</p></body></html>')
-        self.labelInvAngstrom_dQ_low.setText('%')
+        self.lbl_Smearing_dQ_high.setText('')
+        self.lblInvAngstrom_dQ_high.setText('')
+        self.lbl_Smearing_dQ_low.setText('<html><head/><body><p>dQ/Q</p></body></html>')
+        self.lblInvAngstrom_dQ_low.setText('%')
         self.txt_dQ_low.setText(str(self.pinhole))
 
         self.txt_dQ_high.setEnabled(True)
@@ -265,10 +265,10 @@ class SmearingWidget(QtWidgets.QWidget, Ui_SmearingWidgetUI):
         """
         Use pinhole labels
         """
-        self.label_Smearing_dQ_low.setText('Slit length')
-        self.label_Smearing_dQ_high.setText('Slit width')
-        self.labelInvAngstrom_dQ_low.setText('<html><head/><body><p>Å<span style=" vertical-align:super;">-1</span></p></body></html>')
-        self.labelInvAngstrom_dQ_high.setText('<html><head/><body><p>Å<span style=" vertical-align:super;">-1</span></p></body></html>')
+        self.lbl_Smearing_dQ_low.setText('Slit length')
+        self.lbl_Smearing_dQ_high.setText('Slit width')
+        self.lblInvAngstrom_dQ_low.setText('<html><head/><body><p>Å<span style=" vertical-align:super;">-1</span></p></body></html>')
+        self.lblInvAngstrom_dQ_high.setText('<html><head/><body><p>Å<span style=" vertical-align:super;">-1</span></p></body></html>')
         self.txt_dQ_low.setText(str(self.slit_height))
         self.txt_dQ_high.setText(str(self.slit_width))
         self.txt_dQ_high.setEnabled(True)
@@ -291,11 +291,11 @@ class SmearingWidget(QtWidgets.QWidget, Ui_SmearingWidgetUI):
             text_up = '<html><head/><body><p>&lsaquo;dQ/Q&rsaquo;<span style=" vertical-align:sub;">r</span></p></body></html>'
             text_down = '<html><head/><body><p>&lsaquo;dQ/Q&rsaquo;<span style=" vertical-align:sub;">&phi;</span></p></body></html>'
 
-        self.label_Smearing_dQ_high.setText(text_down)
-        self.label_Smearing_dQ_low.setText(text_up)
+        self.lbl_Smearing_dQ_high.setText(text_down)
+        self.lbl_Smearing_dQ_low.setText(text_up)
 
-        self.labelInvAngstrom_dQ_low.setText(text_unit)
-        self.labelInvAngstrom_dQ_high.setText(text_unit)
+        self.lblInvAngstrom_dQ_low.setText(text_unit)
+        self.lblInvAngstrom_dQ_high.setText(text_unit)
 
         self.txt_dQ_high.setText(str(self.dq_r))
         self.txt_dQ_low.setText(str(self.dq_l))
@@ -306,7 +306,7 @@ class SmearingWidget(QtWidgets.QWidget, Ui_SmearingWidgetUI):
         """
         Returns current state of controls
         """
-        smearing = self.comboBoxInstrumentalSmearing.currentText()
+        smearing = self.cbInstrumentalSmearing.currentText()
         accuracy = ""
         d_down = None
         d_up = None
@@ -498,6 +498,6 @@ class SmearingWidget(QtWidgets.QWidget, Ui_SmearingWidgetUI):
 
     def resetSmearer(self):
         self.current_smearer = None
-        self.comboBoxInstrumentalSmearing.blockSignals(True)
-        self.comboBoxInstrumentalSmearing.clear()
-        self.comboBoxInstrumentalSmearing.blockSignals(False)
+        self.cbInstrumentalSmearing.blockSignals(True)
+        self.cbInstrumentalSmearing.clear()
+        self.cbInstrumentalSmearing.blockSignals(False)

--- a/src/sas/qtgui/Perspectives/Fitting/SmearingWidget.py
+++ b/src/sas/qtgui/Perspectives/Fitting/SmearingWidget.py
@@ -82,14 +82,14 @@ class SmearingWidget(QtWidgets.QWidget, Ui_SmearingWidgetUI):
         self.accuracy = ""
 
         # Let only floats in the line edits
-        self.txtSmearDown.setValidator(GuiUtils.DoubleValidator())
-        self.txtSmearUp.setValidator(GuiUtils.DoubleValidator())
+        self.txt_dQ_high.setValidator(GuiUtils.DoubleValidator())
+        self.txt_dQ_low.setValidator(GuiUtils.DoubleValidator())
 
         # Attach slots
-        self.cbSmearing.currentIndexChanged.connect(self.onIndexChange)
-        self.cbSmearing.setCurrentIndex(0)
-        self.txtSmearUp.setText(str(DEFAULT_PINHOLE_UP))
-        self.txtSmearDown.setText(str(DEFAULT_PINHOLE_DOWN))
+        self.comboBoxInstrumentalSmearing.currentIndexChanged.connect(self.onIndexChange)
+        self.comboBoxInstrumentalSmearing.setCurrentIndex(0)
+        self.txt_dQ_low.setText(str(DEFAULT_PINHOLE_UP))
+        self.txt_dQ_high.setText(str(DEFAULT_PINHOLE_DOWN))
 
         self.initModel()
         self.initMapper()
@@ -113,9 +113,9 @@ class SmearingWidget(QtWidgets.QWidget, Ui_SmearingWidgetUI):
         self.mapper.setModel(self.model)
         self.mapper.setOrientation(QtCore.Qt.Vertical)
 
-        self.mapper.addMapping(self.txtSmearUp,   MODEL.index('PINHOLE_MIN'))
-        self.mapper.addMapping(self.txtSmearDown, MODEL.index('PINHOLE_MAX'))
-        self.mapper.addMapping(self.cbAccuracy,   MODEL.index('ACCURACY'))
+        self.mapper.addMapping(self.txt_dQ_low,   MODEL.index('PINHOLE_MIN'))
+        self.mapper.addMapping(self.txt_dQ_high, MODEL.index('PINHOLE_MAX'))
+        self.mapper.addMapping(self.comboBoxAccuracy,   MODEL.index('ACCURACY'))
 
         self.mapper.toFirst()
 
@@ -124,10 +124,10 @@ class SmearingWidget(QtWidgets.QWidget, Ui_SmearingWidgetUI):
         Update control elements based on data and model passed
         """
         # retain the combobox index
-        old_index = self.cbSmearing.currentIndex()
-        self.cbSmearing.clear()
-        self.cbSmearing.addItem("None")
-        self.gAccuracy.setVisible(False)
+        old_index = self.comboBoxInstrumentalSmearing.currentIndex()
+        self.comboBoxInstrumentalSmearing.clear()
+        self.comboBoxInstrumentalSmearing.addItem("None")
+        self.groupBoxAccuracy.setVisible(False)
         self.data = data
         if data is None:
             self.setElementsVisibility(False)
@@ -139,14 +139,14 @@ class SmearingWidget(QtWidgets.QWidget, Ui_SmearingWidgetUI):
         Update the model
         """
         self.kernel_model = kernel_model
-        # keep the original cbSmearing value, if already set
-        index_to_show = self.cbSmearing.currentIndex()
+        # keep the original comboBoxInstrumentalSmearing value, if already set
+        index_to_show = self.comboBoxInstrumentalSmearing.currentIndex()
         if old_index is not None:
             index_to_show = old_index
 
-        self.cbSmearing.blockSignals(True)
-        self.cbSmearing.clear()
-        self.cbSmearing.addItem("None")
+        self.comboBoxInstrumentalSmearing.blockSignals(True)
+        self.comboBoxInstrumentalSmearing.clear()
+        self.comboBoxInstrumentalSmearing.addItem("None")
         if self.data is None:
             self.setElementsVisibility(False)
             return
@@ -154,25 +154,25 @@ class SmearingWidget(QtWidgets.QWidget, Ui_SmearingWidgetUI):
         self.current_smearer = smear_selection(self.data, self.kernel_model)
         self.setSmearInfo()
         if self.smear_type == "Hankel Transform":
-            self.cbSmearing.addItem(SMEARING_SESANS)
+            self.comboBoxInstrumentalSmearing.addItem(SMEARING_SESANS)
             index_to_show = 1
         elif self.smear_type is not None:
-            self.cbSmearing.addItem(SMEARING_QD)
+            self.comboBoxInstrumentalSmearing.addItem(SMEARING_QD)
             index_to_show = 1 if keep_order else index_to_show
 
         if self.kernel_model is None:
             # No model definend yet - just use data file smearing, if any
-            self.cbSmearing.blockSignals(False)
-            self.cbSmearing.setCurrentIndex(index_to_show)
+            self.comboBoxInstrumentalSmearing.blockSignals(False)
+            self.comboBoxInstrumentalSmearing.setCurrentIndex(index_to_show)
             return
 
         if isinstance(self.data, Data1D):
-            self.cbSmearing.addItems(SMEARING_1D)
+            self.comboBoxInstrumentalSmearing.addItems(SMEARING_1D)
         else:
-            self.cbSmearing.addItems(SMEARING_2D)
-        self.cbSmearing.blockSignals(False)
+            self.comboBoxInstrumentalSmearing.addItems(SMEARING_2D)
+        self.comboBoxInstrumentalSmearing.blockSignals(False)
 
-        self.cbSmearing.setCurrentIndex(index_to_show)
+        self.comboBoxInstrumentalSmearing.setCurrentIndex(index_to_show)
 
     def smearer(self):
         """ Returns the current smearer """
@@ -182,7 +182,7 @@ class SmearingWidget(QtWidgets.QWidget, Ui_SmearingWidgetUI):
         """
         Callback for smearing combobox index change
         """
-        text = self.cbSmearing.currentText()
+        text = self.comboBoxInstrumentalSmearing.currentText()
         if text == 'None':
             self.setElementsVisibility(False)
             self.current_smearer = None
@@ -200,7 +200,7 @@ class SmearingWidget(QtWidgets.QWidget, Ui_SmearingWidgetUI):
             self.onSlitSmear()
         elif text == "Hankel Transform":
             self.setElementsVisibility(False)
-            self.cbSmearing.setEnabled(False)  # turn off ability to change smearing; no other options for sesans
+            self.comboBoxInstrumentalSmearing.setEnabled(False)  # turn off ability to change smearing; no other options for sesans
         self.smearingChangedSignal.emit()
 
     def onModelChange(self):
@@ -208,7 +208,7 @@ class SmearingWidget(QtWidgets.QWidget, Ui_SmearingWidgetUI):
         Respond to model change by notifying any listeners
         """
         # Recalculate the smearing
-        index = self.cbSmearing.currentIndex()
+        index = self.comboBoxInstrumentalSmearing.currentIndex()
         # update the backup values based on model choice
         smearing, accuracy, d_down, d_up = self.state()
         # don't save the state if dQ Data
@@ -230,49 +230,49 @@ class SmearingWidget(QtWidgets.QWidget, Ui_SmearingWidgetUI):
         """
         Labels and linedits visibility control
         """
-        self.lblSmearDown.setVisible(visible)
-        self.lblSmearUp.setVisible(visible)
-        self.txtSmearDown.setVisible(visible)
-        self.txtSmearUp.setVisible(visible)
-        self.lblUnitUp.setVisible(visible)
-        self.lblUnitDown.setVisible(visible)
+        self.label_Smearing_dQ_high.setVisible(visible)
+        self.label_Smearing_dQ_low.setVisible(visible)
+        self.txt_dQ_high.setVisible(visible)
+        self.txt_dQ_low.setVisible(visible)
+        self.labelInvAngstrom_dQ_low.setVisible(visible)
+        self.labelInvAngstrom_dQ_high.setVisible(visible)
         self.setAccuracyVisibility()
 
     def setAccuracyVisibility(self):
         """
         Accuracy combobox visibility
         """
-        if isinstance(self.data, Data2D) and self.cbSmearing.currentIndex() >= 1:
-            self.gAccuracy.setVisible(True)
+        if isinstance(self.data, Data2D) and self.comboBoxInstrumentalSmearing.currentIndex() >= 1:
+            self.groupBoxAccuracy.setVisible(True)
         else:
-            self.gAccuracy.setVisible(False)
+            self.groupBoxAccuracy.setVisible(False)
 
     def setPinholeLabels(self):
         """
         Use pinhole labels
         """
-        self.txtSmearDown.setVisible(False)
-        self.lblSmearDown.setText('')
-        self.lblUnitDown.setText('')
-        self.lblSmearUp.setText('<html><head/><body><p>dQ/Q</p></body></html>')
-        self.lblUnitUp.setText('%')
-        self.txtSmearUp.setText(str(self.pinhole))
+        self.txt_dQ_high.setVisible(False)
+        self.label_Smearing_dQ_high.setText('')
+        self.labelInvAngstrom_dQ_high.setText('')
+        self.label_Smearing_dQ_low.setText('<html><head/><body><p>dQ/Q</p></body></html>')
+        self.labelInvAngstrom_dQ_low.setText('%')
+        self.txt_dQ_low.setText(str(self.pinhole))
 
-        self.txtSmearDown.setEnabled(True)
-        self.txtSmearUp.setEnabled(True)
+        self.txt_dQ_high.setEnabled(True)
+        self.txt_dQ_low.setEnabled(True)
 
     def setSlitLabels(self):
         """
         Use pinhole labels
         """
-        self.lblSmearUp.setText('Slit length')
-        self.lblSmearDown.setText('Slit width')
-        self.lblUnitUp.setText('<html><head/><body><p>Å<span style=" vertical-align:super;">-1</span></p></body></html>')
-        self.lblUnitDown.setText('<html><head/><body><p>Å<span style=" vertical-align:super;">-1</span></p></body></html>')
-        self.txtSmearUp.setText(str(self.slit_height))
-        self.txtSmearDown.setText(str(self.slit_width))
-        self.txtSmearDown.setEnabled(True)
-        self.txtSmearUp.setEnabled(True)
+        self.label_Smearing_dQ_low.setText('Slit length')
+        self.label_Smearing_dQ_high.setText('Slit width')
+        self.labelInvAngstrom_dQ_low.setText('<html><head/><body><p>Å<span style=" vertical-align:super;">-1</span></p></body></html>')
+        self.labelInvAngstrom_dQ_high.setText('<html><head/><body><p>Å<span style=" vertical-align:super;">-1</span></p></body></html>')
+        self.txt_dQ_low.setText(str(self.slit_height))
+        self.txt_dQ_high.setText(str(self.slit_width))
+        self.txt_dQ_high.setEnabled(True)
+        self.txt_dQ_low.setEnabled(True)
 
     def setDQLabels(self):
         """
@@ -291,33 +291,33 @@ class SmearingWidget(QtWidgets.QWidget, Ui_SmearingWidgetUI):
             text_up = '<html><head/><body><p>&lsaquo;dQ/Q&rsaquo;<span style=" vertical-align:sub;">r</span></p></body></html>'
             text_down = '<html><head/><body><p>&lsaquo;dQ/Q&rsaquo;<span style=" vertical-align:sub;">&phi;</span></p></body></html>'
 
-        self.lblSmearDown.setText(text_down)
-        self.lblSmearUp.setText(text_up)
+        self.label_Smearing_dQ_high.setText(text_down)
+        self.label_Smearing_dQ_low.setText(text_up)
 
-        self.lblUnitUp.setText(text_unit)
-        self.lblUnitDown.setText(text_unit)
+        self.labelInvAngstrom_dQ_low.setText(text_unit)
+        self.labelInvAngstrom_dQ_high.setText(text_unit)
 
-        self.txtSmearDown.setText(str(self.dq_r))
-        self.txtSmearUp.setText(str(self.dq_l))
-        self.txtSmearDown.setEnabled(False)
-        self.txtSmearUp.setEnabled(False)
+        self.txt_dQ_high.setText(str(self.dq_r))
+        self.txt_dQ_low.setText(str(self.dq_l))
+        self.txt_dQ_high.setEnabled(False)
+        self.txt_dQ_low.setEnabled(False)
 
     def state(self):
         """
         Returns current state of controls
         """
-        smearing = self.cbSmearing.currentText()
+        smearing = self.comboBoxInstrumentalSmearing.currentText()
         accuracy = ""
         d_down = None
         d_up = None
         if smearing != "None":
             accuracy = str(self.model.item(MODEL.index('ACCURACY')).text())
             try:
-                d_down = float(self.txtSmearDown.text())
+                d_down = float(self.txt_dQ_high.text())
             except ValueError:
                 d_down = 0.0
             try:
-                d_up = float(self.txtSmearUp.text())
+                d_up = float(self.txt_dQ_low.text())
             except ValueError:
                 d_up = 0.0
 
@@ -498,6 +498,6 @@ class SmearingWidget(QtWidgets.QWidget, Ui_SmearingWidgetUI):
 
     def resetSmearer(self):
         self.current_smearer = None
-        self.cbSmearing.blockSignals(True)
-        self.cbSmearing.clear()
-        self.cbSmearing.blockSignals(False)
+        self.comboBoxInstrumentalSmearing.blockSignals(True)
+        self.comboBoxInstrumentalSmearing.clear()
+        self.comboBoxInstrumentalSmearing.blockSignals(False)

--- a/src/sas/qtgui/Perspectives/Fitting/UI/ComplexConstraintUI.ui
+++ b/src/sas/qtgui/Perspectives/Fitting/UI/ComplexConstraintUI.ui
@@ -23,10 +23,10 @@
       <item row="0" column="0">
        <layout class="QHBoxLayout" name="horizontalLayout2ParameterConstraint">
         <item>
-         <widget class="QComboBox" name="comboboxModel1"/>
+         <widget class="QComboBox" name="cbModel1"/>
         </item>
         <item>
-         <widget class="QComboBox" name="comboboxParam1">
+         <widget class="QComboBox" name="cbParam1">
           <property name="sizePolicy">
            <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
             <horstretch>0</horstretch>
@@ -44,7 +44,7 @@
          </widget>
         </item>
         <item>
-         <widget class="QComboBox" name="comboboxOperator">
+         <widget class="QComboBox" name="cbOperator">
           <item>
            <property name="text">
             <string>&gt;</string>
@@ -53,10 +53,10 @@
          </widget>
         </item>
         <item>
-         <widget class="QComboBox" name="comboboxModel2"/>
+         <widget class="QComboBox" name="cbModel2"/>
         </item>
         <item>
-         <widget class="QComboBox" name="comboboxParam2">
+         <widget class="QComboBox" name="cbParam2">
           <property name="sizePolicy">
            <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
             <horstretch>0</horstretch>
@@ -76,7 +76,7 @@
        </layout>
       </item>
       <item row="1" column="0">
-       <widget class="QLabel" name="labelEditComplexConstraint">
+       <widget class="QLabel" name="lblEditComplexConstraint">
         <property name="text">
          <string>Edit complex constraint:</string>
         </property>
@@ -98,14 +98,14 @@
          </widget>
         </item>
         <item>
-         <widget class="QLabel" name="labelOperatorComplexConstraint">
+         <widget class="QLabel" name="lblOperatorComplexConstraint">
           <property name="text">
            <string>=</string>
           </property>
          </widget>
         </item>
         <item>
-         <widget class="QLineEdit" name="textComplexConstraint">
+         <widget class="QLineEdit" name="txtComplexConstraint">
           <property name="text">
            <string/>
           </property>
@@ -152,7 +152,7 @@
       </spacer>
      </item>
      <item>
-      <widget class="QToolButton" name="buttonAddAll">
+      <widget class="QToolButton" name="cmdAddAll">
        <property name="sizePolicy">
         <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
          <horstretch>0</horstretch>
@@ -186,7 +186,7 @@
       </widget>
      </item>
      <item>
-      <widget class="QToolButton" name="buttonOK">
+      <widget class="QToolButton" name="cmdOK">
        <property name="sizePolicy">
         <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
          <horstretch>0</horstretch>
@@ -220,7 +220,7 @@
       </widget>
      </item>
      <item>
-      <widget class="QPushButton" name="buttonHelp">
+      <widget class="QPushButton" name="cmdHelp">
        <property name="text">
         <string>Help</string>
        </property>

--- a/src/sas/qtgui/Perspectives/Fitting/UI/ComplexConstraintUI.ui
+++ b/src/sas/qtgui/Perspectives/Fitting/UI/ComplexConstraintUI.ui
@@ -15,18 +15,18 @@
   </property>
   <layout class="QGridLayout" name="gridLayout_2">
    <item row="0" column="0">
-    <widget class="QGroupBox" name="groupBox">
+    <widget class="QGroupBox" name="groupBox2ParameterConstraint">
      <property name="title">
       <string>2 parameter constraint</string>
      </property>
      <layout class="QGridLayout" name="gridLayout">
       <item row="0" column="0">
-       <layout class="QHBoxLayout" name="horizontalLayout">
+       <layout class="QHBoxLayout" name="horizontalLayout2ParameterConstraint">
         <item>
-         <widget class="QComboBox" name="cbModel1"/>
+         <widget class="QComboBox" name="comboboxModel1"/>
         </item>
         <item>
-         <widget class="QComboBox" name="cbParam1">
+         <widget class="QComboBox" name="comboboxParam1">
           <property name="sizePolicy">
            <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
             <horstretch>0</horstretch>
@@ -44,7 +44,7 @@
          </widget>
         </item>
         <item>
-         <widget class="QComboBox" name="cbOperator">
+         <widget class="QComboBox" name="comboboxOperator">
           <item>
            <property name="text">
             <string>&gt;</string>
@@ -53,10 +53,10 @@
          </widget>
         </item>
         <item>
-         <widget class="QComboBox" name="cbModel2"/>
+         <widget class="QComboBox" name="comboboxModel2"/>
         </item>
         <item>
-         <widget class="QComboBox" name="cbParam2">
+         <widget class="QComboBox" name="comboboxParam2">
           <property name="sizePolicy">
            <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
             <horstretch>0</horstretch>
@@ -76,16 +76,16 @@
        </layout>
       </item>
       <item row="1" column="0">
-       <widget class="QLabel" name="label">
+       <widget class="QLabel" name="labelEditComplexConstraint">
         <property name="text">
          <string>Edit complex constraint:</string>
         </property>
        </widget>
       </item>
       <item row="2" column="0">
-       <layout class="QHBoxLayout" name="horizontalLayout_2">
+       <layout class="QHBoxLayout" name="horizontalLayout_EditComplexConstraint">
         <item>
-         <widget class="QLabel" name="txtParam">
+         <widget class="QLabel" name="textParamComplexConstraint">
           <property name="sizePolicy">
            <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
             <horstretch>0</horstretch>
@@ -98,14 +98,14 @@
          </widget>
         </item>
         <item>
-         <widget class="QLabel" name="txtOperator">
+         <widget class="QLabel" name="labelOperatorComplexConstraint">
           <property name="text">
            <string>=</string>
           </property>
          </widget>
         </item>
         <item>
-         <widget class="QLineEdit" name="txtConstraint">
+         <widget class="QLineEdit" name="textComplexConstraint">
           <property name="text">
            <string/>
           </property>
@@ -137,7 +137,7 @@
     </spacer>
    </item>
    <item row="3" column="0">
-    <layout class="QHBoxLayout" name="horizontalLayout_3">
+    <layout class="QHBoxLayout" name="horizontalLayout_bottom">
      <item>
       <spacer name="horizontalSpacer_2">
        <property name="orientation">
@@ -152,7 +152,7 @@
       </spacer>
      </item>
      <item>
-      <widget class="QToolButton" name="cmdAddAll">
+      <widget class="QToolButton" name="buttonAddAll">
        <property name="sizePolicy">
         <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
          <horstretch>0</horstretch>
@@ -186,7 +186,7 @@
       </widget>
      </item>
      <item>
-      <widget class="QToolButton" name="cmdOK">
+      <widget class="QToolButton" name="buttonOK">
        <property name="sizePolicy">
         <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
          <horstretch>0</horstretch>
@@ -220,7 +220,7 @@
       </widget>
      </item>
      <item>
-      <widget class="QPushButton" name="cmdHelp">
+      <widget class="QPushButton" name="buttonHelp">
        <property name="text">
         <string>Help</string>
        </property>

--- a/src/sas/qtgui/Perspectives/Fitting/UI/ConstraintWidgetUI.ui
+++ b/src/sas/qtgui/Perspectives/Fitting/UI/ConstraintWidgetUI.ui
@@ -40,14 +40,14 @@
          </widget>
         </item>
         <item row="0" column="2">
-         <widget class="QCheckBox" name="cbWeight">
+         <widget class="QCheckBox" name="chkWeight">
           <property name="text">
            <string>Modify weighting</string>
           </property>
          </widget>
         </item>
         <item row="0" column="3">
-         <widget class="QCheckBox" name="cbChainedFit">
+         <widget class="QCheckBox" name="chkChainedFit">
           <property name="text">
            <string>Chained fit</string>
           </property>
@@ -214,8 +214,8 @@
  <tabstops>
   <tabstop>rbSingleFits</tabstop>
   <tabstop>rbBatchFits</tabstop>
-  <tabstop>cbWeight</tabstop>
-  <tabstop>cbChainedFit</tabstop>
+  <tabstop>chkWeight</tabstop>
+  <tabstop>chkChainedFit</tabstop>
   <tabstop>cbSpecialCases</tabstop>
   <tabstop>cmdAddConstraints</tabstop>
   <tabstop>tblConstraints</tabstop>

--- a/src/sas/qtgui/Perspectives/Fitting/UI/ConstraintWidgetUI.ui
+++ b/src/sas/qtgui/Perspectives/Fitting/UI/ConstraintWidgetUI.ui
@@ -15,15 +15,15 @@
   </property>
   <layout class="QGridLayout" name="gridLayout_4">
    <item row="0" column="0">
-    <widget class="QGroupBox" name="groupBox">
+    <widget class="QGroupBox" name="groupBoxSourceChoice">
      <property name="title">
       <string>Source choice for simultaneous fitting</string>
      </property>
      <layout class="QGridLayout" name="gridLayout_3">
       <item row="0" column="0">
-       <layout class="QGridLayout" name="gridLayout_2">
+       <layout class="QGridLayout" name="gridLayout_SourceChoice">
         <item row="0" column="0">
-         <widget class="QRadioButton" name="btnSingle">
+         <widget class="QRadioButton" name="radioButtonSingle">
           <property name="text">
            <string>Single fits</string>
           </property>
@@ -33,21 +33,21 @@
          </widget>
         </item>
         <item row="0" column="1">
-         <widget class="QRadioButton" name="btnBatch">
+         <widget class="QRadioButton" name="radioButtonBatch">
           <property name="text">
            <string>Batch fits</string>
           </property>
          </widget>
         </item>
         <item row="0" column="2">
-         <widget class="QCheckBox" name="chkWeight">
+         <widget class="QCheckBox" name="checkBoxWeight">
           <property name="text">
            <string>Modify weighting</string>
           </property>
          </widget>
         </item>
         <item row="0" column="3">
-         <widget class="QCheckBox" name="chkChain">
+         <widget class="QCheckBox" name="checkBoxChainedFit">
           <property name="text">
            <string>Chained fit</string>
           </property>
@@ -75,24 +75,24 @@
     </widget>
    </item>
    <item row="1" column="0">
-    <widget class="QGroupBox" name="groupBox_2">
+    <widget class="QGroupBox" name="groupBox_Constraints">
      <property name="title">
       <string>Constraints</string>
      </property>
      <layout class="QGridLayout" name="gridLayout">
       <item row="0" column="0">
-       <layout class="QHBoxLayout" name="horizontalLayout_4">
+       <layout class="QHBoxLayout" name="horizontalLayout_SpecialCases">
         <item>
-         <layout class="QHBoxLayout" name="horizontalLayout">
+         <layout class="QHBoxLayout" name="horizontalLayoutSpecialCases">
           <item>
-           <widget class="QLabel" name="label">
+           <widget class="QLabel" name="labelSpecialCases">
             <property name="text">
              <string>Special cases</string>
             </property>
            </widget>
           </item>
           <item>
-           <widget class="QComboBox" name="cbCases">
+           <widget class="QComboBox" name="comboboxSpecialCases">
             <item>
              <property name="text">
               <string>None</string>
@@ -116,7 +116,7 @@
          </spacer>
         </item>
         <item>
-         <widget class="QPushButton" name="cmdAdd">
+         <widget class="QPushButton" name="buttonAddConstraints">
           <property name="toolTip">
            <string>Define constraints between two fit pages.</string>
           </property>
@@ -149,7 +149,7 @@
     </widget>
    </item>
    <item row="2" column="0">
-    <layout class="QHBoxLayout" name="horizontalLayout_3">
+    <layout class="QHBoxLayout" name="horizontalLayout_bottom">
      <item>
       <spacer name="horizontalSpacer_2">
        <property name="orientation">
@@ -164,7 +164,7 @@
       </spacer>
      </item>
      <item>
-      <widget class="QPushButton" name="cmdFit">
+      <widget class="QPushButton" name="buttonFit">
        <property name="sizePolicy">
         <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
          <horstretch>0</horstretch>
@@ -186,7 +186,7 @@
       </widget>
      </item>
      <item>
-      <widget class="QPushButton" name="cmdHelp">
+      <widget class="QPushButton" name="buttonHelp">
        <property name="sizePolicy">
         <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
          <horstretch>0</horstretch>
@@ -212,15 +212,15 @@
   </layout>
  </widget>
  <tabstops>
-  <tabstop>btnSingle</tabstop>
-  <tabstop>btnBatch</tabstop>
-  <tabstop>chkWeight</tabstop>
-  <tabstop>chkChain</tabstop>
-  <tabstop>cbCases</tabstop>
-  <tabstop>cmdAdd</tabstop>
+  <tabstop>radioButtonSingle</tabstop>
+  <tabstop>radioButtonBatch</tabstop>
+  <tabstop>checkBoxWeight</tabstop>
+  <tabstop>checkBoxChainedFit</tabstop>
+  <tabstop>comboboxSpecialCases</tabstop>
+  <tabstop>buttonAddConstraints</tabstop>
   <tabstop>tblConstraints</tabstop>
-  <tabstop>cmdFit</tabstop>
-  <tabstop>cmdHelp</tabstop>
+  <tabstop>buttonFit</tabstop>
+  <tabstop>buttonHelp</tabstop>
  </tabstops>
  <resources/>
  <connections/>

--- a/src/sas/qtgui/Perspectives/Fitting/UI/ConstraintWidgetUI.ui
+++ b/src/sas/qtgui/Perspectives/Fitting/UI/ConstraintWidgetUI.ui
@@ -23,7 +23,7 @@
       <item row="0" column="0">
        <layout class="QGridLayout" name="gridLayout_SourceChoice">
         <item row="0" column="0">
-         <widget class="QRadioButton" name="radioButtonSingle">
+         <widget class="QRadioButton" name="rbSingleFits">
           <property name="text">
            <string>Single fits</string>
           </property>
@@ -33,21 +33,21 @@
          </widget>
         </item>
         <item row="0" column="1">
-         <widget class="QRadioButton" name="radioButtonBatch">
+         <widget class="QRadioButton" name="rbBatchFits">
           <property name="text">
            <string>Batch fits</string>
           </property>
          </widget>
         </item>
         <item row="0" column="2">
-         <widget class="QCheckBox" name="checkBoxWeight">
+         <widget class="QCheckBox" name="cbWeight">
           <property name="text">
            <string>Modify weighting</string>
           </property>
          </widget>
         </item>
         <item row="0" column="3">
-         <widget class="QCheckBox" name="checkBoxChainedFit">
+         <widget class="QCheckBox" name="cbChainedFit">
           <property name="text">
            <string>Chained fit</string>
           </property>
@@ -85,14 +85,14 @@
         <item>
          <layout class="QHBoxLayout" name="horizontalLayoutSpecialCases">
           <item>
-           <widget class="QLabel" name="labelSpecialCases">
+           <widget class="QLabel" name="lblSpecialCases">
             <property name="text">
              <string>Special cases</string>
             </property>
            </widget>
           </item>
           <item>
-           <widget class="QComboBox" name="comboboxSpecialCases">
+           <widget class="QComboBox" name="cbSpecialCases">
             <item>
              <property name="text">
               <string>None</string>
@@ -116,7 +116,7 @@
          </spacer>
         </item>
         <item>
-         <widget class="QPushButton" name="buttonAddConstraints">
+         <widget class="QPushButton" name="cmdAddConstraints">
           <property name="toolTip">
            <string>Define constraints between two fit pages.</string>
           </property>
@@ -164,7 +164,7 @@
       </spacer>
      </item>
      <item>
-      <widget class="QPushButton" name="buttonFit">
+      <widget class="QPushButton" name="cmdFit">
        <property name="sizePolicy">
         <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
          <horstretch>0</horstretch>
@@ -186,7 +186,7 @@
       </widget>
      </item>
      <item>
-      <widget class="QPushButton" name="buttonHelp">
+      <widget class="QPushButton" name="cmdHelp">
        <property name="sizePolicy">
         <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
          <horstretch>0</horstretch>
@@ -212,15 +212,15 @@
   </layout>
  </widget>
  <tabstops>
-  <tabstop>radioButtonSingle</tabstop>
-  <tabstop>radioButtonBatch</tabstop>
-  <tabstop>checkBoxWeight</tabstop>
-  <tabstop>checkBoxChainedFit</tabstop>
-  <tabstop>comboboxSpecialCases</tabstop>
-  <tabstop>buttonAddConstraints</tabstop>
+  <tabstop>rbSingleFits</tabstop>
+  <tabstop>rbBatchFits</tabstop>
+  <tabstop>cbWeight</tabstop>
+  <tabstop>cbChainedFit</tabstop>
+  <tabstop>cbSpecialCases</tabstop>
+  <tabstop>cmdAddConstraints</tabstop>
   <tabstop>tblConstraints</tabstop>
-  <tabstop>buttonFit</tabstop>
-  <tabstop>buttonHelp</tabstop>
+  <tabstop>cmdFit</tabstop>
+  <tabstop>cmdHelp</tabstop>
  </tabstops>
  <resources/>
  <connections/>

--- a/src/sas/qtgui/Perspectives/Fitting/UI/FittingOptionsUI.ui
+++ b/src/sas/qtgui/Perspectives/Fitting/UI/FittingOptionsUI.ui
@@ -50,7 +50,7 @@
        <enum>QFrame::NoFrame</enum>
       </property>
       <property name="currentIndex">
-       <number>2</number>
+       <number>4</number>
       </property>
       <widget class="QWidget" name="page_dream">
        <layout class="QGridLayout" name="gridLayout_2">
@@ -67,21 +67,21 @@
           </property>
           <layout class="QGridLayout" name="gridLayout">
            <item row="0" column="0">
-            <widget class="QLabel" name="label_samples_dream">
+            <widget class="QLabel" name="lbl_samples_dream">
              <property name="text">
               <string>Samples:</string>
              </property>
             </widget>
            </item>
            <item row="2" column="0">
-            <widget class="QLabel" name="label_population_dream">
+            <widget class="QLabel" name="lbl_population_dream">
              <property name="text">
               <string>Population:</string>
              </property>
             </widget>
            </item>
            <item row="3" column="1">
-            <widget class="QComboBox" name="combobox_initializer_dream">
+            <widget class="QComboBox" name="cb_initializer_dream">
              <property name="toolTip">
               <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-style:italic;&quot;&gt;Initializer&lt;/span&gt; determines how the population will be initialized. The options are as follows:&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-style:italic;&quot;&gt;eps&lt;/span&gt; (epsilon ball), in which the entire initial population is chosen at random from within a tiny hypersphere centered about the initial point&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-style:italic;&quot;&gt;lhs&lt;/span&gt; (latin hypersquare), which chops the bounds within each dimension in &lt;span style=&quot; font-weight:600;&quot;&gt;k&lt;/span&gt; equal sized chunks where &lt;span style=&quot; font-weight:600;&quot;&gt;k&lt;/span&gt; is the size of the population and makes sure that each parameter has at least one value within each chunk across the population.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-style:italic;&quot;&gt;cov&lt;/span&gt; (covariance matrix), in which the uncertainty is estimated using the covariance matrix at the initial point, and points are selected at random from the corresponding gaussian ellipsoid&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-style:italic;&quot;&gt;random&lt;/span&gt; (uniform random), in which the points are selected at random within the bounds of the parameters&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
              </property>
@@ -115,14 +115,14 @@
             </widget>
            </item>
            <item row="4" column="0">
-            <widget class="QLabel" name="label_thinning_dream">
+            <widget class="QLabel" name="lbl_thinning_dream">
              <property name="text">
               <string>Thinning:</string>
              </property>
             </widget>
            </item>
            <item row="3" column="0">
-            <widget class="QLabel" name="label_initializer_dream">
+            <widget class="QLabel" name="lbl_initializer_dream">
              <property name="text">
               <string>Initializer:</string>
              </property>
@@ -136,14 +136,14 @@
             </widget>
            </item>
            <item row="5" column="0">
-            <widget class="QLabel" name="label_steps_dream">
+            <widget class="QLabel" name="lbl_steps_dream">
              <property name="text">
               <string>Steps:</string>
              </property>
             </widget>
            </item>
            <item row="1" column="0">
-            <widget class="QLabel" name="label_burn_in_steps_dream">
+            <widget class="QLabel" name="lbl_burn_in_steps_dream">
              <property name="text">
               <string>Burn-in Steps:</string>
              </property>
@@ -184,7 +184,7 @@
           </property>
           <layout class="QGridLayout" name="gridLayout_3">
            <item row="0" column="0">
-            <widget class="QLabel" name="label_steps_lm">
+            <widget class="QLabel" name="lbl_steps_lm">
              <property name="text">
               <string>Steps:</string>
              </property>
@@ -198,7 +198,7 @@
             </widget>
            </item>
            <item row="1" column="0">
-            <widget class="QLabel" name="label_f_x_tolerance_lm">
+            <widget class="QLabel" name="lbl_f_x_tolerance_lm">
              <property name="text">
               <string>f(x) tolerance:</string>
              </property>
@@ -212,7 +212,7 @@
             </widget>
            </item>
            <item row="2" column="0">
-            <widget class="QLabel" name="label_x_tolerance_lm">
+            <widget class="QLabel" name="lbl_x_tolerance_lm">
              <property name="text">
               <string>x tolerance:</string>
              </property>
@@ -252,7 +252,7 @@
           </property>
           <layout class="QGridLayout" name="gridLayout_5">
            <item row="0" column="0">
-            <widget class="QLabel" name="label_steps_newton">
+            <widget class="QLabel" name="lbl_steps_newton">
              <property name="text">
               <string>Steps:</string>
              </property>
@@ -266,7 +266,7 @@
             </widget>
            </item>
            <item row="1" column="0">
-            <widget class="QLabel" name="label_starts_newton">
+            <widget class="QLabel" name="lbl_starts_newton">
              <property name="text">
               <string>Starts:</string>
              </property>
@@ -280,7 +280,7 @@
             </widget>
            </item>
            <item row="2" column="0">
-            <widget class="QLabel" name="label_f_x_tolerance_newton">
+            <widget class="QLabel" name="lbl_f_x_tolerance_newton">
              <property name="text">
               <string>f(x) tolerance:</string>
              </property>
@@ -294,7 +294,7 @@
             </widget>
            </item>
            <item row="3" column="0">
-            <widget class="QLabel" name="label_x_tolerance_newton">
+            <widget class="QLabel" name="lbl_x_tolerance_newton">
              <property name="text">
               <string>x tolerance:</string>
              </property>
@@ -334,7 +334,7 @@
           </property>
           <layout class="QGridLayout" name="gridLayout_6">
            <item row="0" column="0">
-            <widget class="QLabel" name="label_steps_de">
+            <widget class="QLabel" name="lbl_steps_de">
              <property name="text">
               <string>Steps:</string>
              </property>
@@ -348,7 +348,7 @@
             </widget>
            </item>
            <item row="1" column="0">
-            <widget class="QLabel" name="label_population_de">
+            <widget class="QLabel" name="lbl_population_de">
              <property name="text">
               <string>Population:</string>
              </property>
@@ -358,7 +358,7 @@
             <widget class="QLineEdit" name="pop_de"/>
            </item>
            <item row="2" column="0">
-            <widget class="QLabel" name="label_crossover_ratio_de">
+            <widget class="QLabel" name="lbl_crossover_ratio_de">
              <property name="text">
               <string>Crossover ratio:</string>
              </property>
@@ -372,7 +372,7 @@
             </widget>
            </item>
            <item row="3" column="0">
-            <widget class="QLabel" name="label_scale_de">
+            <widget class="QLabel" name="lbl_scale_de">
              <property name="text">
               <string>Scale:</string>
              </property>
@@ -386,7 +386,7 @@
             </widget>
            </item>
            <item row="4" column="0">
-            <widget class="QLabel" name="label_f_x_tolerance_de">
+            <widget class="QLabel" name="lbl_f_x_tolerance_de">
              <property name="text">
               <string>f(x) tolerance:</string>
              </property>
@@ -400,7 +400,7 @@
             </widget>
            </item>
            <item row="5" column="0">
-            <widget class="QLabel" name="label_x_tolerance_de">
+            <widget class="QLabel" name="lbl_x_tolerance_de">
              <property name="text">
               <string>x tolerance:</string>
              </property>
@@ -440,7 +440,7 @@
           </property>
           <layout class="QGridLayout" name="gridLayout_11">
            <item row="0" column="0">
-            <widget class="QLabel" name="label_steps_amoeba">
+            <widget class="QLabel" name="lbl_steps_amoeba">
              <property name="text">
               <string>Steps:</string>
              </property>
@@ -454,7 +454,7 @@
             </widget>
            </item>
            <item row="1" column="0">
-            <widget class="QLabel" name="label_starts_amoeba">
+            <widget class="QLabel" name="lbl_starts_amoeba">
              <property name="text">
               <string>Starts:</string>
              </property>
@@ -468,7 +468,7 @@
             </widget>
            </item>
            <item row="2" column="0">
-            <widget class="QLabel" name="label_simplex_radius_amoeba">
+            <widget class="QLabel" name="lbl_simplex_radius_amoeba">
              <property name="text">
               <string>Simplex radius:</string>
              </property>
@@ -496,7 +496,7 @@
             </widget>
            </item>
            <item row="4" column="0">
-            <widget class="QLabel" name="label_x_tolerance_amoeba">
+            <widget class="QLabel" name="lbl_x_tolerance_amoeba">
              <property name="text">
               <string>x tolerance:</string>
              </property>
@@ -530,7 +530,7 @@
      </widget>
     </item>
     <item row="0" column="0">
-     <widget class="QComboBox" name="comboboxFitAlgorithms">
+     <widget class="QComboBox" name="cbFitAlgorithms">
       <property name="sizePolicy">
        <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
         <horstretch>0</horstretch>
@@ -564,7 +564,7 @@
    </property>
    <layout class="QGridLayout" name="gridLayout_12">
     <item row="0" column="0">
-     <widget class="QComboBox" name="comboboxDefaultFitAlgorithm">
+     <widget class="QComboBox" name="cbDefaultFitAlgorithm">
       <property name="sizePolicy">
        <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
         <horstretch>0</horstretch>

--- a/src/sas/qtgui/Perspectives/Fitting/UI/FittingOptionsUI.ui
+++ b/src/sas/qtgui/Perspectives/Fitting/UI/FittingOptionsUI.ui
@@ -25,7 +25,7 @@
   <property name="windowTitle">
    <string>Form</string>
   </property>
-  <widget class="QGroupBox" name="groupBox">
+  <widget class="QGroupBox" name="groupBoxFitAlgorithms">
    <property name="geometry">
     <rect>
      <x>0</x>
@@ -45,17 +45,17 @@
    </property>
    <layout class="QGridLayout" name="gridLayout_9">
     <item row="1" column="0">
-     <widget class="QStackedWidget" name="stackedWidget">
+     <widget class="QStackedWidget" name="stackedWidgetFitAlgorithms">
       <property name="frameShape">
        <enum>QFrame::NoFrame</enum>
       </property>
       <property name="currentIndex">
-       <number>0</number>
+       <number>2</number>
       </property>
       <widget class="QWidget" name="page_dream">
        <layout class="QGridLayout" name="gridLayout_2">
         <item row="0" column="0">
-         <widget class="QGroupBox" name="groupBox_2">
+         <widget class="QGroupBox" name="groupBox_dream">
           <property name="sizePolicy">
            <sizepolicy hsizetype="MinimumExpanding" vsizetype="MinimumExpanding">
             <horstretch>0</horstretch>
@@ -67,21 +67,21 @@
           </property>
           <layout class="QGridLayout" name="gridLayout">
            <item row="0" column="0">
-            <widget class="QLabel" name="label">
+            <widget class="QLabel" name="label_samples_dream">
              <property name="text">
               <string>Samples:</string>
              </property>
             </widget>
            </item>
            <item row="2" column="0">
-            <widget class="QLabel" name="label_3">
+            <widget class="QLabel" name="label_population_dream">
              <property name="text">
               <string>Population:</string>
              </property>
             </widget>
            </item>
            <item row="3" column="1">
-            <widget class="QComboBox" name="init_dream">
+            <widget class="QComboBox" name="combobox_initializer_dream">
              <property name="toolTip">
               <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-style:italic;&quot;&gt;Initializer&lt;/span&gt; determines how the population will be initialized. The options are as follows:&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-style:italic;&quot;&gt;eps&lt;/span&gt; (epsilon ball), in which the entire initial population is chosen at random from within a tiny hypersphere centered about the initial point&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-style:italic;&quot;&gt;lhs&lt;/span&gt; (latin hypersquare), which chops the bounds within each dimension in &lt;span style=&quot; font-weight:600;&quot;&gt;k&lt;/span&gt; equal sized chunks where &lt;span style=&quot; font-weight:600;&quot;&gt;k&lt;/span&gt; is the size of the population and makes sure that each parameter has at least one value within each chunk across the population.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-style:italic;&quot;&gt;cov&lt;/span&gt; (covariance matrix), in which the uncertainty is estimated using the covariance matrix at the initial point, and points are selected at random from the corresponding gaussian ellipsoid&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-style:italic;&quot;&gt;random&lt;/span&gt; (uniform random), in which the points are selected at random within the bounds of the parameters&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
              </property>
@@ -115,14 +115,14 @@
             </widget>
            </item>
            <item row="4" column="0">
-            <widget class="QLabel" name="label_5">
+            <widget class="QLabel" name="label_thinning_dream">
              <property name="text">
               <string>Thinning:</string>
              </property>
             </widget>
            </item>
            <item row="3" column="0">
-            <widget class="QLabel" name="label_4">
+            <widget class="QLabel" name="label_initializer_dream">
              <property name="text">
               <string>Initializer:</string>
              </property>
@@ -136,14 +136,14 @@
             </widget>
            </item>
            <item row="5" column="0">
-            <widget class="QLabel" name="label_6">
+            <widget class="QLabel" name="label_steps_dream">
              <property name="text">
               <string>Steps:</string>
              </property>
             </widget>
            </item>
            <item row="1" column="0">
-            <widget class="QLabel" name="label_2">
+            <widget class="QLabel" name="label_burn_in_steps_dream">
              <property name="text">
               <string>Burn-in Steps:</string>
              </property>
@@ -178,13 +178,13 @@
       <widget class="QWidget" name="page_lm">
        <layout class="QGridLayout" name="gridLayout_4">
         <item row="0" column="0">
-         <widget class="QGroupBox" name="groupBox_3">
+         <widget class="QGroupBox" name="groupBox_lm">
           <property name="title">
            <string>Levenberg</string>
           </property>
           <layout class="QGridLayout" name="gridLayout_3">
            <item row="0" column="0">
-            <widget class="QLabel" name="label_7">
+            <widget class="QLabel" name="label_steps_lm">
              <property name="text">
               <string>Steps:</string>
              </property>
@@ -198,21 +198,21 @@
             </widget>
            </item>
            <item row="1" column="0">
-            <widget class="QLabel" name="label_8">
+            <widget class="QLabel" name="label_f_x_tolerance_lm">
              <property name="text">
               <string>f(x) tolerance:</string>
              </property>
             </widget>
            </item>
            <item row="1" column="1">
-            <widget class="QLineEdit" name="ftol_lm">
+            <widget class="QLineEdit" name="f_x_tolerance_lm">
              <property name="toolTip">
               <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Used to determine when the fit has reached the point where no significant improvement is expected.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
              </property>
             </widget>
            </item>
            <item row="2" column="0">
-            <widget class="QLabel" name="label_9">
+            <widget class="QLabel" name="label_x_tolerance_lm">
              <property name="text">
               <string>x tolerance:</string>
              </property>
@@ -246,13 +246,13 @@
       <widget class="QWidget" name="page_newton">
        <layout class="QGridLayout" name="gridLayout_7">
         <item row="0" column="0">
-         <widget class="QGroupBox" name="groupBox_5">
+         <widget class="QGroupBox" name="groupBox_newton">
           <property name="title">
            <string>Quasi-Newton BFGS </string>
           </property>
           <layout class="QGridLayout" name="gridLayout_5">
            <item row="0" column="0">
-            <widget class="QLabel" name="label_10">
+            <widget class="QLabel" name="label_steps_newton">
              <property name="text">
               <string>Steps:</string>
              </property>
@@ -266,7 +266,7 @@
             </widget>
            </item>
            <item row="1" column="0">
-            <widget class="QLabel" name="label_13">
+            <widget class="QLabel" name="label_starts_newton">
              <property name="text">
               <string>Starts:</string>
              </property>
@@ -280,7 +280,7 @@
             </widget>
            </item>
            <item row="2" column="0">
-            <widget class="QLabel" name="label_11">
+            <widget class="QLabel" name="label_f_x_tolerance_newton">
              <property name="text">
               <string>f(x) tolerance:</string>
              </property>
@@ -294,7 +294,7 @@
             </widget>
            </item>
            <item row="3" column="0">
-            <widget class="QLabel" name="label_12">
+            <widget class="QLabel" name="label_x_tolerance_newton">
              <property name="text">
               <string>x tolerance:</string>
              </property>
@@ -328,13 +328,13 @@
       <widget class="QWidget" name="page_de">
        <layout class="QGridLayout" name="gridLayout_8">
         <item row="0" column="0">
-         <widget class="QGroupBox" name="groupBox_6">
+         <widget class="QGroupBox" name="groupBox_de">
           <property name="title">
            <string>Differential Evolution</string>
           </property>
           <layout class="QGridLayout" name="gridLayout_6">
            <item row="0" column="0">
-            <widget class="QLabel" name="label_14">
+            <widget class="QLabel" name="label_steps_de">
              <property name="text">
               <string>Steps:</string>
              </property>
@@ -348,7 +348,7 @@
             </widget>
            </item>
            <item row="1" column="0">
-            <widget class="QLabel" name="label_15">
+            <widget class="QLabel" name="label_population_de">
              <property name="text">
               <string>Population:</string>
              </property>
@@ -358,7 +358,7 @@
             <widget class="QLineEdit" name="pop_de"/>
            </item>
            <item row="2" column="0">
-            <widget class="QLabel" name="label_18">
+            <widget class="QLabel" name="label_crossover_ratio_de">
              <property name="text">
               <string>Crossover ratio:</string>
              </property>
@@ -372,7 +372,7 @@
             </widget>
            </item>
            <item row="3" column="0">
-            <widget class="QLabel" name="label_19">
+            <widget class="QLabel" name="label_scale_de">
              <property name="text">
               <string>Scale:</string>
              </property>
@@ -386,7 +386,7 @@
             </widget>
            </item>
            <item row="4" column="0">
-            <widget class="QLabel" name="label_16">
+            <widget class="QLabel" name="label_f_x_tolerance_de">
              <property name="text">
               <string>f(x) tolerance:</string>
              </property>
@@ -400,7 +400,7 @@
             </widget>
            </item>
            <item row="5" column="0">
-            <widget class="QLabel" name="label_17">
+            <widget class="QLabel" name="label_x_tolerance_de">
              <property name="text">
               <string>x tolerance:</string>
              </property>
@@ -434,13 +434,13 @@
       <widget class="QWidget" name="page_amoeba">
        <layout class="QGridLayout" name="gridLayout_10">
         <item row="0" column="0">
-         <widget class="QGroupBox" name="groupBox_7">
+         <widget class="QGroupBox" name="groupBox_amoeba">
           <property name="title">
            <string>Nelder-Mead Simplex</string>
           </property>
           <layout class="QGridLayout" name="gridLayout_11">
            <item row="0" column="0">
-            <widget class="QLabel" name="label_20">
+            <widget class="QLabel" name="label_steps_amoeba">
              <property name="text">
               <string>Steps:</string>
              </property>
@@ -454,7 +454,7 @@
             </widget>
            </item>
            <item row="1" column="0">
-            <widget class="QLabel" name="label_21">
+            <widget class="QLabel" name="label_starts_amoeba">
              <property name="text">
               <string>Starts:</string>
              </property>
@@ -468,7 +468,7 @@
             </widget>
            </item>
            <item row="2" column="0">
-            <widget class="QLabel" name="label_22">
+            <widget class="QLabel" name="label_simplex_radius_amoeba">
              <property name="text">
               <string>Simplex radius:</string>
              </property>
@@ -482,7 +482,7 @@
             </widget>
            </item>
            <item row="3" column="0">
-            <widget class="QLabel" name="label_24">
+            <widget class="QLabel" name="label_f_x_tolerance_amoeba">
              <property name="text">
               <string>f(x) tolerance:</string>
              </property>
@@ -496,7 +496,7 @@
             </widget>
            </item>
            <item row="4" column="0">
-            <widget class="QLabel" name="label_25">
+            <widget class="QLabel" name="label_x_tolerance_amoeba">
              <property name="text">
               <string>x tolerance:</string>
              </property>
@@ -530,7 +530,7 @@
      </widget>
     </item>
     <item row="0" column="0">
-     <widget class="QComboBox" name="cbAlgorithm">
+     <widget class="QComboBox" name="comboboxFitAlgorithms">
       <property name="sizePolicy">
        <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
         <horstretch>0</horstretch>
@@ -544,7 +544,7 @@
     </item>
    </layout>
   </widget>
-  <widget class="QGroupBox" name="groupBox_4">
+  <widget class="QGroupBox" name="groupBox_DefaultFitAlgorithm">
    <property name="geometry">
     <rect>
      <x>0</x>
@@ -564,7 +564,7 @@
    </property>
    <layout class="QGridLayout" name="gridLayout_12">
     <item row="0" column="0">
-     <widget class="QComboBox" name="cbAlgorithmDefault">
+     <widget class="QComboBox" name="comboboxDefaultFitAlgorithm">
       <property name="sizePolicy">
        <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
         <horstretch>0</horstretch>

--- a/src/sas/qtgui/Perspectives/Fitting/UI/FittingOptionsUI.ui
+++ b/src/sas/qtgui/Perspectives/Fitting/UI/FittingOptionsUI.ui
@@ -50,7 +50,7 @@
        <enum>QFrame::NoFrame</enum>
       </property>
       <property name="currentIndex">
-       <number>4</number>
+       <number>0</number>
       </property>
       <widget class="QWidget" name="page_dream">
        <layout class="QGridLayout" name="gridLayout_2">

--- a/src/sas/qtgui/Perspectives/Fitting/UI/FittingWidgetUI.ui
+++ b/src/sas/qtgui/Perspectives/Fitting/UI/FittingWidgetUI.ui
@@ -29,7 +29,7 @@
    <item row="0" column="0">
     <layout class="QHBoxLayout" name="horizontalLayout_top">
      <item>
-      <widget class="QLabel" name="labelFilenameLeft">
+      <widget class="QLabel" name="lblFilenameLeft">
        <property name="text">
         <string>File name:</string>
        </property>
@@ -38,7 +38,7 @@
      <item>
       <layout class="QGridLayout" name="gridLayout_top">
        <item row="0" column="0">
-        <widget class="QComboBox" name="comboboxFileNames">
+        <widget class="QComboBox" name="cbFileNames">
          <property name="toolTip">
           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Choose a file to set initial fit parameters.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
          </property>
@@ -48,7 +48,7 @@
         </widget>
        </item>
        <item row="0" column="1">
-        <widget class="QLabel" name="labelFilenameRight">
+        <widget class="QLabel" name="lblFilenameRight">
          <property name="text">
           <string>None</string>
          </property>
@@ -96,42 +96,42 @@
           <item row="0" column="0">
            <layout class="QGridLayout" name="gridLayout_Category_ModelName_StructureFactor">
             <item row="0" column="0">
-             <widget class="QLabel" name="labelCategory">
+             <widget class="QLabel" name="lblCategory">
               <property name="text">
                <string>Category</string>
               </property>
              </widget>
             </item>
             <item row="0" column="1">
-             <widget class="QLabel" name="labelModel">
+             <widget class="QLabel" name="lblModel">
               <property name="text">
                <string>Model name</string>
               </property>
              </widget>
             </item>
             <item row="0" column="2">
-             <widget class="QLabel" name="labelStructure">
+             <widget class="QLabel" name="lblStructure">
               <property name="text">
                <string>Structure factor</string>
               </property>
              </widget>
             </item>
             <item row="1" column="0">
-             <widget class="QComboBox" name="comboboxCategory">
+             <widget class="QComboBox" name="cbCategory">
               <property name="toolTip">
                <string>Select a category</string>
               </property>
              </widget>
             </item>
             <item row="1" column="1">
-             <widget class="QComboBox" name="comboboxModel">
+             <widget class="QComboBox" name="cbModel">
               <property name="toolTip">
                <string>Select a model</string>
               </property>
              </widget>
             </item>
             <item row="1" column="2">
-             <widget class="QComboBox" name="comboboxStructureFactor">
+             <widget class="QComboBox" name="cbStructureFactor">
               <property name="toolTip">
                <string>Select a structure factor</string>
               </property>
@@ -140,7 +140,7 @@
            </layout>
           </item>
           <item row="1" column="0">
-           <widget class="QTreeView" name="listModelParameters">
+           <widget class="QTreeView" name="lstModelParameters">
             <property name="styleSheet">
              <string notr="true"/>
             </property>
@@ -162,7 +162,7 @@
          </property>
          <layout class="QVBoxLayout" name="verticalLayout">
           <item>
-           <widget class="QCheckBox" name="checkboxPolydispersity">
+           <widget class="QCheckBox" name="chkPolydispersity">
             <property name="enabled">
              <bool>true</bool>
             </property>
@@ -178,7 +178,7 @@
            </widget>
           </item>
           <item>
-           <widget class="QCheckBox" name="checkbox2DView">
+           <widget class="QCheckBox" name="chk2DView">
             <property name="enabled">
              <bool>true</bool>
             </property>
@@ -194,7 +194,7 @@
            </widget>
           </item>
           <item>
-           <widget class="QCheckBox" name="checkboxMagnetism">
+           <widget class="QCheckBox" name="chkMagnetism">
             <property name="enabled">
              <bool>true</bool>
             </property>
@@ -210,7 +210,7 @@
            </widget>
           </item>
           <item>
-           <widget class="QCheckBox" name="checkboxChainFit">
+           <widget class="QCheckBox" name="chkChainFit">
             <property name="enabled">
              <bool>true</bool>
             </property>
@@ -237,42 +237,42 @@
           <item row="0" column="0" colspan="2">
            <layout class="QGridLayout" name="gridLayout_FittingDetails_MinRange_MaxRange">
             <item row="0" column="0">
-             <widget class="QLabel" name="labelMinRangeDisplay">
+             <widget class="QLabel" name="lblMinRangeDisplay">
               <property name="text">
                <string>Min range</string>
               </property>
              </widget>
             </item>
             <item row="0" column="1">
-             <widget class="QLabel" name="labelMinRangeValue">
+             <widget class="QLabel" name="lblMinRangeValue">
               <property name="text">
                <string>0.005</string>
               </property>
              </widget>
             </item>
             <item row="0" column="2">
-             <widget class="QLabel" name="labelAngstromLetterUp">
+             <widget class="QLabel" name="lblAngstromLetterUp">
               <property name="text">
                <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Å&lt;span style=&quot; vertical-align:super;&quot;&gt;-1&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
               </property>
              </widget>
             </item>
             <item row="1" column="0">
-             <widget class="QLabel" name="labelMaxRangeDisplay">
+             <widget class="QLabel" name="lblMaxRangeDisplay">
               <property name="text">
                <string>Max range</string>
               </property>
              </widget>
             </item>
             <item row="1" column="1">
-             <widget class="QLabel" name="labelMaxRangeValue">
+             <widget class="QLabel" name="lblMaxRangeValue">
               <property name="text">
                <string>0.1</string>
               </property>
              </widget>
             </item>
             <item row="1" column="2">
-             <widget class="QLabel" name="labelAngstromLetterDown">
+             <widget class="QLabel" name="lblAngstromLetterDown">
               <property name="text">
                <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Å&lt;span style=&quot; vertical-align:super;&quot;&gt;-1&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
               </property>
@@ -281,14 +281,14 @@
            </layout>
           </item>
           <item row="1" column="0">
-           <widget class="QLabel" name="labelSmearing">
+           <widget class="QLabel" name="lblSmearing">
             <property name="text">
              <string>Smearing:</string>
             </property>
            </widget>
           </item>
           <item row="1" column="1">
-           <widget class="QLabel" name="labelSmearingValue">
+           <widget class="QLabel" name="lblSmearingValue">
             <property name="text">
              <string>None</string>
             </property>
@@ -322,14 +322,14 @@
           <item row="0" column="0">
            <layout class="QHBoxLayout" name="horizontalLayout_FittingError">
             <item>
-             <widget class="QLabel" name="labelChiSquaredLetter">
+             <widget class="QLabel" name="lblChiSquaredLetter">
               <property name="text">
                <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;χ&lt;/span&gt;&lt;span style=&quot; font-weight:600; vertical-align:super;&quot;&gt;2&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
               </property>
              </widget>
             </item>
             <item>
-             <widget class="QLabel" name="labelChiSquaredValue">
+             <widget class="QLabel" name="lblChiSquaredValue">
               <property name="text">
                <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;0.01625&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
               </property>
@@ -364,7 +364,7 @@
          </property>
          <layout class="QGridLayout" name="gridLayout_9">
           <item row="0" column="0">
-           <widget class="QTableView" name="listPolydispersity">
+           <widget class="QTableView" name="lstPolydispersity">
             <property name="editTriggers">
              <set>QAbstractItemView::AllEditTriggers</set>
             </property>
@@ -409,10 +409,10 @@
            </spacer>
           </item>
           <item row="0" column="0" colspan="3">
-           <widget class="QTableView" name="listPolarisation_Magnetic_Scattering"/>
+           <widget class="QTableView" name="lstPolarisation_Magnetic_Scattering"/>
           </item>
           <item row="1" column="2">
-           <widget class="QPushButton" name="buttonDisplayMagneticAngles">
+           <widget class="QPushButton" name="cmdDisplayMagneticAngles">
             <property name="text">
              <string>Display
 magnetic
@@ -448,7 +448,7 @@ angles</string>
       </spacer>
      </item>
      <item>
-      <widget class="QPushButton" name="buttonPlot">
+      <widget class="QPushButton" name="cmdPlot">
        <property name="sizePolicy">
         <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
          <horstretch>0</horstretch>
@@ -470,7 +470,7 @@ angles</string>
       </widget>
      </item>
      <item>
-      <widget class="QPushButton" name="buttonFit">
+      <widget class="QPushButton" name="cmdFit">
        <property name="sizePolicy">
         <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
          <horstretch>0</horstretch>
@@ -489,7 +489,7 @@ angles</string>
       </widget>
      </item>
      <item>
-      <widget class="QPushButton" name="buttonHelp">
+      <widget class="QPushButton" name="cmdHelp">
        <property name="sizePolicy">
         <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
          <horstretch>0</horstretch>
@@ -512,22 +512,22 @@ angles</string>
   </layout>
  </widget>
  <tabstops>
-  <tabstop>comboboxFileNames</tabstop>
+  <tabstop>cbFileNames</tabstop>
   <tabstop>tabOverviewFitting</tabstop>
-  <tabstop>comboboxCategory</tabstop>
-  <tabstop>comboboxModel</tabstop>
-  <tabstop>comboboxStructureFactor</tabstop>
-  <tabstop>listModelParameters</tabstop>
-  <tabstop>checkboxPolydispersity</tabstop>
-  <tabstop>checkbox2DView</tabstop>
-  <tabstop>checkboxMagnetism</tabstop>
-  <tabstop>checkboxChainFit</tabstop>
-  <tabstop>listPolydispersity</tabstop>
-  <tabstop>listPolarisation_Magnetic_Scattering</tabstop>
-  <tabstop>buttonDisplayMagneticAngles</tabstop>
-  <tabstop>buttonPlot</tabstop>
-  <tabstop>buttonFit</tabstop>
-  <tabstop>buttonHelp</tabstop>
+  <tabstop>cbCategory</tabstop>
+  <tabstop>cbModel</tabstop>
+  <tabstop>cbStructureFactor</tabstop>
+  <tabstop>lstModelParameters</tabstop>
+  <tabstop>chkPolydispersity</tabstop>
+  <tabstop>chk2DView</tabstop>
+  <tabstop>chkMagnetism</tabstop>
+  <tabstop>chkChainFit</tabstop>
+  <tabstop>lstPolydispersity</tabstop>
+  <tabstop>lstPolarisation_Magnetic_Scattering</tabstop>
+  <tabstop>cmdDisplayMagneticAngles</tabstop>
+  <tabstop>cmdPlot</tabstop>
+  <tabstop>cmdFit</tabstop>
+  <tabstop>cmdHelp</tabstop>
  </tabstops>
  <resources/>
  <connections/>

--- a/src/sas/qtgui/Perspectives/Fitting/UI/FittingWidgetUI.ui
+++ b/src/sas/qtgui/Perspectives/Fitting/UI/FittingWidgetUI.ui
@@ -72,7 +72,7 @@
     </layout>
    </item>
    <item row="1" column="0">
-    <widget class="QTabWidget" name="tabOverviewFitting">
+    <widget class="QTabWidget" name="tabFitting">
      <property name="currentIndex">
       <number>0</number>
      </property>
@@ -322,14 +322,14 @@
           <item row="0" column="0">
            <layout class="QHBoxLayout" name="horizontalLayout_FittingError">
             <item>
-             <widget class="QLabel" name="lblChiSquaredLetter">
+             <widget class="QLabel" name="lblChi2Letter">
               <property name="text">
                <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;χ&lt;/span&gt;&lt;span style=&quot; font-weight:600; vertical-align:super;&quot;&gt;2&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
               </property>
              </widget>
             </item>
             <item>
-             <widget class="QLabel" name="lblChiSquaredValue">
+             <widget class="QLabel" name="lblChi2Value">
               <property name="text">
                <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;0.01625&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
               </property>
@@ -513,7 +513,7 @@ angles</string>
  </widget>
  <tabstops>
   <tabstop>cbFileNames</tabstop>
-  <tabstop>tabOverviewFitting</tabstop>
+  <tabstop>tabFitting</tabstop>
   <tabstop>cbCategory</tabstop>
   <tabstop>cbModel</tabstop>
   <tabstop>cbStructureFactor</tabstop>

--- a/src/sas/qtgui/Perspectives/Fitting/UI/FittingWidgetUI.ui
+++ b/src/sas/qtgui/Perspectives/Fitting/UI/FittingWidgetUI.ui
@@ -27,18 +27,18 @@
   </property>
   <layout class="QGridLayout" name="gridLayout_5">
    <item row="0" column="0">
-    <layout class="QHBoxLayout" name="horizontalLayout">
+    <layout class="QHBoxLayout" name="horizontalLayout_top">
      <item>
-      <widget class="QLabel" name="label">
+      <widget class="QLabel" name="labelFilenameLeft">
        <property name="text">
         <string>File name:</string>
        </property>
       </widget>
      </item>
      <item>
-      <layout class="QGridLayout" name="gridLayout_3">
+      <layout class="QGridLayout" name="gridLayout_top">
        <item row="0" column="0">
-        <widget class="QComboBox" name="cbFileNames">
+        <widget class="QComboBox" name="comboboxFileNames">
          <property name="toolTip">
           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Choose a file to set initial fit parameters.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
          </property>
@@ -48,7 +48,7 @@
         </widget>
        </item>
        <item row="0" column="1">
-        <widget class="QLabel" name="lblFilename">
+        <widget class="QLabel" name="labelFilenameRight">
          <property name="text">
           <string>None</string>
          </property>
@@ -72,17 +72,17 @@
     </layout>
    </item>
    <item row="1" column="0">
-    <widget class="QTabWidget" name="tabFitting">
+    <widget class="QTabWidget" name="tabOverviewFitting">
      <property name="currentIndex">
       <number>0</number>
      </property>
-     <widget class="QWidget" name="tab_3">
+     <widget class="QWidget" name="tabModel">
       <attribute name="title">
        <string>Model</string>
       </attribute>
       <layout class="QGridLayout" name="gridLayout_4">
        <item row="0" column="0" colspan="4">
-        <widget class="QGroupBox" name="groupBox_6">
+        <widget class="QGroupBox" name="groupBox_Model">
          <property name="sizePolicy">
           <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
            <horstretch>0</horstretch>
@@ -94,44 +94,44 @@
          </property>
          <layout class="QGridLayout" name="gridLayout_2">
           <item row="0" column="0">
-           <layout class="QGridLayout" name="gridLayout">
+           <layout class="QGridLayout" name="gridLayout_Category_ModelName_StructureFactor">
             <item row="0" column="0">
-             <widget class="QLabel" name="label_2">
+             <widget class="QLabel" name="labelCategory">
               <property name="text">
                <string>Category</string>
               </property>
              </widget>
             </item>
             <item row="0" column="1">
-             <widget class="QLabel" name="lblModel">
+             <widget class="QLabel" name="labelModel">
               <property name="text">
                <string>Model name</string>
               </property>
              </widget>
             </item>
             <item row="0" column="2">
-             <widget class="QLabel" name="lblStructure">
+             <widget class="QLabel" name="labelStructure">
               <property name="text">
                <string>Structure factor</string>
               </property>
              </widget>
             </item>
             <item row="1" column="0">
-             <widget class="QComboBox" name="cbCategory">
+             <widget class="QComboBox" name="comboboxCategory">
               <property name="toolTip">
                <string>Select a category</string>
               </property>
              </widget>
             </item>
             <item row="1" column="1">
-             <widget class="QComboBox" name="cbModel">
+             <widget class="QComboBox" name="comboboxModel">
               <property name="toolTip">
                <string>Select a model</string>
               </property>
              </widget>
             </item>
             <item row="1" column="2">
-             <widget class="QComboBox" name="cbStructureFactor">
+             <widget class="QComboBox" name="comboboxStructureFactor">
               <property name="toolTip">
                <string>Select a structure factor</string>
               </property>
@@ -140,7 +140,7 @@
            </layout>
           </item>
           <item row="1" column="0">
-           <widget class="QTreeView" name="lstParams">
+           <widget class="QTreeView" name="listModelParameters">
             <property name="styleSheet">
              <string notr="true"/>
             </property>
@@ -156,13 +156,13 @@
         </widget>
        </item>
        <item row="1" column="0">
-        <widget class="QGroupBox" name="groupBox_7">
+        <widget class="QGroupBox" name="groupBox_Options">
          <property name="title">
           <string>Options </string>
          </property>
          <layout class="QVBoxLayout" name="verticalLayout">
           <item>
-           <widget class="QCheckBox" name="chkPolydispersity">
+           <widget class="QCheckBox" name="checkboxPolydispersity">
             <property name="enabled">
              <bool>true</bool>
             </property>
@@ -178,7 +178,7 @@
            </widget>
           </item>
           <item>
-           <widget class="QCheckBox" name="chk2DView">
+           <widget class="QCheckBox" name="checkbox2DView">
             <property name="enabled">
              <bool>true</bool>
             </property>
@@ -194,7 +194,7 @@
            </widget>
           </item>
           <item>
-           <widget class="QCheckBox" name="chkMagnetism">
+           <widget class="QCheckBox" name="checkboxMagnetism">
             <property name="enabled">
              <bool>true</bool>
             </property>
@@ -210,7 +210,7 @@
            </widget>
           </item>
           <item>
-           <widget class="QCheckBox" name="chkChainFit">
+           <widget class="QCheckBox" name="checkboxChainFit">
             <property name="enabled">
              <bool>true</bool>
             </property>
@@ -229,50 +229,50 @@
         </widget>
        </item>
        <item row="1" column="1">
-        <widget class="QGroupBox" name="groupBox_8">
+        <widget class="QGroupBox" name="groupBox_FittingDetails">
          <property name="title">
           <string>Fitting details </string>
          </property>
          <layout class="QGridLayout" name="gridLayout_17">
           <item row="0" column="0" colspan="2">
-           <layout class="QGridLayout" name="gridLayout_8">
+           <layout class="QGridLayout" name="gridLayout_FittingDetails_MinRange_MaxRange">
             <item row="0" column="0">
-             <widget class="QLabel" name="label_16">
+             <widget class="QLabel" name="labelMinRangeDisplay">
               <property name="text">
                <string>Min range</string>
               </property>
              </widget>
             </item>
             <item row="0" column="1">
-             <widget class="QLabel" name="lblMinRangeDef">
+             <widget class="QLabel" name="labelMinRangeValue">
               <property name="text">
                <string>0.005</string>
               </property>
              </widget>
             </item>
             <item row="0" column="2">
-             <widget class="QLabel" name="label_17">
+             <widget class="QLabel" name="labelAngstromLetterUp">
               <property name="text">
                <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Å&lt;span style=&quot; vertical-align:super;&quot;&gt;-1&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
               </property>
              </widget>
             </item>
             <item row="1" column="0">
-             <widget class="QLabel" name="label_18">
+             <widget class="QLabel" name="labelMaxRangeDisplay">
               <property name="text">
                <string>Max range</string>
               </property>
              </widget>
             </item>
             <item row="1" column="1">
-             <widget class="QLabel" name="lblMaxRangeDef">
+             <widget class="QLabel" name="labelMaxRangeValue">
               <property name="text">
                <string>0.1</string>
               </property>
              </widget>
             </item>
             <item row="1" column="2">
-             <widget class="QLabel" name="label_19">
+             <widget class="QLabel" name="labelAngstromLetterDown">
               <property name="text">
                <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Å&lt;span style=&quot; vertical-align:super;&quot;&gt;-1&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
               </property>
@@ -281,14 +281,14 @@
            </layout>
           </item>
           <item row="1" column="0">
-           <widget class="QLabel" name="label_20">
+           <widget class="QLabel" name="labelSmearing">
             <property name="text">
              <string>Smearing:</string>
             </property>
            </widget>
           </item>
           <item row="1" column="1">
-           <widget class="QLabel" name="lblCurrentSmearing">
+           <widget class="QLabel" name="labelSmearingValue">
             <property name="text">
              <string>None</string>
             </property>
@@ -311,7 +311,7 @@
         </spacer>
        </item>
        <item row="1" column="3">
-        <widget class="QGroupBox" name="groupBox_9">
+        <widget class="QGroupBox" name="groupBox_FittingError">
          <property name="toolTip">
           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;χ&lt;span style=&quot; vertical-align:super;&quot;&gt;2&lt;/span&gt;/DOF (DOF=N&lt;span style=&quot; vertical-align:sub;&quot;&gt;pts&lt;/span&gt;-N&lt;span style=&quot; vertical-align:sub;&quot;&gt;par&lt;/span&gt; fitted)&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
          </property>
@@ -320,16 +320,16 @@
          </property>
          <layout class="QGridLayout" name="gridLayout_18">
           <item row="0" column="0">
-           <layout class="QHBoxLayout" name="horizontalLayout_2">
+           <layout class="QHBoxLayout" name="horizontalLayout_FittingError">
             <item>
-             <widget class="QLabel" name="label_23">
+             <widget class="QLabel" name="labelChiSquaredLetter">
               <property name="text">
                <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;χ&lt;/span&gt;&lt;span style=&quot; font-weight:600; vertical-align:super;&quot;&gt;2&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
               </property>
              </widget>
             </item>
             <item>
-             <widget class="QLabel" name="lblChi2Value">
+             <widget class="QLabel" name="labelChiSquaredValue">
               <property name="text">
                <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;0.01625&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
               </property>
@@ -352,19 +352,19 @@
        <string>Resolution</string>
       </attribute>
      </widget>
-     <widget class="QWidget" name="tab_4">
+     <widget class="QWidget" name="tab_Polydispersity">
       <attribute name="title">
        <string>Polydispersity</string>
       </attribute>
       <layout class="QGridLayout" name="gridLayout_10">
        <item row="0" column="0">
-        <widget class="QGroupBox" name="groupBox_3">
+        <widget class="QGroupBox" name="groupBox_Polydispersity">
          <property name="title">
           <string>Number-average Polydispersity and Orientational Distribution</string>
          </property>
          <layout class="QGridLayout" name="gridLayout_9">
           <item row="0" column="0">
-           <widget class="QTableView" name="lstPoly">
+           <widget class="QTableView" name="listPolydispersity">
             <property name="editTriggers">
              <set>QAbstractItemView::AllEditTriggers</set>
             </property>
@@ -384,13 +384,13 @@
        </item>
       </layout>
      </widget>
-     <widget class="QWidget" name="tab_6">
+     <widget class="QWidget" name="tab_Magnetism">
       <attribute name="title">
        <string>Magnetism</string>
       </attribute>
       <layout class="QGridLayout" name="gridLayout_22">
        <item row="0" column="0">
-        <widget class="QGroupBox" name="groupBox_10">
+        <widget class="QGroupBox" name="groupBox_Magnetism">
          <property name="title">
           <string>Polarisation/Magnetic Scattering </string>
          </property>
@@ -409,10 +409,10 @@
            </spacer>
           </item>
           <item row="0" column="0" colspan="3">
-           <widget class="QTableView" name="lstMagnetic"/>
+           <widget class="QTableView" name="listPolarisation_Magnetic_Scattering"/>
           </item>
           <item row="1" column="2">
-           <widget class="QPushButton" name="cmdMagneticDisplay">
+           <widget class="QPushButton" name="buttonDisplayMagneticAngles">
             <property name="text">
              <string>Display
 magnetic
@@ -433,7 +433,7 @@ angles</string>
     </widget>
    </item>
    <item row="2" column="0">
-    <layout class="QHBoxLayout" name="horizontalLayout_3">
+    <layout class="QHBoxLayout" name="horizontalLayout_bottom">
      <item>
       <spacer name="horizontalSpacer">
        <property name="orientation">
@@ -448,7 +448,7 @@ angles</string>
       </spacer>
      </item>
      <item>
-      <widget class="QPushButton" name="cmdPlot">
+      <widget class="QPushButton" name="buttonPlot">
        <property name="sizePolicy">
         <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
          <horstretch>0</horstretch>
@@ -470,7 +470,7 @@ angles</string>
       </widget>
      </item>
      <item>
-      <widget class="QPushButton" name="cmdFit">
+      <widget class="QPushButton" name="buttonFit">
        <property name="sizePolicy">
         <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
          <horstretch>0</horstretch>
@@ -489,7 +489,7 @@ angles</string>
       </widget>
      </item>
      <item>
-      <widget class="QPushButton" name="cmdHelp">
+      <widget class="QPushButton" name="buttonHelp">
        <property name="sizePolicy">
         <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
          <horstretch>0</horstretch>
@@ -512,22 +512,22 @@ angles</string>
   </layout>
  </widget>
  <tabstops>
-  <tabstop>cbFileNames</tabstop>
-  <tabstop>tabFitting</tabstop>
-  <tabstop>cbCategory</tabstop>
-  <tabstop>cbModel</tabstop>
-  <tabstop>cbStructureFactor</tabstop>
-  <tabstop>lstParams</tabstop>
-  <tabstop>chkPolydispersity</tabstop>
-  <tabstop>chk2DView</tabstop>
-  <tabstop>chkMagnetism</tabstop>
-  <tabstop>chkChainFit</tabstop>
-  <tabstop>lstPoly</tabstop>
-  <tabstop>lstMagnetic</tabstop>
-  <tabstop>cmdMagneticDisplay</tabstop>
-  <tabstop>cmdPlot</tabstop>
-  <tabstop>cmdFit</tabstop>
-  <tabstop>cmdHelp</tabstop>
+  <tabstop>comboboxFileNames</tabstop>
+  <tabstop>tabOverviewFitting</tabstop>
+  <tabstop>comboboxCategory</tabstop>
+  <tabstop>comboboxModel</tabstop>
+  <tabstop>comboboxStructureFactor</tabstop>
+  <tabstop>listModelParameters</tabstop>
+  <tabstop>checkboxPolydispersity</tabstop>
+  <tabstop>checkbox2DView</tabstop>
+  <tabstop>checkboxMagnetism</tabstop>
+  <tabstop>checkboxChainFit</tabstop>
+  <tabstop>listPolydispersity</tabstop>
+  <tabstop>listPolarisation_Magnetic_Scattering</tabstop>
+  <tabstop>buttonDisplayMagneticAngles</tabstop>
+  <tabstop>buttonPlot</tabstop>
+  <tabstop>buttonFit</tabstop>
+  <tabstop>buttonHelp</tabstop>
  </tabstops>
  <resources/>
  <connections/>

--- a/src/sas/qtgui/Perspectives/Fitting/UI/GPUOptionsUI.ui
+++ b/src/sas/qtgui/Perspectives/Fitting/UI/GPUOptionsUI.ui
@@ -87,14 +87,14 @@
       <enum>QLayout::SetMinimumSize</enum>
      </property>
      <item>
-      <widget class="QPushButton" name="testButton">
+      <widget class="QPushButton" name="cmdTest">
        <property name="text">
         <string>Test</string>
        </property>
       </widget>
      </item>
      <item>
-      <widget class="QPushButton" name="helpButton">
+      <widget class="QPushButton" name="cmdHelp">
        <property name="text">
         <string>Help</string>
        </property>

--- a/src/sas/qtgui/Perspectives/Fitting/UI/GPUOptionsUI.ui
+++ b/src/sas/qtgui/Perspectives/Fitting/UI/GPUOptionsUI.ui
@@ -21,7 +21,7 @@
   </property>
   <property name="windowIcon">
    <iconset>
-    <normaloff>../../../../../../../../../../../Users/UI/res/ball.ico</normaloff>../../../../../../../../../../../Users/UI/res/ball.ico</iconset>
+    <normaloff>../../../../../../../../../Users/UI/res/ball.ico</normaloff>../../../../../../../../../Users/UI/res/ball.ico</iconset>
   </property>
   <layout class="QGridLayout" name="gridLayout">
    <item row="0" column="0" colspan="2">
@@ -82,7 +82,7 @@
     </spacer>
    </item>
    <item row="2" column="1">
-    <layout class="QHBoxLayout" name="horizontalLayout">
+    <layout class="QHBoxLayout" name="horizontalLayout_bottom">
      <property name="sizeConstraint">
       <enum>QLayout::SetMinimumSize</enum>
      </property>
@@ -108,4 +108,5 @@
   </layout>
  </widget>
  <resources/>
+ <connections/>
 </ui>

--- a/src/sas/qtgui/Perspectives/Fitting/UI/GPUOptionsUI.ui
+++ b/src/sas/qtgui/Perspectives/Fitting/UI/GPUOptionsUI.ui
@@ -21,7 +21,7 @@
   </property>
   <property name="windowIcon">
    <iconset>
-    <normaloff>../../../../../../../../../Users/UI/res/ball.ico</normaloff>../../../../../../../../../Users/UI/res/ball.ico</iconset>
+    <normaloff>../../../../../../../../../../../Users/UI/res/ball.ico</normaloff>../../../../../../../../../../../Users/UI/res/ball.ico</iconset>
   </property>
   <layout class="QGridLayout" name="gridLayout">
    <item row="0" column="0" colspan="2">

--- a/src/sas/qtgui/Perspectives/Fitting/UI/GPUTestResultsUI.ui
+++ b/src/sas/qtgui/Perspectives/Fitting/UI/GPUTestResultsUI.ui
@@ -55,7 +55,7 @@
       </widget>
      </item>
      <item row="1" column="0">
-      <widget class="QLabel" name="label_falingTestsNoOpenCL">
+      <widget class="QLabel" name="lblFailingTestsNoOpenCL">
        <property name="text">
         <string>If tests fail on OpenCL devices, please select the No OpenCL option.</string>
        </property>
@@ -65,7 +65,7 @@
       </widget>
      </item>
      <item row="2" column="0">
-      <widget class="QLabel" name="label_howToReportIssues">
+      <widget class="QLabel" name="lblHowToReportIssues">
        <property name="text">
         <string>In the case where many tests are failing, please consider sending the above report to help@sasview.org.</string>
        </property>
@@ -93,7 +93,7 @@
         </spacer>
        </item>
        <item>
-        <widget class="QDialogButtonBox" name="okButton">
+        <widget class="QDialogButtonBox" name="cmdOK">
          <property name="orientation">
           <enum>Qt::Horizontal</enum>
          </property>
@@ -114,7 +114,7 @@
  <resources/>
  <connections>
   <connection>
-   <sender>okButton</sender>
+   <sender>cmdOK</sender>
    <signal>accepted()</signal>
    <receiver>GPUTestResults</receiver>
    <slot>accept()</slot>
@@ -130,7 +130,7 @@
    </hints>
   </connection>
   <connection>
-   <sender>okButton</sender>
+   <sender>cmdOK</sender>
    <signal>rejected()</signal>
    <receiver>GPUTestResults</receiver>
    <slot>reject()</slot>

--- a/src/sas/qtgui/Perspectives/Fitting/UI/GPUTestResultsUI.ui
+++ b/src/sas/qtgui/Perspectives/Fitting/UI/GPUTestResultsUI.ui
@@ -19,9 +19,9 @@
   </property>
   <layout class="QGridLayout" name="gridLayout_3">
    <item row="0" column="0">
-    <layout class="QGridLayout" name="gridLayout_2">
+    <layout class="QGridLayout" name="gridLayout_OpenCL_test_results">
      <item row="0" column="0">
-      <widget class="QGroupBox" name="TestResultsBox">
+      <widget class="QGroupBox" name="GroupBox_test_results">
        <property name="sizePolicy">
         <sizepolicy hsizetype="MinimumExpanding" vsizetype="MinimumExpanding">
          <horstretch>0</horstretch>
@@ -55,7 +55,7 @@
       </widget>
      </item>
      <item row="1" column="0">
-      <widget class="QLabel" name="falingTestsNoOpenCL">
+      <widget class="QLabel" name="label_falingTestsNoOpenCL">
        <property name="text">
         <string>If tests fail on OpenCL devices, please select the No OpenCL option.</string>
        </property>
@@ -65,7 +65,7 @@
       </widget>
      </item>
      <item row="2" column="0">
-      <widget class="QLabel" name="howToReportIssues">
+      <widget class="QLabel" name="label_howToReportIssues">
        <property name="text">
         <string>In the case where many tests are failing, please consider sending the above report to help@sasview.org.</string>
        </property>
@@ -78,7 +78,7 @@
       </widget>
      </item>
      <item row="3" column="0">
-      <layout class="QHBoxLayout" name="horizontalLayout">
+      <layout class="QHBoxLayout" name="horizontalLayout_bottom">
        <item>
         <spacer name="horizontalSpacer">
          <property name="orientation">

--- a/src/sas/qtgui/Perspectives/Fitting/UI/MultiConstraintUI.ui
+++ b/src/sas/qtgui/Perspectives/Fitting/UI/MultiConstraintUI.ui
@@ -27,9 +27,9 @@
   </property>
   <layout class="QGridLayout" name="gridLayout">
    <item row="0" column="0">
-    <layout class="QHBoxLayout" name="horizontalLayout">
+    <layout class="QHBoxLayout" name="horizontalLayout_with_SwapButton">
      <item>
-      <widget class="QLabel" name="txtParam1">
+      <widget class="QLabel" name="label_Parameter1_SwapBox">
        <property name="sizePolicy">
         <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
          <horstretch>0</horstretch>
@@ -42,14 +42,14 @@
       </widget>
      </item>
      <item>
-      <widget class="QLabel" name="label">
+      <widget class="QLabel" name="label_equals_function">
        <property name="text">
         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;= function(&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
        </property>
       </widget>
      </item>
      <item>
-      <widget class="QLabel" name="txtParam2">
+      <widget class="QLabel" name="label_Parameter2_SwapBox">
        <property name="sizePolicy">
         <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
          <horstretch>0</horstretch>
@@ -62,14 +62,14 @@
       </widget>
      </item>
      <item>
-      <widget class="QLabel" name="label_3">
+      <widget class="QLabel" name="label_close_bracket">
        <property name="text">
         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;)&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
        </property>
       </widget>
      </item>
      <item>
-      <spacer name="horizontalSpacer_2">
+      <spacer name="horizontalSpacer_SwapBox">
        <property name="orientation">
         <enum>Qt::Horizontal</enum>
        </property>
@@ -82,7 +82,7 @@
       </spacer>
      </item>
      <item>
-      <widget class="QPushButton" name="cmdRevert">
+      <widget class="QPushButton" name="buttonSwap">
        <property name="text">
         <string>Swap</string>
        </property>
@@ -91,9 +91,9 @@
     </layout>
    </item>
    <item row="1" column="0">
-    <layout class="QHBoxLayout" name="horizontalLayout_3">
+    <layout class="QHBoxLayout" name="horizontalLayout_Parameter_TextBox">
      <item>
-      <widget class="QLabel" name="txtParam1_2">
+      <widget class="QLabel" name="label_Parameter1_TextBox">
        <property name="sizePolicy">
         <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
          <horstretch>0</horstretch>
@@ -106,26 +106,26 @@
       </widget>
      </item>
      <item>
-      <widget class="QLabel" name="label_2">
+      <widget class="QLabel" name="label_EqualSign_TextBox">
        <property name="text">
         <string>=</string>
        </property>
       </widget>
      </item>
      <item>
-      <widget class="QLineEdit" name="txtConstraint"/>
+      <widget class="QLineEdit" name="textConstraint"/>
      </item>
     </layout>
    </item>
    <item row="2" column="0">
-    <widget class="QLabel" name="lblWarning">
+    <widget class="QLabel" name="labelWarning">
      <property name="text">
       <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; color:#ff0000;&quot;&gt;Warning! Polydisperse parameter selected.&lt;br/&gt;&lt;/span&gt;Constraints involving polydisperse parameters only apply to&lt;br/&gt;starting values and are not re-applied during size or angle polydispersity&lt;br/&gt;integrations. To do so requires creating a custom model.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
      </property>
     </widget>
    </item>
    <item row="3" column="0">
-    <spacer name="verticalSpacer">
+    <spacer name="verticalSpacer_bottom">
      <property name="orientation">
       <enum>Qt::Vertical</enum>
      </property>
@@ -138,7 +138,7 @@
     </spacer>
    </item>
    <item row="4" column="0">
-    <layout class="QHBoxLayout" name="horizontalLayout_2">
+    <layout class="QHBoxLayout" name="horizontalLayout_OK_Cancel_Help">
      <item>
       <spacer name="horizontalSpacer">
        <property name="orientation">
@@ -153,7 +153,7 @@
       </spacer>
      </item>
      <item>
-      <widget class="QPushButton" name="cmdOK">
+      <widget class="QPushButton" name="buttonOK">
        <property name="text">
         <string>OK</string>
        </property>
@@ -163,14 +163,14 @@
       </widget>
      </item>
      <item>
-      <widget class="QPushButton" name="cmdCancel">
+      <widget class="QPushButton" name="buttonCancel">
        <property name="text">
         <string>Cancel</string>
        </property>
       </widget>
      </item>
      <item>
-      <widget class="QPushButton" name="cmdHelp">
+      <widget class="QPushButton" name="buttonHelp">
        <property name="text">
         <string>Help</string>
        </property>
@@ -183,7 +183,7 @@
  <resources/>
  <connections>
   <connection>
-   <sender>cmdCancel</sender>
+   <sender>buttonCancel</sender>
    <signal>clicked()</signal>
    <receiver>MultiConstraintUI</receiver>
    <slot>reject()</slot>
@@ -199,7 +199,7 @@
    </hints>
   </connection>
   <connection>
-   <sender>cmdOK</sender>
+   <sender>buttonOK</sender>
    <signal>clicked()</signal>
    <receiver>MultiConstraintUI</receiver>
    <slot>accept()</slot>

--- a/src/sas/qtgui/Perspectives/Fitting/UI/MultiConstraintUI.ui
+++ b/src/sas/qtgui/Perspectives/Fitting/UI/MultiConstraintUI.ui
@@ -113,7 +113,7 @@
       </widget>
      </item>
      <item>
-      <widget class="QLineEdit" name="textConstraint"/>
+      <widget class="QLineEdit" name="txtConstraint"/>
      </item>
     </layout>
    </item>

--- a/src/sas/qtgui/Perspectives/Fitting/UI/MultiConstraintUI.ui
+++ b/src/sas/qtgui/Perspectives/Fitting/UI/MultiConstraintUI.ui
@@ -29,7 +29,7 @@
    <item row="0" column="0">
     <layout class="QHBoxLayout" name="horizontalLayout_with_SwapButton">
      <item>
-      <widget class="QLabel" name="label_Parameter1_SwapBox">
+      <widget class="QLabel" name="lbl_Parameter1_SwapBox">
        <property name="sizePolicy">
         <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
          <horstretch>0</horstretch>
@@ -42,14 +42,14 @@
       </widget>
      </item>
      <item>
-      <widget class="QLabel" name="label_equals_function">
+      <widget class="QLabel" name="lbl_equals_function">
        <property name="text">
         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;= function(&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
        </property>
       </widget>
      </item>
      <item>
-      <widget class="QLabel" name="label_Parameter2_SwapBox">
+      <widget class="QLabel" name="lbl_Parameter2_SwapBox">
        <property name="sizePolicy">
         <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
          <horstretch>0</horstretch>
@@ -62,7 +62,7 @@
       </widget>
      </item>
      <item>
-      <widget class="QLabel" name="label_close_bracket">
+      <widget class="QLabel" name="lbl_close_bracket">
        <property name="text">
         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;)&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
        </property>
@@ -82,7 +82,7 @@
       </spacer>
      </item>
      <item>
-      <widget class="QPushButton" name="buttonSwap">
+      <widget class="QPushButton" name="cmdSwap">
        <property name="text">
         <string>Swap</string>
        </property>
@@ -93,7 +93,7 @@
    <item row="1" column="0">
     <layout class="QHBoxLayout" name="horizontalLayout_Parameter_TextBox">
      <item>
-      <widget class="QLabel" name="label_Parameter1_TextBox">
+      <widget class="QLabel" name="lbl_Parameter1_TextBox">
        <property name="sizePolicy">
         <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
          <horstretch>0</horstretch>
@@ -106,7 +106,7 @@
       </widget>
      </item>
      <item>
-      <widget class="QLabel" name="label_EqualSign_TextBox">
+      <widget class="QLabel" name="lbl_EqualSign_TextBox">
        <property name="text">
         <string>=</string>
        </property>
@@ -118,7 +118,7 @@
     </layout>
    </item>
    <item row="2" column="0">
-    <widget class="QLabel" name="labelWarning">
+    <widget class="QLabel" name="lblWarning">
      <property name="text">
       <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; color:#ff0000;&quot;&gt;Warning! Polydisperse parameter selected.&lt;br/&gt;&lt;/span&gt;Constraints involving polydisperse parameters only apply to&lt;br/&gt;starting values and are not re-applied during size or angle polydispersity&lt;br/&gt;integrations. To do so requires creating a custom model.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
      </property>
@@ -153,7 +153,7 @@
       </spacer>
      </item>
      <item>
-      <widget class="QPushButton" name="buttonOK">
+      <widget class="QPushButton" name="cmdOK">
        <property name="text">
         <string>OK</string>
        </property>
@@ -163,14 +163,14 @@
       </widget>
      </item>
      <item>
-      <widget class="QPushButton" name="buttonCancel">
+      <widget class="QPushButton" name="cmdCancel">
        <property name="text">
         <string>Cancel</string>
        </property>
       </widget>
      </item>
      <item>
-      <widget class="QPushButton" name="buttonHelp">
+      <widget class="QPushButton" name="cmdHelp">
        <property name="text">
         <string>Help</string>
        </property>
@@ -183,7 +183,7 @@
  <resources/>
  <connections>
   <connection>
-   <sender>buttonCancel</sender>
+   <sender>cmdCancel</sender>
    <signal>clicked()</signal>
    <receiver>MultiConstraintUI</receiver>
    <slot>reject()</slot>
@@ -199,7 +199,7 @@
    </hints>
   </connection>
   <connection>
-   <sender>buttonOK</sender>
+   <sender>cmdOK</sender>
    <signal>clicked()</signal>
    <receiver>MultiConstraintUI</receiver>
    <slot>accept()</slot>

--- a/src/sas/qtgui/Perspectives/Fitting/UI/OptionsWidgetUI.ui
+++ b/src/sas/qtgui/Perspectives/Fitting/UI/OptionsWidgetUI.ui
@@ -15,15 +15,15 @@
   </property>
   <layout class="QGridLayout" name="gridLayout_23">
    <item row="0" column="0">
-    <widget class="QGroupBox" name="groupBox_4">
+    <widget class="QGroupBox" name="groupBoxFittingRange">
      <property name="title">
       <string>Fitting range</string>
      </property>
      <layout class="QGridLayout" name="gridLayout_11">
       <item row="0" column="0" rowspan="2">
-       <layout class="QGridLayout" name="gridLayout_13">
+       <layout class="QGridLayout" name="gridLayoutMinRangeMaxRange">
         <item row="0" column="0">
-         <widget class="QLabel" name="label_9">
+         <widget class="QLabel" name="labelMinRange">
           <property name="text">
            <string>Min range</string>
           </property>
@@ -43,14 +43,14 @@
          </widget>
         </item>
         <item row="0" column="2">
-         <widget class="QLabel" name="label_13">
+         <widget class="QLabel" name="labelAngstromInvMinRange">
           <property name="text">
            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Å&lt;span style=&quot; vertical-align:super;&quot;&gt;-1&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
           </property>
          </widget>
         </item>
         <item row="1" column="0">
-         <widget class="QLabel" name="label_14">
+         <widget class="QLabel" name="labelMaxRange">
           <property name="text">
            <string>Max range</string>
           </property>
@@ -70,7 +70,7 @@
          </widget>
         </item>
         <item row="1" column="2">
-         <widget class="QLabel" name="label_15">
+         <widget class="QLabel" name="labelAngstromInvMaxRange">
           <property name="text">
            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Å&lt;span style=&quot; vertical-align:super;&quot;&gt;-1&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
           </property>
@@ -79,7 +79,7 @@
        </layout>
       </item>
       <item row="0" column="1" rowspan="2">
-       <spacer name="horizontalSpacer_8">
+       <spacer name="horizontalSpacerFittingRange">
         <property name="orientation">
          <enum>Qt::Horizontal</enum>
         </property>
@@ -92,7 +92,7 @@
        </spacer>
       </item>
       <item row="0" column="2">
-       <widget class="QPushButton" name="cmdReset">
+       <widget class="QPushButton" name="buttonReset">
         <property name="toolTip">
          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Reset the Q range to the default.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
         </property>
@@ -102,7 +102,7 @@
        </widget>
       </item>
       <item row="1" column="2">
-       <widget class="QPushButton" name="cmdMaskEdit">
+       <widget class="QPushButton" name="buttonMaskEdit">
         <property name="text">
          <string>Mask Editor</string>
         </property>
@@ -112,15 +112,15 @@
     </widget>
    </item>
    <item row="1" column="0">
-    <widget class="QGroupBox" name="groupBox_5">
+    <widget class="QGroupBox" name="groupBoxDataPoints">
      <property name="title">
       <string>Data points</string>
      </property>
      <layout class="QGridLayout" name="gridLayout_14">
       <item row="0" column="0">
-       <layout class="QGridLayout" name="gridLayout_15">
+       <layout class="QGridLayout" name="gridLayoutDataPoints">
         <item row="1" column="2">
-         <spacer name="horizontalSpacer_9">
+         <spacer name="horizontalSpacerDataPoints">
           <property name="orientation">
            <enum>Qt::Horizontal</enum>
           </property>
@@ -140,7 +140,7 @@
          </widget>
         </item>
         <item row="1" column="0">
-         <widget class="QLabel" name="label_22">
+         <widget class="QLabel" name="labelNptsFit">
           <property name="text">
            <string>Npts(Fit)</string>
           </property>
@@ -157,7 +157,7 @@
          </widget>
         </item>
         <item row="0" column="2">
-         <widget class="QCheckBox" name="chkLogData">
+         <widget class="QCheckBox" name="checkBoxLogSpacedPoints">
           <property name="toolTip">
            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Check to use log spaced points.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
           </property>
@@ -170,7 +170,7 @@
          </widget>
         </item>
         <item row="0" column="0">
-         <widget class="QLabel" name="label_21">
+         <widget class="QLabel" name="labelNpts">
           <property name="text">
            <string>Npts</string>
           </property>
@@ -188,9 +188,9 @@
      </property>
      <layout class="QGridLayout" name="gridLayout_20">
       <item row="0" column="0">
-       <layout class="QVBoxLayout" name="verticalLayout">
+       <layout class="QVBoxLayout" name="verticalLayoutWeighting">
         <item>
-         <widget class="QRadioButton" name="rbWeighting1">
+         <widget class="QRadioButton" name="radioButtonWeightingNone">
           <property name="text">
            <string>None</string>
           </property>
@@ -200,21 +200,21 @@
          </widget>
         </item>
         <item>
-         <widget class="QRadioButton" name="rbWeighting2">
+         <widget class="QRadioButton" name="radioButtonWeightingUsedIData">
           <property name="text">
            <string>Use dI Data</string>
           </property>
          </widget>
         </item>
         <item>
-         <widget class="QRadioButton" name="rbWeighting3">
+         <widget class="QRadioButton" name="radioButtonWeightingUseAbsSqrtIData">
           <property name="text">
            <string>Use |sqrt(I Data)|</string>
           </property>
          </widget>
         </item>
         <item>
-         <widget class="QRadioButton" name="rbWeighting4">
+         <widget class="QRadioButton" name="radioButtonWeightingUseAbsIData">
           <property name="text">
            <string>Use |I Data|</string>
           </property>
@@ -244,14 +244,14 @@
   <tabstop>txtMinRange</tabstop>
   <tabstop>txtMaxRange</tabstop>
   <tabstop>txtNpts</tabstop>
-  <tabstop>chkLogData</tabstop>
+  <tabstop>checkBoxLogSpacedPoints</tabstop>
   <tabstop>txtNptsFit</tabstop>
-  <tabstop>rbWeighting1</tabstop>
-  <tabstop>rbWeighting2</tabstop>
-  <tabstop>rbWeighting3</tabstop>
-  <tabstop>rbWeighting4</tabstop>
-  <tabstop>cmdReset</tabstop>
-  <tabstop>cmdMaskEdit</tabstop>
+  <tabstop>radioButtonWeightingNone</tabstop>
+  <tabstop>radioButtonWeightingUsedIData</tabstop>
+  <tabstop>radioButtonWeightingUseAbsSqrtIData</tabstop>
+  <tabstop>radioButtonWeightingUseAbsIData</tabstop>
+  <tabstop>buttonReset</tabstop>
+  <tabstop>buttonMaskEdit</tabstop>
  </tabstops>
  <resources/>
  <connections/>

--- a/src/sas/qtgui/Perspectives/Fitting/UI/OptionsWidgetUI.ui
+++ b/src/sas/qtgui/Perspectives/Fitting/UI/OptionsWidgetUI.ui
@@ -23,7 +23,7 @@
       <item row="0" column="0" rowspan="2">
        <layout class="QGridLayout" name="gridLayoutMinRangeMaxRange">
         <item row="0" column="0">
-         <widget class="QLabel" name="labelMinRange">
+         <widget class="QLabel" name="lblMinRange">
           <property name="text">
            <string>Min range</string>
           </property>
@@ -43,14 +43,14 @@
          </widget>
         </item>
         <item row="0" column="2">
-         <widget class="QLabel" name="labelAngstromInvMinRange">
+         <widget class="QLabel" name="lblAngstromInvMinRange">
           <property name="text">
            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Å&lt;span style=&quot; vertical-align:super;&quot;&gt;-1&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
           </property>
          </widget>
         </item>
         <item row="1" column="0">
-         <widget class="QLabel" name="labelMaxRange">
+         <widget class="QLabel" name="lblMaxRange">
           <property name="text">
            <string>Max range</string>
           </property>
@@ -70,7 +70,7 @@
          </widget>
         </item>
         <item row="1" column="2">
-         <widget class="QLabel" name="labelAngstromInvMaxRange">
+         <widget class="QLabel" name="lblAngstromInvMaxRange">
           <property name="text">
            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Å&lt;span style=&quot; vertical-align:super;&quot;&gt;-1&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
           </property>
@@ -92,7 +92,7 @@
        </spacer>
       </item>
       <item row="0" column="2">
-       <widget class="QPushButton" name="buttonReset">
+       <widget class="QPushButton" name="cmdReset">
         <property name="toolTip">
          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Reset the Q range to the default.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
         </property>
@@ -102,7 +102,7 @@
        </widget>
       </item>
       <item row="1" column="2">
-       <widget class="QPushButton" name="buttonMaskEdit">
+       <widget class="QPushButton" name="cmdMaskEdit">
         <property name="text">
          <string>Mask Editor</string>
         </property>
@@ -140,7 +140,7 @@
          </widget>
         </item>
         <item row="1" column="0">
-         <widget class="QLabel" name="labelNptsFit">
+         <widget class="QLabel" name="lblNptsFit">
           <property name="text">
            <string>Npts(Fit)</string>
           </property>
@@ -157,7 +157,7 @@
          </widget>
         </item>
         <item row="0" column="2">
-         <widget class="QCheckBox" name="checkBoxLogSpacedPoints">
+         <widget class="QCheckBox" name="chkLogSpacedPoints">
           <property name="toolTip">
            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Check to use log spaced points.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
           </property>
@@ -170,7 +170,7 @@
          </widget>
         </item>
         <item row="0" column="0">
-         <widget class="QLabel" name="labelNpts">
+         <widget class="QLabel" name="lblNpts">
           <property name="text">
            <string>Npts</string>
           </property>
@@ -190,7 +190,7 @@
       <item row="0" column="0">
        <layout class="QVBoxLayout" name="verticalLayoutWeighting">
         <item>
-         <widget class="QRadioButton" name="radioButtonWeightingNone">
+         <widget class="QRadioButton" name="rbWeightingNone">
           <property name="text">
            <string>None</string>
           </property>
@@ -200,21 +200,21 @@
          </widget>
         </item>
         <item>
-         <widget class="QRadioButton" name="radioButtonWeightingUsedIData">
+         <widget class="QRadioButton" name="rbWeightingUsedIData">
           <property name="text">
            <string>Use dI Data</string>
           </property>
          </widget>
         </item>
         <item>
-         <widget class="QRadioButton" name="radioButtonWeightingUseAbsSqrtIData">
+         <widget class="QRadioButton" name="rbWeightingUseAbsSqrtIData">
           <property name="text">
            <string>Use |sqrt(I Data)|</string>
           </property>
          </widget>
         </item>
         <item>
-         <widget class="QRadioButton" name="radioButtonWeightingUseAbsIData">
+         <widget class="QRadioButton" name="rbWeightingUseAbsIData">
           <property name="text">
            <string>Use |I Data|</string>
           </property>
@@ -244,14 +244,14 @@
   <tabstop>txtMinRange</tabstop>
   <tabstop>txtMaxRange</tabstop>
   <tabstop>txtNpts</tabstop>
-  <tabstop>checkBoxLogSpacedPoints</tabstop>
+  <tabstop>chkLogSpacedPoints</tabstop>
   <tabstop>txtNptsFit</tabstop>
-  <tabstop>radioButtonWeightingNone</tabstop>
-  <tabstop>radioButtonWeightingUsedIData</tabstop>
-  <tabstop>radioButtonWeightingUseAbsSqrtIData</tabstop>
-  <tabstop>radioButtonWeightingUseAbsIData</tabstop>
-  <tabstop>buttonReset</tabstop>
-  <tabstop>buttonMaskEdit</tabstop>
+  <tabstop>rbWeightingNone</tabstop>
+  <tabstop>rbWeightingUsedIData</tabstop>
+  <tabstop>rbWeightingUseAbsSqrtIData</tabstop>
+  <tabstop>rbWeightingUseAbsIData</tabstop>
+  <tabstop>cmdReset</tabstop>
+  <tabstop>cmdMaskEdit</tabstop>
  </tabstops>
  <resources/>
  <connections/>

--- a/src/sas/qtgui/Perspectives/Fitting/UI/OrderWidgetUI.ui
+++ b/src/sas/qtgui/Perspectives/Fitting/UI/OrderWidgetUI.ui
@@ -28,7 +28,7 @@
        </widget>
       </item>
       <item row="1" column="0">
-       <widget class="QListWidget" name="listDataOrder">
+       <widget class="QListWidget" name="lstDataOrder">
         <property name="editTriggers">
          <set>QAbstractItemView::NoEditTriggers</set>
         </property>

--- a/src/sas/qtgui/Perspectives/Fitting/UI/OrderWidgetUI.ui
+++ b/src/sas/qtgui/Perspectives/Fitting/UI/OrderWidgetUI.ui
@@ -21,7 +21,7 @@
      </property>
      <layout class="QGridLayout" name="gridLayout">
       <item row="0" column="0">
-       <widget class="QLabel" name="labelDataOrder">
+       <widget class="QLabel" name="lblDataOrder">
         <property name="text">
          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Drag and move items to define the order of fitting.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
         </property>

--- a/src/sas/qtgui/Perspectives/Fitting/UI/OrderWidgetUI.ui
+++ b/src/sas/qtgui/Perspectives/Fitting/UI/OrderWidgetUI.ui
@@ -15,20 +15,20 @@
   </property>
   <layout class="QGridLayout" name="gridLayout_2">
    <item row="0" column="0">
-    <widget class="QGroupBox" name="groupBox">
+    <widget class="QGroupBox" name="groupBoxDataOrder">
      <property name="title">
       <string>Data Order</string>
      </property>
      <layout class="QGridLayout" name="gridLayout">
       <item row="0" column="0">
-       <widget class="QLabel" name="label">
+       <widget class="QLabel" name="labelDataOrder">
         <property name="text">
          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Drag and move items to define the order of fitting.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
         </property>
        </widget>
       </item>
       <item row="1" column="0">
-       <widget class="QListWidget" name="lstOrder">
+       <widget class="QListWidget" name="listDataOrder">
         <property name="editTriggers">
          <set>QAbstractItemView::NoEditTriggers</set>
         </property>

--- a/src/sas/qtgui/Perspectives/Fitting/UI/SmearingWidgetUI.ui
+++ b/src/sas/qtgui/Perspectives/Fitting/UI/SmearingWidgetUI.ui
@@ -29,7 +29,7 @@
       <item row="0" column="0">
        <layout class="QGridLayout" name="gridLayoutInstrumentalSmearing">
         <item row="0" column="0">
-         <widget class="QComboBox" name="comboBoxInstrumentalSmearing">
+         <widget class="QComboBox" name="cbInstrumentalSmearing">
           <property name="currentIndex">
            <number>0</number>
           </property>
@@ -66,7 +66,7 @@
         <item row="0" column="1" rowspan="2">
          <layout class="QGridLayout" name="gridLayout_dQ">
           <item row="0" column="0">
-           <widget class="QLabel" name="label_Smearing_dQ_low">
+           <widget class="QLabel" name="lbl_Smearing_dQ_low">
             <property name="text">
              <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;dQ&lt;span style=&quot; vertical-align:sub;&quot;&gt;low&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
             </property>
@@ -76,14 +76,14 @@
            <widget class="QLineEdit" name="txt_dQ_low"/>
           </item>
           <item row="0" column="2">
-           <widget class="QLabel" name="labelInvAngstrom_dQ_low">
+           <widget class="QLabel" name="lblInvAngstrom_dQ_low">
             <property name="text">
              <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Å&lt;span style=&quot; vertical-align:super;&quot;&gt;-1&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
             </property>
            </widget>
           </item>
           <item row="1" column="0">
-           <widget class="QLabel" name="label_Smearing_dQ_high">
+           <widget class="QLabel" name="lbl_Smearing_dQ_high">
             <property name="text">
              <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;dQ&lt;span style=&quot; vertical-align:sub;&quot;&gt;high&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
             </property>
@@ -93,7 +93,7 @@
            <widget class="QLineEdit" name="txt_dQ_high"/>
           </item>
           <item row="1" column="2">
-           <widget class="QLabel" name="labelInvAngstrom_dQ_high">
+           <widget class="QLabel" name="lblInvAngstrom_dQ_high">
             <property name="text">
              <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Å&lt;span style=&quot; vertical-align:super;&quot;&gt;-1&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
             </property>
@@ -111,7 +111,7 @@
           </property>
           <layout class="QGridLayout" name="gridLayout">
            <item row="0" column="0">
-            <widget class="QComboBox" name="comboBoxAccuracy">
+            <widget class="QComboBox" name="cbAccuracy">
              <item>
               <property name="text">
                <string>Low</string>

--- a/src/sas/qtgui/Perspectives/Fitting/UI/SmearingWidgetUI.ui
+++ b/src/sas/qtgui/Perspectives/Fitting/UI/SmearingWidgetUI.ui
@@ -15,7 +15,7 @@
   </property>
   <layout class="QGridLayout" name="gridLayout_4">
    <item row="0" column="0">
-    <widget class="QGroupBox" name="groupBox_4">
+    <widget class="QGroupBox" name="groupBoxInstrumentalSmearing">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
        <horstretch>0</horstretch>
@@ -27,9 +27,9 @@
      </property>
      <layout class="QGridLayout" name="gridLayout_3">
       <item row="0" column="0">
-       <layout class="QGridLayout" name="gridLayout_2">
+       <layout class="QGridLayout" name="gridLayoutInstrumentalSmearing">
         <item row="0" column="0">
-         <widget class="QComboBox" name="cbSmearing">
+         <widget class="QComboBox" name="comboBoxInstrumentalSmearing">
           <property name="currentIndex">
            <number>0</number>
           </property>
@@ -64,36 +64,36 @@
          </widget>
         </item>
         <item row="0" column="1" rowspan="2">
-         <layout class="QGridLayout" name="gridLayout_11">
+         <layout class="QGridLayout" name="gridLayout_dQ">
           <item row="0" column="0">
-           <widget class="QLabel" name="lblSmearUp">
+           <widget class="QLabel" name="label_Smearing_dQ_low">
             <property name="text">
              <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;dQ&lt;span style=&quot; vertical-align:sub;&quot;&gt;low&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
             </property>
            </widget>
           </item>
           <item row="0" column="1">
-           <widget class="QLineEdit" name="txtSmearUp"/>
+           <widget class="QLineEdit" name="txt_dQ_low"/>
           </item>
           <item row="0" column="2">
-           <widget class="QLabel" name="lblUnitUp">
+           <widget class="QLabel" name="labelInvAngstrom_dQ_low">
             <property name="text">
              <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Å&lt;span style=&quot; vertical-align:super;&quot;&gt;-1&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
             </property>
            </widget>
           </item>
           <item row="1" column="0">
-           <widget class="QLabel" name="lblSmearDown">
+           <widget class="QLabel" name="label_Smearing_dQ_high">
             <property name="text">
              <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;dQ&lt;span style=&quot; vertical-align:sub;&quot;&gt;high&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
             </property>
            </widget>
           </item>
           <item row="1" column="1">
-           <widget class="QLineEdit" name="txtSmearDown"/>
+           <widget class="QLineEdit" name="txt_dQ_high"/>
           </item>
           <item row="1" column="2">
-           <widget class="QLabel" name="lblUnitDown">
+           <widget class="QLabel" name="labelInvAngstrom_dQ_high">
             <property name="text">
              <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Å&lt;span style=&quot; vertical-align:super;&quot;&gt;-1&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
             </property>
@@ -102,16 +102,16 @@
          </layout>
         </item>
         <item row="0" column="2" rowspan="2">
-         <widget class="QGroupBox" name="gAccuracy">
+         <widget class="QGroupBox" name="groupBoxAccuracy">
+          <property name="toolTip">
+           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Higher accuracy is very expensive. Use it with care!&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+          </property>
           <property name="title">
            <string>Accuracy</string>
           </property>
-          <property name="toolTip">
-             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Higher accuracy is very expensive. Use it with care!&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-          </property>
           <layout class="QGridLayout" name="gridLayout">
            <item row="0" column="0">
-            <widget class="QComboBox" name="cbAccuracy">
+            <widget class="QComboBox" name="comboBoxAccuracy">
              <item>
               <property name="text">
                <string>Low</string>
@@ -138,7 +138,7 @@
          </widget>
         </item>
         <item row="1" column="0">
-         <spacer name="verticalSpacer_2">
+         <spacer name="verticalSpacer2InstrumentalSmearing">
           <property name="orientation">
            <enum>Qt::Vertical</enum>
           </property>
@@ -156,7 +156,7 @@
     </widget>
    </item>
    <item row="0" column="1">
-    <spacer name="horizontalSpacer_2">
+    <spacer name="horizontalSpacerInstrumentalSmearing">
      <property name="orientation">
       <enum>Qt::Horizontal</enum>
      </property>
@@ -169,7 +169,7 @@
     </spacer>
    </item>
    <item row="1" column="0">
-    <spacer name="verticalSpacer">
+    <spacer name="verticalSpacerInstrumentalSmearing">
      <property name="orientation">
       <enum>Qt::Vertical</enum>
      </property>

--- a/src/sas/qtgui/Perspectives/Invariant/InvariantDetails.py
+++ b/src/sas/qtgui/Perspectives/Invariant/InvariantDetails.py
@@ -54,7 +54,7 @@ class DetailsDialog(QtWidgets.QDialog, Ui_Dialog):
         self.lblQDataUnits.setStyleSheet(new_font)
         self.lblQHighQUnits.setStyleSheet(new_font)
 
-        self.cmdOK.clicked.connect(self.accept)
+        self.buttonOK.clicked.connect(self.accept)
 
         self.warning_msg = "No Details on calculations available...\n"
 

--- a/src/sas/qtgui/Perspectives/Invariant/InvariantDetails.py
+++ b/src/sas/qtgui/Perspectives/Invariant/InvariantDetails.py
@@ -54,7 +54,7 @@ class DetailsDialog(QtWidgets.QDialog, Ui_Dialog):
         self.lblQDataUnits.setStyleSheet(new_font)
         self.lblQHighQUnits.setStyleSheet(new_font)
 
-        self.buttonOK.clicked.connect(self.accept)
+        self.cmdOK.clicked.connect(self.accept)
 
         self.warning_msg = "No Details on calculations available...\n"
 

--- a/src/sas/qtgui/Perspectives/Invariant/InvariantPerspective.py
+++ b/src/sas/qtgui/Perspectives/Invariant/InvariantPerspective.py
@@ -67,7 +67,7 @@ class InvariantWindow(QtWidgets.QDialog, Ui_tabbedInvariantUI, Perspective):
         self._model_item = QtGui.QStandardItem()
 
         self.detailsDialog = DetailsDialog(self)
-        self.detailsDialog.cmdOK.clicked.connect(self.enabling)
+        self.detailsDialog.buttonOK.clicked.connect(self.enabling)
 
         self._low_extrapolate = False
         self._low_guinier = True
@@ -129,7 +129,7 @@ class InvariantWindow(QtWidgets.QDialog, Ui_tabbedInvariantUI, Perspective):
         self.setupMapper()
 
         # Default enablement
-        self.cmdCalculate.setEnabled(False)
+        self.buttonCalculate.setEnabled(False)
 
         # validator: double
         self.txtExtrapolQMin.setValidator(GuiUtils.DoubleValidator())
@@ -169,7 +169,7 @@ class InvariantWindow(QtWidgets.QDialog, Ui_tabbedInvariantUI, Perspective):
 
     def enabling(self):
         """ """
-        self.cmdStatus.setEnabled(True)
+        self.buttonStatus.setEnabled(True)
 
     def setClosable(self, value: bool=True):
         """ Allow outsiders close this widget """
@@ -232,8 +232,8 @@ class InvariantWindow(QtWidgets.QDialog, Ui_tabbedInvariantUI, Perspective):
             extrapolation = "low"
 
         # modify the Calculate button to indicate background process
-        self.cmdCalculate.setText("Calculating...")
-        self.cmdCalculate.setEnabled(False)
+        self.buttonCalculate.setText("Calculating...")
+        self.buttonCalculate.setEnabled(False)
 
         # Send the calculations to separate thread.
         d = threads.deferToThread(self.calculateThread, extrapolation)
@@ -255,8 +255,8 @@ class InvariantWindow(QtWidgets.QDialog, Ui_tabbedInvariantUI, Perspective):
 
     def allow_calculation(self):
         # Set the calculate button to available
-        self.cmdCalculate.setEnabled(True)
-        self.cmdCalculate.setText("Calculate")
+        self.buttonCalculate.setEnabled(True)
+        self.buttonCalculate.setText("Calculate")
 
     def plotResult(self, model): # TODO: Pythonic name, typing
         """ Plot result of calculation """
@@ -430,10 +430,10 @@ class InvariantWindow(QtWidgets.QDialog, Ui_tabbedInvariantUI, Perspective):
             reactor.callFromThread(self.updateModelFromThread, WIDGETS.W_SPECIFIC_SURFACE_ERR, surface_error)
 
         # Enable the status button
-        self.cmdStatus.setEnabled(True)
+        self.buttonStatus.setEnabled(True)
         # Early exit if calculations failed
         if calculation_failed:
-            self.cmdStatus.setEnabled(False)
+            self.buttonStatus.setEnabled(False)
             logging.warning('Calculation failed: {}'.format(msg))
             return self.model
 
@@ -522,7 +522,7 @@ class InvariantWindow(QtWidgets.QDialog, Ui_tabbedInvariantUI, Perspective):
         """
         self.detailsDialog.setModel(self.model)
         self.detailsDialog.showDialog()
-        self.cmdStatus.setEnabled(False)
+        self.buttonStatus.setEnabled(False)
 
     def onHelp(self):
         """ Display help when clicking on Help button """
@@ -531,9 +531,9 @@ class InvariantWindow(QtWidgets.QDialog, Ui_tabbedInvariantUI, Perspective):
 
     def setupSlots(self):
         """ """
-        self.cmdCalculate.clicked.connect(self.calculateInvariant)
-        self.cmdStatus.clicked.connect(self.onStatus)
-        self.cmdHelp.clicked.connect(self.onHelp)
+        self.buttonCalculate.clicked.connect(self.calculateInvariant)
+        self.buttonStatus.clicked.connect(self.onStatus)
+        self.buttonHelp.clicked.connect(self.onHelp)
 
         self.chkLowQ.stateChanged.connect(self.stateChanged)
         self.chkLowQ.stateChanged.connect(self.checkQExtrapolatedData)
@@ -605,7 +605,7 @@ class InvariantWindow(QtWidgets.QDialog, Ui_tabbedInvariantUI, Perspective):
         Validators of number of points for extrapolation.
         Error if it is larger than the distribution length
         """
-        self.cmdCalculate.setEnabled(False)
+        self.buttonCalculate.setEnabled(False)
         try:
             int_value = int(self.sender().text())
         except ValueError:
@@ -716,7 +716,7 @@ class InvariantWindow(QtWidgets.QDialog, Ui_tabbedInvariantUI, Perspective):
         if calculate:
             self.allow_calculation()
         else:
-            self.cmdCalculate.setEnabled(False)
+            self.buttonCalculate.setEnabled(False)
 
     def updateFromGui(self):
         """ Update model when new user inputs """
@@ -747,7 +747,7 @@ class InvariantWindow(QtWidgets.QDialog, Ui_tabbedInvariantUI, Perspective):
         except ValueError:
             # empty field, just skip
             self.sender().setStyleSheet(BG_RED)
-            self.cmdCalculate.setEnabled(False)
+            self.buttonCalculate.setEnabled(False)
 
     def lowGuinierAndPowerToggle(self, toggle):
         """
@@ -964,8 +964,8 @@ class InvariantWindow(QtWidgets.QDialog, Ui_tabbedInvariantUI, Perspective):
         # Pass an empty dictionary to set all inputs to their default values
         self.updateFromParameters({})
         # Disable buttons to return to base state
-        self.cmdCalculate.setEnabled(False)
-        self.cmdStatus.setEnabled(False)
+        self.buttonCalculate.setEnabled(False)
+        self.buttonStatus.setEnabled(False)
 
     def updateGuiFromFile(self, data=None):
         """
@@ -1007,7 +1007,7 @@ class InvariantWindow(QtWidgets.QDialog, Ui_tabbedInvariantUI, Perspective):
 
         # Calculate and add to GUI: volume fraction, invariant total,
         # and specific surface if porod checked
-        if self.cmdCalculate.isEnabled():
+        if self.buttonCalculate.isEnabled():
             self.calculateInvariant()
 
     def serializeAll(self):

--- a/src/sas/qtgui/Perspectives/Invariant/InvariantPerspective.py
+++ b/src/sas/qtgui/Perspectives/Invariant/InvariantPerspective.py
@@ -129,7 +129,7 @@ class InvariantWindow(QtWidgets.QDialog, Ui_tabbedInvariantUI, Perspective):
         self.setupMapper()
 
         # Default enablement
-        self.buttonCalculate.setEnabled(False)
+        self.cmdCalculate.setEnabled(False)
 
         # validator: double
         self.txtExtrapolQMin.setValidator(GuiUtils.DoubleValidator())
@@ -169,7 +169,7 @@ class InvariantWindow(QtWidgets.QDialog, Ui_tabbedInvariantUI, Perspective):
 
     def enabling(self):
         """ """
-        self.buttonStatus.setEnabled(True)
+        self.cmdStatus.setEnabled(True)
 
     def setClosable(self, value: bool=True):
         """ Allow outsiders close this widget """
@@ -232,8 +232,8 @@ class InvariantWindow(QtWidgets.QDialog, Ui_tabbedInvariantUI, Perspective):
             extrapolation = "low"
 
         # modify the Calculate button to indicate background process
-        self.buttonCalculate.setText("Calculating...")
-        self.buttonCalculate.setEnabled(False)
+        self.cmdCalculate.setText("Calculating...")
+        self.cmdCalculate.setEnabled(False)
 
         # Send the calculations to separate thread.
         d = threads.deferToThread(self.calculateThread, extrapolation)
@@ -255,8 +255,8 @@ class InvariantWindow(QtWidgets.QDialog, Ui_tabbedInvariantUI, Perspective):
 
     def allow_calculation(self):
         # Set the calculate button to available
-        self.buttonCalculate.setEnabled(True)
-        self.buttonCalculate.setText("Calculate")
+        self.cmdCalculate.setEnabled(True)
+        self.cmdCalculate.setText("Calculate")
 
     def plotResult(self, model): # TODO: Pythonic name, typing
         """ Plot result of calculation """
@@ -430,10 +430,10 @@ class InvariantWindow(QtWidgets.QDialog, Ui_tabbedInvariantUI, Perspective):
             reactor.callFromThread(self.updateModelFromThread, WIDGETS.W_SPECIFIC_SURFACE_ERR, surface_error)
 
         # Enable the status button
-        self.buttonStatus.setEnabled(True)
+        self.cmdStatus.setEnabled(True)
         # Early exit if calculations failed
         if calculation_failed:
-            self.buttonStatus.setEnabled(False)
+            self.cmdStatus.setEnabled(False)
             logging.warning('Calculation failed: {}'.format(msg))
             return self.model
 
@@ -522,7 +522,7 @@ class InvariantWindow(QtWidgets.QDialog, Ui_tabbedInvariantUI, Perspective):
         """
         self.detailsDialog.setModel(self.model)
         self.detailsDialog.showDialog()
-        self.buttonStatus.setEnabled(False)
+        self.cmdStatus.setEnabled(False)
 
     def onHelp(self):
         """ Display help when clicking on Help button """
@@ -531,9 +531,9 @@ class InvariantWindow(QtWidgets.QDialog, Ui_tabbedInvariantUI, Perspective):
 
     def setupSlots(self):
         """ """
-        self.buttonCalculate.clicked.connect(self.calculateInvariant)
-        self.buttonStatus.clicked.connect(self.onStatus)
-        self.buttonHelp.clicked.connect(self.onHelp)
+        self.cmdCalculate.clicked.connect(self.calculateInvariant)
+        self.cmdStatus.clicked.connect(self.onStatus)
+        self.cmdHelp.clicked.connect(self.onHelp)
 
         self.chkLowQ.stateChanged.connect(self.stateChanged)
         self.chkLowQ.stateChanged.connect(self.checkQExtrapolatedData)
@@ -605,7 +605,7 @@ class InvariantWindow(QtWidgets.QDialog, Ui_tabbedInvariantUI, Perspective):
         Validators of number of points for extrapolation.
         Error if it is larger than the distribution length
         """
-        self.buttonCalculate.setEnabled(False)
+        self.cmdCalculate.setEnabled(False)
         try:
             int_value = int(self.sender().text())
         except ValueError:
@@ -716,7 +716,7 @@ class InvariantWindow(QtWidgets.QDialog, Ui_tabbedInvariantUI, Perspective):
         if calculate:
             self.allow_calculation()
         else:
-            self.buttonCalculate.setEnabled(False)
+            self.cmdCalculate.setEnabled(False)
 
     def updateFromGui(self):
         """ Update model when new user inputs """
@@ -747,7 +747,7 @@ class InvariantWindow(QtWidgets.QDialog, Ui_tabbedInvariantUI, Perspective):
         except ValueError:
             # empty field, just skip
             self.sender().setStyleSheet(BG_RED)
-            self.buttonCalculate.setEnabled(False)
+            self.cmdCalculate.setEnabled(False)
 
     def lowGuinierAndPowerToggle(self, toggle):
         """
@@ -964,8 +964,8 @@ class InvariantWindow(QtWidgets.QDialog, Ui_tabbedInvariantUI, Perspective):
         # Pass an empty dictionary to set all inputs to their default values
         self.updateFromParameters({})
         # Disable buttons to return to base state
-        self.buttonCalculate.setEnabled(False)
-        self.buttonStatus.setEnabled(False)
+        self.cmdCalculate.setEnabled(False)
+        self.cmdStatus.setEnabled(False)
 
     def updateGuiFromFile(self, data=None):
         """
@@ -1007,7 +1007,7 @@ class InvariantWindow(QtWidgets.QDialog, Ui_tabbedInvariantUI, Perspective):
 
         # Calculate and add to GUI: volume fraction, invariant total,
         # and specific surface if porod checked
-        if self.buttonCalculate.isEnabled():
+        if self.cmdCalculate.isEnabled():
             self.calculateInvariant()
 
     def serializeAll(self):

--- a/src/sas/qtgui/Perspectives/Invariant/InvariantPerspective.py
+++ b/src/sas/qtgui/Perspectives/Invariant/InvariantPerspective.py
@@ -67,7 +67,7 @@ class InvariantWindow(QtWidgets.QDialog, Ui_tabbedInvariantUI, Perspective):
         self._model_item = QtGui.QStandardItem()
 
         self.detailsDialog = DetailsDialog(self)
-        self.detailsDialog.buttonOK.clicked.connect(self.enabling)
+        self.detailsDialog.cmdOK.clicked.connect(self.enabling)
 
         self._low_extrapolate = False
         self._low_guinier = True

--- a/src/sas/qtgui/Perspectives/Invariant/UI/InvariantDetailsUI.ui
+++ b/src/sas/qtgui/Perspectives/Invariant/UI/InvariantDetailsUI.ui
@@ -27,7 +27,7 @@
      </property>
      <layout class="QGridLayout" name="gridLayout_2">
       <item row="0" column="0">
-       <widget class="QLabel" name="labelQStarLowQ">
+       <widget class="QLabel" name="lblQStarLowQ">
         <property name="text">
          <string>Q* from Low-Q</string>
         </property>
@@ -41,7 +41,7 @@
        </widget>
       </item>
       <item row="1" column="0">
-       <widget class="QLabel" name="labelQStarFromData">
+       <widget class="QLabel" name="lblQStarFromData">
         <property name="text">
          <string>Q* from Data</string>
         </property>
@@ -55,7 +55,7 @@
        </widget>
       </item>
       <item row="2" column="0">
-       <widget class="QLabel" name="labelQStarHighQ">
+       <widget class="QLabel" name="lblQStarHighQ">
         <property name="text">
          <string>Q* from High-Q</string>
         </property>
@@ -78,7 +78,7 @@
      </property>
      <layout class="QGridLayout" name="gridLayout">
       <item row="0" column="0">
-       <widget class="QLabel" name="labelNumValQStarLowQ">
+       <widget class="QLabel" name="lblNumValQStarLowQ">
         <property name="text">
          <string>Q* from Low-Q</string>
         </property>
@@ -95,7 +95,7 @@
        </widget>
       </item>
       <item row="0" column="2">
-       <widget class="QLabel" name="labelNumValPlusMinus1">
+       <widget class="QLabel" name="lblNumValPlusMinus1">
         <property name="text">
          <string>+/-</string>
         </property>
@@ -119,7 +119,7 @@
        </widget>
       </item>
       <item row="1" column="0">
-       <widget class="QLabel" name="labelNumValQStarData">
+       <widget class="QLabel" name="lblNumValQStarData">
         <property name="text">
          <string>Q* from Data</string>
         </property>
@@ -136,7 +136,7 @@
        </widget>
       </item>
       <item row="1" column="2">
-       <widget class="QLabel" name="labelNumValPlusMinus2">
+       <widget class="QLabel" name="lblNumValPlusMinus2">
         <property name="text">
          <string>+/-</string>
         </property>
@@ -160,7 +160,7 @@
        </widget>
       </item>
       <item row="2" column="0">
-       <widget class="QLabel" name="labelQStarHighQ_2">
+       <widget class="QLabel" name="lblQStarHighQ_2">
         <property name="text">
          <string>Q* from High-Q</string>
         </property>
@@ -177,7 +177,7 @@
        </widget>
       </item>
       <item row="2" column="2">
-       <widget class="QLabel" name="labelPlusMinus3">
+       <widget class="QLabel" name="lblPlusMinus3">
         <property name="text">
          <string>+/-</string>
         </property>
@@ -223,7 +223,7 @@
     </widget>
    </item>
    <item row="3" column="0">
-    <widget class="QDialogButtonBox" name="buttonOK">
+    <widget class="QDialogButtonBox" name="cmdOK">
      <property name="orientation">
       <enum>Qt::Horizontal</enum>
      </property>
@@ -237,7 +237,7 @@
  <resources/>
  <connections>
   <connection>
-   <sender>buttonOK</sender>
+   <sender>cmdOK</sender>
    <signal>accepted()</signal>
    <receiver>Dialog</receiver>
    <slot>accept()</slot>
@@ -253,7 +253,7 @@
    </hints>
   </connection>
   <connection>
-   <sender>buttonOK</sender>
+   <sender>cmdOK</sender>
    <signal>rejected()</signal>
    <receiver>Dialog</receiver>
    <slot>reject()</slot>

--- a/src/sas/qtgui/Perspectives/Invariant/UI/InvariantDetailsUI.ui
+++ b/src/sas/qtgui/Perspectives/Invariant/UI/InvariantDetailsUI.ui
@@ -223,7 +223,7 @@
     </widget>
    </item>
    <item row="3" column="0">
-    <widget class="QDialogButtonBox" name="cmdOK">
+    <widget class="QDialogButtonBox" name="buttonOK">
      <property name="orientation">
       <enum>Qt::Horizontal</enum>
      </property>
@@ -237,7 +237,7 @@
  <resources/>
  <connections>
   <connection>
-   <sender>cmdOK</sender>
+   <sender>buttonOK</sender>
    <signal>accepted()</signal>
    <receiver>Dialog</receiver>
    <slot>accept()</slot>
@@ -253,7 +253,7 @@
    </hints>
   </connection>
   <connection>
-   <sender>cmdOK</sender>
+   <sender>buttonOK</sender>
    <signal>rejected()</signal>
    <receiver>Dialog</receiver>
    <slot>reject()</slot>

--- a/src/sas/qtgui/Perspectives/Invariant/UI/InvariantDetailsUI.ui
+++ b/src/sas/qtgui/Perspectives/Invariant/UI/InvariantDetailsUI.ui
@@ -27,7 +27,7 @@
      </property>
      <layout class="QGridLayout" name="gridLayout_2">
       <item row="0" column="0">
-       <widget class="QLabel" name="label_12">
+       <widget class="QLabel" name="labelQStarLowQ">
         <property name="text">
          <string>Q* from Low-Q</string>
         </property>
@@ -41,7 +41,7 @@
        </widget>
       </item>
       <item row="1" column="0">
-       <widget class="QLabel" name="label_10">
+       <widget class="QLabel" name="labelQStarFromData">
         <property name="text">
          <string>Q* from Data</string>
         </property>
@@ -55,7 +55,7 @@
        </widget>
       </item>
       <item row="2" column="0">
-       <widget class="QLabel" name="label_11">
+       <widget class="QLabel" name="labelQStarHighQ">
         <property name="text">
          <string>Q* from High-Q</string>
         </property>
@@ -78,7 +78,7 @@
      </property>
      <layout class="QGridLayout" name="gridLayout">
       <item row="0" column="0">
-       <widget class="QLabel" name="label">
+       <widget class="QLabel" name="labelNumValQStarLowQ">
         <property name="text">
          <string>Q* from Low-Q</string>
         </property>
@@ -95,7 +95,7 @@
        </widget>
       </item>
       <item row="0" column="2">
-       <widget class="QLabel" name="label_2">
+       <widget class="QLabel" name="labelNumValPlusMinus1">
         <property name="text">
          <string>+/-</string>
         </property>
@@ -119,7 +119,7 @@
        </widget>
       </item>
       <item row="1" column="0">
-       <widget class="QLabel" name="label_5">
+       <widget class="QLabel" name="labelNumValQStarData">
         <property name="text">
          <string>Q* from Data</string>
         </property>
@@ -136,7 +136,7 @@
        </widget>
       </item>
       <item row="1" column="2">
-       <widget class="QLabel" name="label_6">
+       <widget class="QLabel" name="labelNumValPlusMinus2">
         <property name="text">
          <string>+/-</string>
         </property>
@@ -160,7 +160,7 @@
        </widget>
       </item>
       <item row="2" column="0">
-       <widget class="QLabel" name="label_8">
+       <widget class="QLabel" name="labelQStarHighQ_2">
         <property name="text">
          <string>Q* from High-Q</string>
         </property>
@@ -177,7 +177,7 @@
        </widget>
       </item>
       <item row="2" column="2">
-       <widget class="QLabel" name="label_9">
+       <widget class="QLabel" name="labelPlusMinus3">
         <property name="text">
          <string>+/-</string>
         </property>

--- a/src/sas/qtgui/Perspectives/Invariant/UI/TabbedInvariantUI.ui
+++ b/src/sas/qtgui/Perspectives/Invariant/UI/TabbedInvariantUI.ui
@@ -86,7 +86,7 @@
    <item row="0" column="0">
     <widget class="QTabWidget" name="tabWidget">
      <property name="currentIndex">
-      <number>1</number>
+      <number>0</number>
      </property>
      <widget class="QWidget" name="tabMain">
       <attribute name="title">

--- a/src/sas/qtgui/Perspectives/Invariant/UI/TabbedInvariantUI.ui
+++ b/src/sas/qtgui/Perspectives/Invariant/UI/TabbedInvariantUI.ui
@@ -36,7 +36,7 @@
    <item row="2" column="0">
     <layout class="QHBoxLayout" name="horizontalLayout_8">
      <item>
-      <widget class="QPushButton" name="cmdCalculate">
+      <widget class="QPushButton" name="buttonCalculate">
        <property name="toolTip">
         <string>Compute invariant</string>
        </property>
@@ -59,7 +59,7 @@
       </spacer>
      </item>
      <item>
-      <widget class="QPushButton" name="cmdStatus">
+      <widget class="QPushButton" name="buttonStatus">
        <property name="enabled">
         <bool>false</bool>
        </property>
@@ -72,7 +72,7 @@
       </widget>
      </item>
      <item>
-      <widget class="QPushButton" name="cmdHelp">
+      <widget class="QPushButton" name="buttonHelp">
        <property name="toolTip">
         <string/>
        </property>
@@ -86,7 +86,7 @@
    <item row="0" column="0">
     <widget class="QTabWidget" name="tabWidget">
      <property name="currentIndex">
-      <number>0</number>
+      <number>1</number>
      </property>
      <widget class="QWidget" name="tabMain">
       <attribute name="title">
@@ -749,9 +749,9 @@ while extrapolating the low-Q region</string>
   <tabstop>txtSpecSurfErr</tabstop>
   <tabstop>txtInvariantTot</tabstop>
   <tabstop>txtInvariantTotErr</tabstop>
-  <tabstop>cmdCalculate</tabstop>
-  <tabstop>cmdStatus</tabstop>
-  <tabstop>cmdHelp</tabstop>
+  <tabstop>buttonCalculate</tabstop>
+  <tabstop>buttonStatus</tabstop>
+  <tabstop>buttonHelp</tabstop>
   <tabstop>txtBackgd</tabstop>
   <tabstop>txtScale</tabstop>
   <tabstop>txtContrast</tabstop>

--- a/src/sas/qtgui/Perspectives/Invariant/UI/TabbedInvariantUI.ui
+++ b/src/sas/qtgui/Perspectives/Invariant/UI/TabbedInvariantUI.ui
@@ -391,7 +391,7 @@
           <item row="0" column="0">
            <layout class="QGridLayout" name="gridLayout_3">
             <item row="0" column="0">
-             <widget class="QLabel" name="label_5">
+             <widget class="QLabel" name="labelCustomizedInputBackground">
               <property name="text">
                <string>Background:</string>
               </property>
@@ -401,14 +401,14 @@
              <widget class="QLineEdit" name="txtBackgd"/>
             </item>
             <item row="0" column="2">
-             <widget class="QLabel" name="label_8">
+             <widget class="QLabel" name="labelCustomizedInputBackgroundUnit">
               <property name="text">
                <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;cm&lt;span style=&quot; vertical-align:super;&quot;&gt;-1&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
               </property>
              </widget>
             </item>
             <item row="0" column="3">
-             <widget class="QLabel" name="label_9">
+             <widget class="QLabel" name="labelCustomizedInputScale">
               <property name="text">
                <string>Scale:</string>
               </property>
@@ -418,7 +418,7 @@
              <widget class="QLineEdit" name="txtScale"/>
             </item>
             <item row="1" column="0">
-             <widget class="QLabel" name="label_6">
+             <widget class="QLabel" name="labelCustomizedInputContrast">
               <property name="text">
                <string>Contrast:</string>
               </property>
@@ -435,7 +435,7 @@
              </widget>
             </item>
             <item row="1" column="3">
-             <widget class="QLabel" name="label_10">
+             <widget class="QLabel" name="labelCustomizedInputPorodConstant">
               <property name="text">
                <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Porod&lt;br/&gt;constant:&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
               </property>
@@ -469,14 +469,14 @@
           <item row="0" column="0" colspan="2">
            <layout class="QHBoxLayout" name="horizontalLayout_2">
             <item>
-             <widget class="QLabel" name="label_12">
+             <widget class="QLabel" name="labelExtrapolationQRange">
               <property name="text">
                <string>Q Range:</string>
               </property>
              </widget>
             </item>
             <item>
-             <widget class="QLabel" name="label_14">
+             <widget class="QLabel" name="labelExtrapolationQRangeMin">
               <property name="text">
                <string>Min</string>
               </property>
@@ -496,7 +496,7 @@
              </widget>
             </item>
             <item>
-             <widget class="QLabel" name="label_13">
+             <widget class="QLabel" name="labelExtrapolarionQRangeMax">
               <property name="text">
                <string>Max</string>
               </property>
@@ -530,7 +530,7 @@
              <item row="1" column="0" colspan="2">
               <layout class="QHBoxLayout" name="horizontalLayout_3">
                <item>
-                <widget class="QLabel" name="label_16">
+                <widget class="QLabel" name="labelExtrapolationLowQNpts">
                  <property name="text">
                   <string>Npts:</string>
                  </property>
@@ -579,7 +579,7 @@ while extrapolating the low-Q region</string>
              <item row="3" column="0" colspan="2">
               <layout class="QHBoxLayout" name="horizontalLayout_6">
                <item>
-                <widget class="QLabel" name="label_17">
+                <widget class="QLabel" name="labelExtrapolationPowerLowQ">
                  <property name="text">
                   <string>Power:</string>
                  </property>
@@ -665,7 +665,7 @@ while extrapolating the low-Q region</string>
              <item row="1" column="0">
               <layout class="QHBoxLayout" name="horizontalLayout_5">
                <item>
-                <widget class="QLabel" name="label_18">
+                <widget class="QLabel" name="labelExtrapolationNptsHighQ">
                  <property name="text">
                   <string>Npts:</string>
                  </property>
@@ -711,7 +711,7 @@ while extrapolating the low-Q region</string>
              <item row="3" column="0">
               <layout class="QHBoxLayout" name="horizontalLayout_7">
                <item>
-                <widget class="QLabel" name="label_19">
+                <widget class="QLabel" name="labelExtrapolationPowerHighQ">
                  <property name="text">
                   <string>Power:</string>
                  </property>

--- a/src/sas/qtgui/Perspectives/Invariant/UI/TabbedInvariantUI.ui
+++ b/src/sas/qtgui/Perspectives/Invariant/UI/TabbedInvariantUI.ui
@@ -36,7 +36,7 @@
    <item row="2" column="0">
     <layout class="QHBoxLayout" name="horizontalLayout_8">
      <item>
-      <widget class="QPushButton" name="buttonCalculate">
+      <widget class="QPushButton" name="cmdCalculate">
        <property name="toolTip">
         <string>Compute invariant</string>
        </property>
@@ -59,7 +59,7 @@
       </spacer>
      </item>
      <item>
-      <widget class="QPushButton" name="buttonStatus">
+      <widget class="QPushButton" name="cmdStatus">
        <property name="enabled">
         <bool>false</bool>
        </property>
@@ -72,7 +72,7 @@
       </widget>
      </item>
      <item>
-      <widget class="QPushButton" name="buttonHelp">
+      <widget class="QPushButton" name="cmdHelp">
        <property name="toolTip">
         <string/>
        </property>
@@ -187,7 +187,7 @@
          </property>
          <layout class="QGridLayout" name="gridLayout_5">
           <item row="0" column="0">
-           <widget class="QLabel" name="label_21">
+           <widget class="QLabel" name="lblVolumeFraction">
             <property name="text">
              <string>Volume fraction:</string>
             </property>
@@ -219,7 +219,7 @@
            </widget>
           </item>
           <item row="0" column="2">
-           <widget class="QLabel" name="label_20">
+           <widget class="QLabel" name="lblPlusMinus1">
             <property name="text">
              <string>+/-</string>
             </property>
@@ -245,7 +245,7 @@
            </widget>
           </item>
           <item row="1" column="0">
-           <widget class="QLabel" name="label_22">
+           <widget class="QLabel" name="lblSpecificSurface">
             <property name="text">
              <string>Specific Surface:</string>
             </property>
@@ -271,7 +271,7 @@
            </widget>
           </item>
           <item row="1" column="2">
-           <widget class="QLabel" name="label_23">
+           <widget class="QLabel" name="lblPlusMinus2">
             <property name="text">
              <string>+/-</string>
             </property>
@@ -311,7 +311,7 @@
            </widget>
           </item>
           <item row="3" column="0">
-           <widget class="QLabel" name="label_25">
+           <widget class="QLabel" name="lblInvariantTotal">
             <property name="text">
              <string>Invariant Total [Q]:</string>
             </property>
@@ -340,7 +340,7 @@
            </widget>
           </item>
           <item row="3" column="2">
-           <widget class="QLabel" name="label_26">
+           <widget class="QLabel" name="lblPlusMinus3">
             <property name="text">
              <string>+/-</string>
             </property>
@@ -391,7 +391,7 @@
           <item row="0" column="0">
            <layout class="QGridLayout" name="gridLayout_3">
             <item row="0" column="0">
-             <widget class="QLabel" name="labelCustomizedInputBackground">
+             <widget class="QLabel" name="lblCustomizedInputBackground">
               <property name="text">
                <string>Background:</string>
               </property>
@@ -401,14 +401,14 @@
              <widget class="QLineEdit" name="txtBackgd"/>
             </item>
             <item row="0" column="2">
-             <widget class="QLabel" name="labelCustomizedInputBackgroundUnit">
+             <widget class="QLabel" name="lblCustomizedInputBackgroundUnit">
               <property name="text">
                <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;cm&lt;span style=&quot; vertical-align:super;&quot;&gt;-1&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
               </property>
              </widget>
             </item>
             <item row="0" column="3">
-             <widget class="QLabel" name="labelCustomizedInputScale">
+             <widget class="QLabel" name="lblCustomizedInputScale">
               <property name="text">
                <string>Scale:</string>
               </property>
@@ -418,7 +418,7 @@
              <widget class="QLineEdit" name="txtScale"/>
             </item>
             <item row="1" column="0">
-             <widget class="QLabel" name="labelCustomizedInputContrast">
+             <widget class="QLabel" name="lblCustomizedInputContrast">
               <property name="text">
                <string>Contrast:</string>
               </property>
@@ -435,7 +435,7 @@
              </widget>
             </item>
             <item row="1" column="3">
-             <widget class="QLabel" name="labelCustomizedInputPorodConstant">
+             <widget class="QLabel" name="lblCustomizedInputPorodConstant">
               <property name="text">
                <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Porod&lt;br/&gt;constant:&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
               </property>
@@ -469,14 +469,14 @@
           <item row="0" column="0" colspan="2">
            <layout class="QHBoxLayout" name="horizontalLayout_2">
             <item>
-             <widget class="QLabel" name="labelExtrapolationQRange">
+             <widget class="QLabel" name="lblExtrapolationQRange">
               <property name="text">
                <string>Q Range:</string>
               </property>
              </widget>
             </item>
             <item>
-             <widget class="QLabel" name="labelExtrapolationQRangeMin">
+             <widget class="QLabel" name="lblExtrapolationQRangeMin">
               <property name="text">
                <string>Min</string>
               </property>
@@ -496,7 +496,7 @@
              </widget>
             </item>
             <item>
-             <widget class="QLabel" name="labelExtrapolarionQRangeMax">
+             <widget class="QLabel" name="lblExtrapolarionQRangeMax">
               <property name="text">
                <string>Max</string>
               </property>
@@ -530,7 +530,7 @@
              <item row="1" column="0" colspan="2">
               <layout class="QHBoxLayout" name="horizontalLayout_3">
                <item>
-                <widget class="QLabel" name="labelExtrapolationLowQNpts">
+                <widget class="QLabel" name="lblExtrapolationLowQNpts">
                  <property name="text">
                   <string>Npts:</string>
                  </property>
@@ -579,7 +579,7 @@ while extrapolating the low-Q region</string>
              <item row="3" column="0" colspan="2">
               <layout class="QHBoxLayout" name="horizontalLayout_6">
                <item>
-                <widget class="QLabel" name="labelExtrapolationPowerLowQ">
+                <widget class="QLabel" name="lblExtrapolationPowerLowQ">
                  <property name="text">
                   <string>Power:</string>
                  </property>
@@ -665,7 +665,7 @@ while extrapolating the low-Q region</string>
              <item row="1" column="0">
               <layout class="QHBoxLayout" name="horizontalLayout_5">
                <item>
-                <widget class="QLabel" name="labelExtrapolationNptsHighQ">
+                <widget class="QLabel" name="lblExtrapolationNptsHighQ">
                  <property name="text">
                   <string>Npts:</string>
                  </property>
@@ -711,7 +711,7 @@ while extrapolating the low-Q region</string>
              <item row="3" column="0">
               <layout class="QHBoxLayout" name="horizontalLayout_7">
                <item>
-                <widget class="QLabel" name="labelExtrapolationPowerHighQ">
+                <widget class="QLabel" name="lblExtrapolationPowerHighQ">
                  <property name="text">
                   <string>Power:</string>
                  </property>
@@ -749,9 +749,9 @@ while extrapolating the low-Q region</string>
   <tabstop>txtSpecSurfErr</tabstop>
   <tabstop>txtInvariantTot</tabstop>
   <tabstop>txtInvariantTotErr</tabstop>
-  <tabstop>buttonCalculate</tabstop>
-  <tabstop>buttonStatus</tabstop>
-  <tabstop>buttonHelp</tabstop>
+  <tabstop>cmdCalculate</tabstop>
+  <tabstop>cmdStatus</tabstop>
+  <tabstop>cmdHelp</tabstop>
   <tabstop>txtBackgd</tabstop>
   <tabstop>txtScale</tabstop>
   <tabstop>txtContrast</tabstop>

--- a/src/sas/qtgui/Perspectives/Inversion/DMaxExplorerWidget.py
+++ b/src/sas/qtgui/Perspectives/Inversion/DMaxExplorerWidget.py
@@ -76,9 +76,9 @@ class DmaxWindow(QtWidgets.QDialog, Ui_DmaxExplorer):
         self.maxDist.setValidator(GuiUtils.DoubleValidator())
 
     def setupSlots(self):
-        self.closeButton.clicked.connect(self.close)
+        self.cmdClose.clicked.connect(self.close)
         self.model.itemChanged.connect(self.modelChanged)
-        self.dependentVariable.currentIndexChanged.connect(lambda:self.modelChanged(None))
+        self.cbDependentVariable.currentIndexChanged.connect(lambda:self.modelChanged(None))
 
     def setupModel(self):
         self.model.blockSignals(True)
@@ -101,7 +101,7 @@ class DmaxWindow(QtWidgets.QDialog, Ui_DmaxExplorer):
         self.mapper.addMapping(self.Npts, W.NPTS)
         self.mapper.addMapping(self.minDist, W.DMIN)
         self.mapper.addMapping(self.maxDist, W.DMAX)
-        self.mapper.addMapping(self.dependentVariable, W.VARIABLE)
+        self.mapper.addMapping(self.cbDependentVariable, W.VARIABLE)
 
         self.mapper.toFirst()
 
@@ -157,7 +157,7 @@ class DmaxWindow(QtWidgets.QDialog, Ui_DmaxExplorer):
             msg += "for D_max=%s\n%s" % (str(x), ex)
             logger.error(msg)
 
-        plotter = self.dependentVariable.currentText()
+        plotter = self.cbDependentVariable.currentText()
         x_label = "D_{max}"
         x_unit = "A"
         if plotter == "χ²/dof":

--- a/src/sas/qtgui/Perspectives/Inversion/InversionPerspective.py
+++ b/src/sas/qtgui/Perspectives/Inversion/InversionPerspective.py
@@ -123,7 +123,7 @@ class InversionWindow(QtWidgets.QDialog, Ui_PrInversion, Perspective):
         self.setupMapper()
 
         #Hidding calculate all buton
-        self.calculateAllButton.setVisible(False)
+        self.cmdCalculateAll.setVisible(False)
         # Set base window state
         self.setupWindow()
 
@@ -194,29 +194,29 @@ class InversionWindow(QtWidgets.QDialog, Ui_PrInversion, Perspective):
     def setupLinks(self):
         """Connect the use controls to their appropriate methods"""
         self.dataList.currentIndexChanged.connect(self.displayChange)
-        self.calculateAllButton.clicked.connect(self.startThreadAll)
-        self.calculateThisButton.clicked.connect(self.startThread)
-        self.stopButton.clicked.connect(self.stopCalculation)
-        self.removeButton.clicked.connect(self.removeData)
-        self.helpButton.clicked.connect(self.help)
-        self.estimateBgd.toggled.connect(self.toggleBgd)
-        self.manualBgd.toggled.connect(self.toggleBgd)
-        self.regConstantSuggestionButton.clicked.connect(self.acceptAlpha)
-        self.noOfTermsSuggestionButton.clicked.connect(self.acceptNoTerms)
-        self.explorerButton.clicked.connect(self.openExplorerWindow)
+        self.cmdCalculateAll.clicked.connect(self.startThreadAll)
+        self.cmdCalculateThis.clicked.connect(self.startThread)
+        self.cmdStop.clicked.connect(self.stopCalculation)
+        self.cmdRemove.clicked.connect(self.removeData)
+        self.cmdHelp.clicked.connect(self.help)
+        self.rbEstimateBackground.toggled.connect(self.toggleBgd)
+        self.rbManualBackground.toggled.connect(self.toggleBgd)
+        self.cmdRegConstantSuggestion.clicked.connect(self.acceptAlpha)
+        self.cmdNoOfTermsSuggestion.clicked.connect(self.acceptNoTerms)
+        self.cmdExplorer.clicked.connect(self.openExplorerWindow)
 
-        self.backgroundInput.textChanged.connect(
-            lambda: self.set_background(self.backgroundInput.text()))
-        self.regularizationConstantInput.textChanged.connect(
-            lambda: self._calculator.set_alpha(str_to_float(self.regularizationConstantInput.text())))
-        self.maxDistanceInput.textChanged.connect(
-            lambda: self._calculator.set_dmax(str_to_float(self.maxDistanceInput.text())))
+        self.txtBackgroundInput.textChanged.connect(
+            lambda: self.set_background(self.txtBackgroundInput.text()))
+        self.txtRegularizationConstantInput.textChanged.connect(
+            lambda: self._calculator.set_alpha(str_to_float(self.txtRegularizationConstantInput.text())))
+        self.txtMaxDistanceInput.textChanged.connect(
+            lambda: self._calculator.set_dmax(str_to_float(self.txtMaxDistanceInput.text())))
         self.maxQInput.editingFinished.connect(self.check_q_high)
         self.minQInput.editingFinished.connect(self.check_q_low)
-        self.slitHeightInput.textChanged.connect(
-            lambda: self._calculator.set_slit_height(str_to_float(self.slitHeightInput.text())))
-        self.slitWidthInput.textChanged.connect(
-            lambda: self._calculator.set_slit_width(str_to_float(self.slitWidthInput.text())))
+        self.txtSlitHeightInput.textChanged.connect(
+            lambda: self._calculator.set_slit_height(str_to_float(self.txtSlitHeightInput.text())))
+        self.txtSlitWidthInput.textChanged.connect(
+            lambda: self._calculator.set_slit_width(str_to_float(self.txtSlitWidthInput.text())))
 
         self.model.itemChanged.connect(self.model_changed)
         self.estimateNTSignal.connect(self._estimateNTUpdate)
@@ -225,7 +225,7 @@ class InversionWindow(QtWidgets.QDialog, Ui_PrInversion, Perspective):
         self.estimateSignal.connect(self._estimateUpdate)
         self.calculateSignal.connect(self._calculateUpdate)
 
-        self.maxDistanceInput.textEdited.connect(self.performEstimateDynamic)
+        self.txtMaxDistanceInput.textEdited.connect(self.performEstimateDynamic)
 
     def setupMapper(self):
         # Set up the mapper.
@@ -235,25 +235,25 @@ class InversionWindow(QtWidgets.QDialog, Ui_PrInversion, Perspective):
         # Filename
         self.mapper.addMapping(self.dataList, WIDGETS.W_FILENAME)
         # Background
-        self.mapper.addMapping(self.backgroundInput, WIDGETS.W_BACKGROUND_INPUT)
-        self.mapper.addMapping(self.estimateBgd, WIDGETS.W_ESTIMATE)
-        self.mapper.addMapping(self.manualBgd, WIDGETS.W_MANUAL_INPUT)
+        self.mapper.addMapping(self.txtBackgroundInput, WIDGETS.W_BACKGROUND_INPUT)
+        self.mapper.addMapping(self.rbEstimateBackground, WIDGETS.W_ESTIMATE)
+        self.mapper.addMapping(self.rbManualBackground, WIDGETS.W_MANUAL_INPUT)
 
         # Qmin/Qmax
         self.mapper.addMapping(self.minQInput, WIDGETS.W_QMIN)
         self.mapper.addMapping(self.maxQInput, WIDGETS.W_QMAX)
 
         # Slit Parameter items
-        self.mapper.addMapping(self.slitWidthInput, WIDGETS.W_SLIT_WIDTH)
-        self.mapper.addMapping(self.slitHeightInput, WIDGETS.W_SLIT_HEIGHT)
+        self.mapper.addMapping(self.txtSlitWidthInput, WIDGETS.W_SLIT_WIDTH)
+        self.mapper.addMapping(self.txtSlitHeightInput, WIDGETS.W_SLIT_HEIGHT)
 
         # Parameter Items
-        self.mapper.addMapping(self.regularizationConstantInput, WIDGETS.W_REGULARIZATION)
-        self.mapper.addMapping(self.regConstantSuggestionButton, WIDGETS.W_REGULARIZATION_SUGGEST)
-        self.mapper.addMapping(self.explorerButton, WIDGETS.W_EXPLORE)
-        self.mapper.addMapping(self.maxDistanceInput, WIDGETS.W_MAX_DIST)
-        self.mapper.addMapping(self.noOfTermsInput, WIDGETS.W_NO_TERMS)
-        self.mapper.addMapping(self.noOfTermsSuggestionButton, WIDGETS.W_NO_TERMS_SUGGEST)
+        self.mapper.addMapping(self.txtRegularizationConstantInput, WIDGETS.W_REGULARIZATION)
+        self.mapper.addMapping(self.cmdRegConstantSuggestion, WIDGETS.W_REGULARIZATION_SUGGEST)
+        self.mapper.addMapping(self.cmdExplorer, WIDGETS.W_EXPLORE)
+        self.mapper.addMapping(self.txtMaxDistanceInput, WIDGETS.W_MAX_DIST)
+        self.mapper.addMapping(self.txtNoOfTermsInput, WIDGETS.W_NO_TERMS)
+        self.mapper.addMapping(self.cmdNoOfTermsSuggestion, WIDGETS.W_NO_TERMS_SUGGEST)
 
         # Output
         self.mapper.addMapping(self.rgValue, WIDGETS.W_RG)
@@ -266,10 +266,10 @@ class InversionWindow(QtWidgets.QDialog, Ui_PrInversion, Perspective):
         self.mapper.addMapping(self.sigmaPosFractionValue, WIDGETS.W_SIGMA_POS_FRACTION)
 
         # Main Buttons
-        self.mapper.addMapping(self.removeButton, WIDGETS.W_REMOVE)
-        self.mapper.addMapping(self.calculateAllButton, WIDGETS.W_CALCULATE_ALL)
-        self.mapper.addMapping(self.calculateThisButton, WIDGETS.W_CALCULATE_VISIBLE)
-        self.mapper.addMapping(self.helpButton, WIDGETS.W_HELP)
+        self.mapper.addMapping(self.cmdRemove, WIDGETS.W_REMOVE)
+        self.mapper.addMapping(self.cmdCalculateAll, WIDGETS.W_CALCULATE_ALL)
+        self.mapper.addMapping(self.cmdCalculateThis, WIDGETS.W_CALCULATE_VISIBLE)
+        self.mapper.addMapping(self.cmdHelp, WIDGETS.W_HELP)
 
         self.mapper.toFirst()
 
@@ -313,17 +313,17 @@ class InversionWindow(QtWidgets.QDialog, Ui_PrInversion, Perspective):
     def setupWindow(self):
         """Initialize base window state on init"""
         self.enableButtons()
-        self.estimateBgd.setChecked(True)
+        self.rbEstimateBackground.setChecked(True)
 
     def setupValidators(self):
         """Apply validators to editable line edits"""
-        self.noOfTermsInput.setValidator(QtGui.QIntValidator())
-        self.regularizationConstantInput.setValidator(GuiUtils.DoubleValidator())
-        self.maxDistanceInput.setValidator(GuiUtils.DoubleValidator())
+        self.txtNoOfTermsInput.setValidator(QtGui.QIntValidator())
+        self.txtRegularizationConstantInput.setValidator(GuiUtils.DoubleValidator())
+        self.txtMaxDistanceInput.setValidator(GuiUtils.DoubleValidator())
         self.minQInput.setValidator(GuiUtils.DoubleValidator())
         self.maxQInput.setValidator(GuiUtils.DoubleValidator())
-        self.slitHeightInput.setValidator(GuiUtils.DoubleValidator())
-        self.slitWidthInput.setValidator(GuiUtils.DoubleValidator())
+        self.txtSlitHeightInput.setValidator(GuiUtils.DoubleValidator())
+        self.txtSlitWidthInput.setValidator(GuiUtils.DoubleValidator())
 
     ######################################################################
     # Methods for updating GUI
@@ -332,17 +332,17 @@ class InversionWindow(QtWidgets.QDialog, Ui_PrInversion, Perspective):
         """
         Enable buttons when data is present, else disable them
         """
-        self.calculateAllButton.setEnabled(len(self._dataList) > 1
+        self.cmdCalculateAll.setEnabled(len(self._dataList) > 1
                                            and not self.isBatch
                                            and not self.isCalculating)
-        self.calculateThisButton.setEnabled(self.logic.data_is_loaded
+        self.cmdCalculateThis.setEnabled(self.logic.data_is_loaded
                                             and not self.isBatch
                                             and not self.isCalculating)
-        self.removeButton.setEnabled(self.logic.data_is_loaded and not self.isCalculating)
-        self.explorerButton.setEnabled(self.logic.data_is_loaded and not self.isCalculating)
-        self.stopButton.setVisible(self.isCalculating)
-        self.regConstantSuggestionButton.setEnabled(self.logic.data_is_loaded and not self.isCalculating)
-        self.noOfTermsSuggestionButton.setEnabled(self.logic.data_is_loaded and not self.isCalculating)
+        self.cmdRemove.setEnabled(self.logic.data_is_loaded and not self.isCalculating)
+        self.cmdExplorer.setEnabled(self.logic.data_is_loaded and not self.isCalculating)
+        self.cmdStop.setVisible(self.isCalculating)
+        self.cmdRegConstantSuggestion.setEnabled(self.logic.data_is_loaded and not self.isCalculating)
+        self.cmdNoOfTermsSuggestion.setEnabled(self.logic.data_is_loaded and not self.isCalculating)
 
     def populateDataComboBox(self, name, data_ref):
         """
@@ -355,12 +355,12 @@ class InversionWindow(QtWidgets.QDialog, Ui_PrInversion, Perspective):
     def acceptNoTerms(self):
         """Send estimated no of terms to input"""
         self.model.setItem(WIDGETS.W_NO_TERMS, QtGui.QStandardItem(
-            self.noOfTermsSuggestionButton.text()))
+            self.cmdNoOfTermsSuggestion.text()))
 
     def acceptAlpha(self):
         """Send estimated alpha to input"""
         self.model.setItem(WIDGETS.W_REGULARIZATION, QtGui.QStandardItem(
-            self.regConstantSuggestionButton.text()))
+            self.cmdRegConstantSuggestion.text()))
 
     def displayChange(self, data_index=0):
         """Switch to another item in the data list"""
@@ -377,7 +377,7 @@ class InversionWindow(QtWidgets.QDialog, Ui_PrInversion, Perspective):
         self._calculator.set_x(self.logic.data.x)
         self._calculator.set_y(self.logic.data.y)
         self._calculator.set_err(self.logic.data.dy)
-        self.set_background(self.backgroundInput.text())
+        self.set_background(self.txtBackgroundInput.text())
 
     def set_background(self, value):
         self._calculator.background = float(value)
@@ -413,13 +413,13 @@ class InversionWindow(QtWidgets.QDialog, Ui_PrInversion, Perspective):
         Toggle the background between manual and estimated
         """
         self.model.blockSignals(True)
-        value = 1 if self.estimateBgd.isChecked() else 0
+        value = 1 if self.rbEstimateBackground.isChecked() else 0
         itemt = QtGui.QStandardItem(str(value == 1).lower())
         self.model.setItem(WIDGETS.W_ESTIMATE, itemt)
         itemt = QtGui.QStandardItem(str(value == 0).lower())
         self.model.setItem(WIDGETS.W_MANUAL_INPUT, itemt)
         self._calculator.set_est_bck(value)
-        self.backgroundInput.setEnabled(self._calculator.est_bck == 0)
+        self.txtBackgroundInput.setEnabled(self._calculator.est_bck == 0)
         self.model.blockSignals(False)
 
     def openExplorerWindow(self):
@@ -582,11 +582,11 @@ class InversionWindow(QtWidgets.QDialog, Ui_PrInversion, Perspective):
     def getNFunc(self):
         """Get the n_func value from the GUI object"""
         try:
-            nfunc = int(self.noOfTermsInput.text())
+            nfunc = int(self.txtNoOfTermsInput.text())
         except ValueError:
             logger.error("Incorrect number of terms specified: %s"
-                          %self.noOfTermsInput.text())
-            self.noOfTermsInput.setText(str(NUMBER_OF_TERMS))
+                          %self.txtNoOfTermsInput.text())
+            self.txtNoOfTermsInput.setText(str(NUMBER_OF_TERMS))
             nfunc = NUMBER_OF_TERMS
         return nfunc
 
@@ -610,8 +610,8 @@ class InversionWindow(QtWidgets.QDialog, Ui_PrInversion, Perspective):
         alpha = self._calculator.suggested_alpha
         self.model.setItem(WIDGETS.W_MAX_DIST,
                             QtGui.QStandardItem("{:.4g}".format(pr.get_dmax())))
-        self.regConstantSuggestionButton.setText("{:-3.2g}".format(alpha))
-        self.noOfTermsSuggestionButton.setText(
+        self.cmdRegConstantSuggestion.setText("{:-3.2g}".format(alpha))
+        self.cmdNoOfTermsSuggestion.setText(
              "{:n}".format(self.nTermsSuggested))
 
         self.enableButtons()
@@ -632,7 +632,7 @@ class InversionWindow(QtWidgets.QDialog, Ui_PrInversion, Perspective):
                            QtGui.QStandardItem("{:.4g}".format(elapsed)))
         self.model.setItem(WIDGETS.W_MAX_DIST,
                            QtGui.QStandardItem("{:.4g}".format(pr.get_dmax())))
-        self.regConstantSuggestionButton.setText("{:.2g}".format(alpha))
+        self.cmdRegConstantSuggestion.setText("{:.2g}".format(alpha))
 
         if isinstance(pr.chi2, np.ndarray):
             self.model.setItem(WIDGETS.W_CHI_SQUARED,
@@ -696,9 +696,9 @@ class InversionWindow(QtWidgets.QDialog, Ui_PrInversion, Perspective):
             self._calculator = Invertor()
             self.closeBatchResults()
             self.nTermsSuggested = NUMBER_OF_TERMS
-            self.noOfTermsSuggestionButton.setText("{:n}".format(
+            self.cmdNoOfTermsSuggestion.setText("{:n}".format(
                 self.nTermsSuggested))
-            self.regConstantSuggestionButton.setText("{:-3.2g}".format(
+            self.cmdRegConstantSuggestion.setText("{:-3.2g}".format(
                 REGULARIZATION))
             # self.updateGuiValues()
             self.setupModel()
@@ -780,7 +780,7 @@ class InversionWindow(QtWidgets.QDialog, Ui_PrInversion, Perspective):
         self.isCalculating = True
         self.isBatch = True
         self.batchComplete = []
-        self.calculateAllButton.setText("Calculating...")
+        self.cmdCalculateAll.setText("Calculating...")
         self.enableButtons()
         self.batchResultsWindow = BatchInversionOutputPanel(
             parent=self, output_data=self.batchResults)
@@ -801,7 +801,7 @@ class InversionWindow(QtWidgets.QDialog, Ui_PrInversion, Perspective):
             # If no data sets left, end batch calculation
             self.isCalculating = False
             self.batchComplete = []
-            self.calculateAllButton.setText("Calculate All")
+            self.cmdCalculateAll.setText("Calculate All")
             self.showBatchOutput()
             self.enableButtons()
 

--- a/src/sas/qtgui/Perspectives/Inversion/UI/DMaxExplorer.ui
+++ b/src/sas/qtgui/Perspectives/Inversion/UI/DMaxExplorer.ui
@@ -97,7 +97,7 @@
        <item row="1" column="0">
         <layout class="QHBoxLayout" name="horizontalLayout_2">
          <item>
-          <widget class="QLabel" name="label_2">
+          <widget class="QLabel" name="labelNpts">
            <property name="text">
             <string>Npts</string>
            </property>
@@ -107,7 +107,7 @@
           <widget class="QLineEdit" name="Npts"/>
          </item>
          <item>
-          <widget class="QLabel" name="label_3">
+          <widget class="QLabel" name="labelMinDistance">
            <property name="text">
             <string>Min Distance [Å]</string>
            </property>
@@ -117,7 +117,7 @@
           <widget class="QLineEdit" name="minDist"/>
          </item>
          <item>
-          <widget class="QLabel" name="label_4">
+          <widget class="QLabel" name="labelMaxDistance">
            <property name="text">
             <string>Max Distance [Å]</string>
            </property>

--- a/src/sas/qtgui/Perspectives/Inversion/UI/DMaxExplorer.ui
+++ b/src/sas/qtgui/Perspectives/Inversion/UI/DMaxExplorer.ui
@@ -34,14 +34,14 @@
        <item row="0" column="0">
         <layout class="QHBoxLayout" name="horizontalLayout_3">
          <item>
-          <widget class="QLabel" name="label">
+          <widget class="QLabel" name="lblDependentVariable">
            <property name="text">
             <string>Dependent Variable:</string>
            </property>
           </widget>
          </item>
          <item>
-          <widget class="QComboBox" name="dependentVariable">
+          <widget class="QComboBox" name="cbDependentVariable">
            <item>
             <property name="text">
              <string>1-σ positive fraction</string>
@@ -97,7 +97,7 @@
        <item row="1" column="0">
         <layout class="QHBoxLayout" name="horizontalLayout_2">
          <item>
-          <widget class="QLabel" name="labelNpts">
+          <widget class="QLabel" name="lblNpts">
            <property name="text">
             <string>Npts</string>
            </property>
@@ -107,7 +107,7 @@
           <widget class="QLineEdit" name="Npts"/>
          </item>
          <item>
-          <widget class="QLabel" name="labelMinDistance">
+          <widget class="QLabel" name="lblMinDistance">
            <property name="text">
             <string>Min Distance [Å]</string>
            </property>
@@ -117,7 +117,7 @@
           <widget class="QLineEdit" name="minDist"/>
          </item>
          <item>
-          <widget class="QLabel" name="labelMaxDistance">
+          <widget class="QLabel" name="lblMaxDistance">
            <property name="text">
             <string>Max Distance [Å]</string>
            </property>
@@ -144,7 +144,7 @@
           </spacer>
          </item>
          <item>
-          <widget class="QPushButton" name="closeButton">
+          <widget class="QPushButton" name="cmdClose">
            <property name="text">
             <string>Close</string>
            </property>

--- a/src/sas/qtgui/Perspectives/Inversion/UI/TabbedInversionUI.ui
+++ b/src/sas/qtgui/Perspectives/Inversion/UI/TabbedInversionUI.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>446</width>
+    <width>518</width>
     <height>480</height>
    </rect>
   </property>
@@ -47,7 +47,7 @@
       </size>
      </property>
      <property name="currentIndex">
-      <number>0</number>
+      <number>1</number>
      </property>
      <widget class="QWidget" name="tabMain">
       <attribute name="title">
@@ -69,7 +69,7 @@
           <item row="0" column="0">
            <layout class="QHBoxLayout" name="horizontalLayout_2">
             <item>
-             <widget class="QLabel" name="label">
+             <widget class="QLabel" name="labelDataFileName">
               <property name="text">
                <string>Data File Name:</string>
               </property>
@@ -126,7 +126,7 @@ p, li { white-space: pre-wrap; }
          </property>
          <layout class="QGridLayout" name="gridLayout">
           <item row="0" column="0">
-           <widget class="QLabel" name="label_12">
+           <widget class="QLabel" name="labelParametersNumberOfTerms">
             <property name="sizePolicy">
              <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
               <horstretch>0</horstretch>
@@ -165,7 +165,7 @@ p, li { white-space: pre-wrap; }
            </widget>
           </item>
           <item row="1" column="0">
-           <widget class="QLabel" name="label_13">
+           <widget class="QLabel" name="labelParametersRegConstant">
             <property name="sizePolicy">
              <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
               <horstretch>0</horstretch>
@@ -210,7 +210,7 @@ p, li { white-space: pre-wrap; }
            </widget>
           </item>
           <item row="2" column="0">
-           <widget class="QLabel" name="label_14">
+           <widget class="QLabel" name="labelParametersMaxDistance">
             <property name="sizePolicy">
              <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
               <horstretch>0</horstretch>
@@ -270,9 +270,9 @@ p, li { white-space: pre-wrap; }
          <zorder>regConstantSuggestionButton</zorder>
          <zorder>maxDistanceInput</zorder>
          <zorder>explorerButton</zorder>
-         <zorder>label_13</zorder>
-         <zorder>label_12</zorder>
-         <zorder>label_14</zorder>
+         <zorder>labelParametersRegConstant</zorder>
+         <zorder>labelParametersNumberOfTerms</zorder>
+         <zorder>labelParametersMaxDistance</zorder>
         </widget>
        </item>
        <item row="2" column="0">
@@ -282,7 +282,7 @@ p, li { white-space: pre-wrap; }
          </property>
          <layout class="QGridLayout" name="gridLayout_4">
           <item row="0" column="0">
-           <widget class="QLabel" name="label_15">
+           <widget class="QLabel" name="labelOutputsR_g">
             <property name="text">
              <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;R&lt;span style=&quot; vertical-align:sub;&quot;&gt;g&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
             </property>
@@ -307,29 +307,8 @@ p, li { white-space: pre-wrap; }
             </property>
            </widget>
           </item>
-          <item row="0" column="2">
-           <widget class="QLabel" name="label_24">
-            <property name="text">
-             <string>Å</string>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="3">
-           <widget class="QLabel" name="label_22">
-            <property name="text">
-             <string/>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="4">
-           <widget class="QLabel" name="label_19">
-            <property name="text">
-             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;χ&lt;span style=&quot; vertical-align:super;&quot;&gt;2&lt;/span&gt;/dof&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="5">
-           <widget class="QLineEdit" name="chiDofValue">
+          <item row="2" column="4">
+           <widget class="QLineEdit" name="posFractionValue">
             <property name="enabled">
              <bool>true</bool>
             </property>
@@ -347,10 +326,67 @@ p, li { white-space: pre-wrap; }
             </property>
            </widget>
           </item>
-          <item row="1" column="0">
-           <widget class="QLabel" name="label_16">
+          <item row="3" column="3">
+           <widget class="QLabel" name="labelPOneMinSigmaFraction">
             <property name="text">
-             <string>I(Q=0)</string>
+             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;P&lt;span style=&quot; vertical-align:super;&quot;&gt;+&lt;/span&gt;&lt;span style=&quot; vertical-align:sub;&quot;&gt;1-σ&lt;/span&gt; fraction&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="4">
+           <widget class="QLineEdit" name="sigmaPosFractionValue">
+            <property name="enabled">
+             <bool>true</bool>
+            </property>
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="focusPolicy">
+             <enum>Qt::ClickFocus</enum>
+            </property>
+            <property name="readOnly">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="1">
+           <widget class="QLineEdit" name="backgroundValue">
+            <property name="enabled">
+             <bool>true</bool>
+            </property>
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="focusPolicy">
+             <enum>Qt::ClickFocus</enum>
+            </property>
+            <property name="readOnly">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="4">
+           <widget class="QLineEdit" name="chiDofValue">
+            <property name="enabled">
+             <bool>true</bool>
+            </property>
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="focusPolicy">
+             <enum>Qt::ClickFocus</enum>
+            </property>
+            <property name="readOnly">
+             <bool>true</bool>
             </property>
            </widget>
           </item>
@@ -374,20 +410,48 @@ p, li { white-space: pre-wrap; }
            </widget>
           </item>
           <item row="1" column="2">
-           <widget class="QLabel" name="label_25">
+           <widget class="QLabel" name="labelOutputsI_Q_0Unit">
             <property name="text">
              <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Å&lt;span style=&quot; vertical-align:super;&quot;&gt;-1&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
             </property>
            </widget>
           </item>
-          <item row="1" column="4">
-           <widget class="QLabel" name="label_20">
+          <item row="3" column="2">
+           <widget class="QLabel" name="labelOutputsCalcTimeUnit">
             <property name="text">
-             <string>Oscillations</string>
+             <string>secs</string>
             </property>
            </widget>
           </item>
-          <item row="1" column="5">
+          <item row="2" column="3">
+           <widget class="QLabel" name="labelOuputsPFraction">
+            <property name="text">
+             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;P&lt;span style=&quot; vertical-align:super;&quot;&gt;+&lt;/span&gt; Fraction&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="0">
+           <widget class="QLabel" name="labelOutputsI_Q_0">
+            <property name="text">
+             <string>I(Q=0)</string>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="0">
+           <widget class="QLabel" name="labelOutputsCalcTime">
+            <property name="text">
+             <string>Calc. Time</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="3">
+           <widget class="QLabel" name="labelOutputsChiSquaredDivDOF">
+            <property name="text">
+             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;χ&lt;span style=&quot; vertical-align:super;&quot;&gt;2&lt;/span&gt;/dof&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="4">
            <widget class="QLineEdit" name="oscillationValue">
             <property name="enabled">
              <bool>true</bool>
@@ -407,106 +471,35 @@ p, li { white-space: pre-wrap; }
            </widget>
           </item>
           <item row="2" column="0">
-           <widget class="QLabel" name="label_17">
+           <widget class="QLabel" name="labelOutputsBackground">
             <property name="text">
              <string>Background</string>
             </property>
            </widget>
           </item>
-          <item row="2" column="1">
-           <widget class="QLineEdit" name="backgroundValue">
-            <property name="enabled">
-             <bool>true</bool>
-            </property>
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="focusPolicy">
-             <enum>Qt::ClickFocus</enum>
-            </property>
-            <property name="readOnly">
-             <bool>true</bool>
-            </property>
-           </widget>
-          </item>
           <item row="2" column="2">
-           <widget class="QLabel" name="label_26">
+           <widget class="QLabel" name="labelOutputsBackgroundUnit">
             <property name="text">
              <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Å&lt;span style=&quot; vertical-align:super;&quot;&gt;-1&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
             </property>
            </widget>
           </item>
-          <item row="2" column="4">
-           <widget class="QLabel" name="label_21">
+          <item row="0" column="2">
+           <widget class="QLabel" name="labelOutputsR_g_Unit">
             <property name="text">
-             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;P&lt;span style=&quot; vertical-align:super;&quot;&gt;+&lt;/span&gt; Fraction&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+             <string>Å</string>
             </property>
            </widget>
           </item>
-          <item row="2" column="5">
-           <widget class="QLineEdit" name="posFractionValue">
-            <property name="enabled">
-             <bool>true</bool>
-            </property>
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="focusPolicy">
-             <enum>Qt::ClickFocus</enum>
-            </property>
-            <property name="readOnly">
-             <bool>true</bool>
-            </property>
-           </widget>
-          </item>
-          <item row="3" column="0">
-           <widget class="QLabel" name="label_18">
+          <item row="1" column="3">
+           <widget class="QLabel" name="labelOutputsOscillations">
             <property name="text">
-             <string>Calc. Time</string>
+             <string>Oscillations</string>
             </property>
            </widget>
           </item>
           <item row="3" column="1">
            <widget class="QLineEdit" name="computationTimeValue">
-            <property name="enabled">
-             <bool>true</bool>
-            </property>
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="focusPolicy">
-             <enum>Qt::ClickFocus</enum>
-            </property>
-            <property name="readOnly">
-             <bool>true</bool>
-            </property>
-           </widget>
-          </item>
-          <item row="3" column="2">
-           <widget class="QLabel" name="label_27">
-            <property name="text">
-             <string>secs</string>
-            </property>
-           </widget>
-          </item>
-          <item row="3" column="4">
-           <widget class="QLabel" name="label_29">
-            <property name="text">
-             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;P&lt;span style=&quot; vertical-align:super;&quot;&gt;+&lt;/span&gt;&lt;span style=&quot; vertical-align:sub;&quot;&gt;1-σ&lt;/span&gt; fraction&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-            </property>
-           </widget>
-          </item>
-          <item row="3" column="5">
-           <widget class="QLineEdit" name="sigmaPosFractionValue">
             <property name="enabled">
              <bool>true</bool>
             </property>
@@ -543,7 +536,7 @@ p, li { white-space: pre-wrap; }
           <item row="0" column="0">
            <layout class="QHBoxLayout" name="horizontalLayout_3" stretch="2,1,0,2,2">
             <item>
-             <widget class="QLabel" name="label_5">
+             <widget class="QLabel" name="labelOptionsBackgroundLevel">
               <property name="text">
                <string>Background Level:</string>
               </property>
@@ -560,7 +553,7 @@ p, li { white-space: pre-wrap; }
              </widget>
             </item>
             <item>
-             <widget class="QLabel" name="label_10">
+             <widget class="QLabel" name="labelOptionsBackgroundLevelUnit">
               <property name="text">
                <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Å&lt;span style=&quot; vertical-align:super;&quot;&gt;-1&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
               </property>
@@ -591,7 +584,7 @@ p, li { white-space: pre-wrap; }
              <item row="0" column="0">
               <layout class="QHBoxLayout" name="horizontalLayout_4">
                <item>
-                <widget class="QLabel" name="label_7">
+                <widget class="QLabel" name="labelTotalQRangeMin">
                  <property name="text">
                   <string>Min:</string>
                  </property>
@@ -611,14 +604,14 @@ p, li { white-space: pre-wrap; }
                 </widget>
                </item>
                <item>
-                <widget class="QLabel" name="label_11">
+                <widget class="QLabel" name="labelTotalQRangeMinUnit">
                  <property name="text">
                   <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Å&lt;span style=&quot; vertical-align:super;&quot;&gt;-1&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
                  </property>
                 </widget>
                </item>
                <item>
-                <widget class="QLabel" name="label_8">
+                <widget class="QLabel" name="labelTotalQRangeMax">
                  <property name="text">
                   <string>Max:</string>
                  </property>
@@ -638,7 +631,7 @@ p, li { white-space: pre-wrap; }
                 </widget>
                </item>
                <item>
-                <widget class="QLabel" name="label_9">
+                <widget class="QLabel" name="labelTotalQRangeMaxUnit">
                  <property name="text">
                   <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Å&lt;span style=&quot; vertical-align:super;&quot;&gt;-1&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
                  </property>
@@ -658,7 +651,7 @@ p, li { white-space: pre-wrap; }
              <item row="0" column="0">
               <layout class="QHBoxLayout" name="horizontalLayout">
                <item>
-                <widget class="QLabel" name="label_3">
+                <widget class="QLabel" name="labelSlitParametersHeight">
                  <property name="text">
                   <string>Height</string>
                  </property>
@@ -678,14 +671,14 @@ p, li { white-space: pre-wrap; }
                 </widget>
                </item>
                <item>
-                <widget class="QLabel" name="label_6">
+                <widget class="QLabel" name="labelSlitParametersHeightUnit">
                  <property name="text">
                   <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Å&lt;span style=&quot; vertical-align:super;&quot;&gt;-1&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
                  </property>
                 </widget>
                </item>
                <item>
-                <widget class="QLabel" name="label_4">
+                <widget class="QLabel" name="labelSlitParametersWidth">
                  <property name="text">
                   <string>Width</string>
                  </property>
@@ -705,7 +698,7 @@ p, li { white-space: pre-wrap; }
                 </widget>
                </item>
                <item>
-                <widget class="QLabel" name="label_2">
+                <widget class="QLabel" name="labelSlitParametersWidthUnit">
                  <property name="text">
                   <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Å&lt;span style=&quot; vertical-align:super;&quot;&gt;-1&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
                  </property>

--- a/src/sas/qtgui/Perspectives/Inversion/UI/TabbedInversionUI.ui
+++ b/src/sas/qtgui/Perspectives/Inversion/UI/TabbedInversionUI.ui
@@ -47,7 +47,7 @@
       </size>
      </property>
      <property name="currentIndex">
-      <number>1</number>
+      <number>0</number>
      </property>
      <widget class="QWidget" name="tabMain">
       <attribute name="title">
@@ -69,7 +69,7 @@
           <item row="0" column="0">
            <layout class="QHBoxLayout" name="horizontalLayout_2">
             <item>
-             <widget class="QLabel" name="labelDataFileName">
+             <widget class="QLabel" name="lblDataFileName">
               <property name="text">
                <string>Data File Name:</string>
               </property>
@@ -86,7 +86,7 @@
              </widget>
             </item>
             <item>
-             <widget class="QPushButton" name="removeButton">
+             <widget class="QPushButton" name="cmdRemove">
               <property name="enabled">
                <bool>false</bool>
               </property>
@@ -126,7 +126,7 @@ p, li { white-space: pre-wrap; }
          </property>
          <layout class="QGridLayout" name="gridLayout">
           <item row="0" column="0">
-           <widget class="QLabel" name="labelParametersNumberOfTerms">
+           <widget class="QLabel" name="lblParametersNumberOfTerms">
             <property name="sizePolicy">
              <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
               <horstretch>0</horstretch>
@@ -139,7 +139,7 @@ p, li { white-space: pre-wrap; }
            </widget>
           </item>
           <item row="0" column="1">
-           <widget class="QLineEdit" name="noOfTermsInput">
+           <widget class="QLineEdit" name="txtNoOfTermsInput">
             <property name="sizePolicy">
              <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
               <horstretch>0</horstretch>
@@ -155,7 +155,7 @@ p, li { white-space: pre-wrap; }
            </widget>
           </item>
           <item row="0" column="2">
-           <widget class="QPushButton" name="noOfTermsSuggestionButton">
+           <widget class="QPushButton" name="cmdNoOfTermsSuggestion">
             <property name="enabled">
              <bool>false</bool>
             </property>
@@ -165,7 +165,7 @@ p, li { white-space: pre-wrap; }
            </widget>
           </item>
           <item row="1" column="0">
-           <widget class="QLabel" name="labelParametersRegConstant">
+           <widget class="QLabel" name="lblParametersRegConstant">
             <property name="sizePolicy">
              <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
               <horstretch>0</horstretch>
@@ -184,7 +184,7 @@ p, li { white-space: pre-wrap; }
            </widget>
           </item>
           <item row="1" column="1">
-           <widget class="QLineEdit" name="regularizationConstantInput">
+           <widget class="QLineEdit" name="txtRegularizationConstantInput">
             <property name="sizePolicy">
              <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
               <horstretch>0</horstretch>
@@ -200,7 +200,7 @@ p, li { white-space: pre-wrap; }
            </widget>
           </item>
           <item row="1" column="2">
-           <widget class="QPushButton" name="regConstantSuggestionButton">
+           <widget class="QPushButton" name="cmdRegConstantSuggestion">
             <property name="enabled">
              <bool>false</bool>
             </property>
@@ -210,7 +210,7 @@ p, li { white-space: pre-wrap; }
            </widget>
           </item>
           <item row="2" column="0">
-           <widget class="QLabel" name="labelParametersMaxDistance">
+           <widget class="QLabel" name="lblParametersMaxDistance">
             <property name="sizePolicy">
              <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
               <horstretch>0</horstretch>
@@ -223,7 +223,7 @@ p, li { white-space: pre-wrap; }
            </widget>
           </item>
           <item row="2" column="1">
-           <widget class="QLineEdit" name="maxDistanceInput">
+           <widget class="QLineEdit" name="txtMaxDistanceInput">
             <property name="sizePolicy">
              <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
               <horstretch>0</horstretch>
@@ -239,7 +239,7 @@ p, li { white-space: pre-wrap; }
            </widget>
           </item>
           <item row="2" column="2">
-           <widget class="QPushButton" name="explorerButton">
+           <widget class="QPushButton" name="cmdExplorer">
             <property name="sizePolicy">
              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
               <horstretch>0</horstretch>
@@ -264,15 +264,15 @@ p, li { white-space: pre-wrap; }
            </widget>
           </item>
          </layout>
-         <zorder>noOfTermsInput</zorder>
-         <zorder>noOfTermsSuggestionButton</zorder>
-         <zorder>regularizationConstantInput</zorder>
-         <zorder>regConstantSuggestionButton</zorder>
-         <zorder>maxDistanceInput</zorder>
-         <zorder>explorerButton</zorder>
-         <zorder>labelParametersRegConstant</zorder>
-         <zorder>labelParametersNumberOfTerms</zorder>
-         <zorder>labelParametersMaxDistance</zorder>
+         <zorder>txtNoOfTermsInput</zorder>
+         <zorder>cmdNoOfTermsSuggestion</zorder>
+         <zorder>txtRegularizationConstantInput</zorder>
+         <zorder>cmdRegConstantSuggestion</zorder>
+         <zorder>txtMaxDistanceInput</zorder>
+         <zorder>cmdExplorer</zorder>
+         <zorder>lblParametersRegConstant</zorder>
+         <zorder>lblParametersNumberOfTerms</zorder>
+         <zorder>lblParametersMaxDistance</zorder>
         </widget>
        </item>
        <item row="2" column="0">
@@ -282,7 +282,7 @@ p, li { white-space: pre-wrap; }
          </property>
          <layout class="QGridLayout" name="gridLayout_4">
           <item row="0" column="0">
-           <widget class="QLabel" name="labelOutputsR_g">
+           <widget class="QLabel" name="lblOutputsR_g">
             <property name="text">
              <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;R&lt;span style=&quot; vertical-align:sub;&quot;&gt;g&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
             </property>
@@ -327,7 +327,7 @@ p, li { white-space: pre-wrap; }
            </widget>
           </item>
           <item row="3" column="3">
-           <widget class="QLabel" name="labelPOneMinSigmaFraction">
+           <widget class="QLabel" name="lblPOneMinSigmaFraction">
             <property name="text">
              <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;P&lt;span style=&quot; vertical-align:super;&quot;&gt;+&lt;/span&gt;&lt;span style=&quot; vertical-align:sub;&quot;&gt;1-σ&lt;/span&gt; fraction&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
             </property>
@@ -410,42 +410,42 @@ p, li { white-space: pre-wrap; }
            </widget>
           </item>
           <item row="1" column="2">
-           <widget class="QLabel" name="labelOutputsI_Q_0Unit">
+           <widget class="QLabel" name="lblOutputsI_Q_0Unit">
             <property name="text">
              <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Å&lt;span style=&quot; vertical-align:super;&quot;&gt;-1&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
             </property>
            </widget>
           </item>
           <item row="3" column="2">
-           <widget class="QLabel" name="labelOutputsCalcTimeUnit">
+           <widget class="QLabel" name="lblOutputsCalcTimeUnit">
             <property name="text">
              <string>secs</string>
             </property>
            </widget>
           </item>
           <item row="2" column="3">
-           <widget class="QLabel" name="labelOuputsPFraction">
+           <widget class="QLabel" name="lblOuputsPFraction">
             <property name="text">
              <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;P&lt;span style=&quot; vertical-align:super;&quot;&gt;+&lt;/span&gt; Fraction&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
             </property>
            </widget>
           </item>
           <item row="1" column="0">
-           <widget class="QLabel" name="labelOutputsI_Q_0">
+           <widget class="QLabel" name="lblOutputsI_Q_0">
             <property name="text">
              <string>I(Q=0)</string>
             </property>
            </widget>
           </item>
           <item row="3" column="0">
-           <widget class="QLabel" name="labelOutputsCalcTime">
+           <widget class="QLabel" name="lblOutputsCalcTime">
             <property name="text">
              <string>Calc. Time</string>
             </property>
            </widget>
           </item>
           <item row="0" column="3">
-           <widget class="QLabel" name="labelOutputsChiSquaredDivDOF">
+           <widget class="QLabel" name="lblOutputsChiSquaredDivDOF">
             <property name="text">
              <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;χ&lt;span style=&quot; vertical-align:super;&quot;&gt;2&lt;/span&gt;/dof&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
             </property>
@@ -471,28 +471,28 @@ p, li { white-space: pre-wrap; }
            </widget>
           </item>
           <item row="2" column="0">
-           <widget class="QLabel" name="labelOutputsBackground">
+           <widget class="QLabel" name="lblOutputsBackground">
             <property name="text">
              <string>Background</string>
             </property>
            </widget>
           </item>
           <item row="2" column="2">
-           <widget class="QLabel" name="labelOutputsBackgroundUnit">
+           <widget class="QLabel" name="lblOutputsBackgroundUnit">
             <property name="text">
              <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Å&lt;span style=&quot; vertical-align:super;&quot;&gt;-1&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
             </property>
            </widget>
           </item>
           <item row="0" column="2">
-           <widget class="QLabel" name="labelOutputsR_g_Unit">
+           <widget class="QLabel" name="lblOutputsR_g_Unit">
             <property name="text">
              <string>Å</string>
             </property>
            </widget>
           </item>
           <item row="1" column="3">
-           <widget class="QLabel" name="labelOutputsOscillations">
+           <widget class="QLabel" name="lblOutputsOscillations">
             <property name="text">
              <string>Oscillations</string>
             </property>
@@ -536,14 +536,14 @@ p, li { white-space: pre-wrap; }
           <item row="0" column="0">
            <layout class="QHBoxLayout" name="horizontalLayout_3" stretch="2,1,0,2,2">
             <item>
-             <widget class="QLabel" name="labelOptionsBackgroundLevel">
+             <widget class="QLabel" name="lblOptionsBackgroundLevel">
               <property name="text">
                <string>Background Level:</string>
               </property>
              </widget>
             </item>
             <item>
-             <widget class="QLineEdit" name="backgroundInput">
+             <widget class="QLineEdit" name="txtBackgroundInput">
               <property name="enabled">
                <bool>false</bool>
               </property>
@@ -553,21 +553,21 @@ p, li { white-space: pre-wrap; }
              </widget>
             </item>
             <item>
-             <widget class="QLabel" name="labelOptionsBackgroundLevelUnit">
+             <widget class="QLabel" name="lblOptionsBackgroundLevelUnit">
               <property name="text">
                <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Å&lt;span style=&quot; vertical-align:super;&quot;&gt;-1&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
               </property>
              </widget>
             </item>
             <item>
-             <widget class="QRadioButton" name="estimateBgd">
+             <widget class="QRadioButton" name="rbEstimateBackground">
               <property name="text">
                <string>Estimate</string>
               </property>
              </widget>
             </item>
             <item>
-             <widget class="QRadioButton" name="manualBgd">
+             <widget class="QRadioButton" name="rbManualBackground">
               <property name="text">
                <string>Manual Input</string>
               </property>
@@ -584,7 +584,7 @@ p, li { white-space: pre-wrap; }
              <item row="0" column="0">
               <layout class="QHBoxLayout" name="horizontalLayout_4">
                <item>
-                <widget class="QLabel" name="labelTotalQRangeMin">
+                <widget class="QLabel" name="lblTotalQRangeMin">
                  <property name="text">
                   <string>Min:</string>
                  </property>
@@ -604,14 +604,14 @@ p, li { white-space: pre-wrap; }
                 </widget>
                </item>
                <item>
-                <widget class="QLabel" name="labelTotalQRangeMinUnit">
+                <widget class="QLabel" name="lblTotalQRangeMinUnit">
                  <property name="text">
                   <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Å&lt;span style=&quot; vertical-align:super;&quot;&gt;-1&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
                  </property>
                 </widget>
                </item>
                <item>
-                <widget class="QLabel" name="labelTotalQRangeMax">
+                <widget class="QLabel" name="lblTotalQRangeMax">
                  <property name="text">
                   <string>Max:</string>
                  </property>
@@ -631,7 +631,7 @@ p, li { white-space: pre-wrap; }
                 </widget>
                </item>
                <item>
-                <widget class="QLabel" name="labelTotalQRangeMaxUnit">
+                <widget class="QLabel" name="lblTotalQRangeMaxUnit">
                  <property name="text">
                   <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Å&lt;span style=&quot; vertical-align:super;&quot;&gt;-1&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
                  </property>
@@ -651,14 +651,14 @@ p, li { white-space: pre-wrap; }
              <item row="0" column="0">
               <layout class="QHBoxLayout" name="horizontalLayout">
                <item>
-                <widget class="QLabel" name="labelSlitParametersHeight">
+                <widget class="QLabel" name="lblSlitParametersHeight">
                  <property name="text">
                   <string>Height</string>
                  </property>
                 </widget>
                </item>
                <item>
-                <widget class="QLineEdit" name="slitHeightInput">
+                <widget class="QLineEdit" name="txtSlitHeightInput">
                  <property name="enabled">
                   <bool>true</bool>
                  </property>
@@ -671,21 +671,21 @@ p, li { white-space: pre-wrap; }
                 </widget>
                </item>
                <item>
-                <widget class="QLabel" name="labelSlitParametersHeightUnit">
+                <widget class="QLabel" name="lblSlitParametersHeightUnit">
                  <property name="text">
                   <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Å&lt;span style=&quot; vertical-align:super;&quot;&gt;-1&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
                  </property>
                 </widget>
                </item>
                <item>
-                <widget class="QLabel" name="labelSlitParametersWidth">
+                <widget class="QLabel" name="lblSlitParametersWidth">
                  <property name="text">
                   <string>Width</string>
                  </property>
                 </widget>
                </item>
                <item>
-                <widget class="QLineEdit" name="slitWidthInput">
+                <widget class="QLineEdit" name="txtSlitWidthInput">
                  <property name="enabled">
                   <bool>true</bool>
                  </property>
@@ -698,7 +698,7 @@ p, li { white-space: pre-wrap; }
                 </widget>
                </item>
                <item>
-                <widget class="QLabel" name="labelSlitParametersWidthUnit">
+                <widget class="QLabel" name="lblSlitParametersWidthUnit">
                  <property name="text">
                   <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Å&lt;span style=&quot; vertical-align:super;&quot;&gt;-1&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
                  </property>
@@ -735,7 +735,7 @@ p, li { white-space: pre-wrap; }
       <enum>QLayout::SetDefaultConstraint</enum>
      </property>
      <item>
-      <widget class="QPushButton" name="calculateThisButton">
+      <widget class="QPushButton" name="cmdCalculateThis">
        <property name="enabled">
         <bool>true</bool>
        </property>
@@ -745,7 +745,7 @@ p, li { white-space: pre-wrap; }
       </widget>
      </item>
      <item>
-      <widget class="QPushButton" name="calculateAllButton">
+      <widget class="QPushButton" name="cmdCalculateAll">
        <property name="enabled">
         <bool>false</bool>
        </property>
@@ -761,7 +761,7 @@ p, li { white-space: pre-wrap; }
       </widget>
      </item>
      <item>
-      <widget class="QPushButton" name="stopButton">
+      <widget class="QPushButton" name="cmdStop">
        <property name="text">
         <string>Stop P(r)</string>
        </property>
@@ -784,7 +784,7 @@ p, li { white-space: pre-wrap; }
       </spacer>
      </item>
      <item>
-      <widget class="QPushButton" name="helpButton">
+      <widget class="QPushButton" name="cmdHelp">
        <property name="sizePolicy">
         <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
          <horstretch>0</horstretch>
@@ -802,13 +802,13 @@ p, li { white-space: pre-wrap; }
  </widget>
  <tabstops>
   <tabstop>dataList</tabstop>
-  <tabstop>removeButton</tabstop>
-  <tabstop>noOfTermsInput</tabstop>
-  <tabstop>noOfTermsSuggestionButton</tabstop>
-  <tabstop>regularizationConstantInput</tabstop>
-  <tabstop>regConstantSuggestionButton</tabstop>
-  <tabstop>maxDistanceInput</tabstop>
-  <tabstop>explorerButton</tabstop>
+  <tabstop>cmdRemove</tabstop>
+  <tabstop>txtNoOfTermsInput</tabstop>
+  <tabstop>cmdNoOfTermsSuggestion</tabstop>
+  <tabstop>txtRegularizationConstantInput</tabstop>
+  <tabstop>cmdRegConstantSuggestion</tabstop>
+  <tabstop>txtMaxDistanceInput</tabstop>
+  <tabstop>cmdExplorer</tabstop>
   <tabstop>rgValue</tabstop>
   <tabstop>chiDofValue</tabstop>
   <tabstop>iQ0Value</tabstop>
@@ -817,18 +817,18 @@ p, li { white-space: pre-wrap; }
   <tabstop>posFractionValue</tabstop>
   <tabstop>computationTimeValue</tabstop>
   <tabstop>sigmaPosFractionValue</tabstop>
-  <tabstop>calculateThisButton</tabstop>
-  <tabstop>calculateAllButton</tabstop>
-  <tabstop>stopButton</tabstop>
-  <tabstop>helpButton</tabstop>
+  <tabstop>cmdCalculateThis</tabstop>
+  <tabstop>cmdCalculateAll</tabstop>
+  <tabstop>cmdStop</tabstop>
+  <tabstop>cmdHelp</tabstop>
   <tabstop>PrTabWidget</tabstop>
-  <tabstop>backgroundInput</tabstop>
-  <tabstop>estimateBgd</tabstop>
-  <tabstop>manualBgd</tabstop>
+  <tabstop>txtBackgroundInput</tabstop>
+  <tabstop>rbEstimateBackground</tabstop>
+  <tabstop>rbManualBackground</tabstop>
   <tabstop>minQInput</tabstop>
   <tabstop>maxQInput</tabstop>
-  <tabstop>slitHeightInput</tabstop>
-  <tabstop>slitWidthInput</tabstop>
+  <tabstop>txtSlitHeightInput</tabstop>
+  <tabstop>txtSlitWidthInput</tabstop>
  </tabstops>
  <resources/>
  <connections/>

--- a/src/sas/qtgui/Perspectives/Inversion/UI/TabbedInversionUI.ui
+++ b/src/sas/qtgui/Perspectives/Inversion/UI/TabbedInversionUI.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>518</width>
+    <width>446</width>
     <height>480</height>
    </rect>
   </property>
@@ -139,7 +139,7 @@ p, li { white-space: pre-wrap; }
            </widget>
           </item>
           <item row="0" column="1">
-           <widget class="QLineEdit" name="txtNoOfTermsInput">
+           <widget class="QLineEdit" name="noOfTermsInput">
             <property name="sizePolicy">
              <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
               <horstretch>0</horstretch>
@@ -165,7 +165,7 @@ p, li { white-space: pre-wrap; }
            </widget>
           </item>
           <item row="1" column="0">
-           <widget class="QLabel" name="lblParametersRegConstant">
+           <widget class="QLabel" name="lblParamatersRegConstant">
             <property name="sizePolicy">
              <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
               <horstretch>0</horstretch>
@@ -184,7 +184,7 @@ p, li { white-space: pre-wrap; }
            </widget>
           </item>
           <item row="1" column="1">
-           <widget class="QLineEdit" name="txtRegularizationConstantInput">
+           <widget class="QLineEdit" name="regularizationConstantInput">
             <property name="sizePolicy">
              <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
               <horstretch>0</horstretch>
@@ -223,7 +223,7 @@ p, li { white-space: pre-wrap; }
            </widget>
           </item>
           <item row="2" column="1">
-           <widget class="QLineEdit" name="txtMaxDistanceInput">
+           <widget class="QLineEdit" name="maxDistanceInput">
             <property name="sizePolicy">
              <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
               <horstretch>0</horstretch>
@@ -264,13 +264,13 @@ p, li { white-space: pre-wrap; }
            </widget>
           </item>
          </layout>
-         <zorder>txtNoOfTermsInput</zorder>
+         <zorder>noOfTermsInput</zorder>
          <zorder>cmdNoOfTermsSuggestion</zorder>
-         <zorder>txtRegularizationConstantInput</zorder>
+         <zorder>regularizationConstantInput</zorder>
          <zorder>cmdRegConstantSuggestion</zorder>
-         <zorder>txtMaxDistanceInput</zorder>
+         <zorder>maxDistanceInput</zorder>
          <zorder>cmdExplorer</zorder>
-         <zorder>lblParametersRegConstant</zorder>
+         <zorder>lblParamatersRegConstant</zorder>
          <zorder>lblParametersNumberOfTerms</zorder>
          <zorder>lblParametersMaxDistance</zorder>
         </widget>
@@ -307,71 +307,28 @@ p, li { white-space: pre-wrap; }
             </property>
            </widget>
           </item>
-          <item row="2" column="4">
-           <widget class="QLineEdit" name="posFractionValue">
-            <property name="enabled">
-             <bool>true</bool>
-            </property>
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="focusPolicy">
-             <enum>Qt::ClickFocus</enum>
-            </property>
-            <property name="readOnly">
-             <bool>true</bool>
-            </property>
-           </widget>
-          </item>
-          <item row="3" column="3">
-           <widget class="QLabel" name="lblPOneMinSigmaFraction">
+          <item row="0" column="2">
+           <widget class="QLabel" name="lblOutputsR_g_Unit">
             <property name="text">
-             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;P&lt;span style=&quot; vertical-align:super;&quot;&gt;+&lt;/span&gt;&lt;span style=&quot; vertical-align:sub;&quot;&gt;1-σ&lt;/span&gt; fraction&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+             <string>Å</string>
             </property>
            </widget>
           </item>
-          <item row="3" column="4">
-           <widget class="QLineEdit" name="sigmaPosFractionValue">
-            <property name="enabled">
-             <bool>true</bool>
-            </property>
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="focusPolicy">
-             <enum>Qt::ClickFocus</enum>
-            </property>
-            <property name="readOnly">
-             <bool>true</bool>
-            </property>
-           </widget>
-          </item>
-          <item row="2" column="1">
-           <widget class="QLineEdit" name="backgroundValue">
-            <property name="enabled">
-             <bool>true</bool>
-            </property>
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="focusPolicy">
-             <enum>Qt::ClickFocus</enum>
-            </property>
-            <property name="readOnly">
-             <bool>true</bool>
+          <item row="0" column="3">
+           <widget class="QLabel" name="labelSpacer">
+            <property name="text">
+             <string/>
             </property>
            </widget>
           </item>
           <item row="0" column="4">
+           <widget class="QLabel" name="lblOutputsChi2DivDof">
+            <property name="text">
+             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;χ&lt;span style=&quot; vertical-align:super;&quot;&gt;2&lt;/span&gt;/dof&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="5">
            <widget class="QLineEdit" name="chiDofValue">
             <property name="enabled">
              <bool>true</bool>
@@ -387,6 +344,13 @@ p, li { white-space: pre-wrap; }
             </property>
             <property name="readOnly">
              <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="0">
+           <widget class="QLabel" name="lblOutputsI_Q_0">
+            <property name="text">
+             <string>I(Q=0)</string>
             </property>
            </widget>
           </item>
@@ -416,42 +380,14 @@ p, li { white-space: pre-wrap; }
             </property>
            </widget>
           </item>
-          <item row="3" column="2">
-           <widget class="QLabel" name="lblOutputsCalcTimeUnit">
-            <property name="text">
-             <string>secs</string>
-            </property>
-           </widget>
-          </item>
-          <item row="2" column="3">
-           <widget class="QLabel" name="lblOuputsPFraction">
-            <property name="text">
-             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;P&lt;span style=&quot; vertical-align:super;&quot;&gt;+&lt;/span&gt; Fraction&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="0">
-           <widget class="QLabel" name="lblOutputsI_Q_0">
-            <property name="text">
-             <string>I(Q=0)</string>
-            </property>
-           </widget>
-          </item>
-          <item row="3" column="0">
-           <widget class="QLabel" name="lblOutputsCalcTime">
-            <property name="text">
-             <string>Calc. Time</string>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="3">
-           <widget class="QLabel" name="lblOutputsChiSquaredDivDOF">
-            <property name="text">
-             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;χ&lt;span style=&quot; vertical-align:super;&quot;&gt;2&lt;/span&gt;/dof&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-            </property>
-           </widget>
-          </item>
           <item row="1" column="4">
+           <widget class="QLabel" name="lblOutputsOscillations">
+            <property name="text">
+             <string>Oscillations</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="5">
            <widget class="QLineEdit" name="oscillationValue">
             <property name="enabled">
              <bool>true</bool>
@@ -477,6 +413,25 @@ p, li { white-space: pre-wrap; }
             </property>
            </widget>
           </item>
+          <item row="2" column="1">
+           <widget class="QLineEdit" name="backgroundValue">
+            <property name="enabled">
+             <bool>true</bool>
+            </property>
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="focusPolicy">
+             <enum>Qt::ClickFocus</enum>
+            </property>
+            <property name="readOnly">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
           <item row="2" column="2">
            <widget class="QLabel" name="lblOutputsBackgroundUnit">
             <property name="text">
@@ -484,22 +439,74 @@ p, li { white-space: pre-wrap; }
             </property>
            </widget>
           </item>
-          <item row="0" column="2">
-           <widget class="QLabel" name="lblOutputsR_g_Unit">
+          <item row="2" column="4">
+           <widget class="QLabel" name="lblOutputsPFraction">
             <property name="text">
-             <string>Å</string>
+             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;P&lt;span style=&quot; vertical-align:super;&quot;&gt;+&lt;/span&gt; Fraction&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
             </property>
            </widget>
           </item>
-          <item row="1" column="3">
-           <widget class="QLabel" name="lblOutputsOscillations">
+          <item row="2" column="5">
+           <widget class="QLineEdit" name="posFractionValue">
+            <property name="enabled">
+             <bool>true</bool>
+            </property>
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="focusPolicy">
+             <enum>Qt::ClickFocus</enum>
+            </property>
+            <property name="readOnly">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="0">
+           <widget class="QLabel" name="lblOutputsBalcTime">
             <property name="text">
-             <string>Oscillations</string>
+             <string>Calc. Time</string>
             </property>
            </widget>
           </item>
           <item row="3" column="1">
            <widget class="QLineEdit" name="computationTimeValue">
+            <property name="enabled">
+             <bool>true</bool>
+            </property>
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="focusPolicy">
+             <enum>Qt::ClickFocus</enum>
+            </property>
+            <property name="readOnly">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="2">
+           <widget class="QLabel" name="lblOutputsCalcTimeUnit">
+            <property name="text">
+             <string>secs</string>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="4">
+           <widget class="QLabel" name="lblPOneMinSigmaFraction">
+            <property name="text">
+             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;P&lt;span style=&quot; vertical-align:super;&quot;&gt;+&lt;/span&gt;&lt;span style=&quot; vertical-align:sub;&quot;&gt;1-σ&lt;/span&gt; fraction&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="5">
+           <widget class="QLineEdit" name="sigmaPosFractionValue">
             <property name="enabled">
              <bool>true</bool>
             </property>
@@ -803,11 +810,11 @@ p, li { white-space: pre-wrap; }
  <tabstops>
   <tabstop>dataList</tabstop>
   <tabstop>cmdRemove</tabstop>
-  <tabstop>txtNoOfTermsInput</tabstop>
+  <tabstop>noOfTermsInput</tabstop>
   <tabstop>cmdNoOfTermsSuggestion</tabstop>
-  <tabstop>txtRegularizationConstantInput</tabstop>
+  <tabstop>regularizationConstantInput</tabstop>
   <tabstop>cmdRegConstantSuggestion</tabstop>
-  <tabstop>txtMaxDistanceInput</tabstop>
+  <tabstop>maxDistanceInput</tabstop>
   <tabstop>cmdExplorer</tabstop>
   <tabstop>rgValue</tabstop>
   <tabstop>chiDofValue</tabstop>

--- a/src/sas/qtgui/Perspectives/ParticleEditor/CodeToolBar.py
+++ b/src/sas/qtgui/Perspectives/ParticleEditor/CodeToolBar.py
@@ -12,16 +12,16 @@ class CodeToolBar(QtWidgets.QWidget, Ui_CodeToolBar):
 
         load_icon = QtGui.QIcon()
         load_icon.addPixmap(QtGui.QPixmap(":/particle_editor/upload-icon.png"), QtGui.QIcon.Normal, QtGui.QIcon.Off)
-        self.loadButton.setIcon(load_icon)
+        self.cmdLoad.setIcon(load_icon)
 
         save_icon = QtGui.QIcon()
         save_icon.addPixmap(QtGui.QPixmap(":/particle_editor/download-icon.png"), QtGui.QIcon.Normal, QtGui.QIcon.Off)
-        self.saveButton.setIcon(save_icon)
+        self.cmdSave.setIcon(save_icon)
 
         build_icon = QtGui.QIcon()
         build_icon.addPixmap(QtGui.QPixmap(":/particle_editor/hammer-icon.png"), QtGui.QIcon.Normal, QtGui.QIcon.Off)
-        self.buildButton.setIcon(build_icon)
+        self.cmdBuild.setIcon(build_icon)
 
         scatter_icon = QtGui.QIcon()
         scatter_icon.addPixmap(QtGui.QPixmap(":/particle_editor/scatter-icon.png"), QtGui.QIcon.Normal, QtGui.QIcon.Off)
-        self.scatterButton.setIcon(scatter_icon)
+        self.cmdScatter.setIcon(scatter_icon)

--- a/src/sas/qtgui/Perspectives/ParticleEditor/DesignWindow.py
+++ b/src/sas/qtgui/Perspectives/ParticleEditor/DesignWindow.py
@@ -120,26 +120,26 @@ class DesignWindow(QtWidgets.QDialog, Ui_DesignWindow):
 
         self.topLayout.addWidget(self.angularSamplingMethodSelector, 0, 1)
 
-        self.structureFactorCombo.addItem("None") # TODO: Structure Factor Options
+        self.cbStructureFactor.addItem("None") # TODO: Structure Factor Options
 
 
         #
         # Calculation Tab
         #
-        self.methodComboOptions = ["Grid", "Random"]
-        for option in self.methodComboOptions:
-            self.methodCombo.addItem(option)
+        self.cbSampleMethodOptions = ["Grid", "Random"]
+        for option in self.cbSampleMethodOptions:
+            self.cbSampleMethod.addItem(option)
 
         # Spatial sampling changed
-        self.nSamplePoints.valueChanged.connect(self.onTimeEstimateParametersChanged)
+        self.spinBoxNSamplePoints.valueChanged.connect(self.onTimeEstimateParametersChanged)
 
         # Q sampling changed
-        # self.useLogQ.clicked.connect(self.updateQSampling)
-        # self.qMinBox.textChanged.connect(self.updateQSampling)
-        # self.qMaxBox.textChanged.connect(self.updateQSampling)
-        # self.qSamplesBox.valueChanged.connect(self.updateQSampling)
+        # self.cbUseLogQ.clicked.connect(self.updateQSampling)
+        # self.txtQMin.textChanged.connect(self.updateQSampling)
+        # self.txtQMin.textChanged.connect(self.updateQSampling)
+        # self.spinBoxQSamples.valueChanged.connect(self.updateQSampling)
 
-        self.qSamplesBox.valueChanged.connect(self.onTimeEstimateParametersChanged)
+        self.spinBoxQSamples.valueChanged.connect(self.onTimeEstimateParametersChanged)
 
         #
         # Output Tabs
@@ -173,8 +173,8 @@ class DesignWindow(QtWidgets.QDialog, Ui_DesignWindow):
         self.magnetism_coordinate_mapping: Optional[np.ndarray] = None
 
     def onRadiusChanged(self):
-        if self.radiusFromParticleTab.isChecked():
-            self.sampleRadius.setValue(self.functionViewer.radius_control.radius())
+        if self.cbRadiusFromParticleTab.isChecked():
+            self.doubleSpinSampleRadius.setValue(self.functionViewer.radius_control.radius())
 
     def onTimeEstimateParametersChanged(self):
         """ Called when the number of samples changes """
@@ -190,9 +190,9 @@ class DesignWindow(QtWidgets.QDialog, Ui_DesignWindow):
         if self.last_calculation_time is not None:
             time_per_sample = self.last_calculation_time / self.last_calculation_n_r
 
-            est_time = time_per_sample * int(self.nSamplePoints.value()) * int(self.qSamplesBox.value())
+            est_time = time_per_sample * int(self.spinBoxNSamplePoints.value()) * int(self.spinBoxQSamples.value())
 
-            self.timeEstimateLabel.setText(f"Estimated Time: {format_time_estimate(est_time)}")
+            self.lblTimeEstimate.setText(f"Estimated Time: {format_time_estimate(est_time)}")
 
     def onLoad(self):
         print("Load clicked")
@@ -254,21 +254,21 @@ class DesignWindow(QtWidgets.QDialog, Ui_DesignWindow):
         return self.angularSamplingMethodSelector.generate_sampler()
 
     def qSampling(self) -> QSample:
-        q_min = float(self.qMinBox.text()) # TODO: Use better box
-        q_max = float(self.qMaxBox.text())
-        n_q = int(self.qSamplesBox.value())
-        is_log = bool(self.useLogQ.isChecked())
+        q_min = float(self.txtQMin.text()) # TODO: Use better box
+        q_max = float(self.txtQMin.text())
+        n_q = int(self.spinBoxQSamples.value())
+        is_log = bool(self.cbUseLogQ.isChecked())
 
         return QSample(q_min, q_max, n_q, is_log)
 
     def spatialSampling(self) -> SpatialDistribution:
         """ Calculate the spatial sampling object based on current gui settings"""
-        sample_type = self.methodCombo.currentIndex()
+        sample_type = self.cbSampleMethod.currentIndex()
 
         # All the methods need the radius, number of points, etc
-        radius = float(self.sampleRadius.value())
-        n_points = int(self.nSamplePoints.value())
-        seed = int(self.randomSeed.text()) if self.fixRandomSeed.isChecked() else None
+        radius = float(self.doubleSpinSampleRadius.value())
+        n_points = int(self.spinBoxNSamplePoints.value())
+        seed = int(self.txtRandomSeed.text()) if self.cbFixRandomSeed.isChecked() else None
 
         if sample_type == 0:
             return GridSampling(radius=radius, desired_points=n_points)
@@ -310,7 +310,7 @@ class DesignWindow(QtWidgets.QDialog, Ui_DesignWindow):
         return np.array([0,0,1])
 
     def currentSeed(self):
-        return self.randomSeed
+        return self.txtRandomSeed
 
     def scatteringCalculation(self) -> ScatteringCalculation:
         """ Get the ScatteringCalculation object that represents the calculation that
@@ -322,7 +322,7 @@ class DesignWindow(QtWidgets.QDialog, Ui_DesignWindow):
         parameter_definition = self.parametersForCalculation()
         polarisation_vector = self.polarisationVector()
         seed = self.currentSeed()
-        bounding_surface_check = self.continuityCheck.isChecked()
+        bounding_surface_check = self.cbContinuityCheck.isChecked()
 
         return ScatteringCalculation(
             q_sampling=q_sampling,
@@ -393,10 +393,10 @@ class DesignWindow(QtWidgets.QDialog, Ui_DesignWindow):
 
     def qSampling(self) -> QSample:
         """ Calculate the q sampling object based on current gui settings"""
-        is_log = self.useLogQ.isEnabled() and self.useLogQ.isChecked() # Only when it's an option
-        min_q = float(self.qMinBox.text())
-        max_q = float(self.qMaxBox.text())
-        n_samples = int(self.qSamplesBox.value())
+        is_log = self.cbUseLogQ.isEnabled() and self.cbUseLogQ.isChecked() # Only when it's an option
+        min_q = float(self.txtQMin.text())
+        max_q = float(self.txtQMin.text())
+        n_samples = int(self.spinBoxQSamples.value())
 
         return QSample(min_q, max_q, n_samples, is_log)
 

--- a/src/sas/qtgui/Perspectives/ParticleEditor/FunctionViewer.py
+++ b/src/sas/qtgui/Perspectives/ParticleEditor/FunctionViewer.py
@@ -128,8 +128,8 @@ class FunctionViewer(QtWidgets.QWidget):
         # Magnetism controls
 
         self.sld_magnetism_option = SLDMagnetismOption()
-        self.sld_magnetism_option.sldOption.clicked.connect(self.onDisplayTypeSelected)
-        self.sld_magnetism_option.magnetismOption.clicked.connect(self.onDisplayTypeSelected)
+        self.sld_magnetism_option.rbSldOption.clicked.connect(self.onDisplayTypeSelected)
+        self.sld_magnetism_option.rbMagnetismOption.clicked.connect(self.onDisplayTypeSelected)
 
         self.mag_theta_slider = LabelledSlider("θ", -180, 180, 0)
         self.mag_theta_slider.valueChanged.connect(self.onMagThetaChanged)
@@ -234,7 +234,7 @@ class FunctionViewer(QtWidgets.QWidget):
 
         if self.sld_magnetism_option.magnetismOption.isChecked():
             print("Magnetic view selected")
-        if self.sld_magnetism_option.sldOption.isChecked():
+        if self.sld_magnetism_option.rbSldOption.isChecked():
             print("SLD view selected")
 
     # def onThetaChanged(self):

--- a/src/sas/qtgui/Perspectives/ParticleEditor/FunctionViewer.py
+++ b/src/sas/qtgui/Perspectives/ParticleEditor/FunctionViewer.py
@@ -232,7 +232,7 @@ class FunctionViewer(QtWidgets.QWidget):
     def onDisplayTypeSelected(self):
         """ Switch between SLD and magnetism view """
 
-        if self.sld_magnetism_option.magnetismOption.isChecked():
+        if self.sld_magnetism_option.rbMagnetismOption.isChecked():
             print("Magnetic view selected")
         if self.sld_magnetism_option.rbSldOption.isChecked():
             print("SLD view selected")

--- a/src/sas/qtgui/Perspectives/ParticleEditor/RadiusSelection.py
+++ b/src/sas/qtgui/Perspectives/ParticleEditor/RadiusSelection.py
@@ -11,8 +11,8 @@ class RadiusSelection(QtWidgets.QWidget, Ui_RadiusSelection):
         self.setupUi(self)
 
         if text is not None:
-            self.label.setText(text)
+            self.lblRadius.setText(text)
 
 
     def radius(self):
-        return float(self.radiusField.value())
+        return float(self.doubleSpinRadius.value())

--- a/src/sas/qtgui/Perspectives/ParticleEditor/UI/AxisButtonsUI.ui
+++ b/src/sas/qtgui/Perspectives/ParticleEditor/UI/AxisButtonsUI.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>100</width>
-    <height>19</height>
+    <width>102</width>
+    <height>24</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -27,7 +27,7 @@
     <number>0</number>
    </property>
    <item>
-    <widget class="QPushButton" name="selectX">
+    <widget class="QPushButton" name="cmdSelectX">
      <property name="minimumSize">
       <size>
        <width>30</width>
@@ -40,7 +40,7 @@
     </widget>
    </item>
    <item>
-    <widget class="QPushButton" name="selectY">
+    <widget class="QPushButton" name="cmdSelectY">
      <property name="minimumSize">
       <size>
        <width>30</width>
@@ -53,7 +53,7 @@
     </widget>
    </item>
    <item>
-    <widget class="QPushButton" name="selectZ">
+    <widget class="QPushButton" name="cmdSelectZ">
      <property name="minimumSize">
       <size>
        <width>30</width>

--- a/src/sas/qtgui/Perspectives/ParticleEditor/UI/CodeToolBarUI.ui
+++ b/src/sas/qtgui/Perspectives/ParticleEditor/UI/CodeToolBarUI.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>460</width>
-    <height>20</height>
+    <height>24</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -27,14 +27,14 @@
     <number>0</number>
    </property>
    <item>
-    <widget class="QPushButton" name="loadButton">
+    <widget class="QPushButton" name="cmdLoad">
      <property name="text">
       <string>Load</string>
      </property>
     </widget>
    </item>
    <item>
-    <widget class="QPushButton" name="saveButton">
+    <widget class="QPushButton" name="cmdSave">
      <property name="text">
       <string>Save</string>
      </property>
@@ -54,7 +54,7 @@
     </spacer>
    </item>
    <item>
-    <widget class="QPushButton" name="buildButton">
+    <widget class="QPushButton" name="cmdBuild">
      <property name="toolTip">
       <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Build the current code&lt;/p&gt;&lt;p&gt;Shortcut: shift-Enter&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
      </property>
@@ -64,7 +64,7 @@
     </widget>
    </item>
    <item>
-    <widget class="QPushButton" name="scatterButton">
+    <widget class="QPushButton" name="cmdScatter">
      <property name="text">
       <string>Scatter</string>
      </property>

--- a/src/sas/qtgui/Perspectives/ParticleEditor/UI/DesignWindowUI.ui
+++ b/src/sas/qtgui/Perspectives/ParticleEditor/UI/DesignWindowUI.ui
@@ -20,7 +20,7 @@
       <string/>
      </property>
      <property name="currentIndex">
-      <number>3</number>
+      <number>0</number>
      </property>
      <widget class="QWidget" name="definitionTab">
       <attribute name="title">

--- a/src/sas/qtgui/Perspectives/ParticleEditor/UI/DesignWindowUI.ui
+++ b/src/sas/qtgui/Perspectives/ParticleEditor/UI/DesignWindowUI.ui
@@ -20,7 +20,7 @@
       <string/>
      </property>
      <property name="currentIndex">
-      <number>0</number>
+      <number>3</number>
      </property>
      <widget class="QWidget" name="definitionTab">
       <attribute name="title">
@@ -79,7 +79,7 @@
                 <number>10</number>
                </property>
                <item row="1" column="0">
-                <widget class="QLabel" name="label_5">
+                <widget class="QLabel" name="labelStructureFactor">
                  <property name="text">
                   <string>Structure Factor</string>
                  </property>
@@ -92,7 +92,7 @@
                 <widget class="QComboBox" name="structureFactorCombo"/>
                </item>
                <item row="0" column="0">
-                <widget class="QLabel" name="label_2">
+                <widget class="QLabel" name="labelOrientationalDistribution">
                  <property name="text">
                   <string>Orientational Distribution</string>
                  </property>
@@ -119,7 +119,7 @@
             </layout>
            </item>
            <item>
-            <widget class="QLabel" name="label_6">
+            <widget class="QLabel" name="labelStructureFactorParameters">
              <property name="text">
               <string>Structure Factor Parameters</string>
              </property>
@@ -197,7 +197,7 @@
              <widget class="QFrame" name="frame_3">
               <layout class="QGridLayout" name="gridLayout_2">
                <item row="8" column="0">
-                <widget class="QLabel" name="label_11">
+                <widget class="QLabel" name="labelQMax">
                  <property name="text">
                   <string>Q Max</string>
                  </property>
@@ -207,7 +207,7 @@
                 </widget>
                </item>
                <item row="8" column="3">
-                <widget class="QLabel" name="label_10">
+                <widget class="QLabel" name="labelQMaxUnit">
                  <property name="text">
                   <string>Ang&lt;sup&gt;-1&lt;/sup&gt;</string>
                  </property>
@@ -240,7 +240,7 @@
                 </widget>
                </item>
                <item row="11" column="0">
-                <widget class="QLabel" name="label_12">
+                <widget class="QLabel" name="labelNeutronPolarisation">
                  <property name="text">
                   <string>Neutron Polarisation</string>
                  </property>
@@ -254,7 +254,7 @@
                 </widget>
                </item>
                <item row="9" column="0">
-                <widget class="QLabel" name="label_7">
+                <widget class="QLabel" name="labelQSamples">
                  <property name="text">
                   <string>Q Samples</string>
                  </property>
@@ -342,7 +342,7 @@
                 </layout>
                </item>
                <item row="3" column="0">
-                <widget class="QLabel" name="label_14">
+                <widget class="QLabel" name="labelSampleRadius">
                  <property name="text">
                   <string>Sample Radius</string>
                  </property>
@@ -352,7 +352,7 @@
                 </widget>
                </item>
                <item row="7" column="0">
-                <widget class="QLabel" name="label_8">
+                <widget class="QLabel" name="labelQMin">
                  <property name="text">
                   <string>Q Min</string>
                  </property>
@@ -362,7 +362,7 @@
                 </widget>
                </item>
                <item row="5" column="0">
-                <widget class="QLabel" name="label_4">
+                <widget class="QLabel" name="labelSamplePoints">
                  <property name="text">
                   <string>Sample Points</string>
                  </property>
@@ -372,7 +372,7 @@
                 </widget>
                </item>
                <item row="4" column="0">
-                <widget class="QLabel" name="label_3">
+                <widget class="QLabel" name="labelSampleMethod">
                  <property name="text">
                   <string>Sample Method</string>
                  </property>
@@ -382,7 +382,7 @@
                 </widget>
                </item>
                <item row="6" column="0">
-                <widget class="QLabel" name="label_16">
+                <widget class="QLabel" name="labelRandomSeed">
                  <property name="text">
                   <string>Random Seed</string>
                  </property>
@@ -434,7 +434,7 @@
                 </layout>
                </item>
                <item row="7" column="3">
-                <widget class="QLabel" name="label_9">
+                <widget class="QLabel" name="labelQMinUnit">
                  <property name="text">
                   <string>Ang&lt;sup&gt;-1&lt;/sup&gt;</string>
                  </property>

--- a/src/sas/qtgui/Perspectives/ParticleEditor/UI/DesignWindowUI.ui
+++ b/src/sas/qtgui/Perspectives/ParticleEditor/UI/DesignWindowUI.ui
@@ -20,7 +20,7 @@
       <string/>
      </property>
      <property name="currentIndex">
-      <number>0</number>
+      <number>3</number>
      </property>
      <widget class="QWidget" name="definitionTab">
       <attribute name="title">
@@ -79,7 +79,7 @@
                 <number>10</number>
                </property>
                <item row="1" column="0">
-                <widget class="QLabel" name="labelStructureFactor">
+                <widget class="QLabel" name="lblStructureFactor">
                  <property name="text">
                   <string>Structure Factor</string>
                  </property>
@@ -89,10 +89,10 @@
                 </widget>
                </item>
                <item row="1" column="1">
-                <widget class="QComboBox" name="structureFactorCombo"/>
+                <widget class="QComboBox" name="cbStructureFactor"/>
                </item>
                <item row="0" column="0">
-                <widget class="QLabel" name="labelOrientationalDistribution">
+                <widget class="QLabel" name="lblOrientationalDistribution">
                  <property name="text">
                   <string>Orientational Distribution</string>
                  </property>
@@ -119,7 +119,7 @@
             </layout>
            </item>
            <item>
-            <widget class="QLabel" name="labelStructureFactorParameters">
+            <widget class="QLabel" name="lblStructureFactorParameters">
              <property name="text">
               <string>Structure Factor Parameters</string>
              </property>
@@ -197,7 +197,7 @@
              <widget class="QFrame" name="frame_3">
               <layout class="QGridLayout" name="gridLayout_2">
                <item row="8" column="0">
-                <widget class="QLabel" name="labelQMax">
+                <widget class="QLabel" name="lblQMax">
                  <property name="text">
                   <string>Q Max</string>
                  </property>
@@ -207,14 +207,14 @@
                 </widget>
                </item>
                <item row="8" column="3">
-                <widget class="QLabel" name="labelQMaxUnit">
+                <widget class="QLabel" name="lblQMaxUnit">
                  <property name="text">
                   <string>Ang&lt;sup&gt;-1&lt;/sup&gt;</string>
                  </property>
                 </widget>
                </item>
                <item row="9" column="2">
-                <widget class="QSpinBox" name="qSamplesBox">
+                <widget class="QSpinBox" name="spinBoxQSamples">
                  <property name="minimum">
                   <number>10</number>
                  </property>
@@ -230,7 +230,7 @@
                 </widget>
                </item>
                <item row="10" column="2">
-                <widget class="QCheckBox" name="useLogQ">
+                <widget class="QCheckBox" name="cbUseLogQ">
                  <property name="text">
                   <string>Logaritmic</string>
                  </property>
@@ -240,7 +240,7 @@
                 </widget>
                </item>
                <item row="11" column="0">
-                <widget class="QLabel" name="labelNeutronPolarisation">
+                <widget class="QLabel" name="lblNeutronPolarisation">
                  <property name="text">
                   <string>Neutron Polarisation</string>
                  </property>
@@ -254,7 +254,7 @@
                 </widget>
                </item>
                <item row="9" column="0">
-                <widget class="QLabel" name="labelQSamples">
+                <widget class="QLabel" name="lblQSamples">
                  <property name="text">
                   <string>Q Samples</string>
                  </property>
@@ -289,7 +289,7 @@
                 </layout>
                </item>
                <item row="12" column="2">
-                <widget class="QCheckBox" name="continuityCheck">
+                <widget class="QCheckBox" name="cbContinuityCheck">
                  <property name="text">
                   <string>Check sampling boundary for SLD continuity</string>
                  </property>
@@ -299,7 +299,7 @@
                 </widget>
                </item>
                <item row="13" column="2">
-                <widget class="QLabel" name="timeEstimateLabel">
+                <widget class="QLabel" name="lblTimeEstimate">
                  <property name="text">
                   <string/>
                  </property>
@@ -309,12 +309,12 @@
                 </widget>
                </item>
                <item row="4" column="2">
-                <widget class="QComboBox" name="methodCombo"/>
+                <widget class="QComboBox" name="cbSampleMethod"/>
                </item>
                <item row="3" column="2">
                 <layout class="QHBoxLayout" name="horizontalLayout_6">
                  <item>
-                  <widget class="QDoubleSpinBox" name="sampleRadius">
+                  <widget class="QDoubleSpinBox" name="doubleSpinSampleRadius">
                    <property name="enabled">
                     <bool>false</bool>
                    </property>
@@ -330,7 +330,7 @@
                   </widget>
                  </item>
                  <item>
-                  <widget class="QCheckBox" name="radiusFromParticleTab">
+                  <widget class="QCheckBox" name="cbRadiusFromParticleTab">
                    <property name="text">
                     <string>Get From 'Definition' Tab</string>
                    </property>
@@ -342,7 +342,7 @@
                 </layout>
                </item>
                <item row="3" column="0">
-                <widget class="QLabel" name="labelSampleRadius">
+                <widget class="QLabel" name="lblSampleRadius">
                  <property name="text">
                   <string>Sample Radius</string>
                  </property>
@@ -352,7 +352,7 @@
                 </widget>
                </item>
                <item row="7" column="0">
-                <widget class="QLabel" name="labelQMin">
+                <widget class="QLabel" name="lblQMin">
                  <property name="text">
                   <string>Q Min</string>
                  </property>
@@ -362,7 +362,7 @@
                 </widget>
                </item>
                <item row="5" column="0">
-                <widget class="QLabel" name="labelSamplePoints">
+                <widget class="QLabel" name="lblSamplePoints">
                  <property name="text">
                   <string>Sample Points</string>
                  </property>
@@ -372,7 +372,7 @@
                 </widget>
                </item>
                <item row="4" column="0">
-                <widget class="QLabel" name="labelSampleMethod">
+                <widget class="QLabel" name="lblSampleMethod">
                  <property name="text">
                   <string>Sample Method</string>
                  </property>
@@ -382,7 +382,7 @@
                 </widget>
                </item>
                <item row="6" column="0">
-                <widget class="QLabel" name="labelRandomSeed">
+                <widget class="QLabel" name="lblRandomSeed">
                  <property name="text">
                   <string>Random Seed</string>
                  </property>
@@ -394,14 +394,14 @@
                <item row="6" column="2">
                 <layout class="QHBoxLayout" name="horizontalLayout_9">
                  <item>
-                  <widget class="QLineEdit" name="randomSeed">
+                  <widget class="QLineEdit" name="txtRandomSeed">
                    <property name="text">
                     <string>0</string>
                    </property>
                   </widget>
                  </item>
                  <item>
-                  <widget class="QCheckBox" name="fixRandomSeed">
+                  <widget class="QCheckBox" name="cbFixRandomSeed">
                    <property name="text">
                     <string>Fix Seed</string>
                    </property>
@@ -412,7 +412,7 @@
                <item row="5" column="2">
                 <layout class="QHBoxLayout" name="horizontalLayout_8">
                  <item>
-                  <widget class="QSpinBox" name="nSamplePoints">
+                  <widget class="QSpinBox" name="spinBoxNSamplePoints">
                    <property name="maximum">
                     <number>100000000</number>
                    </property>
@@ -425,7 +425,7 @@
                   </widget>
                  </item>
                  <item>
-                  <widget class="QLabel" name="sampleDetails">
+                  <widget class="QLabel" name="lblSampleDetails">
                    <property name="text">
                     <string/>
                    </property>
@@ -434,14 +434,14 @@
                 </layout>
                </item>
                <item row="7" column="3">
-                <widget class="QLabel" name="labelQMinUnit">
+                <widget class="QLabel" name="lblQMinUnit">
                  <property name="text">
                   <string>Ang&lt;sup&gt;-1&lt;/sup&gt;</string>
                  </property>
                 </widget>
                </item>
                <item row="7" column="2">
-                <widget class="QLineEdit" name="qMinBox">
+                <widget class="QLineEdit" name="txtQMin">
                  <property name="text">
                   <string>0.0005</string>
                  </property>

--- a/src/sas/qtgui/Perspectives/ParticleEditor/UI/PlaneButtonsUI.ui
+++ b/src/sas/qtgui/Perspectives/ParticleEditor/UI/PlaneButtonsUI.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>100</width>
-    <height>19</height>
+    <width>102</width>
+    <height>24</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -27,7 +27,7 @@
     <number>0</number>
    </property>
    <item>
-    <widget class="QPushButton" name="selectXY">
+    <widget class="QPushButton" name="cmdSelectXY">
      <property name="minimumSize">
       <size>
        <width>30</width>
@@ -40,7 +40,7 @@
     </widget>
    </item>
    <item>
-    <widget class="QPushButton" name="selectYZ">
+    <widget class="QPushButton" name="cmdSelectYZ">
      <property name="minimumSize">
       <size>
        <width>30</width>
@@ -53,7 +53,7 @@
     </widget>
    </item>
    <item>
-    <widget class="QPushButton" name="selectXZ">
+    <widget class="QPushButton" name="cmdSelectXZ">
      <property name="minimumSize">
       <size>
        <width>30</width>

--- a/src/sas/qtgui/Perspectives/ParticleEditor/UI/RadiusSelectionUI.ui
+++ b/src/sas/qtgui/Perspectives/ParticleEditor/UI/RadiusSelectionUI.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>265</width>
-    <height>20</height>
+    <height>21</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -40,7 +40,7 @@
     </spacer>
    </item>
    <item>
-    <widget class="QLabel" name="label">
+    <widget class="QLabel" name="labelRadius">
      <property name="text">
       <string>Radius</string>
      </property>
@@ -60,7 +60,7 @@
     </widget>
    </item>
    <item>
-    <widget class="QLabel" name="label_2">
+    <widget class="QLabel" name="labelRadiusUnit">
      <property name="text">
       <string>Å</string>
      </property>

--- a/src/sas/qtgui/Perspectives/ParticleEditor/UI/RadiusSelectionUI.ui
+++ b/src/sas/qtgui/Perspectives/ParticleEditor/UI/RadiusSelectionUI.ui
@@ -40,7 +40,7 @@
     </spacer>
    </item>
    <item>
-    <widget class="QLabel" name="labelRadius">
+    <widget class="QLabel" name="lblRadius">
      <property name="text">
       <string>Radius</string>
      </property>
@@ -60,7 +60,7 @@
     </widget>
    </item>
    <item>
-    <widget class="QLabel" name="labelRadiusUnit">
+    <widget class="QLabel" name="lblRadiusUnit">
      <property name="text">
       <string>Å</string>
      </property>

--- a/src/sas/qtgui/Perspectives/ParticleEditor/UI/SLDMagOptionUI.ui
+++ b/src/sas/qtgui/Perspectives/ParticleEditor/UI/SLDMagOptionUI.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>104</width>
-    <height>16</height>
+    <width>133</width>
+    <height>20</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -37,7 +37,7 @@
     </widget>
    </item>
    <item>
-    <widget class="QRadioButton" name="magnetismOption">
+    <widget class="QRadioButton" name="rbMagnetismOption">
      <property name="text">
       <string>Magnetism</string>
      </property>

--- a/src/sas/qtgui/Perspectives/ParticleEditor/ViewerButtons.py
+++ b/src/sas/qtgui/Perspectives/ParticleEditor/ViewerButtons.py
@@ -18,9 +18,9 @@ class PlaneButtons(QtWidgets.QWidget, Ui_PlaneSelection):
 
         self.setAngles = set_angles_function
 
-        self.selectXY.clicked.connect(lambda: self.setAngles(*z_angles))
-        self.selectYZ.clicked.connect(lambda: self.setAngles(*x_angles))
-        self.selectXZ.clicked.connect(lambda: self.setAngles(*y_angles))
+        self.cmdSelectXY.clicked.connect(lambda: self.setAngles(*z_angles))
+        self.cmdSelectYZ.clicked.connect(lambda: self.setAngles(*x_angles))
+        self.cmdSelectXZ.clicked.connect(lambda: self.setAngles(*y_angles))
 
 
 
@@ -33,7 +33,7 @@ class AxisButtons(QtWidgets.QWidget, Ui_AxisSelection):
 
         self.setAngles = set_angles_function
 
-        self.selectX.clicked.connect(lambda: self.setAngles(*x_angles))
-        self.selectY.clicked.connect(lambda: self.setAngles(*y_angles))
-        self.selectZ.clicked.connect(lambda: self.setAngles(*z_angles))
+        self.cmdSelectX.clicked.connect(lambda: self.setAngles(*x_angles))
+        self.cmdSelectY.clicked.connect(lambda: self.setAngles(*y_angles))
+        self.cmdSelectZ.clicked.connect(lambda: self.setAngles(*z_angles))
 

--- a/src/sas/qtgui/Plotting/AddText.py
+++ b/src/sas/qtgui/Plotting/AddText.py
@@ -14,8 +14,8 @@ class AddText(QtWidgets.QDialog, Ui_AddText):
 
         self._font = QtGui.QFont()
         self._color = "black"
-        self.btnFont.clicked.connect(self.onFontChange)
-        self.btnColor.clicked.connect(self.onColorChange)
+        self.cmdFont.clicked.connect(self.onFontChange)
+        self.cmdColor.clicked.connect(self.onColorChange)
 
     def text(self):
         return self.textEdit.toPlainText()

--- a/src/sas/qtgui/Plotting/LinearFit.py
+++ b/src/sas/qtgui/Plotting/LinearFit.py
@@ -212,9 +212,9 @@ class LinearFit(QtWidgets.QDialog, Ui_LinearFitUI):
 
         # Possibly Guinier analysis
         i0 = numpy.exp(cstB)
-        self.txtGuinier_1.setText(formatNumber(i0))
+        self.txtGuinier_I_q_0.setText(formatNumber(i0))
         err = numpy.abs(numpy.exp(cstB) * errB)
-        self.txtGuinier1_Err.setText(formatNumber(err))
+        self.txtGuinier_I_q_0_Err.setText(formatNumber(err))
 
         if self.rg_yx:
             rg = numpy.sqrt(-2 * float(cstA))
@@ -233,13 +233,13 @@ class LinearFit(QtWidgets.QDialog, Ui_LinearFitUI):
             else:
                 err = ''
 
-        self.txtGuinier_2.setText(value)
-        self.txtGuinier2_Err.setText(err)
+        self.txtGuinier_R_g.setText(value)
+        self.txtGuinier_R_g_Err.setText(err)
 
         value = formatNumber(rg * self.floatInvTransform(self.xminFit))
-        self.txtGuinier_4.setText(value)
+        self.txtGuinier_R_g_times_Q_min.setText(value)
         value = formatNumber(rg * self.floatInvTransform(self.xmaxFit))
-        self.txtGuinier_3.setText(value)
+        self.txtGuinier_R_g_times_Q_max.setText(value)
 
         tempx = numpy.array(tempx)
         tempy = numpy.array(tempy)

--- a/src/sas/qtgui/Plotting/LinearFit.py
+++ b/src/sas/qtgui/Plotting/LinearFit.py
@@ -57,14 +57,14 @@ class LinearFit(QtWidgets.QDialog, Ui_LinearFitUI):
         if (self.yLabel == "ln(y)" or self.yLabel == "ln(y*x)") and \
                 (self.xLabel == "x^(2)"):
             if self.yLabel == "ln(y*x)":
-                self.label_12.setText('<html><head/><body><p>Rod diameter [Å]</p></body></html>')
+                self.lblGuinier_R_g.setText('<html><head/><body><p>Rod diameter [Å]</p></body></html>')
                 self.rg_yx = True
             self.rg_on = True
             self.guinier_box.setVisible(True)
 
         if (self.xLabel == "x^(4)") and (self.yLabel == "y*x^(4)"):
             self.bg_on = True
-            self.label_3.setText('Background')
+            self.lblFitParameter_a.setText('Background')
 
         self.x_is_log = self.xLabel == "log10(x)"
         self.y_is_log = self.yLabel == "log10(y)"

--- a/src/sas/qtgui/Plotting/PlotProperties.py
+++ b/src/sas/qtgui/Plotting/PlotProperties.py
@@ -45,7 +45,7 @@ class PlotProperties(QtWidgets.QDialog, Ui_PlotPropertiesUI):
             self.cbShape.setCurrentIndex(marker_index)
         if self._legend:
             self.txtLegend.setText(self._legend)
-        self.sbSize.setValue(self._markersize)
+        self.spinBoxSize.setValue(self._markersize)
 
         # Connect slots
         self.cmdCustom.clicked.connect(self.onColorChange)
@@ -61,7 +61,7 @@ class PlotProperties(QtWidgets.QDialog, Ui_PlotPropertiesUI):
 
     def markersize(self):
         ''' return marker size (int) '''
-        return self.sbSize.value()
+        return self.spinBoxSize.value()
 
     def color(self):
         ''' return current color: index in COLORS or a hex string '''

--- a/src/sas/qtgui/Plotting/SlicerParameters.py
+++ b/src/sas/qtgui/Plotting/SlicerParameters.py
@@ -241,7 +241,7 @@ class SlicerParameters(QtWidgets.QDialog, Ui_SlicerParametersUI):
         self.txtExtension.setEnabled(enabled)
         self.cmdFiles.setEnabled(enabled)
         self.cbFitOptions.setEnabled(enabled)
-        self.label_4.setEnabled(enabled)
+        self.lblAs.setEnabled(enabled)
         self.cbSaveExt.setEnabled(enabled)
 
     def onParamChange(self):

--- a/src/sas/qtgui/Plotting/UI/AddTextUI.ui
+++ b/src/sas/qtgui/Plotting/UI/AddTextUI.ui
@@ -10,7 +10,7 @@
     <x>0</x>
     <y>0</y>
     <width>432</width>
-    <height>324</height>
+    <height>328</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -64,14 +64,14 @@
    <item row="2" column="0">
     <layout class="QHBoxLayout" name="horizontalLayout">
      <item>
-      <widget class="QPushButton" name="btnFont">
+      <widget class="QPushButton" name="cmdFont">
        <property name="text">
         <string>Font...</string>
        </property>
       </widget>
      </item>
      <item>
-      <widget class="QPushButton" name="btnColor">
+      <widget class="QPushButton" name="cmdColor">
        <property name="text">
         <string>Color...</string>
        </property>

--- a/src/sas/qtgui/Plotting/UI/BoxSumUI.ui
+++ b/src/sas/qtgui/Plotting/UI/BoxSumUI.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>322</width>
-    <height>313</height>
+    <width>330</width>
+    <height>340</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -49,7 +49,7 @@
         </property>
         <layout class="QGridLayout" name="gridLayout">
          <item row="0" column="0">
-          <widget class="QLabel" name="label">
+          <widget class="QLabel" name="labelBoxSizeHeight">
            <property name="sizePolicy">
             <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
              <horstretch>0</horstretch>
@@ -90,7 +90,7 @@
           </widget>
          </item>
          <item row="0" column="2">
-          <widget class="QLabel" name="label_10">
+          <widget class="QLabel" name="labelBoxSizeHeightUnit">
            <property name="sizePolicy">
             <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
              <horstretch>0</horstretch>
@@ -103,7 +103,7 @@
           </widget>
          </item>
          <item row="1" column="0">
-          <widget class="QLabel" name="label_2">
+          <widget class="QLabel" name="labelBoxSizeWidth">
            <property name="sizePolicy">
             <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
              <horstretch>0</horstretch>
@@ -144,7 +144,7 @@
           </widget>
          </item>
          <item row="1" column="2">
-          <widget class="QLabel" name="label_11">
+          <widget class="QLabel" name="labelBoxSizeWidthUnit">
            <property name="sizePolicy">
             <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
              <horstretch>0</horstretch>
@@ -172,7 +172,7 @@
         </property>
         <layout class="QGridLayout" name="gridLayout_2">
          <item row="0" column="0">
-          <widget class="QLabel" name="label_3">
+          <widget class="QLabel" name="labelQx">
            <property name="toolTip">
             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;X coordinate of the center of the box.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
            </property>
@@ -207,14 +207,14 @@
           </widget>
          </item>
          <item row="0" column="2">
-          <widget class="QLabel" name="label_13">
+          <widget class="QLabel" name="labelQxUnit">
            <property name="text">
             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Å&lt;span style=&quot; vertical-align:super;&quot;&gt;-1&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
            </property>
           </widget>
          </item>
          <item row="1" column="0">
-          <widget class="QLabel" name="label_4">
+          <widget class="QLabel" name="labelQy">
            <property name="toolTip">
             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Y coordinate of the center of the box.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
            </property>
@@ -252,7 +252,7 @@
           </widget>
          </item>
          <item row="1" column="2">
-          <widget class="QLabel" name="label_12">
+          <widget class="QLabel" name="labelQyUnit">
            <property name="text">
             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Å&lt;span style=&quot; vertical-align:super;&quot;&gt;-1&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
            </property>
@@ -279,7 +279,7 @@
       <item row="0" column="0">
        <layout class="QFormLayout" name="formLayout">
         <item row="0" column="0">
-         <widget class="QLabel" name="label_5">
+         <widget class="QLabel" name="labelAvg">
           <property name="toolTip">
            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Average point count in selected region.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
           </property>
@@ -299,7 +299,7 @@
          </widget>
         </item>
         <item row="1" column="0">
-         <widget class="QLabel" name="label_6">
+         <widget class="QLabel" name="labelAvgError">
           <property name="toolTip">
            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Error of average point count in selected region.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
           </property>
@@ -319,7 +319,7 @@
          </widget>
         </item>
         <item row="2" column="0">
-         <widget class="QLabel" name="label_7">
+         <widget class="QLabel" name="labelNumOfPoints">
           <property name="toolTip">
            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Total number of points in the selected region.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
           </property>
@@ -339,7 +339,7 @@
          </widget>
         </item>
         <item row="3" column="0">
-         <widget class="QLabel" name="label_8">
+         <widget class="QLabel" name="labelSum">
           <property name="toolTip">
            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Sum of point intensities for all points in the selected region.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
           </property>
@@ -359,7 +359,7 @@
          </widget>
         </item>
         <item row="4" column="0">
-         <widget class="QLabel" name="label_9">
+         <widget class="QLabel" name="labelSumError">
           <property name="toolTip">
            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Error of point intensity sum for all points in the selected region.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
           </property>

--- a/src/sas/qtgui/Plotting/UI/BoxSumUI.ui
+++ b/src/sas/qtgui/Plotting/UI/BoxSumUI.ui
@@ -49,7 +49,7 @@
         </property>
         <layout class="QGridLayout" name="gridLayout">
          <item row="0" column="0">
-          <widget class="QLabel" name="labelBoxSizeHeight">
+          <widget class="QLabel" name="lblBoxSizeHeight">
            <property name="sizePolicy">
             <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
              <horstretch>0</horstretch>
@@ -90,7 +90,7 @@
           </widget>
          </item>
          <item row="0" column="2">
-          <widget class="QLabel" name="labelBoxSizeHeightUnit">
+          <widget class="QLabel" name="lblBoxSizeHeightUnit">
            <property name="sizePolicy">
             <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
              <horstretch>0</horstretch>
@@ -103,7 +103,7 @@
           </widget>
          </item>
          <item row="1" column="0">
-          <widget class="QLabel" name="labelBoxSizeWidth">
+          <widget class="QLabel" name="lblBoxSizeWidth">
            <property name="sizePolicy">
             <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
              <horstretch>0</horstretch>
@@ -144,7 +144,7 @@
           </widget>
          </item>
          <item row="1" column="2">
-          <widget class="QLabel" name="labelBoxSizeWidthUnit">
+          <widget class="QLabel" name="lblBoxSizeWidthUnit">
            <property name="sizePolicy">
             <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
              <horstretch>0</horstretch>
@@ -172,7 +172,7 @@
         </property>
         <layout class="QGridLayout" name="gridLayout_2">
          <item row="0" column="0">
-          <widget class="QLabel" name="labelQx">
+          <widget class="QLabel" name="lblQx">
            <property name="toolTip">
             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;X coordinate of the center of the box.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
            </property>
@@ -207,14 +207,14 @@
           </widget>
          </item>
          <item row="0" column="2">
-          <widget class="QLabel" name="labelQxUnit">
+          <widget class="QLabel" name="lblQxUnit">
            <property name="text">
             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Å&lt;span style=&quot; vertical-align:super;&quot;&gt;-1&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
            </property>
           </widget>
          </item>
          <item row="1" column="0">
-          <widget class="QLabel" name="labelQy">
+          <widget class="QLabel" name="lblQy">
            <property name="toolTip">
             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Y coordinate of the center of the box.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
            </property>
@@ -252,7 +252,7 @@
           </widget>
          </item>
          <item row="1" column="2">
-          <widget class="QLabel" name="labelQyUnit">
+          <widget class="QLabel" name="lblQyUnit">
            <property name="text">
             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Å&lt;span style=&quot; vertical-align:super;&quot;&gt;-1&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
            </property>
@@ -279,7 +279,7 @@
       <item row="0" column="0">
        <layout class="QFormLayout" name="formLayout">
         <item row="0" column="0">
-         <widget class="QLabel" name="labelAvg">
+         <widget class="QLabel" name="lblAvg_2">
           <property name="toolTip">
            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Average point count in selected region.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
           </property>
@@ -299,7 +299,7 @@
          </widget>
         </item>
         <item row="1" column="0">
-         <widget class="QLabel" name="labelAvgError">
+         <widget class="QLabel" name="lblAvgError">
           <property name="toolTip">
            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Error of average point count in selected region.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
           </property>
@@ -319,7 +319,7 @@
          </widget>
         </item>
         <item row="2" column="0">
-         <widget class="QLabel" name="labelNumOfPoints">
+         <widget class="QLabel" name="lblNumOfPoints">
           <property name="toolTip">
            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Total number of points in the selected region.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
           </property>
@@ -339,7 +339,7 @@
          </widget>
         </item>
         <item row="3" column="0">
-         <widget class="QLabel" name="labelSum">
+         <widget class="QLabel" name="lblSum_2">
           <property name="toolTip">
            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Sum of point intensities for all points in the selected region.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
           </property>
@@ -359,7 +359,7 @@
          </widget>
         </item>
         <item row="4" column="0">
-         <widget class="QLabel" name="labelSumError">
+         <widget class="QLabel" name="lblSumError">
           <property name="toolTip">
            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Error of point intensity sum for all points in the selected region.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
           </property>

--- a/src/sas/qtgui/Plotting/UI/ColorMapUI.ui
+++ b/src/sas/qtgui/Plotting/UI/ColorMapUI.ui
@@ -88,7 +88,7 @@
       <item row="1" column="0">
        <layout class="QGridLayout" name="gridLayout">
         <item row="0" column="0">
-         <widget class="QLabel" name="label_2">
+         <widget class="QLabel" name="labelMinAmpColorMap">
           <property name="toolTip">
            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Enter value for minimum color map amplitude.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
           </property>
@@ -105,7 +105,7 @@
          </widget>
         </item>
         <item row="1" column="0">
-         <widget class="QLabel" name="label_3">
+         <widget class="QLabel" name="labelMaxAmpColorMap">
           <property name="toolTip">
            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Enter value for maximum color map amplitude.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
           </property>
@@ -145,7 +145,7 @@
       <item row="0" column="0">
        <layout class="QGridLayout" name="gridLayout_3">
         <item row="0" column="0">
-         <widget class="QLabel" name="label_4">
+         <widget class="QLabel" name="labelDetectorWidthPixels">
           <property name="toolTip">
            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Detector width.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
           </property>
@@ -162,7 +162,7 @@
          </widget>
         </item>
         <item row="1" column="0">
-         <widget class="QLabel" name="label_5">
+         <widget class="QLabel" name="labelDetectorHeightPixels">
           <property name="toolTip">
            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Detector height.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
           </property>
@@ -179,7 +179,7 @@
          </widget>
         </item>
         <item row="2" column="0">
-         <widget class="QLabel" name="label_6">
+         <widget class="QLabel" name="labelDetectorQmax">
           <property name="toolTip">
            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Maximum absolute Q&lt;span style=&quot; vertical-align:sub;&quot;&gt;x,y&lt;/span&gt; value.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
           </property>
@@ -196,7 +196,7 @@
          </widget>
         </item>
         <item row="3" column="0">
-         <widget class="QLabel" name="label_7">
+         <widget class="QLabel" name="labelDetectorBeamStopRadius">
           <property name="toolTip">
            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Minimum value of Q&lt;span style=&quot; vertical-align:sub;&quot;&gt;x&lt;/span&gt; in units of Q.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
           </property>

--- a/src/sas/qtgui/Plotting/UI/ColorMapUI.ui
+++ b/src/sas/qtgui/Plotting/UI/ColorMapUI.ui
@@ -70,7 +70,7 @@
       <item row="0" column="0">
        <layout class="QHBoxLayout" name="horizontalLayout">
         <item>
-         <widget class="QLabel" name="label">
+         <widget class="QLabel" name="lblSelectColorMap">
           <property name="text">
            <string>Select color map</string>
           </property>
@@ -88,7 +88,7 @@
       <item row="1" column="0">
        <layout class="QGridLayout" name="gridLayout">
         <item row="0" column="0">
-         <widget class="QLabel" name="labelMinAmpColorMap">
+         <widget class="QLabel" name="lblMinAmpColorMap">
           <property name="toolTip">
            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Enter value for minimum color map amplitude.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
           </property>
@@ -105,7 +105,7 @@
          </widget>
         </item>
         <item row="1" column="0">
-         <widget class="QLabel" name="labelMaxAmpColorMap">
+         <widget class="QLabel" name="lblMaxAmpColorMap">
           <property name="toolTip">
            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Enter value for maximum color map amplitude.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
           </property>
@@ -145,7 +145,7 @@
       <item row="0" column="0">
        <layout class="QGridLayout" name="gridLayout_3">
         <item row="0" column="0">
-         <widget class="QLabel" name="labelDetectorWidthPixels">
+         <widget class="QLabel" name="lblDetectorWidthPixels">
           <property name="toolTip">
            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Detector width.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
           </property>
@@ -162,7 +162,7 @@
          </widget>
         </item>
         <item row="1" column="0">
-         <widget class="QLabel" name="labelDetectorHeightPixels">
+         <widget class="QLabel" name="lblDetectorHeightPixels">
           <property name="toolTip">
            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Detector height.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
           </property>
@@ -179,7 +179,7 @@
          </widget>
         </item>
         <item row="2" column="0">
-         <widget class="QLabel" name="labelDetectorQmax">
+         <widget class="QLabel" name="lblDetectorQmax">
           <property name="toolTip">
            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Maximum absolute Q&lt;span style=&quot; vertical-align:sub;&quot;&gt;x,y&lt;/span&gt; value.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
           </property>
@@ -196,7 +196,7 @@
          </widget>
         </item>
         <item row="3" column="0">
-         <widget class="QLabel" name="labelDetectorBeamStopRadius">
+         <widget class="QLabel" name="lblDetectorBeamStopRadius">
           <property name="toolTip">
            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Minimum value of Q&lt;span style=&quot; vertical-align:sub;&quot;&gt;x&lt;/span&gt; in units of Q.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
           </property>

--- a/src/sas/qtgui/Plotting/UI/LinearFitUI.ui
+++ b/src/sas/qtgui/Plotting/UI/LinearFitUI.ui
@@ -69,7 +69,7 @@
            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Minimum value on the x-axis for the plotted data.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
           </property>
           <property name="autoFillBackground">
-           <bool>false</bool>
+           <bool>true</bool>
           </property>
           <property name="styleSheet">
            <string notr="true">color: rgb(0, 0, 0);</string>
@@ -179,7 +179,7 @@
          </widget>
         </item>
         <item row="2" column="0">
-         <widget class="QLabel" name="lblFitParameter_chi_squared_dof">
+         <widget class="QLabel" name="lblFitParameter_chi_2_dof">
           <property name="text">
            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;χ&lt;span style=&quot; vertical-align:super;&quot;&gt;2&lt;/span&gt;/dof&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
           </property>

--- a/src/sas/qtgui/Plotting/UI/LinearFitUI.ui
+++ b/src/sas/qtgui/Plotting/UI/LinearFitUI.ui
@@ -25,7 +25,7 @@
   </property>
   <layout class="QGridLayout" name="gridLayout_5">
    <item row="0" column="0">
-    <widget class="QLabel" name="label">
+    <widget class="QLabel" name="lblPerformFit">
      <property name="text">
       <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Perform fit for &lt;span style=&quot; font-weight:600; font-style:italic;&quot;&gt;y(x) = ax + b&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
      </property>
@@ -40,21 +40,21 @@
       <item row="0" column="0">
        <layout class="QGridLayout" name="gridLayout_2">
         <item row="0" column="1">
-         <widget class="QLabel" name="labelFitRangesMin">
+         <widget class="QLabel" name="lblFitRangesMin">
           <property name="text">
            <string>Min</string>
           </property>
          </widget>
         </item>
         <item row="0" column="2">
-         <widget class="QLabel" name="labelFitRangesMax">
+         <widget class="QLabel" name="lblFitRangesMax">
           <property name="text">
            <string>Max</string>
           </property>
          </widget>
         </item>
         <item row="1" column="0">
-         <widget class="QLabel" name="labelFitRange">
+         <widget class="QLabel" name="lblFitRange">
           <property name="text">
            <string>Range (linear scale)</string>
           </property>
@@ -133,7 +133,7 @@
       <item row="0" column="0">
        <layout class="QFormLayout" name="formLayout">
         <item row="0" column="0">
-         <widget class="QLabel" name="labelFitParameter_a">
+         <widget class="QLabel" name="lblFitParameter_a">
           <property name="text">
            <string>a</string>
           </property>
@@ -156,7 +156,7 @@
          </widget>
         </item>
         <item row="1" column="0">
-         <widget class="QLabel" name="labelFitParameter_x">
+         <widget class="QLabel" name="lblFitParameter_x">
           <property name="text">
            <string>b</string>
           </property>
@@ -179,7 +179,7 @@
          </widget>
         </item>
         <item row="2" column="0">
-         <widget class="QLabel" name="labelFitParameter_chi_squared_dof">
+         <widget class="QLabel" name="lblFitParameter_chi_squared_dof">
           <property name="text">
            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;χ&lt;span style=&quot; vertical-align:super;&quot;&gt;2&lt;/span&gt;/dof&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
           </property>
@@ -206,7 +206,7 @@
       <item row="0" column="1">
        <layout class="QFormLayout" name="formLayout_2">
         <item row="0" column="0">
-         <widget class="QLabel" name="labelPlusMinus1">
+         <widget class="QLabel" name="lblPlusMinus1">
           <property name="text">
            <string>+/-</string>
           </property>
@@ -229,7 +229,7 @@
          </widget>
         </item>
         <item row="1" column="0">
-         <widget class="QLabel" name="labelPlusMinus2">
+         <widget class="QLabel" name="lblPlusMinus2">
           <property name="text">
            <string>+/-</string>
           </property>
@@ -268,7 +268,7 @@
       <item row="0" column="0">
        <layout class="QFormLayout" name="formLayout_4">
         <item row="0" column="0">
-         <widget class="QLabel" name="labelGuinier_I_Q_0">
+         <widget class="QLabel" name="lblGuinier_I_Q_0">
           <property name="text">
            <string>I(q=0)</string>
           </property>
@@ -285,7 +285,7 @@
          </widget>
         </item>
         <item row="1" column="0">
-         <widget class="QLabel" name="labelGuinier_R_g">
+         <widget class="QLabel" name="lblGuinier_R_g">
           <property name="text">
            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;R&lt;span style=&quot; vertical-align:sub;&quot;&gt;g &lt;/span&gt;[Å]&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
           </property>
@@ -302,7 +302,7 @@
          </widget>
         </item>
         <item row="2" column="0">
-         <widget class="QLabel" name="labelGuinier_R_g_times_Q_max">
+         <widget class="QLabel" name="lblGuinier_R_g_times_Q_max">
           <property name="text">
            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;R&lt;span style=&quot; vertical-align:sub;&quot;&gt;g&lt;/span&gt;*Q&lt;span style=&quot; vertical-align:sub;&quot;&gt;max&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
           </property>
@@ -319,7 +319,7 @@
          </widget>
         </item>
         <item row="3" column="0">
-         <widget class="QLabel" name="labelGuinier_R_g_times_Q_min">
+         <widget class="QLabel" name="lblGuinier_R_g_times_Q_min">
           <property name="text">
            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;R&lt;span style=&quot; vertical-align:sub;&quot;&gt;g&lt;/span&gt;*Q&lt;span style=&quot; vertical-align:sub;&quot;&gt;min&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
           </property>
@@ -340,7 +340,7 @@
       <item row="0" column="1">
        <layout class="QFormLayout" name="formLayout_3">
         <item row="0" column="0">
-         <widget class="QLabel" name="labelPlusMinus3">
+         <widget class="QLabel" name="lblPlusMinus3">
           <property name="text">
            <string>+/-</string>
           </property>
@@ -363,7 +363,7 @@
          </widget>
         </item>
         <item row="1" column="0">
-         <widget class="QLabel" name="labelPlusMinus4">
+         <widget class="QLabel" name="lblPlusMinus4">
           <property name="text">
            <string>+/-</string>
           </property>
@@ -391,7 +391,7 @@
     </widget>
    </item>
    <item row="4" column="0" colspan="2">
-    <widget class="QLabel" name="label_2">
+    <widget class="QLabel" name="lblResolutionNotAccounted">
      <property name="text">
       <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; color:#000000;&quot;&gt;Resolution is NOT accounted for.&lt;br/&gt;Slit smeared data will give very wrong answers!&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
      </property>
@@ -447,10 +447,10 @@
    </item>
   </layout>
   <zorder>guinier_box</zorder>
-  <zorder>label</zorder>
+  <zorder>lblPerformFit</zorder>
   <zorder>groupBox_2</zorder>
   <zorder>groupBox</zorder>
-  <zorder>label_2</zorder>
+  <zorder>lblResolutionNotAccounted</zorder>
  </widget>
  <resources/>
  <connections>

--- a/src/sas/qtgui/Plotting/UI/LinearFitUI.ui
+++ b/src/sas/qtgui/Plotting/UI/LinearFitUI.ui
@@ -40,21 +40,21 @@
       <item row="0" column="0">
        <layout class="QGridLayout" name="gridLayout_2">
         <item row="0" column="1">
-         <widget class="QLabel" name="label_9">
+         <widget class="QLabel" name="labelFitRangesMin">
           <property name="text">
            <string>Min</string>
           </property>
          </widget>
         </item>
         <item row="0" column="2">
-         <widget class="QLabel" name="label_10">
+         <widget class="QLabel" name="labelFitRangesMax">
           <property name="text">
            <string>Max</string>
           </property>
          </widget>
         </item>
         <item row="1" column="0">
-         <widget class="QLabel" name="label_8">
+         <widget class="QLabel" name="labelFitRange">
           <property name="text">
            <string>Range (linear scale)</string>
           </property>
@@ -69,7 +69,7 @@
            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Minimum value on the x-axis for the plotted data.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
           </property>
           <property name="autoFillBackground">
-           <bool>true</bool>
+           <bool>false</bool>
           </property>
           <property name="styleSheet">
            <string notr="true">color: rgb(0, 0, 0);</string>
@@ -133,7 +133,7 @@
       <item row="0" column="0">
        <layout class="QFormLayout" name="formLayout">
         <item row="0" column="0">
-         <widget class="QLabel" name="label_3">
+         <widget class="QLabel" name="labelFitParameter_a">
           <property name="text">
            <string>a</string>
           </property>
@@ -156,7 +156,7 @@
          </widget>
         </item>
         <item row="1" column="0">
-         <widget class="QLabel" name="label_4">
+         <widget class="QLabel" name="labelFitParameter_x">
           <property name="text">
            <string>b</string>
           </property>
@@ -179,7 +179,7 @@
          </widget>
         </item>
         <item row="2" column="0">
-         <widget class="QLabel" name="label_7">
+         <widget class="QLabel" name="labelFitParameter_chi_squared_dof">
           <property name="text">
            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;χ&lt;span style=&quot; vertical-align:super;&quot;&gt;2&lt;/span&gt;/dof&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
           </property>
@@ -206,7 +206,7 @@
       <item row="0" column="1">
        <layout class="QFormLayout" name="formLayout_2">
         <item row="0" column="0">
-         <widget class="QLabel" name="label_5">
+         <widget class="QLabel" name="labelPlusMinus1">
           <property name="text">
            <string>+/-</string>
           </property>
@@ -229,7 +229,7 @@
          </widget>
         </item>
         <item row="1" column="0">
-         <widget class="QLabel" name="label_6">
+         <widget class="QLabel" name="labelPlusMinus2">
           <property name="text">
            <string>+/-</string>
           </property>
@@ -268,14 +268,14 @@
       <item row="0" column="0">
        <layout class="QFormLayout" name="formLayout_4">
         <item row="0" column="0">
-         <widget class="QLabel" name="label_11">
+         <widget class="QLabel" name="labelGuinier_I_Q_0">
           <property name="text">
            <string>I(q=0)</string>
           </property>
          </widget>
         </item>
         <item row="0" column="1">
-         <widget class="QLineEdit" name="txtGuinier_1">
+         <widget class="QLineEdit" name="txtGuinier_I_q_0">
           <property name="enabled">
            <bool>false</bool>
           </property>
@@ -285,14 +285,14 @@
          </widget>
         </item>
         <item row="1" column="0">
-         <widget class="QLabel" name="label_12">
+         <widget class="QLabel" name="labelGuinier_R_g">
           <property name="text">
            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;R&lt;span style=&quot; vertical-align:sub;&quot;&gt;g &lt;/span&gt;[Å]&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
           </property>
          </widget>
         </item>
         <item row="1" column="1">
-         <widget class="QLineEdit" name="txtGuinier_2">
+         <widget class="QLineEdit" name="txtGuinier_R_g">
           <property name="enabled">
            <bool>false</bool>
           </property>
@@ -302,14 +302,14 @@
          </widget>
         </item>
         <item row="2" column="0">
-         <widget class="QLabel" name="label_15">
+         <widget class="QLabel" name="labelGuinier_R_g_times_Q_max">
           <property name="text">
            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;R&lt;span style=&quot; vertical-align:sub;&quot;&gt;g&lt;/span&gt;*Q&lt;span style=&quot; vertical-align:sub;&quot;&gt;max&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
           </property>
          </widget>
         </item>
         <item row="2" column="1">
-         <widget class="QLineEdit" name="txtGuinier_3">
+         <widget class="QLineEdit" name="txtGuinier_R_g_times_Q_max">
           <property name="enabled">
            <bool>false</bool>
           </property>
@@ -319,14 +319,14 @@
          </widget>
         </item>
         <item row="3" column="0">
-         <widget class="QLabel" name="label_16">
+         <widget class="QLabel" name="labelGuinier_R_g_times_Q_min">
           <property name="text">
            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;R&lt;span style=&quot; vertical-align:sub;&quot;&gt;g&lt;/span&gt;*Q&lt;span style=&quot; vertical-align:sub;&quot;&gt;min&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
           </property>
          </widget>
         </item>
         <item row="3" column="1">
-         <widget class="QLineEdit" name="txtGuinier_4">
+         <widget class="QLineEdit" name="txtGuinier_R_g_times_Q_min">
           <property name="enabled">
            <bool>false</bool>
           </property>
@@ -340,14 +340,14 @@
       <item row="0" column="1">
        <layout class="QFormLayout" name="formLayout_3">
         <item row="0" column="0">
-         <widget class="QLabel" name="label_13">
+         <widget class="QLabel" name="labelPlusMinus3">
           <property name="text">
            <string>+/-</string>
           </property>
          </widget>
         </item>
         <item row="0" column="1">
-         <widget class="QLineEdit" name="txtGuinier1_Err">
+         <widget class="QLineEdit" name="txtGuinier_I_q_0_Err">
           <property name="enabled">
            <bool>false</bool>
           </property>
@@ -363,7 +363,7 @@
          </widget>
         </item>
         <item row="1" column="0">
-         <widget class="QLabel" name="label_14">
+         <widget class="QLabel" name="labelPlusMinus4">
           <property name="text">
            <string>+/-</string>
           </property>

--- a/src/sas/qtgui/Plotting/UI/PlotLabelPropertiesUI.ui
+++ b/src/sas/qtgui/Plotting/UI/PlotLabelPropertiesUI.ui
@@ -31,7 +31,7 @@
      </property>
      <layout class="QGridLayout" name="gridLayout">
       <item row="0" column="0">
-       <widget class="QLabel" name="label_2">
+       <widget class="QLabel" name="labelXLabelFamily">
         <property name="text">
          <string>Family</string>
         </property>
@@ -41,7 +41,7 @@
        <widget class="QComboBox" name="cbFont"/>
       </item>
       <item row="0" column="3">
-       <widget class="QLabel" name="label_5">
+       <widget class="QLabel" name="labelXLabelWeight">
         <property name="text">
          <string>Weight</string>
         </property>
@@ -51,7 +51,7 @@
        <widget class="QComboBox" name="cbWeight"/>
       </item>
       <item row="1" column="0">
-       <widget class="QLabel" name="label_3">
+       <widget class="QLabel" name="labelXLabelColor">
         <property name="text">
          <string>Color</string>
         </property>
@@ -68,7 +68,7 @@
        </widget>
       </item>
       <item row="1" column="5">
-       <widget class="QLabel" name="label_4">
+       <widget class="QLabel" name="labelXLabelSize">
         <property name="text">
          <string>Size</string>
         </property>
@@ -115,7 +115,7 @@
      </property>
      <layout class="QGridLayout" name="gridLayout_2">
       <item row="0" column="0">
-       <widget class="QLabel" name="label_6">
+       <widget class="QLabel" name="labelYLabelFamily">
         <property name="text">
          <string>Family</string>
         </property>
@@ -125,7 +125,7 @@
        <widget class="QComboBox" name="cbFont_y"/>
       </item>
       <item row="0" column="3">
-       <widget class="QLabel" name="label_7">
+       <widget class="QLabel" name="labelyLabelWeight">
         <property name="text">
          <string>Weight</string>
         </property>
@@ -135,7 +135,7 @@
        <widget class="QComboBox" name="cbWeight_y"/>
       </item>
       <item row="1" column="0">
-       <widget class="QLabel" name="label_8">
+       <widget class="QLabel" name="labelYLabelColor">
         <property name="text">
          <string>Color</string>
         </property>
@@ -152,7 +152,7 @@
        </widget>
       </item>
       <item row="1" column="5">
-       <widget class="QLabel" name="label_9">
+       <widget class="QLabel" name="labelYLabelSize">
         <property name="text">
          <string>Size</string>
         </property>
@@ -171,7 +171,7 @@
       <item row="2" column="0" colspan="7">
        <layout class="QHBoxLayout" name="horizontalLayout_2">
         <item>
-         <widget class="QLabel" name="label_10">
+         <widget class="QLabel" name="labelYLabelLegendLabel">
           <property name="text">
            <string>Legend Label</string>
           </property>

--- a/src/sas/qtgui/Plotting/UI/PlotLabelPropertiesUI.ui
+++ b/src/sas/qtgui/Plotting/UI/PlotLabelPropertiesUI.ui
@@ -31,7 +31,7 @@
      </property>
      <layout class="QGridLayout" name="gridLayout">
       <item row="0" column="0">
-       <widget class="QLabel" name="labelXLabelFamily">
+       <widget class="QLabel" name="lblXLabelFamily">
         <property name="text">
          <string>Family</string>
         </property>
@@ -41,7 +41,7 @@
        <widget class="QComboBox" name="cbFont"/>
       </item>
       <item row="0" column="3">
-       <widget class="QLabel" name="labelXLabelWeight">
+       <widget class="QLabel" name="lblXLabelWeight">
         <property name="text">
          <string>Weight</string>
         </property>
@@ -51,7 +51,7 @@
        <widget class="QComboBox" name="cbWeight"/>
       </item>
       <item row="1" column="0">
-       <widget class="QLabel" name="labelXLabelColor">
+       <widget class="QLabel" name="lblXLabelColor">
         <property name="text">
          <string>Color</string>
         </property>
@@ -68,7 +68,7 @@
        </widget>
       </item>
       <item row="1" column="5">
-       <widget class="QLabel" name="labelXLabelSize">
+       <widget class="QLabel" name="lblXLabelSize">
         <property name="text">
          <string>Size</string>
         </property>
@@ -87,7 +87,7 @@
       <item row="2" column="0" colspan="7">
        <layout class="QHBoxLayout" name="horizontalLayout">
         <item>
-         <widget class="QLabel" name="label">
+         <widget class="QLabel" name="lblLegendLabel">
           <property name="text">
            <string>Legend Label</string>
           </property>
@@ -115,7 +115,7 @@
      </property>
      <layout class="QGridLayout" name="gridLayout_2">
       <item row="0" column="0">
-       <widget class="QLabel" name="labelYLabelFamily">
+       <widget class="QLabel" name="lblYLabelFamily">
         <property name="text">
          <string>Family</string>
         </property>
@@ -125,7 +125,7 @@
        <widget class="QComboBox" name="cbFont_y"/>
       </item>
       <item row="0" column="3">
-       <widget class="QLabel" name="labelyLabelWeight">
+       <widget class="QLabel" name="lblYLabelWeight">
         <property name="text">
          <string>Weight</string>
         </property>
@@ -135,7 +135,7 @@
        <widget class="QComboBox" name="cbWeight_y"/>
       </item>
       <item row="1" column="0">
-       <widget class="QLabel" name="labelYLabelColor">
+       <widget class="QLabel" name="lblYLabelColor">
         <property name="text">
          <string>Color</string>
         </property>
@@ -152,7 +152,7 @@
        </widget>
       </item>
       <item row="1" column="5">
-       <widget class="QLabel" name="labelYLabelSize">
+       <widget class="QLabel" name="lblYLabelSize">
         <property name="text">
          <string>Size</string>
         </property>
@@ -171,7 +171,7 @@
       <item row="2" column="0" colspan="7">
        <layout class="QHBoxLayout" name="horizontalLayout_2">
         <item>
-         <widget class="QLabel" name="labelYLabelLegendLabel">
+         <widget class="QLabel" name="lblYLabelLegendLabel">
           <property name="text">
            <string>Legend Label</string>
           </property>

--- a/src/sas/qtgui/Plotting/UI/PlotPropertiesUI.ui
+++ b/src/sas/qtgui/Plotting/UI/PlotPropertiesUI.ui
@@ -33,7 +33,7 @@
       <item row="0" column="0">
        <layout class="QGridLayout" name="gridLayout">
         <item row="0" column="0">
-         <widget class="QLabel" name="labelShape">
+         <widget class="QLabel" name="lblShape">
           <property name="text">
            <string>Shape</string>
           </property>
@@ -43,14 +43,14 @@
          <widget class="QComboBox" name="cbShape"/>
         </item>
         <item row="0" column="3" alignment="Qt::AlignRight">
-         <widget class="QLabel" name="labelSize">
+         <widget class="QLabel" name="lblSize">
           <property name="text">
            <string>Size</string>
           </property>
          </widget>
         </item>
         <item row="0" column="4">
-         <widget class="QSpinBox" name="sbSize">
+         <widget class="QSpinBox" name="spinBoxSize">
           <property name="minimum">
            <number>1</number>
           </property>
@@ -60,7 +60,7 @@
          </widget>
         </item>
         <item row="1" column="0">
-         <widget class="QLabel" name="labelColor">
+         <widget class="QLabel" name="lblColor">
           <property name="text">
            <string>Color</string>
           </property>

--- a/src/sas/qtgui/Plotting/UI/PlotPropertiesUI.ui
+++ b/src/sas/qtgui/Plotting/UI/PlotPropertiesUI.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>319</width>
-    <height>285</height>
+    <height>292</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -33,7 +33,7 @@
       <item row="0" column="0">
        <layout class="QGridLayout" name="gridLayout">
         <item row="0" column="0">
-         <widget class="QLabel" name="label_2">
+         <widget class="QLabel" name="labelShape">
           <property name="text">
            <string>Shape</string>
           </property>
@@ -43,7 +43,7 @@
          <widget class="QComboBox" name="cbShape"/>
         </item>
         <item row="0" column="3" alignment="Qt::AlignRight">
-         <widget class="QLabel" name="label_4">
+         <widget class="QLabel" name="labelSize">
           <property name="text">
            <string>Size</string>
           </property>
@@ -60,7 +60,7 @@
          </widget>
         </item>
         <item row="1" column="0">
-         <widget class="QLabel" name="label_3">
+         <widget class="QLabel" name="labelColor">
           <property name="text">
            <string>Color</string>
           </property>
@@ -84,7 +84,7 @@
    <item row="1" column="0">
     <layout class="QHBoxLayout" name="horizontalLayout">
      <item>
-      <widget class="QLabel" name="label">
+      <widget class="QLabel" name="labelLegendLabel">
        <property name="text">
         <string>Legend Label</string>
        </property>

--- a/src/sas/qtgui/Plotting/UI/ScalePropertiesUI.ui
+++ b/src/sas/qtgui/Plotting/UI/ScalePropertiesUI.ui
@@ -34,14 +34,14 @@
       </widget>
      </item>
      <item row="0" column="1">
-      <widget class="QLabel" name="labelY">
+      <widget class="QLabel" name="lblY">
        <property name="text">
         <string>Y</string>
        </property>
       </widget>
      </item>
      <item row="0" column="2">
-      <widget class="QLabel" name="labelView">
+      <widget class="QLabel" name="lblView">
        <property name="text">
         <string>View</string>
        </property>

--- a/src/sas/qtgui/Plotting/UI/ScalePropertiesUI.ui
+++ b/src/sas/qtgui/Plotting/UI/ScalePropertiesUI.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>400</width>
-    <height>137</height>
+    <height>139</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -27,21 +27,21 @@
    <item row="0" column="0">
     <layout class="QGridLayout" name="gridLayout">
      <item row="0" column="0">
-      <widget class="QLabel" name="label">
+      <widget class="QLabel" name="labelX">
        <property name="text">
         <string>X</string>
        </property>
       </widget>
      </item>
      <item row="0" column="1">
-      <widget class="QLabel" name="label_2">
+      <widget class="QLabel" name="labelY">
        <property name="text">
         <string>Y</string>
        </property>
       </widget>
      </item>
      <item row="0" column="2">
-      <widget class="QLabel" name="label_3">
+      <widget class="QLabel" name="labelView">
        <property name="text">
         <string>View</string>
        </property>

--- a/src/sas/qtgui/Plotting/UI/SetGraphRangeUI.ui
+++ b/src/sas/qtgui/Plotting/UI/SetGraphRangeUI.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>358</width>
+    <width>366</width>
     <height>144</height>
    </rect>
   </property>
@@ -30,7 +30,7 @@
    <item row="0" column="0">
     <layout class="QGridLayout" name="gridLayout">
      <item row="0" column="0">
-      <widget class="QLabel" name="label">
+      <widget class="QLabel" name="labelXmin">
        <property name="text">
         <string>X min</string>
        </property>
@@ -40,7 +40,7 @@
       <widget class="QLineEdit" name="txtXmin"/>
      </item>
      <item row="0" column="2">
-      <widget class="QLabel" name="label_2">
+      <widget class="QLabel" name="labelXmax">
        <property name="text">
         <string>X max</string>
        </property>
@@ -50,7 +50,7 @@
       <widget class="QLineEdit" name="txtXmax"/>
      </item>
      <item row="1" column="0">
-      <widget class="QLabel" name="label_3">
+      <widget class="QLabel" name="labelYmin">
        <property name="text">
         <string>Y min</string>
        </property>
@@ -60,7 +60,7 @@
       <widget class="QLineEdit" name="txtYmin"/>
      </item>
      <item row="1" column="2">
-      <widget class="QLabel" name="label_4">
+      <widget class="QLabel" name="labelYmax">
        <property name="text">
         <string>Y max</string>
        </property>

--- a/src/sas/qtgui/Plotting/UI/SetGraphRangeUI.ui
+++ b/src/sas/qtgui/Plotting/UI/SetGraphRangeUI.ui
@@ -30,7 +30,7 @@
    <item row="0" column="0">
     <layout class="QGridLayout" name="gridLayout">
      <item row="0" column="0">
-      <widget class="QLabel" name="labelXmin">
+      <widget class="QLabel" name="lblXmin">
        <property name="text">
         <string>X min</string>
        </property>
@@ -50,7 +50,7 @@
       <widget class="QLineEdit" name="txtXmax"/>
      </item>
      <item row="1" column="0">
-      <widget class="QLabel" name="labelYmin">
+      <widget class="QLabel" name="lblYmin">
        <property name="text">
         <string>Y min</string>
        </property>
@@ -60,7 +60,7 @@
       <widget class="QLineEdit" name="txtYmin"/>
      </item>
      <item row="1" column="2">
-      <widget class="QLabel" name="labelYmax">
+      <widget class="QLabel" name="lblYmax">
        <property name="text">
         <string>Y max</string>
        </property>

--- a/src/sas/qtgui/Plotting/UI/SlicerParametersUI.ui
+++ b/src/sas/qtgui/Plotting/UI/SlicerParametersUI.ui
@@ -93,7 +93,7 @@
           <item row="1" column="0">
            <layout class="QHBoxLayout" name="horizontalLayout_2">
             <item>
-             <widget class="QLabel" name="labelSlicerType">
+             <widget class="QLabel" name="lblSlicerType">
               <property name="text">
                <string>Slicer type:</string>
               </property>
@@ -222,7 +222,7 @@
             <item row="0" column="0">
              <layout class="QHBoxLayout" name="horizontalLayout_3">
               <item>
-               <widget class="QLabel" name="labelFileSavedIn">
+               <widget class="QLabel" name="lblFileSavedIn">
                 <property name="text">
                  <string>Files saved in:</string>
                 </property>
@@ -255,7 +255,7 @@
                </widget>
               </item>
               <item>
-               <widget class="QLabel" name="labelAs">
+               <widget class="QLabel" name="lblAs">
                 <property name="text">
                  <string>as </string>
                 </property>
@@ -303,7 +303,7 @@
             <item row="2" column="0">
              <layout class="QHBoxLayout" name="horizontalLayout_4">
               <item>
-               <widget class="QLabel" name="labelFittingOption">
+               <widget class="QLabel" name="lblFittingOption">
                 <property name="text">
                  <string>Fitting Options:</string>
                 </property>

--- a/src/sas/qtgui/Plotting/UI/SlicerParametersUI.ui
+++ b/src/sas/qtgui/Plotting/UI/SlicerParametersUI.ui
@@ -71,7 +71,7 @@
    <item row="0" column="0">
     <widget class="QTabWidget" name="tabWidget">
      <property name="currentIndex">
-      <number>0</number>
+      <number>1</number>
      </property>
      <widget class="QWidget" name="tab">
       <attribute name="title">
@@ -93,7 +93,7 @@
           <item row="1" column="0">
            <layout class="QHBoxLayout" name="horizontalLayout_2">
             <item>
-             <widget class="QLabel" name="label">
+             <widget class="QLabel" name="labelSlicerType">
               <property name="text">
                <string>Slicer type:</string>
               </property>
@@ -222,7 +222,7 @@
             <item row="0" column="0">
              <layout class="QHBoxLayout" name="horizontalLayout_3">
               <item>
-               <widget class="QLabel" name="label_2">
+               <widget class="QLabel" name="labelFileSavedIn">
                 <property name="text">
                  <string>Files saved in:</string>
                 </property>
@@ -255,7 +255,7 @@
                </widget>
               </item>
               <item>
-               <widget class="QLabel" name="label_4">
+               <widget class="QLabel" name="labelAs">
                 <property name="text">
                  <string>as </string>
                 </property>
@@ -303,7 +303,7 @@
             <item row="2" column="0">
              <layout class="QHBoxLayout" name="horizontalLayout_4">
               <item>
-               <widget class="QLabel" name="label_3">
+               <widget class="QLabel" name="labelFittingOption">
                 <property name="text">
                  <string>Fitting Options:</string>
                 </property>

--- a/src/sas/qtgui/Plotting/UI/SlicerParametersUI.ui
+++ b/src/sas/qtgui/Plotting/UI/SlicerParametersUI.ui
@@ -71,7 +71,7 @@
    <item row="0" column="0">
     <widget class="QTabWidget" name="tabWidget">
      <property name="currentIndex">
-      <number>1</number>
+      <number>0</number>
      </property>
      <widget class="QWidget" name="tab">
       <attribute name="title">

--- a/src/sas/qtgui/Plotting/UI/WindowTitleUI.ui
+++ b/src/sas/qtgui/Plotting/UI/WindowTitleUI.ui
@@ -18,7 +18,7 @@
   </property>
   <layout class="QGridLayout" name="gridLayout">
    <item row="0" column="0">
-    <widget class="QLabel" name="label">
+    <widget class="QLabel" name="labelNewTitle">
      <property name="text">
       <string>New title</string>
      </property>

--- a/src/sas/qtgui/Plotting/UI/WindowTitleUI.ui
+++ b/src/sas/qtgui/Plotting/UI/WindowTitleUI.ui
@@ -18,7 +18,7 @@
   </property>
   <layout class="QGridLayout" name="gridLayout">
    <item row="0" column="0">
-    <widget class="QLabel" name="labelNewTitle">
+    <widget class="QLabel" name="lblNewTitle">
      <property name="text">
       <string>New title</string>
      </property>

--- a/src/sas/qtgui/Utilities/DocRegenInProgess.py
+++ b/src/sas/qtgui/Utilities/DocRegenInProgess.py
@@ -15,7 +15,7 @@ class DocRegenProgress(QtWidgets.QWidget, Ui_DocRegenProgress):
         self.parent = parent
 
         self.setWindowTitle("Documentation Regenerating")
-        self.labelDocumentationGenerationInProcess.setText("Regeneration In Progress")
+        self.lblDocumentationGenerationInProcess.setText("Regeneration In Progress")
         self.textBrowser.setText("Placeholder Text.")
         self.file_watcher = QtCore.QFileSystemWatcher()
         self.addSignals()

--- a/src/sas/qtgui/Utilities/DocRegenInProgess.py
+++ b/src/sas/qtgui/Utilities/DocRegenInProgess.py
@@ -15,7 +15,7 @@ class DocRegenProgress(QtWidgets.QWidget, Ui_DocRegenProgress):
         self.parent = parent
 
         self.setWindowTitle("Documentation Regenerating")
-        self.label.setText("Regeneration In Progress")
+        self.labelDocumentationGenerationInProcess.setText("Regeneration In Progress")
         self.textBrowser.setText("Placeholder Text.")
         self.file_watcher = QtCore.QFileSystemWatcher()
         self.addSignals()

--- a/src/sas/qtgui/Utilities/DocViewWidget.py
+++ b/src/sas/qtgui/Utilities/DocViewWidget.py
@@ -48,8 +48,8 @@ class DocViewWindow(QtWidgets.QDialog, Ui_DocViewerWindow):
 
     def initializeSignals(self):
         """Initialize all external signals that will trigger events for the window."""
-        self.editButton.clicked.connect(self.onEdit)
-        self.closeButton.clicked.connect(self.onClose)
+        self.cmdEdit.clicked.connect(self.onEdit)
+        self.cmdClose.clicked.connect(self.onClose)
         self.parent.communicate.documentationRegeneratedSignal.connect(self.refresh)
 
     def onEdit(self):
@@ -106,7 +106,7 @@ class DocViewWindow(QtWidgets.QDialog, Ui_DocViewerWindow):
 
         if not MAIN_DOC_SRC.exists() and not HELP_DIRECTORY_LOCATION.exists():
             # The user docs were never built - disable edit button and do not attempt doc regen
-            self.editButton.setEnabled(False)
+            self.cmdEdit.setEnabled(False)
             self.load404()
             return
 

--- a/src/sas/qtgui/Utilities/FileConverter.py
+++ b/src/sas/qtgui/Utilities/FileConverter.py
@@ -102,9 +102,9 @@ class FileConverterWidget(QtWidgets.QDialog, Ui_FileConverterUI):
         self.cmdClose.clicked.connect(self.accept)
         self.cmdHelp.clicked.connect(self.onHelp)
 
-        self.btnQFile.clicked.connect(self.onQFileOpen)
-        self.btnIFile.clicked.connect(self.onIFileOpen)
-        self.btnOutputFile.clicked.connect(self.onNewFile)
+        self.cmdQFile.clicked.connect(self.onQFileOpen)
+        self.cmdIFile.clicked.connect(self.onIFileOpen)
+        self.cmdOutputFile.clicked.connect(self.onNewFile)
 
         self.txtOutputFile.editingFinished.connect(self.onNewFileEdited)
 
@@ -351,9 +351,9 @@ class FileConverterWidget(QtWidgets.QDialog, Ui_FileConverterUI):
         """
         # ASCII 2D allows for one file only
         self.is1D = not '2D' in self.cbInputFormat.currentText()
-        self.label_7.setVisible(self.is1D)
+        self.lblQAxisData.setVisible(self.is1D)
         self.txtQFile.setVisible(self.is1D)
-        self.btnQFile.setVisible(self.is1D)
+        self.cmdQFile.setVisible(self.is1D)
         self.isBSL = 'BSL' in self.cbInputFormat.currentText()
 
         # clear out filename fields

--- a/src/sas/qtgui/Utilities/UI/AddMultEditorUI.ui
+++ b/src/sas/qtgui/Utilities/UI/AddMultEditorUI.ui
@@ -80,14 +80,14 @@
       <item row="0" column="0">
        <layout class="QGridLayout" name="gridLayout">
         <item row="0" column="0">
-         <widget class="QLabel" name="labelModel1">
+         <widget class="QLabel" name="lblModel1">
           <property name="text">
            <string>model_1</string>
           </property>
          </widget>
         </item>
         <item row="0" column="2">
-         <widget class="QLabel" name="labelModel2">
+         <widget class="QLabel" name="lblModel2">
           <property name="text">
            <string>model_2</string>
           </property>

--- a/src/sas/qtgui/Utilities/UI/AddMultEditorUI.ui
+++ b/src/sas/qtgui/Utilities/UI/AddMultEditorUI.ui
@@ -80,14 +80,14 @@
       <item row="0" column="0">
        <layout class="QGridLayout" name="gridLayout">
         <item row="0" column="0">
-         <widget class="QLabel" name="label">
+         <widget class="QLabel" name="labelModel1">
           <property name="text">
            <string>model_1</string>
           </property>
          </widget>
         </item>
         <item row="0" column="2">
-         <widget class="QLabel" name="label_2">
+         <widget class="QLabel" name="labelModel2">
           <property name="text">
            <string>model_2</string>
           </property>

--- a/src/sas/qtgui/Utilities/UI/DocRegenInProgress.ui
+++ b/src/sas/qtgui/Utilities/UI/DocRegenInProgress.ui
@@ -15,7 +15,7 @@
   </property>
   <layout class="QGridLayout" name="gridLayout_3">
    <item row="0" column="0">
-    <widget class="QLabel" name="label">
+    <widget class="QLabel" name="labelDocumentationGenerationInProcess">
      <property name="text">
       <string>::Documentation Generation In Progress::</string>
      </property>
@@ -25,7 +25,7 @@
     </widget>
    </item>
    <item row="1" column="0">
-    <widget class="QLabel" name="label1">
+    <widget class="QLabel" name="labelMayTakeAFewMinutes">
      <property name="text">
       <string>This process may take a few minutes.</string>
      </property>

--- a/src/sas/qtgui/Utilities/UI/DocRegenInProgress.ui
+++ b/src/sas/qtgui/Utilities/UI/DocRegenInProgress.ui
@@ -15,7 +15,7 @@
   </property>
   <layout class="QGridLayout" name="gridLayout_3">
    <item row="0" column="0">
-    <widget class="QLabel" name="labelDocumentationGenerationInProcess">
+    <widget class="QLabel" name="lbDocumentationGenerationInProcess">
      <property name="text">
       <string>::Documentation Generation In Progress::</string>
      </property>
@@ -25,7 +25,7 @@
     </widget>
    </item>
    <item row="1" column="0">
-    <widget class="QLabel" name="labelMayTakeAFewMinutes">
+    <widget class="QLabel" name="lblMayTakeAFewMinutes">
      <property name="text">
       <string>This process may take a few minutes.</string>
      </property>

--- a/src/sas/qtgui/Utilities/UI/DocRegenInProgress.ui
+++ b/src/sas/qtgui/Utilities/UI/DocRegenInProgress.ui
@@ -15,7 +15,7 @@
   </property>
   <layout class="QGridLayout" name="gridLayout_3">
    <item row="0" column="0">
-    <widget class="QLabel" name="lbDocumentationGenerationInProcess">
+    <widget class="QLabel" name="lblDocumentationGenerationInProcess">
      <property name="text">
       <string>::Documentation Generation In Progress::</string>
      </property>

--- a/src/sas/qtgui/Utilities/UI/DocViewWidgetUI.ui
+++ b/src/sas/qtgui/Utilities/UI/DocViewWidgetUI.ui
@@ -58,7 +58,7 @@
       </widget>
      </item>
      <item>
-      <widget class="QPushButton" name="closeButton">
+      <widget class="QPushButton" name="cmdClose">
        <property name="minimumSize">
         <size>
          <width>100</width>
@@ -73,7 +73,7 @@
     </layout>
    </item>
    <item row="1" column="0">
-    <widget class="QWebEngineView" name="webEngineViewer" native="true">
+    <widget class="QWebEngineView" name="webEngineViewer">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
        <horstretch>0</horstretch>
@@ -88,7 +88,7 @@
   <customwidget>
    <class>QWebEngineView</class>
    <extends>QWidget</extends>
-   <header location="global">qwebengineview.h</header>
+   <header location="global">QtWebEngineWidgets/QWebEngineView</header>
    <container>1</container>
   </customwidget>
  </customwidgets>

--- a/src/sas/qtgui/Utilities/UI/DocViewWidgetUI.ui
+++ b/src/sas/qtgui/Utilities/UI/DocViewWidgetUI.ui
@@ -45,7 +45,7 @@
       </spacer>
      </item>
      <item>
-      <widget class="QPushButton" name="editButton">
+      <widget class="QPushButton" name="cmdEdit">
        <property name="minimumSize">
         <size>
          <width>100</width>
@@ -73,7 +73,7 @@
     </layout>
    </item>
    <item row="1" column="0">
-    <widget class="QWebEngineView" name="webEngineViewer">
+    <widget class="QWebEngineView" name="webEngineViewer" native="true">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
        <horstretch>0</horstretch>
@@ -88,7 +88,7 @@
   <customwidget>
    <class>QWebEngineView</class>
    <extends>QWidget</extends>
-   <header location="global">QtWebEngineWidgets/QWebEngineView</header>
+   <header location="global">qwebengineview.h</header>
    <container>1</container>
   </customwidget>
  </customwidgets>

--- a/src/sas/qtgui/Utilities/UI/FileConverterUI.ui
+++ b/src/sas/qtgui/Utilities/UI/FileConverterUI.ui
@@ -20,7 +20,7 @@
    <item row="0" column="0">
     <widget class="QTabWidget" name="tabWidget">
      <property name="currentIndex">
-      <number>1</number>
+      <number>0</number>
      </property>
      <widget class="QWidget" name="tab">
       <attribute name="title">
@@ -34,7 +34,7 @@
          </property>
          <layout class="QGridLayout" name="gridLayout">
           <item row="0" column="0">
-           <widget class="QLabel" name="labelInputFormat">
+           <widget class="QLabel" name="lblInputFormat">
             <property name="text">
              <string>Input Format:</string>
             </property>
@@ -85,7 +85,7 @@
            </layout>
           </item>
           <item row="1" column="0">
-           <widget class="QLabel" name="labelQAxisData">
+           <widget class="QLabel" name="lblQAxisData">
             <property name="text">
              <string>Q-Axis Data:</string>
             </property>
@@ -95,7 +95,7 @@
            <widget class="QLineEdit" name="txtQFile"/>
           </item>
           <item row="1" column="2">
-           <widget class="QPushButton" name="btnQFile">
+           <widget class="QPushButton" name="cmdQFile">
             <property name="sizePolicy">
              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
               <horstretch>0</horstretch>
@@ -108,7 +108,7 @@
            </widget>
           </item>
           <item row="2" column="0">
-           <widget class="QLabel" name="labelIntensityData">
+           <widget class="QLabel" name="lblIntensityData">
             <property name="text">
              <string>Intensity Data:</string>
             </property>
@@ -118,7 +118,7 @@
            <widget class="QLineEdit" name="txtIFile"/>
           </item>
           <item row="2" column="2">
-           <widget class="QPushButton" name="btnIFile">
+           <widget class="QPushButton" name="cmdIFile">
             <property name="sizePolicy">
              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
               <horstretch>0</horstretch>
@@ -131,7 +131,7 @@
            </widget>
           </item>
           <item row="3" column="0">
-           <widget class="QLabel" name="labelRadiationType">
+           <widget class="QLabel" name="lblRadiationType">
             <property name="text">
              <string>Radiation Type:</string>
             </property>
@@ -182,7 +182,7 @@
            </layout>
           </item>
           <item row="4" column="0">
-           <widget class="QLabel" name="labelOutputFile">
+           <widget class="QLabel" name="lblOutputFile">
             <property name="text">
              <string>Output File:</string>
             </property>
@@ -192,7 +192,7 @@
            <widget class="QLineEdit" name="txtOutputFile"/>
           </item>
           <item row="4" column="2">
-           <widget class="QPushButton" name="btnOutputFile">
+           <widget class="QPushButton" name="cmdOutputFile">
             <property name="sizePolicy">
              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
               <horstretch>0</horstretch>
@@ -255,7 +255,7 @@
              <item>
               <layout class="QGridLayout" name="gridLayout_5">
                <item row="0" column="0">
-                <widget class="QLabel" name="labelTile">
+                <widget class="QLabel" name="lblTile">
                  <property name="text">
                   <string>Title</string>
                  </property>
@@ -265,7 +265,7 @@
                 <widget class="QLineEdit" name="txtMG_Title"/>
                </item>
                <item row="1" column="0">
-                <widget class="QLabel" name="labelRunNumber">
+                <widget class="QLabel" name="lblRunNumber">
                  <property name="text">
                   <string>Run Number</string>
                  </property>
@@ -275,7 +275,7 @@
                 <widget class="QLineEdit" name="txtMG_RunNumber"/>
                </item>
                <item row="2" column="0">
-                <widget class="QLabel" name="labelRunName">
+                <widget class="QLabel" name="lblRunName">
                  <property name="text">
                   <string>Run Name</string>
                  </property>
@@ -285,7 +285,7 @@
                 <widget class="QLineEdit" name="txtMG_RunName"/>
                </item>
                <item row="3" column="0">
-                <widget class="QLabel" name="labelInstrument">
+                <widget class="QLabel" name="lblInstrument">
                  <property name="text">
                   <string>Instrument</string>
                  </property>
@@ -321,7 +321,7 @@
            <item row="0" column="0">
             <layout class="QGridLayout" name="gridLayout_6">
              <item row="0" column="0">
-              <widget class="QLabel" name="labelName">
+              <widget class="QLabel" name="lblName">
                <property name="text">
                 <string>Name:</string>
                </property>
@@ -331,7 +331,7 @@
               <widget class="QLineEdit" name="txtMD_Name"/>
              </item>
              <item row="1" column="0">
-              <widget class="QLabel" name="labelDistance">
+              <widget class="QLabel" name="lblDistance">
                <property name="text">
                 <string>Distance [mm]:</string>
                </property>
@@ -341,7 +341,7 @@
               <widget class="QLineEdit" name="txtMD_Distance"/>
              </item>
              <item row="2" column="0">
-              <widget class="QLabel" name="labelOffset">
+              <widget class="QLabel" name="lblOffset">
                <property name="text">
                 <string>Offset [m]</string>
                </property>
@@ -350,7 +350,7 @@
              <item row="2" column="1">
               <layout class="QHBoxLayout" name="horizontalLayout_4">
                <item>
-                <widget class="QLabel" name="labelOffsetX">
+                <widget class="QLabel" name="lblOffsetX">
                  <property name="text">
                   <string>X:</string>
                  </property>
@@ -360,7 +360,7 @@
                 <widget class="QLineEdit" name="txtMD_OffsetX"/>
                </item>
                <item>
-                <widget class="QLabel" name="labelOffsetY">
+                <widget class="QLabel" name="lblOffsetY">
                  <property name="text">
                   <string>Y:</string>
                  </property>
@@ -372,7 +372,7 @@
               </layout>
              </item>
              <item row="3" column="0">
-              <widget class="QLabel" name="labelOrientation">
+              <widget class="QLabel" name="lblOrientation">
                <property name="text">
                 <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Orientation [°]&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
                </property>
@@ -381,7 +381,7 @@
              <item row="3" column="1">
               <layout class="QHBoxLayout" name="horizontalLayout_5">
                <item>
-                <widget class="QLabel" name="labelOrientationRoll">
+                <widget class="QLabel" name="lblOrientationRoll">
                  <property name="text">
                   <string>Roll:</string>
                  </property>
@@ -391,7 +391,7 @@
                 <widget class="QLineEdit" name="txtMD_OrientRoll"/>
                </item>
                <item>
-                <widget class="QLabel" name="labelOrientationPitch">
+                <widget class="QLabel" name="lblOrientationPitch">
                  <property name="text">
                   <string>Pitch:</string>
                  </property>
@@ -401,7 +401,7 @@
                 <widget class="QLineEdit" name="txtMD_OrientPitch"/>
                </item>
                <item>
-                <widget class="QLabel" name="labelOrientationYaw">
+                <widget class="QLabel" name="lblOrientationYaw">
                  <property name="text">
                   <string>Yaw:</string>
                  </property>
@@ -413,7 +413,7 @@
               </layout>
              </item>
              <item row="4" column="0">
-              <widget class="QLabel" name="labelPixelSize">
+              <widget class="QLabel" name="lblPixelSize">
                <property name="text">
                 <string>Pixel size [mm]</string>
                </property>
@@ -422,7 +422,7 @@
              <item row="4" column="1">
               <layout class="QHBoxLayout" name="horizontalLayout_6">
                <item>
-                <widget class="QLabel" name="labelPixelSizeX">
+                <widget class="QLabel" name="lblPixelSizeX">
                  <property name="text">
                   <string>X:</string>
                  </property>
@@ -432,7 +432,7 @@
                 <widget class="QLineEdit" name="txtMD_PixelX"/>
                </item>
                <item>
-                <widget class="QLabel" name="labelPixelSizeY">
+                <widget class="QLabel" name="lblPixelSizeY">
                  <property name="text">
                   <string>Y:</string>
                  </property>
@@ -444,7 +444,7 @@
               </layout>
              </item>
              <item row="5" column="0">
-              <widget class="QLabel" name="labelBeamCenter">
+              <widget class="QLabel" name="lblBeamCenter">
                <property name="text">
                 <string>Beam center [mm]</string>
                </property>
@@ -453,7 +453,7 @@
              <item row="5" column="1">
               <layout class="QHBoxLayout" name="horizontalLayout_7">
                <item>
-                <widget class="QLabel" name="label_23">
+                <widget class="QLabel" name="lblBeamCenterX">
                  <property name="text">
                   <string>X:</string>
                  </property>
@@ -463,7 +463,7 @@
                 <widget class="QLineEdit" name="txtMD_BeamX"/>
                </item>
                <item>
-                <widget class="QLabel" name="label_24">
+                <widget class="QLabel" name="lblBeamCenterY">
                  <property name="text">
                   <string>Y:</string>
                  </property>
@@ -475,7 +475,7 @@
               </layout>
              </item>
              <item row="6" column="0">
-              <widget class="QLabel" name="labelSlitLength">
+              <widget class="QLabel" name="lblSlitLength">
                <property name="text">
                 <string>Slit length [mm]:</string>
                </property>
@@ -507,7 +507,7 @@
           </attribute>
           <layout class="QGridLayout" name="gridLayout_3">
            <item row="0" column="0">
-            <widget class="QLabel" name="labelNameSample">
+            <widget class="QLabel" name="lblNameSample">
              <property name="text">
               <string>Name:</string>
              </property>
@@ -517,7 +517,7 @@
             <widget class="QLineEdit" name="txtMSa_Name"/>
            </item>
            <item row="1" column="0">
-            <widget class="QLabel" name="labelThicknessSample">
+            <widget class="QLabel" name="lblThicknessSample">
              <property name="text">
               <string>Thickness [mm]:</string>
              </property>
@@ -527,7 +527,7 @@
             <widget class="QLineEdit" name="txtMSa_Thickness"/>
            </item>
            <item row="2" column="0">
-            <widget class="QLabel" name="labelTransmissionSample">
+            <widget class="QLabel" name="lblTransmissionSample">
              <property name="text">
               <string>Transmission:</string>
              </property>
@@ -541,7 +541,7 @@
             </widget>
            </item>
            <item row="3" column="0">
-            <widget class="QLabel" name="labelTemperatureSample">
+            <widget class="QLabel" name="lblTemperatureSample">
              <property name="text">
               <string>Temperature:</string>
              </property>
@@ -557,7 +557,7 @@
               </widget>
              </item>
              <item>
-              <widget class="QLabel" name="labelTemperatureUnitSample">
+              <widget class="QLabel" name="lblTemperatureUnitSample">
                <property name="text">
                 <string>Unit</string>
                </property>
@@ -569,7 +569,7 @@
             </layout>
            </item>
            <item row="4" column="0">
-            <widget class="QLabel" name="labelPositionSample">
+            <widget class="QLabel" name="lblPositionSample">
              <property name="text">
               <string>Position [mm]</string>
              </property>
@@ -578,7 +578,7 @@
            <item row="4" column="1">
             <layout class="QHBoxLayout" name="horizontalLayout_11">
              <item>
-              <widget class="QLabel" name="labelPositionX">
+              <widget class="QLabel" name="lblPositionX">
                <property name="text">
                 <string>X:</string>
                </property>
@@ -588,7 +588,7 @@
               <widget class="QLineEdit" name="txtMSa_PositionX"/>
              </item>
              <item>
-              <widget class="QLabel" name="labelPositionY">
+              <widget class="QLabel" name="lblPositionY">
                <property name="text">
                 <string>Y:</string>
                </property>
@@ -600,7 +600,7 @@
             </layout>
            </item>
            <item row="5" column="0">
-            <widget class="QLabel" name="labelOrientationSample">
+            <widget class="QLabel" name="lblOrientationSample">
              <property name="text">
               <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Orientation [°]&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
              </property>
@@ -609,7 +609,7 @@
            <item row="5" column="1">
             <layout class="QHBoxLayout" name="horizontalLayout_12">
              <item>
-              <widget class="QLabel" name="labelOrientationRollSample">
+              <widget class="QLabel" name="lblOrientationRollSample">
                <property name="text">
                 <string>Roll:</string>
                </property>
@@ -619,7 +619,7 @@
               <widget class="QLineEdit" name="txtMSa_OrientR"/>
              </item>
              <item>
-              <widget class="QLabel" name="labelOrientationPitchSample">
+              <widget class="QLabel" name="lblOrientationPitchSample">
                <property name="text">
                 <string>Pitch:</string>
                </property>
@@ -629,7 +629,7 @@
               <widget class="QLineEdit" name="txtMSa_OrientP"/>
              </item>
              <item>
-              <widget class="QLabel" name="labelOrientationYawSample">
+              <widget class="QLabel" name="lblOrientationYawSample">
                <property name="text">
                 <string>Yaw:</string>
                </property>
@@ -641,7 +641,7 @@
             </layout>
            </item>
            <item row="6" column="0">
-            <widget class="QLabel" name="labelDetailsSample">
+            <widget class="QLabel" name="lblDetailsSample">
              <property name="text">
               <string>Details:</string>
              </property>
@@ -680,7 +680,7 @@
            <item row="0" column="0">
             <layout class="QGridLayout" name="gridLayout_10">
              <item row="0" column="0">
-              <widget class="QLabel" name="labelNameSource">
+              <widget class="QLabel" name="lblNameSource">
                <property name="text">
                 <string>Name:</string>
                </property>
@@ -690,7 +690,7 @@
               <widget class="QLineEdit" name="txtMSo_Name"/>
              </item>
              <item row="1" column="0">
-              <widget class="QLabel" name="labelBeamSizeSource">
+              <widget class="QLabel" name="lblBeamSizeSource">
                <property name="text">
                 <string>Beam size [mm]</string>
                </property>
@@ -699,7 +699,7 @@
              <item row="1" column="1" colspan="2">
               <layout class="QHBoxLayout" name="horizontalLayout_8">
                <item>
-                <widget class="QLabel" name="labelBeamSizeXSource">
+                <widget class="QLabel" name="lblBeamSizeXSource">
                  <property name="text">
                   <string>X:</string>
                  </property>
@@ -709,7 +709,7 @@
                 <widget class="QLineEdit" name="txtMSo_BeamSizeX"/>
                </item>
                <item>
-                <widget class="QLabel" name="labelBeamSizeYSource">
+                <widget class="QLabel" name="lblBeamSizeYSource">
                  <property name="text">
                   <string>Y:</string>
                  </property>
@@ -721,7 +721,7 @@
               </layout>
              </item>
              <item row="2" column="0">
-              <widget class="QLabel" name="labelBeamShapeSource">
+              <widget class="QLabel" name="lblBeamShapeSource">
                <property name="text">
                 <string>Beam shape:</string>
                </property>
@@ -731,7 +731,7 @@
               <widget class="QLineEdit" name="txtMSo_BeamShape"/>
              </item>
              <item row="3" column="0">
-              <widget class="QLabel" name="labelWavelengthSource">
+              <widget class="QLabel" name="lblWavelengthSource">
                <property name="text">
                 <string>Wavelength [Ang]:</string>
                </property>
@@ -741,7 +741,7 @@
               <widget class="QLineEdit" name="txtMSo_BeamWavelength"/>
              </item>
              <item row="4" column="0">
-              <widget class="QLabel" name="labelMinWavelengthSource">
+              <widget class="QLabel" name="lblMinWavelengthSource">
                <property name="text">
                 <string>Min. wavelength [nm]:</string>
                </property>
@@ -751,7 +751,7 @@
               <widget class="QLineEdit" name="txtMSo_MinWavelength"/>
              </item>
              <item row="5" column="0">
-              <widget class="QLabel" name="labelMaxWavelengthSource">
+              <widget class="QLabel" name="lblMaxWavelengthSource">
                <property name="text">
                 <string>Max. wavelength [nm]:</string>
                </property>
@@ -761,7 +761,7 @@
               <widget class="QLineEdit" name="txtMSo_MaxWavelength"/>
              </item>
              <item row="6" column="0" colspan="2">
-              <widget class="QLabel" name="labelWavelengthSpreadSource">
+              <widget class="QLabel" name="lblWavelengthSpreadSource">
                <property name="text">
                 <string>Wavelength spread [%]:</string>
                </property>
@@ -797,7 +797,7 @@
       </attribute>
       <layout class="QGridLayout" name="gridLayout_12">
        <item row="0" column="0">
-        <widget class="QLabel" name="labelInstructions">
+        <widget class="QLabel" name="lblInstructions">
          <property name="frameShape">
           <enum>QFrame::Box</enum>
          </property>

--- a/src/sas/qtgui/Utilities/UI/FileConverterUI.ui
+++ b/src/sas/qtgui/Utilities/UI/FileConverterUI.ui
@@ -243,7 +243,7 @@
        <item row="0" column="0">
         <widget class="QTabWidget" name="tabWidget_2">
          <property name="currentIndex">
-          <number>3</number>
+          <number>0</number>
          </property>
          <widget class="QWidget" name="tab_3">
           <attribute name="title">

--- a/src/sas/qtgui/Utilities/UI/FileConverterUI.ui
+++ b/src/sas/qtgui/Utilities/UI/FileConverterUI.ui
@@ -20,7 +20,7 @@
    <item row="0" column="0">
     <widget class="QTabWidget" name="tabWidget">
      <property name="currentIndex">
-      <number>0</number>
+      <number>1</number>
      </property>
      <widget class="QWidget" name="tab">
       <attribute name="title">
@@ -34,7 +34,7 @@
          </property>
          <layout class="QGridLayout" name="gridLayout">
           <item row="0" column="0">
-           <widget class="QLabel" name="label_6">
+           <widget class="QLabel" name="labelInputFormat">
             <property name="text">
              <string>Input Format:</string>
             </property>
@@ -85,7 +85,7 @@
            </layout>
           </item>
           <item row="1" column="0">
-           <widget class="QLabel" name="label_7">
+           <widget class="QLabel" name="labelQAxisData">
             <property name="text">
              <string>Q-Axis Data:</string>
             </property>
@@ -108,7 +108,7 @@
            </widget>
           </item>
           <item row="2" column="0">
-           <widget class="QLabel" name="label_8">
+           <widget class="QLabel" name="labelIntensityData">
             <property name="text">
              <string>Intensity Data:</string>
             </property>
@@ -131,7 +131,7 @@
            </widget>
           </item>
           <item row="3" column="0">
-           <widget class="QLabel" name="label_9">
+           <widget class="QLabel" name="labelRadiationType">
             <property name="text">
              <string>Radiation Type:</string>
             </property>
@@ -182,7 +182,7 @@
            </layout>
           </item>
           <item row="4" column="0">
-           <widget class="QLabel" name="label_10">
+           <widget class="QLabel" name="labelOutputFile">
             <property name="text">
              <string>Output File:</string>
             </property>
@@ -243,7 +243,7 @@
        <item row="0" column="0">
         <widget class="QTabWidget" name="tabWidget_2">
          <property name="currentIndex">
-          <number>0</number>
+          <number>3</number>
          </property>
          <widget class="QWidget" name="tab_3">
           <attribute name="title">
@@ -255,7 +255,7 @@
              <item>
               <layout class="QGridLayout" name="gridLayout_5">
                <item row="0" column="0">
-                <widget class="QLabel" name="label_2">
+                <widget class="QLabel" name="labelTile">
                  <property name="text">
                   <string>Title</string>
                  </property>
@@ -265,7 +265,7 @@
                 <widget class="QLineEdit" name="txtMG_Title"/>
                </item>
                <item row="1" column="0">
-                <widget class="QLabel" name="label_3">
+                <widget class="QLabel" name="labelRunNumber">
                  <property name="text">
                   <string>Run Number</string>
                  </property>
@@ -275,7 +275,7 @@
                 <widget class="QLineEdit" name="txtMG_RunNumber"/>
                </item>
                <item row="2" column="0">
-                <widget class="QLabel" name="label_4">
+                <widget class="QLabel" name="labelRunName">
                  <property name="text">
                   <string>Run Name</string>
                  </property>
@@ -285,7 +285,7 @@
                 <widget class="QLineEdit" name="txtMG_RunName"/>
                </item>
                <item row="3" column="0">
-                <widget class="QLabel" name="label_5">
+                <widget class="QLabel" name="labelInstrument">
                  <property name="text">
                   <string>Instrument</string>
                  </property>
@@ -321,7 +321,7 @@
            <item row="0" column="0">
             <layout class="QGridLayout" name="gridLayout_6">
              <item row="0" column="0">
-              <widget class="QLabel" name="label">
+              <widget class="QLabel" name="labelName">
                <property name="text">
                 <string>Name:</string>
                </property>
@@ -331,7 +331,7 @@
               <widget class="QLineEdit" name="txtMD_Name"/>
              </item>
              <item row="1" column="0">
-              <widget class="QLabel" name="label_11">
+              <widget class="QLabel" name="labelDistance">
                <property name="text">
                 <string>Distance [mm]:</string>
                </property>
@@ -341,7 +341,7 @@
               <widget class="QLineEdit" name="txtMD_Distance"/>
              </item>
              <item row="2" column="0">
-              <widget class="QLabel" name="label_12">
+              <widget class="QLabel" name="labelOffset">
                <property name="text">
                 <string>Offset [m]</string>
                </property>
@@ -350,7 +350,7 @@
              <item row="2" column="1">
               <layout class="QHBoxLayout" name="horizontalLayout_4">
                <item>
-                <widget class="QLabel" name="label_13">
+                <widget class="QLabel" name="labelOffsetX">
                  <property name="text">
                   <string>X:</string>
                  </property>
@@ -360,7 +360,7 @@
                 <widget class="QLineEdit" name="txtMD_OffsetX"/>
                </item>
                <item>
-                <widget class="QLabel" name="label_14">
+                <widget class="QLabel" name="labelOffsetY">
                  <property name="text">
                   <string>Y:</string>
                  </property>
@@ -372,7 +372,7 @@
               </layout>
              </item>
              <item row="3" column="0">
-              <widget class="QLabel" name="label_15">
+              <widget class="QLabel" name="labelOrientation">
                <property name="text">
                 <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Orientation [°]&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
                </property>
@@ -381,7 +381,7 @@
              <item row="3" column="1">
               <layout class="QHBoxLayout" name="horizontalLayout_5">
                <item>
-                <widget class="QLabel" name="label_16">
+                <widget class="QLabel" name="labelOrientationRoll">
                  <property name="text">
                   <string>Roll:</string>
                  </property>
@@ -391,7 +391,7 @@
                 <widget class="QLineEdit" name="txtMD_OrientRoll"/>
                </item>
                <item>
-                <widget class="QLabel" name="label_17">
+                <widget class="QLabel" name="labelOrientationPitch">
                  <property name="text">
                   <string>Pitch:</string>
                  </property>
@@ -401,7 +401,7 @@
                 <widget class="QLineEdit" name="txtMD_OrientPitch"/>
                </item>
                <item>
-                <widget class="QLabel" name="label_18">
+                <widget class="QLabel" name="labelOrientationYaw">
                  <property name="text">
                   <string>Yaw:</string>
                  </property>
@@ -413,7 +413,7 @@
               </layout>
              </item>
              <item row="4" column="0">
-              <widget class="QLabel" name="label_19">
+              <widget class="QLabel" name="labelPixelSize">
                <property name="text">
                 <string>Pixel size [mm]</string>
                </property>
@@ -422,7 +422,7 @@
              <item row="4" column="1">
               <layout class="QHBoxLayout" name="horizontalLayout_6">
                <item>
-                <widget class="QLabel" name="label_21">
+                <widget class="QLabel" name="labelPixelSizeX">
                  <property name="text">
                   <string>X:</string>
                  </property>
@@ -432,7 +432,7 @@
                 <widget class="QLineEdit" name="txtMD_PixelX"/>
                </item>
                <item>
-                <widget class="QLabel" name="label_20">
+                <widget class="QLabel" name="labelPixelSizeY">
                  <property name="text">
                   <string>Y:</string>
                  </property>
@@ -444,7 +444,7 @@
               </layout>
              </item>
              <item row="5" column="0">
-              <widget class="QLabel" name="label_22">
+              <widget class="QLabel" name="labelBeamCenter">
                <property name="text">
                 <string>Beam center [mm]</string>
                </property>
@@ -475,7 +475,7 @@
               </layout>
              </item>
              <item row="6" column="0">
-              <widget class="QLabel" name="label_25">
+              <widget class="QLabel" name="labelSlitLength">
                <property name="text">
                 <string>Slit length [mm]:</string>
                </property>
@@ -507,7 +507,7 @@
           </attribute>
           <layout class="QGridLayout" name="gridLayout_3">
            <item row="0" column="0">
-            <widget class="QLabel" name="label_26">
+            <widget class="QLabel" name="labelNameSample">
              <property name="text">
               <string>Name:</string>
              </property>
@@ -517,7 +517,7 @@
             <widget class="QLineEdit" name="txtMSa_Name"/>
            </item>
            <item row="1" column="0">
-            <widget class="QLabel" name="label_27">
+            <widget class="QLabel" name="labelThicknessSample">
              <property name="text">
               <string>Thickness [mm]:</string>
              </property>
@@ -527,7 +527,7 @@
             <widget class="QLineEdit" name="txtMSa_Thickness"/>
            </item>
            <item row="2" column="0">
-            <widget class="QLabel" name="label_29">
+            <widget class="QLabel" name="labelTransmissionSample">
              <property name="text">
               <string>Transmission:</string>
              </property>
@@ -541,7 +541,7 @@
             </widget>
            </item>
            <item row="3" column="0">
-            <widget class="QLabel" name="label_30">
+            <widget class="QLabel" name="labelTemperatureSample">
              <property name="text">
               <string>Temperature:</string>
              </property>
@@ -557,7 +557,7 @@
               </widget>
              </item>
              <item>
-              <widget class="QLabel" name="label_28">
+              <widget class="QLabel" name="labelTemperatureUnitSample">
                <property name="text">
                 <string>Unit</string>
                </property>
@@ -569,7 +569,7 @@
             </layout>
            </item>
            <item row="4" column="0">
-            <widget class="QLabel" name="label_31">
+            <widget class="QLabel" name="labelPositionSample">
              <property name="text">
               <string>Position [mm]</string>
              </property>
@@ -578,7 +578,7 @@
            <item row="4" column="1">
             <layout class="QHBoxLayout" name="horizontalLayout_11">
              <item>
-              <widget class="QLabel" name="label_32">
+              <widget class="QLabel" name="labelPositionX">
                <property name="text">
                 <string>X:</string>
                </property>
@@ -588,7 +588,7 @@
               <widget class="QLineEdit" name="txtMSa_PositionX"/>
              </item>
              <item>
-              <widget class="QLabel" name="label_33">
+              <widget class="QLabel" name="labelPositionY">
                <property name="text">
                 <string>Y:</string>
                </property>
@@ -600,7 +600,7 @@
             </layout>
            </item>
            <item row="5" column="0">
-            <widget class="QLabel" name="label_36">
+            <widget class="QLabel" name="labelOrientationSample">
              <property name="text">
               <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Orientation [°]&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
              </property>
@@ -609,7 +609,7 @@
            <item row="5" column="1">
             <layout class="QHBoxLayout" name="horizontalLayout_12">
              <item>
-              <widget class="QLabel" name="label_35">
+              <widget class="QLabel" name="labelOrientationRollSample">
                <property name="text">
                 <string>Roll:</string>
                </property>
@@ -619,7 +619,7 @@
               <widget class="QLineEdit" name="txtMSa_OrientR"/>
              </item>
              <item>
-              <widget class="QLabel" name="label_34">
+              <widget class="QLabel" name="labelOrientationPitchSample">
                <property name="text">
                 <string>Pitch:</string>
                </property>
@@ -629,7 +629,7 @@
               <widget class="QLineEdit" name="txtMSa_OrientP"/>
              </item>
              <item>
-              <widget class="QLabel" name="label_37">
+              <widget class="QLabel" name="labelOrientationYawSample">
                <property name="text">
                 <string>Yaw:</string>
                </property>
@@ -641,7 +641,7 @@
             </layout>
            </item>
            <item row="6" column="0">
-            <widget class="QLabel" name="label_38">
+            <widget class="QLabel" name="labelDetailsSample">
              <property name="text">
               <string>Details:</string>
              </property>
@@ -680,7 +680,7 @@
            <item row="0" column="0">
             <layout class="QGridLayout" name="gridLayout_10">
              <item row="0" column="0">
-              <widget class="QLabel" name="label_39">
+              <widget class="QLabel" name="labelNameSource">
                <property name="text">
                 <string>Name:</string>
                </property>
@@ -690,7 +690,7 @@
               <widget class="QLineEdit" name="txtMSo_Name"/>
              </item>
              <item row="1" column="0">
-              <widget class="QLabel" name="label_40">
+              <widget class="QLabel" name="labelBeamSizeSource">
                <property name="text">
                 <string>Beam size [mm]</string>
                </property>
@@ -699,7 +699,7 @@
              <item row="1" column="1" colspan="2">
               <layout class="QHBoxLayout" name="horizontalLayout_8">
                <item>
-                <widget class="QLabel" name="label_42">
+                <widget class="QLabel" name="labelBeamSizeXSource">
                  <property name="text">
                   <string>X:</string>
                  </property>
@@ -709,7 +709,7 @@
                 <widget class="QLineEdit" name="txtMSo_BeamSizeX"/>
                </item>
                <item>
-                <widget class="QLabel" name="label_41">
+                <widget class="QLabel" name="labelBeamSizeYSource">
                  <property name="text">
                   <string>Y:</string>
                  </property>
@@ -721,7 +721,7 @@
               </layout>
              </item>
              <item row="2" column="0">
-              <widget class="QLabel" name="label_43">
+              <widget class="QLabel" name="labelBeamShapeSource">
                <property name="text">
                 <string>Beam shape:</string>
                </property>
@@ -731,7 +731,7 @@
               <widget class="QLineEdit" name="txtMSo_BeamShape"/>
              </item>
              <item row="3" column="0">
-              <widget class="QLabel" name="label_44">
+              <widget class="QLabel" name="labelWavelengthSource">
                <property name="text">
                 <string>Wavelength [Ang]:</string>
                </property>
@@ -741,7 +741,7 @@
               <widget class="QLineEdit" name="txtMSo_BeamWavelength"/>
              </item>
              <item row="4" column="0">
-              <widget class="QLabel" name="label_45">
+              <widget class="QLabel" name="labelMinWavelengthSource">
                <property name="text">
                 <string>Min. wavelength [nm]:</string>
                </property>
@@ -751,7 +751,7 @@
               <widget class="QLineEdit" name="txtMSo_MinWavelength"/>
              </item>
              <item row="5" column="0">
-              <widget class="QLabel" name="label_46">
+              <widget class="QLabel" name="labelMaxWavelengthSource">
                <property name="text">
                 <string>Max. wavelength [nm]:</string>
                </property>
@@ -761,7 +761,7 @@
               <widget class="QLineEdit" name="txtMSo_MaxWavelength"/>
              </item>
              <item row="6" column="0" colspan="2">
-              <widget class="QLabel" name="label_47">
+              <widget class="QLabel" name="labelWavelengthSpreadSource">
                <property name="text">
                 <string>Wavelength spread [%]:</string>
                </property>
@@ -797,7 +797,7 @@
       </attribute>
       <layout class="QGridLayout" name="gridLayout_12">
        <item row="0" column="0">
-        <widget class="QLabel" name="label_48">
+        <widget class="QLabel" name="labelInstructions">
          <property name="frameShape">
           <enum>QFrame::Box</enum>
          </property>

--- a/src/sas/qtgui/Utilities/UI/FrameSelectUI.ui
+++ b/src/sas/qtgui/Utilities/UI/FrameSelectUI.ui
@@ -10,7 +10,7 @@
     <x>0</x>
     <y>0</y>
     <width>278</width>
-    <height>173</height>
+    <height>183</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -35,7 +35,7 @@
      <item row="1" column="0">
       <layout class="QGridLayout" name="gridLayout">
        <item row="0" column="0">
-        <widget class="QLabel" name="label_2">
+        <widget class="QLabel" name="labelFirstFrame">
          <property name="text">
           <string>First frame:</string>
          </property>
@@ -45,7 +45,7 @@
         <widget class="QLineEdit" name="txtFirstFrame"/>
        </item>
        <item row="1" column="0">
-        <widget class="QLabel" name="label_3">
+        <widget class="QLabel" name="labelLastFrame">
          <property name="text">
           <string>Last frame:</string>
          </property>
@@ -55,7 +55,7 @@
         <widget class="QLineEdit" name="txtLastFrame"/>
        </item>
        <item row="2" column="0">
-        <widget class="QLabel" name="label_4">
+        <widget class="QLabel" name="labelIncrement">
          <property name="text">
           <string>Increment:</string>
          </property>

--- a/src/sas/qtgui/Utilities/UI/FrameSelectUI.ui
+++ b/src/sas/qtgui/Utilities/UI/FrameSelectUI.ui
@@ -35,7 +35,7 @@
      <item row="1" column="0">
       <layout class="QGridLayout" name="gridLayout">
        <item row="0" column="0">
-        <widget class="QLabel" name="labelFirstFrame">
+        <widget class="QLabel" name="lblFirstFrame">
          <property name="text">
           <string>First frame:</string>
          </property>
@@ -45,7 +45,7 @@
         <widget class="QLineEdit" name="txtFirstFrame"/>
        </item>
        <item row="1" column="0">
-        <widget class="QLabel" name="labelLastFrame">
+        <widget class="QLabel" name="lblLastFrame">
          <property name="text">
           <string>Last frame:</string>
          </property>
@@ -55,7 +55,7 @@
         <widget class="QLineEdit" name="txtLastFrame"/>
        </item>
        <item row="2" column="0">
-        <widget class="QLabel" name="labelIncrement">
+        <widget class="QLabel" name="lblIncrement">
          <property name="text">
           <string>Increment:</string>
          </property>

--- a/src/sas/qtgui/Utilities/UI/ImageViewerOptionsUI.ui
+++ b/src/sas/qtgui/Utilities/UI/ImageViewerOptionsUI.ui
@@ -25,14 +25,14 @@
         <item row="0" column="0">
          <layout class="QGridLayout" name="gridLayout">
           <item row="0" column="0">
-           <widget class="QLabel" name="label">
+           <widget class="QLabel" name="labelXVal">
             <property name="text">
              <string>x values from pixel # to:</string>
             </property>
            </widget>
           </item>
           <item row="0" column="1">
-           <widget class="QLabel" name="label_6">
+           <widget class="QLabel" name="labelXmin">
             <property name="text">
              <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;X&lt;span style=&quot; vertical-align:sub;&quot;&gt;min&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
             </property>
@@ -42,14 +42,14 @@
            <widget class="QLineEdit" name="txtXmin"/>
           </item>
           <item row="1" column="0">
-           <widget class="QLabel" name="label_2">
+           <widget class="QLabel" name="labelYVal">
             <property name="text">
              <string>y values from pixel # to:</string>
             </property>
            </widget>
           </item>
           <item row="1" column="1">
-           <widget class="QLabel" name="label_7">
+           <widget class="QLabel" name="labelYmin">
             <property name="text">
              <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Y&lt;span style=&quot; vertical-align:sub;&quot;&gt;min&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
             </property>
@@ -59,14 +59,14 @@
            <widget class="QLineEdit" name="txtYmin"/>
           </item>
           <item row="2" column="0">
-           <widget class="QLabel" name="label_3">
+           <widget class="QLabel" name="labelZValRange">
             <property name="text">
              <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;z value range&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
             </property>
            </widget>
           </item>
           <item row="2" column="1">
-           <widget class="QLabel" name="label_8">
+           <widget class="QLabel" name="labelFromZero">
             <property name="text">
              <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;From 0 to:&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
             </property>
@@ -80,7 +80,7 @@
         <item row="0" column="1">
          <layout class="QFormLayout" name="formLayout_2">
           <item row="0" column="0">
-           <widget class="QLabel" name="label_4">
+           <widget class="QLabel" name="labelXmax">
             <property name="text">
              <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;X&lt;span style=&quot; vertical-align:sub;&quot;&gt;max&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
             </property>
@@ -90,7 +90,7 @@
            <widget class="QLineEdit" name="txtXmax"/>
           </item>
           <item row="1" column="0">
-           <widget class="QLabel" name="label_5">
+           <widget class="QLabel" name="labelYmax">
             <property name="text">
              <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Y&lt;span style=&quot; vertical-align:sub;&quot;&gt;max&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
             </property>
@@ -113,13 +113,16 @@
      </property>
      <property name="html">
       <string>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
-&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
+&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;meta charset=&quot;utf-8&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
-&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'MS Shell Dlg 2'; font-size:7.8pt; font-weight:400; font-style:normal;&quot;&gt;
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:8pt; font-weight:600;&quot;&gt;Note&lt;/span&gt;&lt;span style=&quot; font-size:8pt;&quot;&gt;:&lt;/span&gt;&lt;/p&gt;
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:8pt;&quot;&gt;Recommend to use an image with 8 bit Grey scale (and with No. of pixels &amp;lt; 300 x 300).&lt;/span&gt;&lt;/p&gt;
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:8pt;&quot;&gt;Otherwise, z = 0.299R + 0.587G + 0.114B.&lt;/span&gt;&lt;/p&gt;
-&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-size:8pt;&quot;&gt;&lt;br /&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+hr { height: 1px; border-width: 0; }
+li.unchecked::marker { content: &quot;\2610&quot;; }
+li.checked::marker { content: &quot;\2612&quot;; }
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'Segoe UI'; font-size:9pt; font-weight:400; font-style:normal;&quot;&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:'MS Shell Dlg 2'; font-size:8pt; font-weight:600;&quot;&gt;Note&lt;/span&gt;&lt;span style=&quot; font-family:'MS Shell Dlg 2'; font-size:8pt;&quot;&gt;:&lt;/span&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:'MS Shell Dlg 2'; font-size:8pt;&quot;&gt;Recommend to use an image with 8 bit Grey scale (and with No. of pixels &amp;lt; 300 x 300).&lt;/span&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:'MS Shell Dlg 2'; font-size:8pt;&quot;&gt;Otherwise, z = 0.299R + 0.587G + 0.114B.&lt;/span&gt;&lt;/p&gt;
+&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-family:'MS Shell Dlg 2'; font-size:8pt;&quot;&gt;&lt;br /&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
      </property>
     </widget>
    </item>
@@ -151,9 +154,6 @@ p, li { white-space: pre-wrap; }
     </layout>
    </item>
   </layout>
-  <zorder>groupBox</zorder>
-  <zorder>buttonBox</zorder>
-  <zorder>textBrowser</zorder>
  </widget>
  <resources/>
  <connections>

--- a/src/sas/qtgui/Utilities/UI/ImageViewerOptionsUI.ui
+++ b/src/sas/qtgui/Utilities/UI/ImageViewerOptionsUI.ui
@@ -25,14 +25,14 @@
         <item row="0" column="0">
          <layout class="QGridLayout" name="gridLayout">
           <item row="0" column="0">
-           <widget class="QLabel" name="labelXVal">
+           <widget class="QLabel" name="lblXVal">
             <property name="text">
              <string>x values from pixel # to:</string>
             </property>
            </widget>
           </item>
           <item row="0" column="1">
-           <widget class="QLabel" name="labelXmin">
+           <widget class="QLabel" name="lblXmin">
             <property name="text">
              <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;X&lt;span style=&quot; vertical-align:sub;&quot;&gt;min&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
             </property>
@@ -42,14 +42,14 @@
            <widget class="QLineEdit" name="txtXmin"/>
           </item>
           <item row="1" column="0">
-           <widget class="QLabel" name="labelYVal">
+           <widget class="QLabel" name="lblYVal">
             <property name="text">
              <string>y values from pixel # to:</string>
             </property>
            </widget>
           </item>
           <item row="1" column="1">
-           <widget class="QLabel" name="labelYmin">
+           <widget class="QLabel" name="lblYmin">
             <property name="text">
              <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Y&lt;span style=&quot; vertical-align:sub;&quot;&gt;min&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
             </property>
@@ -59,14 +59,14 @@
            <widget class="QLineEdit" name="txtYmin"/>
           </item>
           <item row="2" column="0">
-           <widget class="QLabel" name="labelZValRange">
+           <widget class="QLabel" name="lblZValRange">
             <property name="text">
              <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;z value range&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
             </property>
            </widget>
           </item>
           <item row="2" column="1">
-           <widget class="QLabel" name="labelFromZero">
+           <widget class="QLabel" name="lblFromZero">
             <property name="text">
              <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;From 0 to:&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
             </property>
@@ -80,7 +80,7 @@
         <item row="0" column="1">
          <layout class="QFormLayout" name="formLayout_2">
           <item row="0" column="0">
-           <widget class="QLabel" name="labelXmax">
+           <widget class="QLabel" name="lblXmax">
             <property name="text">
              <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;X&lt;span style=&quot; vertical-align:sub;&quot;&gt;max&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
             </property>
@@ -90,7 +90,7 @@
            <widget class="QLineEdit" name="txtXmax"/>
           </item>
           <item row="1" column="0">
-           <widget class="QLabel" name="labelYmax">
+           <widget class="QLabel" name="lblYmax">
             <property name="text">
              <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Y&lt;span style=&quot; vertical-align:sub;&quot;&gt;max&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
             </property>


### PR DESCRIPTION
Edit after biweekly call on 09/04/2024: i thouroughly looked all changed files through and followed the mentioned naming conventions with 'cmd' for Buttons, 'txt' for QLineEdit, 'lbl' for QLabel, 'rb' for RadioButtons etc.

In case i still missed some variables that have to be renamed, errors can occure, because the corresponding button is not recognized or similar. 

I tried to look all changed files through afterwards and spotted some window size changes in e.g. AxisButtonsUI.ui or in PlaneButtonsUI.ui. I tried to change them back to their original values but the old sizes cannot be applied for a reason i am not sure of. 

## Description
Edited the variable names of a lot of labels with numbers, e.g. label_5 to something sensible. This is mostly the text that is displayed by the label. E.g. labelPosXUnit in case the label represents the Unit (mostly Angstrom) of an input where some x position is requested. 

In the beginning I also started to change variable names from e.g. rb->RadioButton and cmd->button etc. but did not rename all of them as a lot are already named as something sensible.
Fixes # (issue/issues)
Fixes issue #2761 

## How Has This Been Tested?
Followed through all the src/sas/qtgui/**/UI folders and changed variable names in the underlying QT designer files. Searched the logic files in the same folder afterwards for missing references and changed them to the new naming.

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.
Restarted SasView locally on win10 on several occasions and clicked and changed some things in the various windows. 

## Review Checklist:
I don't really know what to check in these boxes, so I leave it to you, to suggest, what has to be checked.

[if using the editor, use `[x]` in place of `[ ]` to check a box]

**Documentation** (check at least one)
- [x] There is **nothing** that needs documenting
- [ ] Documentation changes are **in this PR**
- [ ] There is an **issue** open for the documentation (link?)

**Installers**
- [ ] There is a chance this will affect the **installers**, if so
  - [ ] **Windows** installer (GH artifact) has been tested (installed and worked) 
  - [ ] **MacOSX** installer (GH artifact) has been tested (installed and worked) 

**Licencing** (untick if necessary)
- [x] The introduced changes comply with SasView license (BSD 3-Clause)

