### PR TITLE
Corrected appearences of load_model_info example string in fitting_help.rst and release.rst

### DIFF
--- a/docs/sphinx-docs/source/user/RELEASE.rst
+++ b/docs/sphinx-docs/source/user/RELEASE.rst
@@ -613,7 +613,7 @@ models directly. For example::
 
      from sasmodels.core import load_model_info
      from sasmodels.sasview_model import make_model_from_info
-     model_info = load_model_info('power_law + fractal + gaussian_peak + gaussian_peak')
+     model_info = load_model_info('power_law+fractal+gaussian_peak+gaussian_peak')
      model_info.name = 'MyBigPluginModel'
      model_info.description = 'For fitting pores in crystalline framework'
      Model = make_model_from_info(model_info)
@@ -1465,7 +1465,7 @@ built-in models directly. For example::
 
      from sasmodels.core import load_model_info
      from sasmodels.sasview_model import make_model_from_info
-     model_info = load_model_info('power_law + fractal + gaussian_peak + gaussian_peak')
+     model_info = load_model_info('power_law+fractal+gaussian_peak+gaussian_peak')
      model_info.name = 'MyBigPluginModel'
      model_info.description = 'For fitting pores in crystalline framework'
      Model = make_model_from_info(model_info)

--- a/src/sas/qtgui/Perspectives/Fitting/media/fitting_help.rst
+++ b/src/sas/qtgui/Perspectives/Fitting/media/fitting_help.rst
@@ -434,7 +434,7 @@ section, change it to::
      from sasmodels.core import load_model_info
      from sasmodels.sasview_model import make_model_from_info
 
-     model_info = load_model_info('power_law + fractal + gaussian_peak + gaussian_peak')
+     model_info = load_model_info('power_law+fractal+gaussian_peak+gaussian_peak')
      model_info.name = 'MyBigPluginModel'
      model_info.description = 'For fitting pores in crystalline framework'
      Model = make_model_from_info(model_info)


### PR DESCRIPTION
**This pull request can be closed. New pull request #2850 against branch release_6.0.0**

## Description
Examples of load_model_info usage in fitting_help.rst and release.rst needed to be fixed. Blank spaces in method call causes an error.

Fixes # (issue/issues)
Searched in files for other appearences of load_model_info besides the implementation itself and fixed all blank spaces in the occurring strings. Fixes issue #2805 
## How Has This Been Tested?
Local build test on win10, tried old version with blank spaces and new version without blank spaces while the old version throws the mentioned error and the new version executes without errors.
## Review Checklist:

[if using the editor, use `[x]` in place of `[ ]` to check a box]

**Documentation** (check at least one)
- [ ] There is **nothing** that needs documenting
- [ ] Documentation changes are **in this PR**
- [ ] There is an **issue** open for the documentation (link?)

**Installers**
- [ ] There is a chance this will affect the **installers**, if so
  - [ ] **Windows** installer (GH artifact) has been tested (installed and worked) 
  - [ ] **MacOSX** installer (GH artifact) has been tested (installed and worked) 

**Licencing** (untick if necessary)
- [x] The introduced changes comply with SasView license (BSD 3-Clause)

