### PR TITLE
1726 allow user to choose default for plot navigation tools - merge into release_6.0.0

### DIFF
--- a/src/sas/qtgui/MainWindow/media/preferences_help.rst
+++ b/src/sas/qtgui/MainWindow/media/preferences_help.rst
@@ -39,7 +39,7 @@ can still be accessed in the data explorer under the data set the fit was perfor
 are completed. The plots can still be accessed in the data explorer under the data set the fit was performed on. *persistent*
 
 **Show toolbar on all new plots**: When selected, all new plots will open a toolbar on the bottom. The toolbar comes
-from Matplotlib. Note: The toolbar can be enabled and disabled in each individual plot by opening the contect menuw with
+from Matplotlib. Note: The toolbar can be enabled and disabled in each individual plot by opening the context menu with
 a right click and selecting 'Toggle Navigation Menu'
 
 .. _Display_Preferences:

--- a/src/sas/qtgui/MainWindow/media/preferences_help.rst
+++ b/src/sas/qtgui/MainWindow/media/preferences_help.rst
@@ -38,6 +38,10 @@ can still be accessed in the data explorer under the data set the fit was perfor
 **Disable Polydispersity Plot Display**: When selected, polydispersity plots are not automatically displayed when fits
 are completed. The plots can still be accessed in the data explorer under the data set the fit was performed on. *persistent*
 
+**Show toolbar on all new plots**: When selected, all new plots will open a toolbar on the bottom. The toolbar comes
+from Matplotlib. Note: The toolbar can be enabled and disabled in each individual plot by opening the contect menuw with
+a right click and selecting 'Toggle Navigation Menu'
+
 .. _Display_Preferences:
 
 Display Preferences

--- a/src/sas/qtgui/Plotting/PlotterBase.py
+++ b/src/sas/qtgui/Plotting/PlotterBase.py
@@ -22,6 +22,8 @@ from sas.qtgui.Plotting.Binder import BindArtist
 import sas.qtgui.Utilities.GuiUtils as GuiUtils
 import sas.qtgui.Plotting.PlotHelper as PlotHelper
 
+from sas import config
+
 
 class PlotterBase(QtWidgets.QWidget):
     #TODO: Describe what this class is
@@ -123,8 +125,10 @@ class PlotterBase(QtWidgets.QWidget):
         layout.addWidget(self.toolbar)
         if not quickplot:
             # Add the toolbar
-            # self.toolbar.show()
-            self.toolbar.hide() # hide for the time being
+            if config.USE_MATPLOTLIB_TOOLBAR:
+                self.toolbar.show()
+            else:
+                self.toolbar.hide() # hide for the time being
             # Notify PlotHelper about the new plot
             self.upatePlotHelper()
         else:

--- a/src/sas/qtgui/Utilities/Preferences/PlottingPreferencesWidget.py
+++ b/src/sas/qtgui/Utilities/Preferences/PlottingPreferencesWidget.py
@@ -40,7 +40,7 @@ class PlottingPreferencesWidget(PreferencesWidget):
         self.disablePolydispersityPlot.clicked.connect(
             lambda: self._stageChange('DISABLE_POLYDISPERSITY_PLOT', self.disablePolydispersityPlot.isChecked()))
         self.useMatplotlibToolbar = self.addCheckBox(
-            title="Use Matplotlib Toolbar",
+            title="Show toolbar on all new plots",
             checked=config.USE_MATPLOTLIB_TOOLBAR)
         self.useMatplotlibToolbar.clicked.connect(
             lambda: self._stageChange('USE_MATPLOTLIB_TOOLBAR', self.useMatplotlibToolbar.isChecked()))
@@ -60,4 +60,4 @@ class PlottingPreferencesWidget(PreferencesWidget):
         self.legendLineLength.setStyleSheet("background-color: white")
         self.disableResidualPlot.setChecked(config.DISABLE_RESIDUAL_PLOT)
         self.disablePolydispersityPlot.setChecked(config.DISABLE_POLYDISPERSITY_PLOT)
-        self.useMatplotlibToolbar.setChecked(config.USE_MATPLOTLIB_PLOT_TOOLBAR)
+        self.useMatplotlibToolbar.setChecked(config.USE_MATPLOTLIB_TOOLBAR)

--- a/src/sas/qtgui/Utilities/Preferences/PlottingPreferencesWidget.py
+++ b/src/sas/qtgui/Utilities/Preferences/PlottingPreferencesWidget.py
@@ -10,7 +10,8 @@ class PlottingPreferencesWidget(PreferencesWidget):
                               'FITTING_PLOT_LEGEND_TRUNCATE',
                               'FITTING_PLOT_LEGEND_MAX_LINE_LENGTH',
                               'DISABLE_RESIDUAL_PLOT',
-                              'DISABLE_POLYDISPERSITY_PLOT']
+                              'DISABLE_POLYDISPERSITY_PLOT',
+                              'USE_MATPLOTLIB_TOOLBAR']
 
     def _addAllWidgets(self):
         self.legendFullWidth = self.addCheckBox(
@@ -38,6 +39,11 @@ class PlottingPreferencesWidget(PreferencesWidget):
             checked=config.DISABLE_POLYDISPERSITY_PLOT)
         self.disablePolydispersityPlot.clicked.connect(
             lambda: self._stageChange('DISABLE_POLYDISPERSITY_PLOT', self.disablePolydispersityPlot.isChecked()))
+        self.useMatplotlibToolbar = self.addCheckBox(
+            title="Use Matplotlib Toolbar",
+            checked=config.USE_MATPLOTLIB_TOOLBAR)
+        self.useMatplotlibToolbar.clicked.connect(
+            lambda: self._stageChange('USE_MATPLOTLIB_TOOLBAR', self.useMatplotlibToolbar.isChecked()))
 
     def _toggleBlockAllSignaling(self, toggle):
         self.legendFullWidth.blockSignals(toggle)
@@ -45,6 +51,7 @@ class PlottingPreferencesWidget(PreferencesWidget):
         self.legendLineLength.blockSignals(toggle)
         self.disableResidualPlot.blockSignals(toggle)
         self.disablePolydispersityPlot.blockSignals(toggle)
+        self.useMatplotlibToolbar.blockSignals(toggle)
 
     def _restoreFromConfig(self):
         self.legendFullWidth.setChecked(bool(config.FITTING_PLOT_FULL_WIDTH_LEGENDS))
@@ -53,3 +60,4 @@ class PlottingPreferencesWidget(PreferencesWidget):
         self.legendLineLength.setStyleSheet("background-color: white")
         self.disableResidualPlot.setChecked(config.DISABLE_RESIDUAL_PLOT)
         self.disablePolydispersityPlot.setChecked(config.DISABLE_POLYDISPERSITY_PLOT)
+        self.useMatplotlibToolbar.setChecked(config.USE_MATPLOTLIB_PLOT_TOOLBAR)

--- a/src/sas/system/config/config.py
+++ b/src/sas/system/config/config.py
@@ -205,6 +205,9 @@ class Config(ConfigBase, metaclass=ConfigMeta):
         # If true, disables polydispersity plot display
         self.DISABLE_POLYDISPERSITY_PLOT = False
 
+        # Using Matplotlib Toolbar in Main Plotting Function
+        self.USE_MATPLOTLIB_TOOLBAR = False
+
         # Default fitting optimizer
         self.FITTING_DEFAULT_OPTIMIZER = 'lm'
 


### PR DESCRIPTION
## Description
Same changes as mentioned in pull request #2845 
Added documentation changes in preferences_help.rst as suggested in #2845 

Added a checkbox in Preferences/Plotting Settings for using the matplotlib toolbar. Therefore edited the config and added USE_MATPLOTLIB_TOOLBAR.

Fixes # (issue/issues)
Fixes issue [https://github.com/SasView/sasview/issues/1726](https://github.com/SasView/sasview/pull/url) , where access to the standard matplotlib toolbar is requested.

## How Has This Been Tested?

Local win10 build, tried plotting with and without the checked checkbox in the preferences. Both worked. Not sure, why the toolbar was disabled by default. Maybe that has to be checked.

## Review Checklist:

[if using the editor, use `[x]` in place of `[ ]` to check a box]

**Documentation** (check at least one)
- [ ] There is **nothing** that needs documenting
- [x] Documentation changes are **in this PR**
- [ ] There is an **issue** open for the documentation (link?)

**Installers**
- [x] There is a chance this will affect the **installers**, if so
  - [ ] **Windows** installer (GH artifact) has been tested (installed and worked) 
  - [ ] **MacOSX** installer (GH artifact) has been tested (installed and worked) 

**Licencing** (untick if necessary)
- [x] The introduced changes comply with SasView license (BSD 3-Clause)
