### PR TITLE
Upgrading pyinstaller

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -202,7 +202,7 @@ jobs:
       - name: Install utilities to build installer
         if: ${{ matrix.installer }}
         run: |
-          python -m pip install pyinstaller==5.13.2
+          python -m pip install pyinstaller
 
       - name: Build sasview with pyinstaller
         if: ${{ matrix.installer }}

--- a/build_tools/requirements.txt
+++ b/build_tools/requirements.txt
@@ -34,4 +34,4 @@ superqt
 pyopengl
 pyopengl_accelerate
 sphinx
-scipy==1.11.4; platform_system == "Darwin"
+scipy==1.12.0; platform_system == "Darwin"

--- a/build_tools/requirements.txt
+++ b/build_tools/requirements.txt
@@ -34,4 +34,4 @@ superqt
 pyopengl
 pyopengl_accelerate
 sphinx
-scipy=1.11.4; platform_system == "Darwin"
+scipy==1.11.4; platform_system == "Darwin"

--- a/build_tools/requirements.txt
+++ b/build_tools/requirements.txt
@@ -34,4 +34,3 @@ superqt
 pyopengl
 pyopengl_accelerate
 sphinx
-pyinstaller

--- a/build_tools/requirements.txt
+++ b/build_tools/requirements.txt
@@ -34,4 +34,4 @@ superqt
 pyopengl
 pyopengl_accelerate
 sphinx
-scipy==1.12.0; platform_system == "Darwin"
+pyinstaller

--- a/build_tools/requirements.txt
+++ b/build_tools/requirements.txt
@@ -34,3 +34,4 @@ superqt
 pyopengl
 pyopengl_accelerate
 sphinx
+scipy=1.11.4; platform_system == "Darwin"


### PR DESCRIPTION
## Description
It seems that we need to use earlier version scipy (1.12), to make MAC installer working. 
As always in such case, the fix should be removed once proper bug fix from scipy is provided. 
Addressing https://github.com/SasView/sasview/issues/2846
