### PR TITLE
1524 when loading data the data explorer should revert to the data tab

### DIFF
--- a/src/sas/qtgui/MainWindow/DataExplorer.py
+++ b/src/sas/qtgui/MainWindow/DataExplorer.py
@@ -222,6 +222,9 @@ class DataExplorerWindow(DroppableDataLoadWidget):
         load_thread.addCallback(self.loadComplete)
         load_thread.addErrback(self.loadFailed)
 
+        # switch to data tab after reading from either file or folder
+        self.setCurrentIndex(0)
+
     def loadFile(self, event=None):
         """
         Called when the "Load" button pressed.

--- a/src/sas/qtgui/Perspectives/Fitting/FittingWidget.py
+++ b/src/sas/qtgui/Perspectives/Fitting/FittingWidget.py
@@ -368,6 +368,12 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         self.lblFilename.setText("")
 
         # Magnetic angles explained in one picture
+        from sas.sascalc.doc_regen.makedocumentation import HELP_DIRECTORY_LOCATION, MAIN_DOC_SRC
+        if not MAIN_DOC_SRC.exists() and not HELP_DIRECTORY_LOCATION.exists():
+            print("docs not exist")
+        print("main doc src", MAIN_DOC_SRC)
+        print("help directory location", HELP_DIRECTORY_LOCATION)
+        print("images directory location", IMAGES_DIRECTORY_LOCATION)
         self.magneticAnglesWidget = QtWidgets.QWidget()
         labl = QtWidgets.QLabel(self.magneticAnglesWidget)
         pixmap = QtGui.QPixmap(IMAGES_DIRECTORY_LOCATION / 'M_angles_pic.png')

--- a/src/sas/qtgui/Perspectives/Fitting/FittingWidget.py
+++ b/src/sas/qtgui/Perspectives/Fitting/FittingWidget.py
@@ -368,12 +368,6 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         self.lblFilename.setText("")
 
         # Magnetic angles explained in one picture
-        from sas.sascalc.doc_regen.makedocumentation import HELP_DIRECTORY_LOCATION, MAIN_DOC_SRC
-        if not MAIN_DOC_SRC.exists() and not HELP_DIRECTORY_LOCATION.exists():
-            print("docs not exist")
-        print("main doc src", MAIN_DOC_SRC)
-        print("help directory location", HELP_DIRECTORY_LOCATION)
-        print("images directory location", IMAGES_DIRECTORY_LOCATION)
         self.magneticAnglesWidget = QtWidgets.QWidget()
         labl = QtWidgets.QLabel(self.magneticAnglesWidget)
         pixmap = QtGui.QPixmap(IMAGES_DIRECTORY_LOCATION / 'M_angles_pic.png')


### PR DESCRIPTION
## Description
Added logic to DataExplorer.py, in which the current tab is changed upon calling loadFromURL() in DataExplorer.py 

Fixes # (issue/issues)
Fixes issue #1524
## How Has This Been Tested?
local win10 build, loaded data and tab changed
## Review Checklist:

[if using the editor, use `[x]` in place of `[ ]` to check a box]

**Documentation** (check at least one)
- [x] There is **nothing** that needs documenting
- [ ] Documentation changes are **in this PR**
- [ ] There is an **issue** open for the documentation (link?)

**Installers**
- [ ] There is a chance this will affect the **installers**, if so
  - [ ] **Windows** installer (GH artifact) has been tested (installed and worked) 
  - [ ] **MacOSX** installer (GH artifact) has been tested (installed and worked) 

**Licencing** (untick if necessary)
- [x] The introduced changes comply with SasView license (BSD 3-Clause)

