### PR TITLE
2800 sld calculator allow user to finish typing

### DIFF
--- a/src/sas/qtgui/Calculators/SldPanel.py
+++ b/src/sas/qtgui/Calculators/SldPanel.py
@@ -127,7 +127,7 @@ class SldPanel(QtWidgets.QDialog):
         # signals
         self.ui.helpButton.clicked.connect(self.displayHelp)
         self.ui.closeButton.clicked.connect(self.closePanel)
-        self.ui.recalculateButton.clicked.connect(self.calculateSLD)
+        self.ui.calculateButton.clicked.connect(self.calculateSLD)
 
     def calculateSLD(self):
         self.recalculateSLD()

--- a/src/sas/qtgui/Calculators/SldPanel.py
+++ b/src/sas/qtgui/Calculators/SldPanel.py
@@ -147,10 +147,10 @@ class SldPanel(QtWidgets.QDialog):
 
         #self.model.dataChanged.connect(self.dataChanged)
 
-        self.ui.editMassDensity.textChanged.connect(self.recalculateSLD)
-        self.ui.editMolecularFormula.textChanged.connect(self.recalculateSLD)
-        self.ui.editNeutronWavelength.textChanged.connect(self.recalculateSLD)
-        self.ui.editXrayWavelength.textChanged.connect(self.recalculateSLD)
+        self.ui.editMassDensity.editingFinished.connect(self.recalculateSLD)
+        self.ui.editMolecularFormula.editingFinished.connect(self.recalculateSLD)
+        self.ui.editNeutronWavelength.editingFinished.connect(self.recalculateSLD)
+        self.ui.editXrayWavelength.editingFinished.connect(self.recalculateSLD)
 
         self.modelReset()
 

--- a/src/sas/qtgui/Calculators/SldPanel.py
+++ b/src/sas/qtgui/Calculators/SldPanel.py
@@ -116,11 +116,8 @@ class SldPanel(QtWidgets.QDialog):
         self.ui.setupUi(self)
 
         # set validators
-        # TODO: GuiUtils.FormulaValidator() crashes with Qt5 - fix
-        #self.ui.editMolecularFormula.setValidator(GuiUtils.FormulaValidator(self.ui.editMolecularFormula))
-
-        # No need for recalculate
-        self.ui.recalculateButton.setVisible(False)
+        # Chemical formula is checked via periodictable.formula module.
+        self.ui.editMolecularFormula.setValidator(GuiUtils.FormulaValidator(self.ui.editMolecularFormula))
 
         rx = QtCore.QRegularExpression("[+\-]?(?:0|[1-9]\d*)(?:\.\d*)?(?:[eE][+\-]?\d+)?")
         self.ui.editMassDensity.setValidator(QtGui.QRegularExpressionValidator(rx, self.ui.editMassDensity))
@@ -146,11 +143,6 @@ class SldPanel(QtWidgets.QDialog):
             self.model.setItem(key, QtGui.QStandardItem())
 
         #self.model.dataChanged.connect(self.dataChanged)
-
-        self.ui.editMassDensity.editingFinished.connect(self.recalculateSLD)
-        self.ui.editMolecularFormula.editingFinished.connect(self.recalculateSLD)
-        self.ui.editNeutronWavelength.editingFinished.connect(self.recalculateSLD)
-        self.ui.editXrayWavelength.editingFinished.connect(self.recalculateSLD)
 
         self.modelReset()
 

--- a/src/sas/qtgui/Calculators/UI/SldPanel.ui
+++ b/src/sas/qtgui/Calculators/UI/SldPanel.ui
@@ -322,7 +322,7 @@
      </property>
      <layout class="QGridLayout" name="gridLayout">
       <item row="0" column="0">
-       <widget class="QPushButton" name="recalculateButton">
+       <widget class="QPushButton" name="calculateButton">
         <property name="enabled">
          <bool>true</bool>
         </property>
@@ -336,10 +336,10 @@
          <enum>Qt::NoFocus</enum>
         </property>
         <property name="text">
-         <string>Recalculate</string>
+         <string>Calculate</string>
         </property>
         <property name="autoDefault">
-         <bool>false</bool>
+         <bool>true</bool>
         </property>
        </widget>
       </item>
@@ -407,7 +407,7 @@
   <tabstop>editNeutronLength</tabstop>
   <tabstop>closeButton</tabstop>
   <tabstop>helpButton</tabstop>
-  <tabstop>recalculateButton</tabstop>
+  <tabstop>calculateButton</tabstop>
  </tabstops>
  <resources/>
  <connections/>

--- a/src/sas/qtgui/Calculators/UI/SldPanel.ui
+++ b/src/sas/qtgui/Calculators/UI/SldPanel.ui
@@ -338,6 +338,9 @@
         <property name="text">
          <string>Recalculate</string>
         </property>
+        <property name="autoDefault">
+         <bool>false</bool>
+        </property>
        </widget>
       </item>
       <item row="0" column="1">
@@ -364,6 +367,9 @@
         <property name="text">
          <string>Close</string>
         </property>
+        <property name="autoDefault">
+         <bool>false</bool>
+        </property>
        </widget>
       </item>
       <item row="0" column="3">
@@ -376,6 +382,9 @@
         </property>
         <property name="text">
          <string>Help</string>
+        </property>
+        <property name="autoDefault">
+         <bool>false</bool>
         </property>
        </widget>
       </item>

--- a/src/sas/qtgui/Utilities/GuiUtils.py
+++ b/src/sas/qtgui/Utilities/GuiUtils.py
@@ -741,16 +741,15 @@ class FormulaValidator(QtGui.QValidator):
     def validate(self, input, pos):
 
         self._setStyleSheet("")
-        return QtGui.QValidator.Acceptable, pos
 
-        #try:
-        #    Formula(str(input))
-        #    self._setStyleSheet("")
-        #    return QtGui.QValidator.Acceptable, pos
+        try:
+            Formula(str(input))
+            self._setStyleSheet("")
+            return QtGui.QValidator.Acceptable
 
-        #except Exception as e:
-        #    self._setStyleSheet("background-color:pink;")
-        #    return QtGui.QValidator.Intermediate, pos
+        except Exception as e:
+            self._setStyleSheet("background-color:pink;")
+            return QtGui.QValidator.Intermediate
 
     def _setStyleSheet(self, value):
         try:


### PR DESCRIPTION
## Description
Issue #2800 contains discussion about the best realization of the checking mechanism behind the chemical formula in the sld calculator. Before, the formula was checked with every key input, which resulted in a lot of errors in the logs.
Now the recalculate button is reintroduced and other signals for recalculating have been disabled. Neither hitting enter in the text box nor key inputs in a text box will trigger the formula checking anymore.

Fixes #2800 (issue/issues)

## How Has This Been Tested?
Trying the recalculation button functionality has been tested on local branch checkout build with win10. Test with installer will follow.
Edit: i wanted to test, but the _cdflib error has not been resolved on main yet, so the program wont execute

## Review Checklist:

[if using the editor, use `[x]` in place of `[ ]` to check a box]

**Documentation** (check at least one)
- [x] There is **nothing** that needs documenting
- [ ] Documentation changes are **in this PR**
- [ ] There is an **issue** open for the documentation (link?)

**Installers**
- [ ] There is a chance this will affect the **installers**, if so
  - [ ] **Windows** installer (GH artifact) has been tested (installed and worked) 
  - [ ] **MacOSX** installer (GH artifact) has been tested (installed and worked) 

**Licencing** (untick if necessary)
- [x] The introduced changes comply with SasView license (BSD 3-Clause)

