### PR TITLE
Pyinstaller 6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -195,7 +195,6 @@ jobs:
       ### Build the installer (if enabled)
 
       - name: Install utilities to build installer
-        if: ${{ matrix.installer && startsWith(matrix.os, 'windows') }}
         run: |
           python -m pip install pyinstaller
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -197,12 +197,7 @@ jobs:
       - name: Install utilities to build installer
         if: ${{ matrix.installer && startsWith(matrix.os, 'windows') }}
         run: |
-          python -m pip install pyinstaller==5.13.2
-
-      - name: Install utilities to build installer
-        if: ${{ matrix.installer && !startsWith(matrix.os, 'windows') }}
-        run: |
-          python -m pip install pyinstaller==6.3.0
+          python -m pip install pyinstaller
 
       - name: Build sasview with pyinstaller
         if: ${{ matrix.installer }}

--- a/installers/installer.iss
+++ b/installers/installer.iss
@@ -26,7 +26,7 @@ UsedUserAreasWarning=no
 LicenseFile=license.txt
 ArchitecturesInstallIn64BitMode=x64
 OutputBaseFilename=setupSasView
-SetupIconFile=dist\sasview\images\ball.ico
+SetupIconFile=dist\sasview\_internal\images\ball.ico
 
 
 ; Uncomment the following line to run in non administrative install mode (install for current user only.)
@@ -56,7 +56,7 @@ end;
 [Files]
 Source: "dist\sasview\sasview.exe"; DestDir: "{app}"; Flags: ignoreversion
 Source: "dist\sasview\*"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs createallsubdirs
-Source: "dist\sasview\plugin_models\*"; DestDir: "{%USERPROFILE}\.sasview\plugin_models"
+Source: "dist\sasview\_internal\plugin_models\*"; DestDir: "{%USERPROFILE}\.sasview\plugin_models"
 
 [Icons]
 Name: "{autodesktop}\{#MyAppName}"; Filename: "{app}\{#MyAppExeName}"; Tasks: desktopicon

--- a/installers/installer.iss
+++ b/installers/installer.iss
@@ -57,7 +57,7 @@ end;
 Source: "dist\sasview\sasview.exe"; DestDir: "{app}"; Flags: ignoreversion
 Source: "dist\sasview\*"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs createallsubdirs
 Source: "dist\sasview\_internal\plugin_models\*"; DestDir: "{%USERPROFILE}\.sasview\plugin_models"
-Source: "dist\sasview\_internal\periodictable-data\*"; DestDir: "{app}\periodictable-data"
+Source: "dist\sasview\_internal\*"; DestDir: "{app}" Flags: ignoreversion recursesubdirs createallsubdirs
 
 [Icons]
 Name: "{autodesktop}\{#MyAppName}"; Filename: "{app}\{#MyAppExeName}"; Tasks: desktopicon

--- a/installers/installer.iss
+++ b/installers/installer.iss
@@ -57,7 +57,7 @@ end;
 Source: "dist\sasview\sasview.exe"; DestDir: "{app}"; Flags: ignoreversion
 Source: "dist\sasview\*"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs createallsubdirs
 Source: "dist\sasview\_internal\plugin_models\*"; DestDir: "{%USERPROFILE}\.sasview\plugin_models"
-Source: "dist\sasview\_internal\*"; DestDir: "{app}" Flags: ignoreversion recursesubdirs createallsubdirs
+Source: "dist\sasview\_internal\*"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs createallsubdirs
 
 [Icons]
 Name: "{autodesktop}\{#MyAppName}"; Filename: "{app}\{#MyAppExeName}"; Tasks: desktopicon

--- a/installers/installer.iss
+++ b/installers/installer.iss
@@ -57,6 +57,7 @@ end;
 Source: "dist\sasview\sasview.exe"; DestDir: "{app}"; Flags: ignoreversion
 Source: "dist\sasview\*"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs createallsubdirs
 Source: "dist\sasview\_internal\plugin_models\*"; DestDir: "{%USERPROFILE}\.sasview\plugin_models"
+Source: "dist\sasview\_internal\periodictable-data\*"; DestDir: "{app}\periodictable-data"
 
 [Icons]
 Name: "{autodesktop}\{#MyAppName}"; Filename: "{app}\{#MyAppExeName}"; Tasks: desktopicon


### PR DESCRIPTION
## Description

This uses the latest version of `pyinstaller` for all OSes, allowing the latest version of `scipy` on MacOS.

Fixes #2546
Fixes #2846 (once the release branch is merged back into main).

## How Has This Been Tested?

I downloaded the installer for both MacOS and Windows and they both launched. More testing is likely required.

## Review Checklist:

[if using the editor, use `[x]` in place of `[ ]` to check a box]

**Documentation** (check at least one)
- [x] There is **nothing** that needs documenting
- [ ] Documentation changes are **in this PR**
- [ ] There is an **issue** open for the documentation (link?)

**Installers**
- [x] There is a chance this will affect the **installers**, if so
  - [ ] **Windows** installer (GH artifact) has been tested (installed and worked) 
  - [x] **MacOSX** installer (GH artifact) has been tested (installed and worked) 

**Licencing** (untick if necessary)
- [x] The introduced changes comply with SasView license (BSD 3-Clause)

