### PR TITLE
Remove pyopengl_accelerate from requirements.txt

### DIFF
--- a/build_tools/requirements.txt
+++ b/build_tools/requirements.txt
@@ -19,7 +19,6 @@ periodictable
 pybind11
 pylint
 pyopengl
-pyopengl_accelerate
 pyparsing
 pytest
 pytest_qt


### PR DESCRIPTION
## Description

Removing pyopengl_accelerate package from requirements.txt because it is not required and causing problems with setting up dev env on Mac.

Note: We will also need to merge it main. 

## How Has This Been Tested?

It has been tested locally by creating a new environment. 

## Review Checklist:

[if using the editor, use `[x]` in place of `[ ]` to check a box]

**Documentation** (check at least one)
- [x] There is **nothing** that needs documenting
- [ ] Documentation changes are **in this PR**
- [ ] There is an **issue** open for the documentation (link?)

**Installers**
- [ ] There is a chance this will affect the **installers**, if so
  - [ ] **Windows** installer (GH artifact) has been tested (installed and worked) 
  - [ ] **MacOSX** installer (GH artifact) has been tested (installed and worked) 

**Licencing** (untick if necessary)
- [x] The introduced changes comply with SasView license (BSD 3-Clause)

