### PR TITLE
2669: Default load directory persistence

### DIFF
--- a/src/sas/qtgui/MainWindow/DataExplorer.py
+++ b/src/sas/qtgui/MainWindow/DataExplorer.py
@@ -153,6 +153,16 @@ class DataExplorerWindow(DroppableDataLoadWidget):
         # Current view on model
         self.current_view = self.treeView
 
+    @property
+    def default_load_location(self) -> str:
+        return self._default_load_location
+
+    @default_load_location.setter
+    def default_load_location(self, value: str):
+        # Ensure the config entry is updated
+        self._default_load_location = value
+        config.DEFAULT_OPEN_FOLDER = value
+
     def createSendToMenu(self):
         self.actionReplace = QtGui.QAction(self)
         self.actionReplace.setObjectName(u"actionReplace")
@@ -218,6 +228,7 @@ class DataExplorerWindow(DroppableDataLoadWidget):
         """
         Threaded file load
         """
+        self.default_load_location = os.path.dirname(url[0])
         load_thread = threads.deferToThread(self.readData, url)
         load_thread.addCallback(self.loadComplete)
         load_thread.addErrback(self.loadFailed)
@@ -252,7 +263,6 @@ class DataExplorerWindow(DroppableDataLoadWidget):
         folder = str(folder)
         if not os.path.isdir(folder):
             return
-        self.default_load_location = folder
         # get content of dir into a list
         path_str = [os.path.join(os.path.abspath(folder), filename)
                     for filename in os.listdir(folder)]
@@ -1335,7 +1345,6 @@ class DataExplorerWindow(DroppableDataLoadWidget):
         if not isinstance(paths, list):
             paths = [paths]
 
-        self.default_load_location = os.path.dirname(paths[0])
         return paths
 
     def readData(self, path):

--- a/src/sas/qtgui/MainWindow/DataExplorer.py
+++ b/src/sas/qtgui/MainWindow/DataExplorer.py
@@ -1336,8 +1336,7 @@ class DataExplorerWindow(DroppableDataLoadWidget):
         caption = 'Choose files'
         directory = self.default_load_location
         filter = wlist
-        options = QtWidgets.QFileDialog.DontUseNativeDialog | QtWidgets.QFileDialog.DontUseCustomDirectoryIcons
-        paths = QtWidgets.QFileDialog.getOpenFileNames(parent, caption, directory, filter, options=options)[0]
+        paths = QtWidgets.QFileDialog.getOpenFileNames(parent, caption, directory, filter)[0]
 
         if not paths:
             return


### PR DESCRIPTION
## Description

This ensures the last directory any file was loaded from, whether it was from the file dialog or drag/drop, is used as the default directory the next time data is loaded. This value also persists between SasView instances.

Fixes #2669

## Review Checklist:

**Documentation** (check at least one)
- [x] There is **nothing** that needs documenting
- [ ] Documentation changes are **in this PR**
- [ ] There is an **issue** open for the documentation (link?)

**Installers**
- [x] There is a chance this will affect the **installers**, if so
  - [ ] **Windows** installer (GH artifact) has been tested (installed and worked) 
  - [ ] **MacOSX** installer (GH artifact) has been tested (installed and worked) 

**Licencing** (untick if necessary)
- [x] The introduced changes comply with SasView license (BSD 3-Clause)

