### PR TITLE
Added automated signing of the Windows installer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -276,6 +276,17 @@ jobs:
         with:
           product-path: "installers/dist/SasView6.dmg"
 
+      - name: Sign binary
+        if: ${{ matrix.installer && startsWith(matrix.os, 'windows') }}
+        uses: lando/code-sign-action@v2
+        with:
+          file: installers/dist/setupSasView.exe
+          certificate-data: ${{ secrets.WINDOZE_CERT_DATA }}
+          certificate-password: ${{ secrets.WINDOZE_CERT_PASSWORD }}
+          keylocker-host: ${{ secrets.KEYLOCKER_HOST }}
+          keylocker-api-key: ${{ secrets.KEYLOCKER_API_KEY }}
+          keylocker-cert-sha1-hash: ${{ secrets.KEYLOCKER_CERT_SHA1_HASH }}
+
       - name: Publish installer package
         if: ${{ matrix.installer }}
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Description

Automated binary signing of the installer with ESS Digicert credentials


## How Has This Been Tested?

Local checks

## Review Checklist:

[if using the editor, use `[x]` in place of `[ ]` to check a box]

**Documentation** (check at least one)
- [X] There is **nothing** that needs documenting
- [ ] Documentation changes are **in this PR**
- [ ] There is an **issue** open for the documentation (link?)

**Installers**
- [ ] There is a chance this will affect the **installers**, if so
  - [X] **Windows** installer (GH artifact) has been tested (installed and worked) 
  - [ ] **MacOSX** installer (GH artifact) has been tested (installed and worked) 

**Licencing** (untick if necessary)
- [x] The introduced changes comply with SasView license (BSD 3-Clause)

