### PR TITLE
2909 gpu options help button throws error

### DIFF
--- a/src/sas/qtgui/Perspectives/Fitting/GPUOptions.py
+++ b/src/sas/qtgui/Perspectives/Fitting/GPUOptions.py
@@ -275,11 +275,13 @@ class GPUOptions(PreferencesWidget, Ui_GPUOptions):
         """
         Open the help menu when the help button is clicked
         """
-        help_location = GuiUtils.HELP_DIRECTORY_LOCATION
-        help_location += "/user/qtgui/Perspectives/Fitting/gpu_setup.html"
-        help_location += "#device-selection"
+        from sas.sascalc.doc_regen.makedocumentation import HELP_DIRECTORY_LOCATION
+
+        help_path = HELP_DIRECTORY_LOCATION / "user" / "qtgui" / "Perspectives" / "Fitting" / "gpu_setup.html"
+        help_location = help_path.as_uri() + "#device-selection"
+
         # Display the page in default browser
-        webbrowser.open('file://' + os.path.realpath(help_location))
+        webbrowser.open(help_location)
 
     def reject(self):
         """

--- a/src/sas/qtgui/Perspectives/Fitting/GPUOptions.py
+++ b/src/sas/qtgui/Perspectives/Fitting/GPUOptions.py
@@ -275,13 +275,11 @@ class GPUOptions(PreferencesWidget, Ui_GPUOptions):
         """
         Open the help menu when the help button is clicked
         """
-        from sas.sascalc.doc_regen.makedocumentation import HELP_DIRECTORY_LOCATION
 
-        help_path = HELP_DIRECTORY_LOCATION / "user" / "qtgui" / "Perspectives" / "Fitting" / "gpu_setup.html"
-        help_location = help_path.as_uri() + "#device-selection"
-
+        # TODO - in future this should be linked to the local documentation, once there is a robust way of doing that
+        
         # Display the page in default browser
-        webbrowser.open(help_location)
+        webbrowser.open("https://www.sasview.org/docs/user/qtgui/Perspectives/Fitting/gpu_setup.html#device-selection")
 
     def reject(self):
         """


### PR DESCRIPTION
## Description

Updated the path to GPU help to reflect recent changes made to documentation

Fixes #2909 

## How Has This Been Tested?

Checked on windows

## Review Checklist:

[if using the editor, use `[x]` in place of `[ ]` to check a box]

**Documentation** (check at least one)
- [x] There is **nothing** that needs documenting
- [ ] Documentation changes are **in this PR**
- [ ] There is an **issue** open for the documentation (link?)

**Installers**
- [ ] There is a chance this will affect the **installers**, if so
  - [ ] **Windows** installer (GH artifact) has been tested (installed and worked) 
  - [ ] **MacOSX** installer (GH artifact) has been tested (installed and worked) 

**Licencing** (untick if necessary)
- [x] The introduced changes comply with SasView license (BSD 3-Clause)

