### PR TITLE
Tutorials open in browser to avoid PDF failure

### DIFF
--- a/src/sas/qtgui/MainWindow/GuiManager.py
+++ b/src/sas/qtgui/MainWindow/GuiManager.py
@@ -1264,8 +1264,9 @@ class GuiManager:
         """
         Open the page with tutorial PDF links
         """
-        helpfile = "/user/tutorial.html"
-        self.showHelp(helpfile)
+
+        help_path = HELP_DIRECTORY_LOCATION / "user" / "tutorial.html"
+        webbrowser.open(help_path.as_uri())
 
     def actionAcknowledge(self):
         """

--- a/src/sas/qtgui/MainWindow/GuiManager.py
+++ b/src/sas/qtgui/MainWindow/GuiManager.py
@@ -1265,8 +1265,7 @@ class GuiManager:
         Open the page with tutorial PDF links
         """
 
-        help_path = HELP_DIRECTORY_LOCATION / "user" / "tutorial.html"
-        webbrowser.open(help_path.as_uri())
+        webbrowser.open("https://www.sasview.org/docs/user/tutorial.html")
 
     def actionAcknowledge(self):
         """


### PR DESCRIPTION
The links to tutorials from the document editor don't work because they're PDF files, and it can't open them

I've changed the tutorial opening behaviour to back to just opening a web link as it did before.

I've opened an issue for updating the editor to handle PDFs - #2926 

fixes #2908

