### PR TITLE
2979: Ensure multiplicity row is set when loading projects

### DIFF
--- a/src/sas/qtgui/Perspectives/Fitting/FittingWidget.py
+++ b/src/sas/qtgui/Perspectives/Fitting/FittingWidget.py
@@ -4467,6 +4467,9 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
             if self.kernel_module.is_multiplicity_model:
                 self.kernel_module.multiplicity=multip
                 self.updateMultiplicityCombo(multip)
+        else:
+            self._n_shells_row = -1
+            self._num_shell_params = -1
 
         if 'tab_name' in line_dict.keys() and self.kernel_module is not None:
             self.kernel_module.name = line_dict['tab_name'][0]

--- a/src/sas/qtgui/Perspectives/Fitting/FittingWidget.py
+++ b/src/sas/qtgui/Perspectives/Fitting/FittingWidget.py
@@ -263,8 +263,8 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         # Utility variable to enable unselectable option in category combobox
         self._previous_category_index = 0
         # Utility variables for multishell display
-        self._n_shells_row = 0
-        self._num_shell_params = 0
+        self._n_shells_row = -1
+        self._num_shell_params = -1
         # Dictionary of {model name: model class} for the current category
         self.models = {}
         # Dictionary of QModels
@@ -4467,9 +4467,6 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
             if self.kernel_module.is_multiplicity_model:
                 self.kernel_module.multiplicity=multip
                 self.updateMultiplicityCombo(multip)
-        else:
-            self._n_shells_row = -1
-            self._num_shell_params = -1
 
         if 'tab_name' in line_dict.keys() and self.kernel_module is not None:
             self.kernel_module.name = line_dict['tab_name'][0]


### PR DESCRIPTION
## Description

The multiplicity row is set to 0 by default, which is the `scale` parameter. When loading a project, this row is ignored because it is handled elsewhere. This sets the row to -1 if there is no multiplicity parameter.

Fixes #2979

## Review Checklist:

[if using the editor, use `[x]` in place of `[ ]` to check a box]

**Documentation** (check at least one)
- [x] There is **nothing** that needs documenting
- [ ] Documentation changes are **in this PR**
- [ ] There is an **issue** open for the documentation (link?)

**Installers**
- [x] There is a chance this will affect the **installers**, if so
  - [ ] **Windows** installer (GH artifact) has been tested (installed and worked) 
  - [ ] **MacOSX** installer (GH artifact) has been tested (installed and worked) 

**Licencing** (untick if necessary)
- [x] The introduced changes comply with SasView license (BSD 3-Clause)

