### PR TITLE
2981: Eliminate Errors on Density Panel Calculation

### DIFF
--- a/src/sas/qtgui/Calculators/DensityPanel.py
+++ b/src/sas/qtgui/Calculators/DensityPanel.py
@@ -56,16 +56,9 @@ class DensityPanel(QtWidgets.QDialog):
 
         self.setFixedSize(self.minimumSizeHint())
 
-        # set validators
-        #self.ui.editMolecularFormula.setValidator(FormulaValidator(self.ui.editMolecularFormula))
-
         rx = QtCore.QRegularExpression("[+\-]?(?:0|[1-9]\d*)(?:\.\d*)?(?:[eE][+\-]?\d+)?")
         self.ui.editMolarVolume.setValidator(QtGui.QRegularExpressionValidator(rx, self.ui.editMolarVolume))
         self.ui.editMassDensity.setValidator(QtGui.QRegularExpressionValidator(rx, self.ui.editMassDensity))
-
-        # signals
-        self.ui.editMolarVolume.textEdited.connect(functools.partial(self.setMode, MODES.VOLUME_TO_DENSITY))
-        self.ui.editMassDensity.textEdited.connect(functools.partial(self.setMode, MODES.DENSITY_TO_VOLUME))
 
         self.ui.buttonBox.button(QtWidgets.QDialogButtonBox.Reset).clicked.connect(self.modelReset)
         self.ui.buttonBox.button(QtWidgets.QDialogButtonBox.Help).clicked.connect(self.displayHelp)
@@ -116,6 +109,7 @@ class DensityPanel(QtWidgets.QDialog):
                 self._updateVolume()
 
     def volumeChanged(self, current_text):
+        self.setMode(MODES.VOLUME_TO_DENSITY)
         try:
             molarMass = float(toMolarMass(self.model.item(MODEL.MOLECULAR_FORMULA).text()))
             molarVolume = float(current_text)
@@ -130,6 +124,7 @@ class DensityPanel(QtWidgets.QDialog):
             self.model.item(MODEL.MASS_DENSITY).setText("")
 
     def massChanged(self, current_text):
+        self.setMode(MODES.DENSITY_TO_VOLUME)
         try:
             molarMass = float(toMolarMass(self.model.item(MODEL.MOLECULAR_FORMULA).text()))
             molarDensity = float(current_text)


### PR DESCRIPTION
## Description

This removes an unneeded signal that was throwing an error when the DensityPanel was running a calculation.

Fixes #2981

## How Has This Been Tested?

Tested locally

## Review Checklist:

[if using the editor, use `[x]` in place of `[ ]` to check a box]

**Documentation** (check at least one)
- [x] There is **nothing** that needs documenting
- [ ] Documentation changes are **in this PR**
- [ ] There is an **issue** open for the documentation (link?)

**Installers**
- [x] There is a chance this will affect the **installers**, if so
  - [ ] **Windows** installer (GH artifact) has been tested (installed and worked) 
  - [ ] **MacOSX** installer (GH artifact) has been tested (installed and worked) 

**Licencing** (untick if necessary)
- [x] The introduced changes comply with SasView license (BSD 3-Clause)

