### PR TITLE
2988: Check if Fit button should be enabled when data is sent to a fit tab

### DIFF
--- a/src/sas/qtgui/Perspectives/Fitting/FittingWidget.py
+++ b/src/sas/qtgui/Perspectives/Fitting/FittingWidget.py
@@ -518,6 +518,8 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         self.onSelectModel()
         # Smearing tab
         self.smearing_widget.updateData(self.data)
+        # Check if a model was already loaded when data is sent to the tab
+        self.cmdFit.setEnabled(self.haveParamsToFit())
 
     def acceptsData(self):
         """ Tells the caller this widget can accept new dataset """


### PR DESCRIPTION
## Description

This adds a check to see if the fit tab is able to be fit when a data set is sent to the tab.

Fixes #2988

## Review Checklist:

[if using the editor, use `[x]` in place of `[ ]` to check a box]

**Documentation** (check at least one)
- [x] There is **nothing** that needs documenting
- [ ] Documentation changes are **in this PR**
- [ ] There is an **issue** open for the documentation (link?)

**Installers**
- [x] There is a chance this will affect the **installers**, if so
  - [ ] **Windows** installer (GH artifact) has been tested (installed and worked) 
  - [ ] **MacOSX** installer (GH artifact) has been tested (installed and worked) 

**Licencing** (untick if necessary)
- [x] The introduced changes comply with SasView license (BSD 3-Clause)

