### PR TITLE
2741: Fix PD parameter issue

### DIFF
--- a/src/sas/qtgui/Perspectives/Fitting/FittingWidget.py
+++ b/src/sas/qtgui/Perspectives/Fitting/FittingWidget.py
@@ -1811,7 +1811,9 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
             # PD[ratio] -> width, npts -> npts, nsigs -> nsigmas
             if model_column not in delegate.columnDict():
                 return
-            self.poly_params[parameter_name_w] = value
+            # Map the column to the poly param that was changed
+            associations = {1: "width", 4: "npts", 5: "nsigmas"}
+            self.poly_params[f"{parameter_name}.{associations.get(model_column, 1)}"] = value
             self.kernel_module.setParam(parameter_name_w, value)
 
             # Update plot
@@ -2218,6 +2220,7 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         """
         Update the model with new parameters, create the errors column
         """
+        print(param_dict)
         assert isinstance(param_dict, dict)
 
         def updateFittedValues(row):
@@ -2237,6 +2240,7 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         def updatePolyValues(row):
             # Utility function for updateof polydispersity part of the main model
             param_name = str(self._model_model.item(row, 0).text())+'.width'
+            print(f"name: {param_name}")
             if not self.isCheckable(row) or param_name not in list(param_dict.keys()):
                 return
             # modify the param value

--- a/src/sas/qtgui/Perspectives/Fitting/FittingWidget.py
+++ b/src/sas/qtgui/Perspectives/Fitting/FittingWidget.py
@@ -2220,7 +2220,6 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         """
         Update the model with new parameters, create the errors column
         """
-        print(param_dict)
         assert isinstance(param_dict, dict)
 
         def updateFittedValues(row):
@@ -2240,7 +2239,6 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         def updatePolyValues(row):
             # Utility function for updateof polydispersity part of the main model
             param_name = str(self._model_model.item(row, 0).text())+'.width'
-            print(f"name: {param_name}")
             if not self.isCheckable(row) or param_name not in list(param_dict.keys()):
                 return
             # modify the param value

--- a/src/sas/qtgui/Perspectives/Fitting/FittingWidget.py
+++ b/src/sas/qtgui/Perspectives/Fitting/FittingWidget.py
@@ -1813,7 +1813,7 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
                 return
             # Map the column to the poly param that was changed
             associations = {1: "width", 4: "npts", 5: "nsigmas"}
-            self.poly_params[f"{parameter_name}.{associations.get(model_column, 1)}"] = value
+            self.poly_params[f"{parameter_name}.{associations.get(model_column, 'width')}"] = value
             self.kernel_module.setParam(parameter_name_w, value)
 
             # Update plot


### PR DESCRIPTION
## Description

A change to the PD params resulted in `width`, `npts`, and `nsigmas` to all change `width` of the underlying model. This corrects that behavior.

Fixes #2741

## Review Checklist:

[if using the editor, use `[x]` in place of `[ ]` to check a box]

**Documentation** (check at least one)
- [x] There is **nothing** that needs documenting
- [ ] Documentation changes are **in this PR**
- [ ] There is an **issue** open for the documentation (link?)

**Installers**
- [x] There is a chance this will affect the **installers**, if so
  - [ ] **Windows** installer (GH artifact) has been tested (installed and worked) 
  - [ ] **MacOSX** installer (GH artifact) has been tested (installed and worked) 

**Licencing** (untick if necessary)
- [x] The introduced changes comply with SasView license (BSD 3-Clause)