### PR TITLE
2999 Fix slow startup time

### DIFF
--- a/src/sas/qtgui/Calculators/GenericScatteringCalculator.py
+++ b/src/sas/qtgui/Calculators/GenericScatteringCalculator.py
@@ -117,7 +117,7 @@ class GenericScatteringCalculator(QtWidgets.QDialog, Ui_GenericScatteringCalcula
             lineEdit.installEventFilter(self)                            # when textbox enabled/disabled
 
         # push buttons
-        self.cmdClose.clicked.connect(self.accept)
+        self.cmdClose.clicked.connect(self.hideWindow)
         self.cmdHelp.clicked.connect(self.onHelp)
 
         self.cmdNucLoad.clicked.connect(self.loadFile)
@@ -1520,8 +1520,18 @@ class GenericScatteringCalculator(QtWidgets.QDialog, Ui_GenericScatteringCalcula
         self.cmdCompute.clicked.connect(self.onCompute)
         self.cmdCompute.setEnabled(True)
         return
-    
-    
+
+    def hideWindow(self):
+        """
+        Hide the window when the close button is clicked
+        """
+        self.hide()
+
+    def closeEvent(self, event):
+        """
+        Overwrite the close event and hide the window instead of closing it
+        """
+        self.hideWindow()
 
     def update_file_name(self):
         if self.checkboxPluginModel.isChecked():

--- a/src/sas/qtgui/Calculators/GenericScatteringCalculator.py
+++ b/src/sas/qtgui/Calculators/GenericScatteringCalculator.py
@@ -1532,6 +1532,7 @@ class GenericScatteringCalculator(QtWidgets.QDialog, Ui_GenericScatteringCalcula
         Overwrite the close event and hide the window instead of closing it
         """
         self.hideWindow()
+        event.ignore()
 
     def update_file_name(self):
         if self.checkboxPluginModel.isChecked():

--- a/src/sas/qtgui/MainWindow/GuiManager.py
+++ b/src/sas/qtgui/MainWindow/GuiManager.py
@@ -206,6 +206,7 @@ class GuiManager:
         self.KIESSIGCalculator = KiessigPanel(self)
         self.SlitSizeCalculator = SlitSizeCalculator(self)
         self.ResolutionCalculator = ResolutionCalculatorPanel(self)
+        self.GENSASCalculator = None
         self.DataOperation = DataOperationUtilityPanel(self)
         self.FileConverter = FileConverterWidget(self)
         self.WhatsNew = WhatsNew(self)
@@ -1041,7 +1042,8 @@ class GuiManager:
         try:
             # delayed import due to numba instantiation in GSC
             from sas.qtgui.Calculators.GenericScatteringCalculator import GenericScatteringCalculator
-            self.GENSASCalculator = GenericScatteringCalculator(self)
+            if self.GENSASCalculator is None:
+                self.GENSASCalculator = GenericScatteringCalculator(self)
             self.GENSASCalculator.show()
         except Exception as ex:
             logging.error(str(ex))

--- a/src/sas/qtgui/MainWindow/GuiManager.py
+++ b/src/sas/qtgui/MainWindow/GuiManager.py
@@ -51,7 +51,6 @@ from sas.qtgui.Calculators.SldPanel import SldPanel
 from sas.qtgui.Calculators.DensityPanel import DensityPanel
 from sas.qtgui.Calculators.KiessigPanel import KiessigPanel
 from sas.qtgui.Calculators.SlitSizeCalculator import SlitSizeCalculator
-from sas.qtgui.Calculators.GenericScatteringCalculator import GenericScatteringCalculator
 from sas.qtgui.Calculators.ResolutionCalculatorPanel import ResolutionCalculatorPanel
 from sas.qtgui.Calculators.DataOperationUtilityPanel import DataOperationUtilityPanel
 
@@ -206,7 +205,6 @@ class GuiManager:
         self.DVCalculator = DensityPanel(self)
         self.KIESSIGCalculator = KiessigPanel(self)
         self.SlitSizeCalculator = SlitSizeCalculator(self)
-        self.GENSASCalculator = GenericScatteringCalculator(self)
         self.ResolutionCalculator = ResolutionCalculatorPanel(self)
         self.DataOperation = DataOperationUtilityPanel(self)
         self.FileConverter = FileConverterWidget(self)
@@ -1041,6 +1039,9 @@ class GuiManager:
         """
         """
         try:
+            # delayed import due to numba instantiation in GSC
+            from sas.qtgui.Calculators.GenericScatteringCalculator import GenericScatteringCalculator
+            self.GENSASCalculator = GenericScatteringCalculator(self)
             self.GENSASCalculator.show()
         except Exception as ex:
             logging.error(str(ex))


### PR DESCRIPTION
## Description

GenericScatteringCalculator instantiation in GuiManager includes importing `sas.sascalc.calculator.geni`.
This module has been extensively "numbaised" and its import is very slow due to numerous JIT decorators.

The simplest/safest solution seems to be postponing the import until the GSC is actually needed.

Price paid: starting the GS calculator takes now a long time.

Fixes #2999 

## How Has This Been Tested?

Local testing on win10

## Review Checklist:

[if using the editor, use `[x]` in place of `[ ]` to check a box]

**Documentation** (check at least one)
- [ X] There is **nothing** that needs documenting
- [ ] Documentation changes are **in this PR**
- [ ] There is an **issue** open for the documentation (link?)

**Installers**
- [ ] There is a chance this will affect the **installers**, if so
  - [ ] **Windows** installer (GH artifact) has been tested (installed and worked) 
  - [ ] **MacOSX** installer (GH artifact) has been tested (installed and worked) 

**Licencing** (untick if necessary)
- [x] The introduced changes comply with SasView license (BSD 3-Clause)

