### PR TITLE
1783: Reset transforms for new plots

### DIFF
--- a/src/sas/qtgui/MainWindow/DataExplorer.py
+++ b/src/sas/qtgui/MainWindow/DataExplorer.py
@@ -1203,6 +1203,10 @@ class DataExplorerWindow(DroppableDataLoadWidget):
                 if 'new_plot' not in locals():
                     new_plot = PlotterWidget(manager=self, parent=self)
                     new_plot.item = item
+                # Ensure new plots use the default transform, not the transform of any previous plots the data were in
+                # TODO: The transform should be part of the PLOT, NOT the data
+                plot_set.xtransform = None
+                plot_set.ytransform = None
                 new_plot.plot(plot_set, transform=transform)
                 # active_plots may contain multiple charts
                 self.active_plots[plot_set.name] = new_plot


### PR DESCRIPTION
## Description
This resets the data transforms held by the Data objects on the creation of new plots.

Fixes #1783
Refs #3021

## How Has This Been Tested?
Running from source, I tested plotting, changing scale, zoom, etc. I then replotted the same data in multiple ways (fit, new plot) and the new plots display in their default state.

## Review Checklist:

**Documentation** (check at least one)
- [ ] There is **nothing** that needs documenting
- [x] Documentation changes are **in this PR** (inline)
- [ ] There is an **issue** open for the documentation (link?)

**Installers**
- [x] There is a chance this will affect the **installers**, if so
  - [ ] **Windows** installer (GH artifact) has been tested (installed and worked) 
  - [ ] **MacOSX** installer (GH artifact) has been tested (installed and worked) 

**Licencing** (untick if necessary)
- [x] The introduced changes comply with SasView license (BSD 3-Clause)

