### PR TITLE
Check successful launch of sasview on CI (linux)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -458,9 +458,28 @@ jobs:
         if: ${{ startsWith(matrix.os, 'ubuntu' )}}
         # If sasview has crashed on its own, then this should return an error
         run: |
-          xvfb-run -a --server-args="-screen 0 1024x768x24" $RUN_SASVIEW &
-          sleep 60s
-          kill %1
+          (
+            echo "## START SASVIEW"
+            xvfb-run -a --server-args="-screen 0 1024x768x24" $RUN_SASVIEW 2>&1 |
+            tee sasview-test.log
+          ) &
+          svpid=$!
+          (
+            set -e
+            sleep 20s
+            echo "## PULSE CHECK"
+            kill -0 $svpid
+            echo "## PULSE OK"
+            sleep 40s
+            echo "## FINISHING SMOKE TEST"
+            kill $svpid
+            echo "## SMOKE TEST COMPLETE"
+            exit 0
+          ) &
+          pulsepid=$1
+          wait $pulsepid
+          # Check the log file for successful startup
+          grep "SasView session started" sasview-test.log
 
       ### Optionally attempt to work with the debug tarball from pyinstaller
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -451,8 +451,10 @@ jobs:
 
       - name: Install X11 libraries (Linux)
         if: ${{ startsWith(matrix.os, 'ubuntu') }}
+        env:
+          DEBIAN_FRONTEND: noninteractive
         run: |
-          sudo apt install libxkbcommon-x11-0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 libxcb-xinerama0 libxcb-xfixes0 x11-utils xvfb
+          sudo apt install libegl1 libopengl0 libxkbcommon-x11-0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 libxcb-xinerama0 libxcb-xfixes0 x11-utils xvfb
 
       - name: Try running the installation (Linux)
         if: ${{ startsWith(matrix.os, 'ubuntu' )}}


### PR DESCRIPTION
## Description

Rework code that starts the linux installer bundle so that it correctly tests if the installer is functional. (Duplicating this PR since PRs from external forks now fail CI due to installer signing)

1. Fix the test harness to correctly detect sasview failing to start
2. Add additional packages to installation so that sasview can start

Fixes #2816

## How Has This Been Tested?

CI

1. fails to start: https://github.com/SasView/sasview/actions/runs/10470305752
2. now starts: https://github.com/SasView/sasview/actions/runs/10470744795

## Review Checklist:

**Documentation** (check at least one)
- [x] There is **nothing** that needs documenting
- [ ] Documentation changes are **in this PR**
- [ ] There is an **issue** open for the documentation (link?)

**Installers**
- [ ] There is a chance this will affect the **installers**, if so
  - [ ] **Windows** installer (GH artifact) has been tested (installed and worked) 
  - [ ] **MacOSX** installer (GH artifact) has been tested (installed and worked) 

**Licencing** (untick if necessary)
- [x] The introduced changes comply with SasView license (BSD 3-Clause)

