### PR TITLE
3057: Change default settings

### DIFF
--- a/src/sas/system/config/config.py
+++ b/src/sas/system/config/config.py
@@ -170,7 +170,6 @@ class Config(ConfigBase, metaclass=ConfigMeta):
         self.DEFAULT_OPEN_FOLDER = ""
         self.TOOLBAR_SHOW = True
         self.DEFAULT_PERSPECTIVE = "Fitting"
-        # self.DEFAULT_PERSPECTIVE = "Corfunc"
 
         # Default threading model
         self.USING_TWISTED = False
@@ -200,10 +199,10 @@ class Config(ConfigBase, metaclass=ConfigMeta):
 
         # Polydispersity plot management
         # If true, disables polydispersity plot display
-        self.DISABLE_POLYDISPERSITY_PLOT = False
+        self.DISABLE_POLYDISPERSITY_PLOT = True
 
         # Using Matplotlib Toolbar in Main Plotting Function
-        self.USE_MATPLOTLIB_TOOLBAR = False
+        self.USE_MATPLOTLIB_TOOLBAR = True
 
         # Default fitting optimizer
         self.FITTING_DEFAULT_OPTIMIZER = 'lm'


### PR DESCRIPTION
## Description

This changes the default settings to show the mpl toolbar, and to not show polydispersity plots.

Fixes #3057

## Review Checklist:
**Documentation** (check at least one)
- [x] There is **nothing** that needs documenting
- [ ] Documentation changes are **in this PR**
- [ ] There is an **issue** open for the documentation (link?)

**Installers**
- [x] There is a chance this will affect the **installers**, if so
  - [x] **Windows** installer (GH artifact) has been tested (installed and worked) 
  - [ ] **MacOSX** installer (GH artifact) has been tested (installed and worked) 

**Licencing** (untick if necessary)
- [x] The introduced changes comply with SasView license (BSD 3-Clause)

