### PR TITLE
Better checks on result object so failed fitting is shown as such.

### DIFF
--- a/src/sas/qtgui/MainWindow/GuiManager.py
+++ b/src/sas/qtgui/MainWindow/GuiManager.py
@@ -1148,7 +1148,7 @@ class GuiManager:
         Show bumps convergence plots
         """
         self.results_frame.setVisible(True)
-        if output_data:
+        if output_data and len(output_data) > 0 and len(output_data[0]) > 0:
             self.results_panel.onPlotResults(output_data, optimizer=self.perspective().optimizer)
 
     def actionAdd_Custom_Model(self):

--- a/src/sas/qtgui/Perspectives/Fitting/ConstraintWidget.py
+++ b/src/sas/qtgui/Perspectives/Fitting/ConstraintWidget.py
@@ -663,13 +663,15 @@ class ConstraintWidget(QtWidgets.QWidget, Ui_ConstraintWidgetUI):
             self.parent.communicate.statusBarUpdateSignal.emit(msg)
             return
 
-        # Get the results list
-        results = result[0][0]
         if isinstance(result[0], str):
             msg = ("Fitting failed with the following message: " +
                    result[0])
             self.parent.communicate.statusBarUpdateSignal.emit(msg)
             return
+
+        # Get the results list
+        results = result[0][0]
+
         if not results[0].success:
             if isinstance(results[0].mesg[0], str):
                 msg = ("Fitting failed with the following message: " +

--- a/src/sas/qtgui/Perspectives/Fitting/FittingWidget.py
+++ b/src/sas/qtgui/Perspectives/Fitting/FittingWidget.py
@@ -2110,6 +2110,10 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
 
         # Don't recalculate chi2 - it's in res.fitness already
         self.fitResults = True
+        if result is None or len(result) == 0 or len(result[0]) == 0:
+            msg = "Fitting failed."
+            self.communicate.statusBarUpdateSignal.emit(msg)
+            return
         res_list = result[0][0]
         res = res_list[0]
         self.chi2 = res.fitness


### PR DESCRIPTION
## Description

For some fitting failures, the result object is either None or an empty list. This causes unhandled behaviour and cryptic messages to the user.

Fixes #2994 (well, not actually fixes it but helps with diagnosis)

## How Has This Been Tested?

Local Win10 build

## Review Checklist:

[if using the editor, use `[x]` in place of `[ ]` to check a box]

**Documentation** (check at least one)
- [X] There is **nothing** that needs documenting
- [ ] Documentation changes are **in this PR**
- [ ] There is an **issue** open for the documentation (link?)

**Installers**
- [ ] There is a chance this will affect the **installers**, if so
  - [ ] **Windows** installer (GH artifact) has been tested (installed and worked) 
  - [ ] **MacOSX** installer (GH artifact) has been tested (installed and worked) 

**Licencing** (untick if necessary)
- [x] The introduced changes comply with SasView license (BSD 3-Clause)

