### PR TITLE
3030: Delete all files in installation directory

### DIFF
--- a/installers/installer.iss
+++ b/installers/installer.iss
@@ -42,6 +42,9 @@ WizardStyle=modern
 [Languages]
 Name: "english"; MessagesFile: "compiler:Default.isl"
 
+[Messages]
+DirExists=The folder:%n%n%1%n%nalready exists. All files and folders in the directory will be deleted. Would you like to install to that folder anyway?
+
 [Tasks]
 Name: "desktopicon"; Description: "{cm:CreateDesktopIcon}"; GroupDescription: "{cm:AdditionalIcons}"; Flags: unchecked
 Name: "quicklaunchicon"; Description: "{cm:CreateQuickLaunchIcon}"; GroupDescription: "{cm:AdditionalIcons}"; OnlyBelowVersion: 6.1; Check: not IsAdminInstallMode

--- a/installers/installer.iss
+++ b/installers/installer.iss
@@ -56,16 +56,14 @@ begin
       Result := True;
 end;
 
-{delete all files in the installation directory prior to installation to prevent conflicts}
-function PrepareToInstall(var NeedsRestart: Boolean): String;
-begin
-    DelTree("{app}", True, True, True);
-end;
-
 [Files]
 Source: "dist\sasview\sasview.exe"; DestDir: "{app}"; Flags: ignoreversion
 Source: "dist\sasview\plugin_models\*"; DestDir: "{%USERPROFILE}\.sasview\plugin_models"
 Source: "dist\sasview\*"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs createallsubdirs
+
+[InstallDelete]
+; Delete all files in the directory prior to installation to prevent version conflicts
+Type: filesandordirs; Name: "{app}"
 
 [Icons]
 Name: "{autodesktop}\{#MyAppName}"; Filename: "{app}\{#MyAppExeName}"; Tasks: desktopicon

--- a/installers/installer.iss
+++ b/installers/installer.iss
@@ -48,16 +48,18 @@ Name: "quicklaunchicon"; Description: "{cm:CreateQuickLaunchIcon}"; GroupDescrip
 
 [Code]
 { If there is a command-line parameter "skiplicense=true", don't display license page }
-begin
-    // delete all files in the installation directory to prevent install conflicts
-    DelTree('{app}', True, True, True);
-end;
 function ShouldSkipPage(PageID: Integer): Boolean;
 begin
   Result := False
   if PageId = wpLicense then
     if ExpandConstant('{param:skiplicense|false}') = 'true' then
       Result := True;
+end;
+
+{delete all files in the installation directory prior to installation to prevent conflicts}
+function PrepareToInstall(var NeedsRestart: Boolean): String;
+begin
+    DelTree("{app}", True, True, True);
 end;
 
 [Files]

--- a/installers/installer.iss
+++ b/installers/installer.iss
@@ -48,6 +48,10 @@ Name: "quicklaunchicon"; Description: "{cm:CreateQuickLaunchIcon}"; GroupDescrip
 
 [Code]
 { If there is a command-line parameter "skiplicense=true", don't display license page }
+begin
+    // delete all files in the installation directory to prevent install conflicts
+    DelTree('{app}', True, True, True);
+end;
 function ShouldSkipPage(PageID: Integer): Boolean;
 begin
   Result := False


### PR DESCRIPTION
## Description

This shows a custom message to the user whenever they choose an existing directory. If the user continues the installation, all files and folders are deleted from the directory.

Fixes #3030

## How Has This Been Tested?

Downloaded the windows installer and tested it works.

## Review Checklist:

**Documentation** (check at least one)
- [x] There is **nothing** that needs documenting
- [ ] Documentation changes are **in this PR**
- [ ] There is an **issue** open for the documentation (link?)

**Installers**
- [x] There is a chance this will affect the **installers**, if so
  - [ ] **Windows** installer (GH artifact) has been tested (installed and worked) 

**Licencing** (untick if necessary)
- [x] The introduced changes comply with SasView license (BSD 3-Clause)

