### PR TITLE
Documentation Window Identify Loaded File

### DIFF
--- a/src/sas/qtgui/Utilities/DocViewWidget.py
+++ b/src/sas/qtgui/Utilities/DocViewWidget.py
@@ -224,28 +224,14 @@ class DocViewWindow(QtWidgets.QDialog, Ui_DocViewerWindow):
         try:
             current_path = re.search(r'//(.*?)\'\)', str(self.webEngineViewer.url()))
             current_path = current_path.group(1)
-            current_path = Path(current_path)
         except:
             self.setWindowTitle("Documentation")
             return
         
-        # Try to add the title of the HTML page to the window title
+        # Try to add the filepath to the window title
         try:
-            with open(current_path, 'r', encoding='utf-8') as file:
-                html_content = file.read()
-
-                # Find the first <h1> tag and extract its content
-                match = re.search(r'<h1[^>]*>(.*?)</h1>', html_content, re.IGNORECASE)
-                if match:
-                    h1_content = match.group(1)
-
-                    # Split the content by any HTML tags and keep only the text before any tags
-                    no_tags_title = re.split(r'<[^>]+>', h1_content)[0]
-                    # Set the window title with the extracted text
-                    self.setWindowTitle(f"Documentation—{no_tags_title.strip()}")
-                    return
-                else:
-                    pass
+            self.setWindowTitle(f"Documentation—{current_path.strip()}")
+            return
         except:
             self.setWindowTitle("Documentation")
 

--- a/src/sas/qtgui/Utilities/DocViewWidget.py
+++ b/src/sas/qtgui/Utilities/DocViewWidget.py
@@ -2,7 +2,6 @@ import sys
 import os
 import logging
 import time
-import re
 from pathlib import Path
 
 from PySide6 import QtCore, QtWidgets, QtWebEngineCore
@@ -208,9 +207,6 @@ class DocViewWindow(QtWidgets.QDialog, Ui_DocViewerWindow):
         settings.setAttribute(QtWebEngineCore.QWebEngineSettings.LocalContentCanAccessRemoteUrls, True)
         settings.setAttribute(QtWebEngineCore.QWebEngineSettings.LocalContentCanAccessFileUrls, True)
         self.webEngineViewer.load(url)
-
-        # Set widget title to include the name of the document loaded
-        self.updateTitle()
 
         # Show widget
         self.onShow()

--- a/src/sas/qtgui/Utilities/DocViewWidget.py
+++ b/src/sas/qtgui/Utilities/DocViewWidget.py
@@ -222,18 +222,11 @@ class DocViewWindow(QtWidgets.QDialog, Ui_DocViewerWindow):
         """
         # Convert QUrl to pathlib path
         try:
-            current_path = re.search(r'//(.*?)\'\)', str(self.webEngineViewer.url()))
-            current_path = current_path.group(1)
-        except:
+            current_path = self.webEngineViewer.url().toLocalFile()
+            self.setWindowTitle(f"Documentation—{current_path.strip()}") # Try to add the filepath to the window title
+        except (AttributeError, TypeError, ValueError) as ex:
             self.setWindowTitle("Documentation")
-            return
-        
-        # Try to add the filepath to the window title
-        try:
-            self.setWindowTitle(f"Documentation—{current_path.strip()}")
-            return
-        except:
-            self.setWindowTitle("Documentation")
+            logging.warning(f"Error updating documentation window title: {ex}")
 
     def load404(self):
         self.webEngineViewer.setHtml(HTML_404)


### PR DESCRIPTION
## Description
Documentation window now displays the path of the file currently loaded in its title bar, which changes when the user navigates to a different file.

**NOTE:** If it is decided to display only the title of the documentation as opposed to the filepath, I have already implemented this in branch [2832-documentation-viewer-identify-file](https://github.com/SasView/sasview/tree/2832-documentation-viewer-identify-file). 

Fixes #2832 

## How Has This Been Tested?

Tested on Mac but not on Windows--I may have overlooked something to do with windows pathing.

## Review Checklist:

[if using the editor, use `[x]` in place of `[ ]` to check a box]

**Documentation** (check at least one)
- [x] There is **nothing** that needs documenting
- [ ] Documentation changes are **in this PR**
- [ ] There is an **issue** open for the documentation (link?)

**Installers**
- [ ] There is a chance this will affect the **installers**, if so
  - [ ] **Windows** installer (GH artifact) has been tested (installed and worked) 
  - [ ] **MacOSX** installer (GH artifact) has been tested (installed and worked) 

**Licencing** (untick if necessary)
- [x] The introduced changes comply with SasView license (BSD 3-Clause)

