### PR TITLE
remove/disable edit button

### DIFF
--- a/src/sas/qtgui/Utilities/DocViewWidget.py
+++ b/src/sas/qtgui/Utilities/DocViewWidget.py
@@ -79,11 +79,14 @@ class DocViewWindow(QtWidgets.QDialog, Ui_DocViewerWindow):
 
         self.initializeSignals()  # Connect signals
 
+        # Hide editing button for 6.0.0 release
+        self.editButton.setVisible(False)
+
         self.regenerateIfNeeded()
 
     def initializeSignals(self):
         """Initialize all external signals that will trigger events for the window."""
-        #self.editButton.clicked.connect(self.onEdit) TODO: Re-enable in later patch, do not delete
+        self.editButton.clicked.connect(self.onEdit)
         self.closeButton.clicked.connect(self.onClose)
         self.parent.communicate.documentationRegeneratedSignal.connect(self.refresh)
 

--- a/src/sas/qtgui/Utilities/DocViewWidget.py
+++ b/src/sas/qtgui/Utilities/DocViewWidget.py
@@ -83,7 +83,7 @@ class DocViewWindow(QtWidgets.QDialog, Ui_DocViewerWindow):
 
     def initializeSignals(self):
         """Initialize all external signals that will trigger events for the window."""
-        self.editButton.clicked.connect(self.onEdit)
+        #self.editButton.clicked.connect(self.onEdit) TODO: Re-enable in later patch, do not delete
         self.closeButton.clicked.connect(self.onClose)
         self.parent.communicate.documentationRegeneratedSignal.connect(self.refresh)
 

--- a/src/sas/qtgui/Utilities/UI/DocViewWidgetUI.ui
+++ b/src/sas/qtgui/Utilities/UI/DocViewWidgetUI.ui
@@ -45,19 +45,6 @@
       </spacer>
      </item>
      <item>
-      <widget class="QPushButton" name="editButton">
-       <property name="minimumSize">
-        <size>
-         <width>100</width>
-         <height>0</height>
-        </size>
-       </property>
-       <property name="text">
-        <string>Edit</string>
-       </property>
-      </widget>
-     </item>
-     <item>
       <widget class="QPushButton" name="closeButton">
        <property name="minimumSize">
         <size>

--- a/src/sas/qtgui/Utilities/UI/DocViewWidgetUI.ui
+++ b/src/sas/qtgui/Utilities/UI/DocViewWidgetUI.ui
@@ -45,6 +45,19 @@
       </spacer>
      </item>
      <item>
+      <widget class="QPushButton" name="editButton">
+       <property name="minimumSize">
+        <size>
+         <width>100</width>
+         <height>0</height>
+        </size>
+       </property>
+       <property name="text">
+        <string>Edit</string>
+       </property>
+      </widget>
+     </item>
+     <item>
       <widget class="QPushButton" name="closeButton">
        <property name="minimumSize">
         <size>


### PR DESCRIPTION
## Description

Remove the edit button in the documentation viewer window to simplify user experience for the 6.0.0 release. **Note** this PR does not remove the code for regenerating/editing documentation from the codebase--it only makes in inaccessible to the user. This will allow easy re-incorporation in a later patch/release.

Fixes #3072 

## How Has This Been Tested?

Tested on Mac--edit button is gone, making it impossible to initiate the documentation regeneration process without creating/loading a new user plugin (or plugin without documentation).

## Review Checklist:

[if using the editor, use `[x]` in place of `[ ]` to check a box]

**Documentation** (check at least one)
- [x] There is **nothing** that needs documenting
- [ ] Documentation changes are **in this PR**
- [ ] There is an **issue** open for the documentation (link?)

**Installers**
- [ ] There is a chance this will affect the **installers**, if so
  - [ ] **Windows** installer (GH artifact) has been tested (installed and worked) 
  - [ ] **MacOSX** installer (GH artifact) has been tested (installed and worked) 

**Licencing** (untick if necessary)
- [x] The introduced changes comply with SasView license (BSD 3-Clause)

