### PR TITLE
3016: Fix to PD changes

### DIFF
--- a/src/sas/qtgui/Perspectives/Fitting/FittingWidget.py
+++ b/src/sas/qtgui/Perspectives/Fitting/FittingWidget.py
@@ -1814,9 +1814,10 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
             if model_column not in delegate.columnDict():
                 return
             # Map the column to the poly param that was changed
-            associations = {1: "width", 4: "npts", 5: "nsigmas"}
-            self.poly_params[f"{parameter_name}.{associations.get(model_column, 'width')}"] = value
-            self.kernel_module.setParam(parameter_name_w, value)
+            associations = {1: "width", delegate.poly_npts: "npts", delegate.poly_nsigs: "nsigmas"}
+            p_name = f"{parameter_name}.{associations.get(model_column, 'width')}"
+            self.poly_params[p_name] = value
+            self.kernel_module.setParam(p_name, value)
 
             # Update plot
             self.updateData()


### PR DESCRIPTION
## Description

This takes the fix applied in #2991 a step further. The original fix did not account for the error column, and continued to modified the `.width` param regardless of the value changed.

Fixes #3016

## How Has This Been Tested?

Tested locally - different function produce different shape distributions.

## Review Checklist:

**Documentation** (check at least one)
- [x] There is **nothing** that needs documenting
- [ ] Documentation changes are **in this PR**
- [ ] There is an **issue** open for the documentation (link?)

**Installers**
- [x] There is a chance this will affect the **installers**, if so
  - [ ] **Windows** installer (GH artifact) has been tested (installed and worked) 
  - [x] **MacOSX** installer (GH artifact) has been tested (installed and worked) 

**Licencing** (untick if necessary)
- [x] The introduced changes comply with SasView license (BSD 3-Clause)

