### PR TITLE
check for empty arrays #3085

### DIFF
--- a/src/sas/qtgui/Plotting/Plotter.py
+++ b/src/sas/qtgui/Plotting/Plotter.py
@@ -285,15 +285,18 @@ class PlotterWidget(PlotterBase):
                 # factors of .99 and 1.01 provides a small gap so end points not shown right at edge
                 pad_delta = 0.01
 
-                default_x_range = ((1-pad_delta)*np.min(x), (1+pad_delta)*np.max(x))
+                default_x_range = self.ax.get_xlim() if not len(x) else ((1-pad_delta)*np.min(x), (1+pad_delta)*np.max(x))
 
                 # Need to make space for error bars
                 dy = data.view.dy
-                if dy is None:
-                    default_y_range = ((1-pad_delta) * np.min(y), (1+pad_delta) * np.max(y))
+                if not len(y):
+                    default_y_range = self.ax.get_ylim()
                 else:
-                    default_y_range = ((1-pad_delta)*np.min(np.array(y) - np.array(dy)),
-                                       (1+pad_delta)*np.max(np.array(y) + np.array(dy)))
+                    if dy is None:
+                        default_y_range = ((1-pad_delta) * np.min(y), (1+pad_delta) * np.max(y))
+                    else:
+                        default_y_range = ((1-pad_delta)*np.min(np.array(y) - np.array(dy)),
+                                        (1+pad_delta)*np.max(np.array(y) + np.array(dy)))
 
             else:
                 # Use default ranges given by matplotlib

--- a/src/sas/qtgui/Plotting/Plotter.py
+++ b/src/sas/qtgui/Plotting/Plotter.py
@@ -279,34 +279,34 @@ class PlotterWidget(PlotterBase):
             default_y_range = self.setRange.defaultYRange
             x_range = self.setRange.xrange()
             y_range = self.setRange.yrange()
-        else:
-            if isinstance(data, Data1D):
-                # Get default ranges from data
-                # factors of .99 and 1.01 provides a small gap so end points not shown right at edge
-                pad_delta = 0.01
+        elif isinstance(data, Data1D):
+            # Get default ranges from data
+            # factors of .99 and 1.01 provides a small gap so end points not shown right at edge
+            pad_delta = 0.01
 
-                default_x_range = self.ax.get_xlim() if not len(x) else ((1-pad_delta)*np.min(x), (1+pad_delta)*np.max(x))
+            default_x_range = self.ax.get_xlim() if not len(x) else ((1-pad_delta)*np.min(x), (1+pad_delta)*np.max(x))
 
-                # Need to make space for error bars
-                dy = data.view.dy
-                if not len(y):
-                    default_y_range = self.ax.get_ylim()
-                else:
-                    if dy is None:
-                        default_y_range = ((1-pad_delta) * np.min(y), (1+pad_delta) * np.max(y))
-                    else:
-                        default_y_range = ((1-pad_delta)*np.min(np.array(y) - np.array(dy)),
-                                        (1+pad_delta)*np.max(np.array(y) + np.array(dy)))
-
-            else:
-                # Use default ranges given by matplotlib
-                default_x_range = self.ax.get_xlim()
+            # Need to make space for error bars
+            dy = data.view.dy
+            if not len(y):
                 default_y_range = self.ax.get_ylim()
-
+            else:
+                if dy is None:
+                    default_y_range = ((1-pad_delta) * np.min(y), (1+pad_delta) * np.max(y))
+                else:
+                    default_y_range = ((1-pad_delta)*np.min(np.array(y) - np.array(dy)),
+                                    (1+pad_delta)*np.max(np.array(y) + np.array(dy)))
             x_range = default_x_range
             y_range = default_y_range
-
             modified = False
+        else:
+            # Use default ranges given by matplotlib
+            default_x_range = self.ax.get_xlim()
+            default_y_range = self.ax.get_ylim()
+            x_range = default_x_range
+            y_range = default_y_range
+            modified = False
+
         self.setRange = SetGraphRange(parent=self, x_range=x_range, y_range=y_range)
         self.setRange.rangeModified = modified
         self.setRange.defaultXRange = default_x_range


### PR DESCRIPTION
## Description

Sometimes when the x array for plotting is empty (empty dataset?), an exception is thrown. This fix should address the immediate problem. There still may be the issue of why the empty arrays are passed to plotting in the first place, though.

Fixes #3085 

## How Has This Been Tested?

Local win10 build

## Review Checklist:

[if using the editor, use `[x]` in place of `[ ]` to check a box]

**Documentation** (check at least one)
- [X] There is **nothing** that needs documenting
- [ ] Documentation changes are **in this PR**
- [ ] There is an **issue** open for the documentation (link?)

**Installers**
- [ ] There is a chance this will affect the **installers**, if so
  - [ ] **Windows** installer (GH artifact) has been tested (installed and worked) 
  - [ ] **MacOSX** installer (GH artifact) has been tested (installed and worked) 

**Licencing** (untick if necessary)
- [x] The introduced changes comply with SasView license (BSD 3-Clause)

