### PR TITLE
Fixed querying of the data dict at the removal step. Fixes #3015

### DIFF
--- a/src/sas/qtgui/MainWindow/DataExplorer.py
+++ b/src/sas/qtgui/MainWindow/DataExplorer.py
@@ -683,8 +683,9 @@ class DataExplorerWindow(DroppableDataLoadWidget):
         Delete selected rows from the model
         """
         # Assure this is indeed wanted
-        delete_msg = "This operation will remove the checked data from the data explorer." +\
-                     "\nDo you want to continue?"
+        delete_msg = "This operation will remove the selected data sets " +\
+                "and all the dependents from SasView." +\
+                "\nDo you want to continue?"
         reply = QtWidgets.QMessageBox.question(self,
                                                'Warning',
                                                delete_msg,
@@ -707,12 +708,13 @@ class DataExplorerWindow(DroppableDataLoadWidget):
                 # Close result panel if results represent the deleted data item
                 # Results panel only stores Data1D/Data2D object
                 #   => QStandardItems must still exist for direct comparison
-                self.closeResultPanelOnDelete(GuiUtils.dataFromItem(item))
+                data = GuiUtils.dataFromItem(item)
+                self.closeResultPanelOnDelete(data)
 
                 # Let others know we deleted data, before we delete it
                 self.communicator.dataDeletedSignal.emit([item])
                 # update stored_data
-                self.manager.update_stored_data([item])
+                self.manager.update_stored_data([data.name])
 
                 self.model.removeRow(ind)
                 # Decrement index since we just deleted it
@@ -1829,7 +1831,7 @@ class DataExplorerWindow(DroppableDataLoadWidget):
         """
         # Assure this is indeed wanted
         delete_msg = "This operation will remove the selected data sets " +\
-                     "and all the dependents from the data explorer." +\
+                     "and all the dependents from SasView." +\
                      "\nDo you want to continue?"
         reply = QtWidgets.QMessageBox.question(self,
                                                'Warning',


### PR DESCRIPTION
## Description

Fixed the issue of data manager keeping references to old, deleted datasets and unified the warning messages for various data deletion paths.

Fixes #3015

## How Has This Been Tested?

Local Win10 build.

## Review Checklist:

[if using the editor, use `[x]` in place of `[ ]` to check a box]

**Documentation** (check at least one)
- [X] There is **nothing** that needs documenting
- [ ] Documentation changes are **in this PR**
- [ ] There is an **issue** open for the documentation (link?)

**Installers**
- [ ] There is a chance this will affect the **installers**, if so
  - [ ] **Windows** installer (GH artifact) has been tested (installed and worked) 
  - [ ] **MacOSX** installer (GH artifact) has been tested (installed and worked) 

**Licencing** (untick if necessary)
- [x] The introduced changes comply with SasView license (BSD 3-Clause)

