### PR TITLE
Make the what's new page appear in front of the main window on Linux

### DIFF
--- a/src/sas/qtgui/MainWindow/GuiManager.py
+++ b/src/sas/qtgui/MainWindow/GuiManager.py
@@ -209,7 +209,7 @@ class GuiManager:
         self.GENSASCalculator = None
         self.DataOperation = DataOperationUtilityPanel(self)
         self.FileConverter = FileConverterWidget(self)
-        self.WhatsNew = WhatsNew(self)
+        self.WhatsNew = WhatsNew(self._parent)
         self.regenProgress = DocRegenProgress(self)
 
     def loadAllPerspectives(self):
@@ -661,7 +661,7 @@ class GuiManager:
         self.welcomePanel.show()
 
     def actionWhatsNew(self):
-        self.WhatsNew = WhatsNew(strictly_newer=False)
+        self.WhatsNew = WhatsNew(self._parent, strictly_newer=False)
         self.WhatsNew.show()
 
     def showWelcomeMessage(self):

--- a/src/sas/qtgui/Utilities/WhatsNew/WhatsNew.py
+++ b/src/sas/qtgui/Utilities/WhatsNew/WhatsNew.py
@@ -97,7 +97,7 @@ class WhatsNew(QDialog):
 
     """
     def __init__(self, parent=None, strictly_newer=True):
-        super().__init__()
+        super().__init__(parent)
 
         self.setWindowTitle(f"What's New in SasView {sasview_version}")
 


### PR DESCRIPTION
## Description

Previously, on my Ubuntu machine, the what's new page would appear behind the main window. This is problematic because the user will not immediately see the what's new page, and also the main window will not be responsive until the what's new window has been closed. This caused me a lot of confusion initially.

The reason for this is because the what's new parent is being set to the GuiManager not the MainWindow, and also this parent does not get passed to the QDialog instance thus QT doesn't internally know about its parent.

One thing that perhaps should be discussed is whether this fix should be implemented for any other windows/widgets in the application. I noticed other widgets are using GuiManager as their parent but wasn't sure if this was intentional, and I only wanted to apply the fix specifically for the what's new window in case something else broke.

## How Has This Been Tested?

Executing the script in the `run.py` file. After the fix, the what's new page appears on top of the main window as expected.

## Review Checklist:

**Documentation** (check at least one)
- [x] There is **nothing** that needs documenting
- [ ] Documentation changes are **in this PR**
- [ ] There is an **issue** open for the documentation (link?)

**Installers**
- [ ] There is a chance this will affect the **installers**, if so
  - [ ] **Windows** installer (GH artifact) has been tested (installed and worked) 
  - [ ] **MacOSX** installer (GH artifact) has been tested (installed and worked) 

**Licencing** 
- [x] The introduced changes comply with SasView license (BSD 3-Clause)

