### PR TITLE
3091: Use standard buttons in QMessageBox

### DIFF
--- a/src/sas/qtgui/MainWindow/DataExplorer.py
+++ b/src/sas/qtgui/MainWindow/DataExplorer.py
@@ -281,12 +281,10 @@ class DataExplorerWindow(DroppableDataLoadWidget):
             msgbox.setText(msg)
             msgbox.setWindowTitle("Project Load")
             # custom buttons
-            button_yes = QtWidgets.QPushButton("Yes")
-            msgbox.addButton(button_yes, QtWidgets.QMessageBox.YesRole)
-            button_no = QtWidgets.QPushButton("No")
-            msgbox.addButton(button_no, QtWidgets.QMessageBox.RejectRole)
-            retval = msgbox.exec_()
-            if retval == QtWidgets.QMessageBox.RejectRole:
+            msgbox.setStandardButtons(QtWidgets.QMessageBox.StandardButton.Yes |
+                                      QtWidgets.QMessageBox.StandardButton.No)
+            retval = msgbox.exec()
+            if retval == QtWidgets.QMessageBox.StandardButton.No:
                 # cancel fit
                 return
 


### PR DESCRIPTION
## Description

Use the standard Yes/No buttons for the QMessageBox instead of homebuilt ones. This fixes an issue where the user could click 'No' in a pop-up message and not cancel future actions.

Fixes #3091

## How Has This Been Tested?
Triggered the message box to load by loading a data set and then selecting 'File' -> 'Load Project'. I then clicked the 'No' button and the prompt returned me to SasView and no data was removed.

## Review Checklist:

**Documentation** (check at least one)
- [x] There is **nothing** that needs documenting
- [ ] Documentation changes are **in this PR**
- [ ] There is an **issue** open for the documentation (link?)

**Installers**
- [x] There is a chance this will affect the **installers**, if so
  - [ ] **Windows** installer (GH artifact) has been tested (installed and worked) 
  - [x] **MacOSX** installer (GH artifact) has been tested (installed and worked) 

**Licencing** (untick if necessary)
- [x] The introduced changes comply with SasView license (BSD 3-Clause)

