### PR TITLE
Make Documentation Viewer Accessible Throughout GUI

### DIFF
--- a/src/sas/qtgui/MainWindow/GuiManager.py
+++ b/src/sas/qtgui/MainWindow/GuiManager.py
@@ -369,7 +369,8 @@ class GuiManager:
         """
         pass
 
-    def showHelp(self, url):
+    @classmethod
+    def showHelp(cls, url):
         """
         Open a local url in the default browser
         """
@@ -383,7 +384,9 @@ class GuiManager:
             url_abs = Path(url)
         try:
             # Help window shows itself
-            self.helpWindow = DocViewWindow(parent=self, source=url_abs)
+            #NOTE: Needs to be a class attribute to keep from garbage collection
+            print(url_abs)
+            cls.helpWindow = GuiUtils.showHelp(url_abs)
         except Exception as ex:
             logging.warning("Cannot display help. %s" % ex)
 

--- a/src/sas/qtgui/MainWindow/GuiManager.py
+++ b/src/sas/qtgui/MainWindow/GuiManager.py
@@ -374,6 +374,8 @@ class GuiManager:
         """
         Open a local url in the default browser
         """
+        counter = 1
+        window_name = "help_window"
         # Remove leading forward slashes from relative paths to allow easy Path building
         if isinstance(url, str):
             url = url.lstrip("//")
@@ -383,9 +385,25 @@ class GuiManager:
         else:
             url_abs = Path(url)
         try:
-            # Help window shows itself
-            #NOTE: Needs to be a class attribute to keep from garbage collection
-            cls.helpWindow = GuiUtils.showHelp(url_abs)
+            # In order to have multiple help windows open simultaneously, we need to create a new class variable
+            # If we just reassign the old one, the old window will be destroyed
+            name_found = False # Have we found an available class variable to assign the help window to?
+            while name_found is False:
+                potential_help_window = getattr(cls, window_name, None) # A potential variable
+                if potential_help_window == None:
+                    # Create a new help window
+                    name_found = True
+                elif potential_help_window.isVisible():
+                    window_name = f"help_window_{counter}"
+                    counter += 1
+                    continue
+                else:
+                    name_found = True
+            
+            # Assign new variable to the GuiManager
+            setattr(cls, window_name, DocViewWindow(url_abs))
+            counter = 1 # Reset for future use of this method
+
         except Exception as ex:
             logging.warning("Cannot display help. %s" % ex)
 

--- a/src/sas/qtgui/MainWindow/GuiManager.py
+++ b/src/sas/qtgui/MainWindow/GuiManager.py
@@ -385,7 +385,6 @@ class GuiManager:
         try:
             # Help window shows itself
             #NOTE: Needs to be a class attribute to keep from garbage collection
-            print(url_abs)
             cls.helpWindow = GuiUtils.showHelp(url_abs)
         except Exception as ex:
             logging.warning("Cannot display help. %s" % ex)

--- a/src/sas/qtgui/Perspectives/Fitting/GPUOptions.py
+++ b/src/sas/qtgui/Perspectives/Fitting/GPUOptions.py
@@ -275,11 +275,9 @@ class GPUOptions(PreferencesWidget, Ui_GPUOptions):
         """
         Open the help menu when the help button is clicked
         """
-
-        # TODO - in future this should be linked to the local documentation, once there is a robust way of doing that
-        
-        # Display the page in default browser
-        webbrowser.open("https://www.sasview.org/docs/user/qtgui/Perspectives/Fitting/gpu_setup.html#device-selection")
+        from sas.qtgui.MainWindow.GuiManager import GuiManager
+        help_location = "user/qtgui/Perspectives/Fitting/gpu_setup.html#device-selection"
+        GuiManager.showHelp(help_location)
 
     def reject(self):
         """

--- a/src/sas/qtgui/Utilities/GuiUtils.py
+++ b/src/sas/qtgui/Utilities/GuiUtils.py
@@ -32,12 +32,14 @@ from sas.qtgui.Plotting.Plottables import Plottable
 from sasdata.dataloader.data_info import Sample, Source, Vector
 from sasdata.dataloader.data_info import Detector, Process, TransmissionSpectrum
 from sasdata.dataloader.data_info import Aperture, Collimation
+from sas.sascalc.doc_regen.makedocumentation import HELP_DIRECTORY_LOCATION
 from sas.qtgui.Plotting.Plottables import View
 from sas.qtgui.Plotting.Plottables import PlottableTheory1D
 from sas.qtgui.Plotting.Plottables import PlottableFit1D
 from sas.qtgui.Plotting.Plottables import Text
 from sas.qtgui.Plotting.Plottables import Chisq
 from sas.qtgui.MainWindow.DataState import DataState
+from sas.qtgui.Utilities.DocViewWidget import DocViewWindow
 
 from sas.sascalc.fit.AbstractFitEngine import FResult
 from sas.sascalc.fit.AbstractFitEngine import FitData1D, FitData2D
@@ -1452,3 +1454,19 @@ def enum(*sequential, **named):
     """Create an enumeration object from a list of strings"""
     enums = dict(zip(sequential, range(len(sequential))), **named)
     return type('Enum', (), enums)
+
+def showHelp(url: str | Path | os.PathLike):
+    if isinstance(url, str):
+        url = url.lstrip("//")
+    url = Path(url)
+    url_abs = HELP_DIRECTORY_LOCATION / url if str(HELP_DIRECTORY_LOCATION.resolve()) not in str(url.absolute()) else url
+
+    try:
+        help_window = DocViewWindow(source=url_abs)
+        help_window.show()
+        help_window.activateWindow()
+        help_window.setFocus()
+        # Return the window so the caller can keep it in scope to prevent garbage collection
+        return help_window
+    except Exception as ex:
+        logging.warning(f"Cannot display help: {ex}")


### PR DESCRIPTION
## Description

Makes the documentation viewer more accessible throughout the entire GUI.

Instead of requiring the documentation viewer widget to be a child of GuiManager, it now has no parent. However, it remains open until it is closed or SasView is closed because it is assigned to a class variable of the GuiManager class, which is always open. If there is already a documentation viewer open, a new (or old but unused) class variable is generated to store the new instance of the documentation window.

Additionally, this allows the GPU preferences `Help` button to be directed to a documentation viewer instead of being sent to a website. Fixes #2952 and resolves the remaining work from #2909.

## How Has This Been Tested?

Tested opening multiple documentation windows together; windows from different parts of the program; and windows that send to pages with section references (#'s).

## Review Checklist:

[if using the editor, use `[x]` in place of `[ ]` to check a box]

**Documentation** (check at least one)
- [x] There is **nothing** that needs documenting
- [ ] Documentation changes are **in this PR**
- [ ] There is an **issue** open for the documentation (link?)

**Installers**
- [ ] There is a chance this will affect the **installers**, if so
  - [ ] **Windows** installer (GH artifact) has been tested (installed and worked) 
  - [ ] **MacOSX** installer (GH artifact) has been tested (installed and worked) 

**Licencing** (untick if necessary)
- [x] The introduced changes comply with SasView license (BSD 3-Clause)

