### PR TITLE
3014: Beta approximation does not run

### DIFF
--- a/src/sas/qtgui/Perspectives/Fitting/FittingWidget.py
+++ b/src/sas/qtgui/Perspectives/Fitting/FittingWidget.py
@@ -2940,8 +2940,7 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
             # don't try to update multiplicity counters if they aren't there.
             # Note that this will fail for proper bad update where the model
             # doesn't contain multiplicity parameter
-            if self.kernel_module.params.get(parameter_name, None):
-                self.kernel_module.setParam(parameter_name, value)
+            self.kernel_module.setParam(parameter_name, value)
         elif model_column == min_column:
             # min/max to be changed in self.kernel_module.details[parameter_name] = ['Ang', 0.0, inf]
             self.kernel_module.details[parameter_name][1] = value


### PR DESCRIPTION
## Description

The changes related to multiplicity models (#2647) took a step too far and broke parameter updates for `structure_factor_mode` and other non-layer-parameter combo boxes. This removes an extra if statement that should not be reachable for the layer parameter. This might have a collateral effect on multiplicity models, though I couldn't find any.

Fixes #3014
Fixes #3053 (possibly)
Fixes #3108 (possibly)

## How Has This Been Tested?

Selected a P*S model and selected the beta approximation. The calculation generated the expected plots. Tested various features of multiplicity models to see if they still worked and did not notice anything off. Also tested the pinning of param values to 0.0 and that is, tangentially fixed.

## Review Checklist:

[if using the editor, use `[x]` in place of `[ ]` to check a box]

**Documentation** (check at least one)
- [x] There is **nothing** that needs documenting
- [ ] Documentation changes are **in this PR**
- [ ] There is an **issue** open for the documentation (link?)

**Installers**
- [x] There is a chance this will affect the **installers**, if so
  - [ ] **Windows** installer (GH artifact) has been tested (installed and worked) 
  - [ ] **MacOSX** installer (GH artifact) has been tested (installed and worked) 

**Licencing** (untick if necessary)
- [x] The introduced changes comply with SasView license (BSD 3-Clause)

