### PR TITLE
3109: Bumps FitProblem fix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,7 +119,7 @@ jobs:
           cd ../sasdata
           rm -rf build
           rm -rf dist
-          mv build/lib/sasdata/example_data/* ../sasview/src/sas/example_data/
+          mv sasdata/example_data/* ../sasview/src/sas/example_data/
           python -m pip install --no-deps .
 
       - name: Build and install sasmodels

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,8 +119,6 @@ jobs:
           cd ../sasdata
           rm -rf build
           rm -rf dist
-          python setup.py clean
-          python setup.py build
           mv build/lib/sasdata/example_data/* ../sasview/src/sas/example_data/
           python -m pip install --no-deps .
 
@@ -129,8 +127,6 @@ jobs:
           cd ../sasmodels
           rm -rf build
           rm -rf dist
-          python setup.py clean
-          python setup.py build
           python -m pip install --no-deps .
 
       - name: Build and install bumps
@@ -138,8 +134,6 @@ jobs:
           cd ../bumps
           rm -rf build
           rm -rf dist
-          python setup.py clean
-          python setup.py build
           python -m pip install --no-deps .
 
       ### Document the build environment
@@ -156,8 +150,6 @@ jobs:
           githash=$( git rev-parse HEAD )
           sed -i.bak s/GIT_COMMIT/$githash/g src/sas/sasview/__init__.py
           # BUILD SASVIEW
-          python setup.py clean
-          python setup.py build
           python -m pip install --no-deps .
 
       ### Run tests (if enabled)

--- a/src/sas/sascalc/fit/BumpsFitting.py
+++ b/src/sas/sascalc/fit/BumpsFitting.py
@@ -316,8 +316,7 @@ class BumpsFit(FitEngine):
         # Check if uncertainty is missing for any parameter
         uncertainty_warning = False
 
-        for fitting_module in problem.models:
-            fitness = fitting_module.fitness
+        for fitness in problem.models:
             pars = fitness.fitted_pars + fitness.computed_pars
             par_names = fitness.fitted_par_names + fitness.computed_par_names
 


### PR DESCRIPTION
## Description

This uses the new interface for bumps where every fit problem is multi-fit. Iterating through the models now directly returns the fitness object instead of the individual fit problem. This change brings SasView in line with this new behavior.

**This only fixes the majority of the issues related to this major change. Fits will continue to fail, but this PR allows the app to build and launch. See the issue for more info.**

Refs #3109

## Review Checklist:

**Licencing** (untick if necessary)
- [x] The introduced changes comply with SasView license (BSD 3-Clause)

