### PR TITLE
3126: Fix OpenCl and covariance issues

### DIFF
--- a/src/sas/qtgui/Perspectives/Fitting/GPUOptions.py
+++ b/src/sas/qtgui/Perspectives/Fitting/GPUOptions.py
@@ -57,6 +57,9 @@ class GPUOptions(PreferencesWidget, Ui_GPUOptions):
         self.add_options()
         self.progressBar.setVisible(False)
         self.progressBar.setFormat(" Test %v / %m")
+
+        # A local flag to know if opencl options have been staged or not. This is to prevent an OpenCL context refresh
+        #  when no refresh is required.
         self._staged_open_cl = None
 
         self.testButton.clicked.connect(self.testButtonClicked)
@@ -77,6 +80,8 @@ class GPUOptions(PreferencesWidget, Ui_GPUOptions):
 
     def applyNonConfigValues(self):
         """Applies values that aren't stored in config. Only widgets that require this need to override this method."""
+        # This is called anytime *any* preference change is made, not only from this widget, but any other preferences
+        #  widget. Track if openCL is changed locally to be sure the setter should be invoked.
         if self._staged_open_cl:
             self.set_sas_open_cl()
             self._staged_open_cl = None
@@ -112,6 +117,7 @@ class GPUOptions(PreferencesWidget, Ui_GPUOptions):
         self.openCLCheckBoxGroup.setMinimumWidth(self.optionsLayout.sizeHint().width()+10)
 
     def _unStageChange(self, key: str):
+        # The only staged change in this panel is the OpenCL selection. If any change is being unstaged, reset the flag.
         self._staged_open_cl = None
         super()._unStageChange(key)
 

--- a/src/sas/sascalc/fit/BumpsFitting.py
+++ b/src/sas/sascalc/fit/BumpsFitting.py
@@ -419,7 +419,6 @@ def run_bumps(problem, handler, curr_thread):
             x = fitdriver.fitter.state.draw().points
             n_parameters = x.shape[1]
             cov = np.cov(x.T, bias=True).reshape((n_parameters, n_parameters))
-            print(cov)
         else:
             cov = fitdriver.cov()
     except Exception as exc:

--- a/src/sas/sascalc/fit/BumpsFitting.py
+++ b/src/sas/sascalc/fit/BumpsFitting.py
@@ -415,8 +415,14 @@ def run_bumps(problem, handler, curr_thread):
     success = best is not None
     try:
         stderr = fitdriver.stderr() if success else None
-        cov = (fitdriver.cov() if not hasattr(fitdriver.fitter, 'state') else
-               np.cov(fitdriver.fitter.state.draw().points.T))
+        if not hasattr(fitdriver.fitter, 'state'):
+            cov = fitdriver.cov()
+        else:
+            x = fitdriver.fitter.state.draw().points
+            if x.shape[1] > 1:
+                cov = np.cov(x.T, bias=1)
+            else:
+                cov = np.array([[np.var(x.T, ddof=1)]])
     except Exception as exc:
         errors.append(str(exc))
         errors.append(traceback.format_exc())

--- a/src/sas/sascalc/fit/BumpsFitting.py
+++ b/src/sas/sascalc/fit/BumpsFitting.py
@@ -415,14 +415,13 @@ def run_bumps(problem, handler, curr_thread):
     success = best is not None
     try:
         stderr = fitdriver.stderr() if success else None
-        if not hasattr(fitdriver.fitter, 'state'):
-            cov = fitdriver.cov()
-        else:
+        if hasattr(fitdriver.fitter, 'state'):
             x = fitdriver.fitter.state.draw().points
-            if x.shape[1] > 1:
-                cov = np.cov(x.T, bias=1)
-            else:
-                cov = np.array([[np.var(x.T, ddof=1)]])
+            n_parameters = x.shape[1]
+            cov = np.cov(x.T, bias=True).reshape((n_parameters, n_parameters))
+            print(cov)
+        else:
+            cov = fitdriver.cov()
     except Exception as exc:
         errors.append(str(exc))
         errors.append(traceback.format_exc())

--- a/src/sas/sascalc/fit/BumpsFitting.py
+++ b/src/sas/sascalc/fit/BumpsFitting.py
@@ -274,6 +274,9 @@ class BumpsFit(FitEngine):
         # Run the fit
         result = run_bumps(problem, handler, curr_thread)
         if handler is not None:
+            if result['errors']:
+                handler.error(result['errors'])
+                return []
             handler.update_fit(last=True)
 
         # TODO: shouldn't reference internal parameters of fit problem


### PR DESCRIPTION
## Description

Any change to a preference was triggering an OpenCL environment reset, which was resulting in an OpenCL error when rerunning fits. This also fixes the tuple out of range issue noted by @wpotrzebowski in https://github.com/SasView/sasview/pull/3122#issuecomment-2414810923.

Fixes #3126

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

## Review Checklist:

**Documentation** (check at least one)
- [x] There is **nothing** that needs documenting
- [ ] Documentation changes are **in this PR**
- [ ] There is an **issue** open for the documentation (link?)

**Installers**
- [x] There is a chance this will affect the **installers**, if so
  - [ ] **Windows** installer (GH artifact) has been tested (installed and worked) 
  - [ ] **MacOSX** installer (GH artifact) has been tested (installed and worked) 

**Licencing** (untick if necessary)
- [x] The introduced changes comply with SasView license (BSD 3-Clause)

