### PR TITLE
Release 6.0.0: Show 404 message instead of regen

### DIFF
--- a/src/sas/qtgui/Perspectives/Fitting/FittingWidget.py
+++ b/src/sas/qtgui/Perspectives/Fitting/FittingWidget.py
@@ -1888,10 +1888,8 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         """
         Show the "Fitting" section of help
         """
-        regen_in_progress = False
         help_location = self.getHelpLocation(HELP_DIRECTORY_LOCATION)
-        if regen_in_progress is False:
-            self.parent.showHelp(help_location)
+        self.parent.showHelp(help_location)
 
     def getHelpLocation(self, tree_base) -> Path:
         # Actual file will depend on the current tab
@@ -1901,7 +1899,11 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         match tab_id:
             case 0:
                 # Look at the model and if set, pull out its help page
-                if self.kernel_module is not None and hasattr(self.kernel_module, 'name'):
+                # TODO: Disable plugin model documentation generation until issues can be resolved
+                plugin_names = [name for name, enabled in self.master_category_dict[CATEGORY_CUSTOM]]
+                if (self.kernel_module is not None
+                        and hasattr(self.kernel_module, 'name')
+                        and self.kernel_module.id not in plugin_names):
                     tree_location = tree_base / "user" / "models"
                     return tree_location / f"{self.kernel_module.id}.html"
                 else:

--- a/src/sas/qtgui/Perspectives/Fitting/FittingWidget.py
+++ b/src/sas/qtgui/Perspectives/Fitting/FittingWidget.py
@@ -1903,7 +1903,8 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
                 plugin_names = [name for name, enabled in self.master_category_dict[CATEGORY_CUSTOM]]
                 if (self.kernel_module is not None
                         and hasattr(self.kernel_module, 'name')
-                        and self.kernel_module.id not in plugin_names):
+                        and self.kernel_module.id not in plugin_names
+                        and not re.match("[A-Za-z0-9_-]+[+*@][A-Za-z0-9_-]+", self.kernel_module.id)):
                     tree_location = tree_base / "user" / "models"
                     return tree_location / f"{self.kernel_module.id}.html"
                 else:

--- a/src/sas/qtgui/Utilities/DocViewWidget.py
+++ b/src/sas/qtgui/Utilities/DocViewWidget.py
@@ -180,16 +180,16 @@ class DocViewWindow(QtWidgets.QDialog, Ui_DocViewerWindow):
                     self.regenerateHtml(self.source.name)
 
             # Test to see if HTML does not exist or is older than python file
-            elif self.newer(self.source, url_str):
-                self.regenerateHtml(self.source.name)
+            elif not os.path.exists(url_str):
+                self.load404()
             # Regenerate RST then HTML if no model file found OR if HTML is older than equivalent .py    
 
         elif "index" in url_str:
             # Regenerate if HTML is older than RST -- for index.html, which gets passed in differently because it is located in a different folder
             regen_string = rst_path / str(self.source.name).replace(".html", ".rst")
                 # Test to see if HTML does not exist or is older than python file
-            if self.newer(regen_string, self.source.absolute()):
-                self.regenerateHtml(regen_string)
+            if not os.path.exists(self.source.absolute()):
+                self.load404()
 
         else:
             # Regenerate if HTML is older than RST
@@ -199,8 +199,8 @@ class DocViewWindow(QtWidgets.QDialog, Ui_DocViewerWindow):
             html_path = html_path / model_local_path.split('#')[0]  # Remove jump links
             regen_string = rst_path / model_local_path.replace('.html', '.rst').split('#')[0] #Remove jump links
                 # Test to see if HTML does not exist or is older than python file
-            if self.newer(regen_string, html_path):
-                self.regenerateHtml(regen_string)
+            if not os.path.exists(html_path):
+                self.load404()
         
         if self.regen_in_progress is False:
             self.loadHtml() #loads the html file specified in the source url to the QWebViewer


### PR DESCRIPTION
## Description

This fixes the documentation issue noted by @wpotrzebowski in https://github.com/SasView/sasview/pull/3129#issuecomment-2425888386. The Mac rst files were all newer than the html files, which triggered the doc generation. Nothing (as of 11:52 EST 10/23) should trigger the documentation generation process at this point. If the files cannot be found, a 404 error will be shown instead of the documentation generation.

Tested using the installer from https://github.com/SasView/sasview/actions/runs/11465366459 and this fix seems to work.
