### PR TITLE
2897, 2922: Use latest version of external (numpy, scipy, PySide) packages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,7 +113,6 @@ jobs:
           git clone --depth=50 --branch=master https://github.com/SasView/sasdata.git ../sasdata
           git clone --depth=50 --branch=master https://github.com/SasView/sasmodels.git ../sasmodels
           git clone --depth=50 --branch=v0.9.3 https://github.com/bumps/bumps.git ../bumps
-          git clone --depth=50 --branch=master https://github.com/pkienzle/periodictable.git ../periodictable
 
       - name: Build and install sasdata
         run: |
@@ -133,13 +132,6 @@ jobs:
       - name: Build and install bumps
         run: |
           cd ../bumps
-          rm -rf build
-          rm -rf dist
-          python -m pip install --no-deps .
-
-      - name: Build and install periodictable
-        run: |
-          cd ../periodictable
           rm -rf build
           rm -rf dist
           python -m pip install --no-deps .

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,7 +112,8 @@ jobs:
         run: |
           git clone --depth=50 --branch=master https://github.com/SasView/sasdata.git ../sasdata
           git clone --depth=50 --branch=master https://github.com/SasView/sasmodels.git ../sasmodels
-          git clone --depth=50 --branch=master https://github.com/bumps/bumps.git ../bumps
+          git clone --depth=50 --branch=v0.9.3 https://github.com/bumps/bumps.git ../bumps
+          git clone --depth=50 --branch=master https://github.com/pkienzle/periodictable.git ../periodictable
 
       - name: Build and install sasdata
         run: |
@@ -132,6 +133,13 @@ jobs:
       - name: Build and install bumps
         run: |
           cd ../bumps
+          rm -rf build
+          rm -rf dist
+          python -m pip install --no-deps .
+
+      - name: Build and install periodictable
+        run: |
+          cd ../periodictable
           rm -rf build
           rm -rf dist
           python -m pip install --no-deps .

--- a/build_tools/requirements.txt
+++ b/build_tools/requirements.txt
@@ -1,6 +1,5 @@
 # Alphabetized list of OS and version agnostic dependencies
 appdirs
-bumps
 cffi
 docutils
 dominate
@@ -14,16 +13,19 @@ lxml
 mako
 matplotlib
 numba
+numpy
 periodictable
 pybind11
 pylint
 pyopengl
 pyparsing
+PySide6
 pytest
 pytest_qt
 pytest-mock
 pytools
 qtconsole
+scipy
 six
 sphinx
 superqt
@@ -38,6 +40,4 @@ zope
 pywin32; platform_system == "Windows"
 
 # Alphabetized list of version-pinned packages
-numpy==1.26.4  # 2.0.0 deprecates many functions used in the codebase (and potentially in dependencies)
-PySide6==6.4.3  # Later versions do not mesh well with pyinstaller < 6.0
-scipy==1.13.1  # 1.14 deprecates some functions used in the codebase (and potentially in dependencies)
+bumps==0.*  # v1.+ is very experimental

--- a/src/sas/sascalc/fit/BumpsFitting.py
+++ b/src/sas/sascalc/fit/BumpsFitting.py
@@ -346,8 +346,8 @@ class BumpsFit(FitEngine):
 
            # TODO: Let the GUI decided how to handle success/failure.
             if not fitting_result.success:
-                fitting_result.stderr[:] = np.NaN
-                fitting_result.fitness = np.NaN
+                fitting_result.stderr[:] = np.nan
+                fitting_result.fitness = np.nan
 
             all_results.append(fitting_result)
 
@@ -398,7 +398,7 @@ def run_bumps(problem, handler, curr_thread):
     try:
         best, fbest = fitdriver.fit()
     except Exception as exc:
-        best, fbest = None, np.NaN
+        best, fbest = None, np.nan
         errors.extend([str(exc), traceback.format_exc()])
     finally:
         mapper.stop_mapper(fitdriver.mapper)

--- a/src/sas/sascalc/fit/BumpsFitting.py
+++ b/src/sas/sascalc/fit/BumpsFitting.py
@@ -317,12 +317,12 @@ class BumpsFit(FitEngine):
         uncertainty_warning = False
 
         for fitting_module in problem.models:
-            # This makes BumpsFitting compatible with both bumps v0.9 and v1.0
+            # CRUFT: This makes BumpsFitting compatible with bumps v0.9 and v1.0
             if isinstance(fitting_module, SasFitness):
-                # Bumps v1+ - A Fitness object is returned
+                # Bumps v1.x+ - A Fitness object is returned
                 fitness = fitting_module
             else:
-                # Bumps v0 - A module is returned that holds the Fitness object
+                # Bumps v0.x - A module is returned that holds the Fitness object
                 fitness = fitting_module.fitness
             pars = fitness.fitted_pars + fitness.computed_pars
             par_names = fitness.fitted_par_names + fitness.computed_par_names

--- a/src/sas/sascalc/fit/BumpsFitting.py
+++ b/src/sas/sascalc/fit/BumpsFitting.py
@@ -316,7 +316,14 @@ class BumpsFit(FitEngine):
         # Check if uncertainty is missing for any parameter
         uncertainty_warning = False
 
-        for fitness in problem.models:
+        for fitting_module in problem.models:
+            # This makes BumpsFitting compatible with both bumps v0.9 and v1.0
+            if isinstance(fitting_module, SasFitness):
+                # Bumps v1+ - A Fitness object is returned
+                fitness = fitting_module
+            else:
+                # Bumps v0 - A module is returned that holds the Fitness object
+                fitness = fitting_module.fitness
             pars = fitness.fitted_pars + fitness.computed_pars
             par_names = fitness.fitted_par_names + fitness.computed_par_names
 


### PR DESCRIPTION
## Description

This updates the requirements file to use the latest versions of PySide6, numpy, and scipy, while locking bumps to versions less than 1. This also updates ci.yml to include these changes, and adds periodictable to the parallel repo list until another release is made with fixes for numpy compatibility.

Fixes #2857
Fixes #2897 
Fixes #2922

This is dependent on https://github.com/SasView/sasmodels/pull/613 and https://github.com/SasView/sasdata/pull/103 and will likely fail to build until they are merged.

## How Has This Been Tested?

Locally, all tests pass and I am able to run the program without issue.

## Review Checklist:
**Documentation** (check at least one)
- [x] There is **nothing** that needs documenting
- [ ] Documentation changes are **in this PR**
- [ ] There is an **issue** open for the documentation (link?)

**Installers**
- [x] There is a chance this will affect the **installers**, if so
  - [ ] **Windows** installer (GH artifact) has been tested (installed and worked) 
  - [ ] **MacOSX** installer (GH artifact) has been tested (installed and worked) 

**Licencing** (untick if necessary)
- [x] The introduced changes comply with SasView license (BSD 3-Clause)

