### PR TITLE
Set proper plot scales for ancillary plots

### DIFF
--- a/src/sas/qtgui/Plotting/Plotter.py
+++ b/src/sas/qtgui/Plotting/Plotter.py
@@ -186,12 +186,8 @@ class PlotterWidget(PlotterBase):
             self.yscale = 'linear'
 
         # Include scaling (log vs. linear)
-        if version.parse(mpl.__version__) < version.parse("3.3"):
-            ax.set_xscale(self.xscale, nonposx='clip') if self.xscale != 'linear' else self.ax.set_xscale(self.xscale)
-            ax.set_yscale(self.yscale, nonposy='clip') if self.yscale != 'linear' else self.ax.set_yscale(self.yscale)
-        else:
-            ax.set_xscale(self.xscale, nonpositive='clip') if self.xscale != 'linear' else self.ax.set_xscale(self.xscale)
-            ax.set_yscale(self.yscale, nonpositive='clip') if self.yscale != 'linear' else self.ax.set_yscale(self.yscale)
+        ax.set_xscale(self.xscale, nonpositive='clip') if self.xscale != 'linear' else self.ax.set_xscale(self.xscale)
+        ax.set_yscale(self.yscale, nonpositive='clip') if self.yscale != 'linear' else self.ax.set_yscale(self.yscale)
 
         # Draw non-standard markers
         l_width = markersize * 0.4

--- a/src/sas/qtgui/Plotting/Plotter.py
+++ b/src/sas/qtgui/Plotting/Plotter.py
@@ -178,6 +178,13 @@ class PlotterWidget(PlotterBase):
 
         markersize = data.markersize
 
+        # Use the plot role to define the x and y scales
+        if data.plot_role in [DataRole.ROLE_POLYDISPERSITY, DataRole.ROLE_RESIDUAL, DataRole.ROLE_STAND_ALONE]:
+            self.xscale = 'linear'
+        # X and Y are separate to accommodate future plot roles that might only need one axis on a linear scale
+        if data.plot_role in [DataRole.ROLE_POLYDISPERSITY, DataRole.ROLE_RESIDUAL, DataRole.ROLE_STAND_ALONE]:
+            self.yscale = 'linear'
+
         # Include scaling (log vs. linear)
         if version.parse(mpl.__version__) < version.parse("3.3"):
             ax.set_xscale(self.xscale, nonposx='clip') if self.xscale != 'linear' else self.ax.set_xscale(self.xscale)


### PR DESCRIPTION
## Description

This sets the default axis scales for plots based on their plot role. All plots are set to log/log in v6.0.0, including residuals, polydispersity, and P(r) plots. This also removes a matplotlib version check that should no longer be relevant.

## Review Checklist:

**Documentation** (check at least one)
- [ ] There is **nothing** that needs documenting
- [X] Documentation changes are **in this PR**
- [ ] There is an **issue** open for the documentation (link?)

**Installers**
- [ ] There is a chance this will affect the **installers**, if so
  - [ ] **Windows** installer (GH artifact) has been tested (installed and worked) 
  - [ ] **MacOSX** installer (GH artifact) has been tested (installed and worked) 

**Licencing** (untick if necessary)
- [x] The introduced changes comply with SasView license (BSD 3-Clause)

