### PR TITLE
Delete intermediate theory plots by tab id not model id.

### DIFF
--- a/src/sas/qtgui/MainWindow/DataExplorer.py
+++ b/src/sas/qtgui/MainWindow/DataExplorer.py
@@ -2069,7 +2069,7 @@ class DataExplorerWindow(DroppableDataLoadWidget):
         self.theory_model.appendRow(model_item)
         return model_item
 
-    def deleteIntermediateTheoryPlotsByModelID(self, model_id):
+    def deleteIntermediateTheoryPlotsByTabId(self, tab_id):
         """Given a model's ID, deletes all items in the theory item model which reference the same ID. Useful in the
         case of intermediate results disappearing when changing calculations (in which case you don't want them to be
         retained in the list)."""

--- a/src/sas/qtgui/MainWindow/GuiManager.py
+++ b/src/sas/qtgui/MainWindow/GuiManager.py
@@ -1331,12 +1331,12 @@ class GuiManager:
             return
         per.currentTab.setTheoryItem(item)
 
-    def deleteIntermediateTheoryPlotsByModelID(self, model_id):
+    def deleteIntermediateTheoryPlotsByModelID(self, tab_id):
         """
         Catch the signal to delete items in the Theory item model which correspond to a model ID.
         Send the request to the DataExplorer for updating the theory model.
         """
-        self.filesWidget.deleteIntermediateTheoryPlotsByModelID(model_id)
+        self.filesWidget.deleteIntermediateTheoryPlotsByModelID(tab_id)
 
     def updateModelFromDataOperationPanel(self, new_item, new_datalist_item):
         """

--- a/src/sas/qtgui/MainWindow/GuiManager.py
+++ b/src/sas/qtgui/MainWindow/GuiManager.py
@@ -697,7 +697,7 @@ class GuiManager:
         self.communicate.progressBarUpdateSignal.connect(self.updateProgressBar)
         self.communicate.perspectiveChangedSignal.connect(self.perspectiveChanged)
         self.communicate.updateTheoryFromPerspectiveSignal.connect(self.updateTheoryFromPerspective)
-        self.communicate.deleteIntermediateTheoryPlotsSignal.connect(self.deleteIntermediateTheoryPlotsByModelID)
+        self.communicate.deleteIntermediateTheoryPlotsSignal.connect(self.deleteIntermediateTheoryPlotsByTabId)
         self.communicate.plotRequestedSignal.connect(self.showPlot)
         self.communicate.plotFromNameSignal.connect(self.showPlotFromName)
         self.communicate.updateModelFromDataOperationPanelSignal.connect(self.updateModelFromDataOperationPanel)
@@ -1331,7 +1331,7 @@ class GuiManager:
             return
         per.currentTab.setTheoryItem(item)
 
-    def deleteIntermediateTheoryPlotsByModelID(self, tab_id):
+    def deleteIntermediateTheoryPlotsByTabId(self, tab_id):
         """
         Catch the signal to delete items in the Theory item model which correspond to a model ID.
         Send the request to the DataExplorer for updating the theory model.

--- a/src/sas/qtgui/MainWindow/GuiManager.py
+++ b/src/sas/qtgui/MainWindow/GuiManager.py
@@ -1336,7 +1336,7 @@ class GuiManager:
         Catch the signal to delete items in the Theory item model which correspond to a model ID.
         Send the request to the DataExplorer for updating the theory model.
         """
-        self.filesWidget.deleteIntermediateTheoryPlotsByModelID(tab_id)
+        self.filesWidget.deleteIntermediateTheoryPlotsByTabId(tab_id)
 
     def updateModelFromDataOperationPanel(self, new_item, new_datalist_item):
         """

--- a/src/sas/qtgui/Perspectives/Fitting/FittingWidget.py
+++ b/src/sas/qtgui/Perspectives/Fitting/FittingWidget.py
@@ -3301,7 +3301,7 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         else:
             # delete theory items for the model, in order to get rid of any
             # redundant items, e.g. beta(Q), S_eff(Q)
-            self.communicate.deleteIntermediateTheoryPlotsSignal.emit(self.kernel_module.id)
+            self.communicate.deleteIntermediateTheoryPlotsSignal.emit(str(self.tab_id))
 
         self._appendPlotsPolyDisp(new_plots, return_data, fitted_data)
 


### PR DESCRIPTION
## Description

I've tried to fix #3159 by changing the `deleteIntermediateTheoryPlotsByModelID` method so that it deletes by tab id, and not model id. This was causing the bug as we had 2 tabs with the same model, and it was trying to delete theory items from the other tab.

While this fixes the problem, I'm not entirely sure how suitable this fix is as I'm not aware of why this method was needed in the first place, and thus it could potentially break some other functionality. It would probably be useful to discuss this fix at the call. 

## How Has This Been Tested?

Followed the reproduction instructions Paul provided in #3159. I am no longer able to reproduce the bug in this pull request.

## Review Checklist:

**Documentation** (check at least one)
- [x] There is **nothing** that needs documenting
- [ ] Documentation changes are **in this PR**
- [ ] There is an **issue** open for the documentation (link?)

**Installers**
- [ ] There is a chance this will affect the **installers**, if so
  - [ ] **Windows** installer (GH artifact) has been tested (installed and worked) 
  - [ ] **MacOSX** installer (GH artifact) has been tested (installed and worked) 

**Licencing** (untick if necessary)
- [x] The introduced changes comply with SasView license (BSD 3-Clause)

