### PR TITLE
Cleaning up ci.yml after release 6.0.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -266,7 +266,7 @@ jobs:
           primary-bundle-id: "org.sasview.SasView6"
           appstore-connect-username: ${{ secrets.NOTARIZATION_USERNAME }}
           appstore-connect-password: ${{ secrets.NOTARIZATION_PASSWORD }}
-          appstore-connect-team-id: W2AG9MPZ43
+          appstore-connect-team-id: 8CX8K63BQM
           verbose: True
 
       - name: Staple Release Build (OSX)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -297,35 +297,6 @@ jobs:
             installers/dist/sasview6.tar.gz
           if-no-files-found: ignore
 
-      - name: Rename artifacts (Windows)
-        if: ${{ matrix.installer && startsWith(matrix.os, 'windows') }}
-        run: |
-          mv installers/dist/setupSasView.exe installers/dist/setupSasView-6.0.0-alpha-Win64.exe
-
-      - name: Rename artifacts (MacOS)
-        if: ${{ matrix.installer && startsWith(matrix.os, 'macos') }}
-        run: |    
-          mv installers/dist/SasView6.dmg  installers/dist/SasView-6.0.0-alpha-MacOSX.dmg
-
-      - name: Rename artifacts (Linux)
-        if: ${{ matrix.installer && startsWith(matrix.os, 'ubuntu') }}
-        run: |    
-          mv installers/dist/sasview6.tar.gz installers/dist/SasView-6.0.0-alpha-Linux.tar.gz
-
-      - name: Upload Release Installer to GitHub
-        if: ${{ matrix.installer }}
-        uses: ncipollo/release-action@v1
-        with:
-          draft: false
-          prerelease: true
-          allowUpdates: true
-          replacesArtifacts: true
-          token: ${{ secrets.GITHUB_TOKEN }}
-          artifacts: "installers/dist/*SasView-6.0.0-*"
-          name: "Release 6.0.0-alpha"
-          bodyFile: "build_tools/release_notes/6.0.0_notes.txt"
-          tag: "v6.0.0-alpha"
-
   test-installer:
     needs: [ build-matrix ]
 


### PR DESCRIPTION
## Description

Removing set of actions required for 6.0.0. Mac and Windows installers will still fail due to cert issues. 

Fixes # (issue/issues)
#3167 

## How Has This Been Tested?

Checked CI and installed and quickly tested Mac installer

## Review Checklist:

[if using the editor, use `[x]` in place of `[ ]` to check a box]

**Documentation** (check at least one)
- [x] There is **nothing** that needs documenting
- [ ] Documentation changes are **in this PR**
- [ ] There is an **issue** open for the documentation (link?)

**Installers**
- [ ] There is a chance this will affect the **installers**, if so
  - [ ] **Windows** installer (GH artifact) has been tested (installed and worked) 
  - [x] **MacOSX** installer (GH artifact) has been tested (installed and worked) 

**Licencing** (untick if necessary)
- [x] The introduced changes comply with SasView license (BSD 3-Clause)

