### PR TITLE
foolproof the fitter against bump's antics

### DIFF
--- a/src/sas/qtgui/Perspectives/Fitting/ConstraintWidget.py
+++ b/src/sas/qtgui/Perspectives/Fitting/ConstraintWidget.py
@@ -658,7 +658,7 @@ class ConstraintWidget(QtWidgets.QWidget, Ui_ConstraintWidgetUI):
         self.parent.fittingStoppedSignal.emit(self.getTabsForFit())
 
         # Assure the fitting succeeded
-        if result is None or not result:
+        if not result or not result[0] or not result[0][0]:
             msg = "Fitting failed."
             self.parent.communicate.statusBarUpdateSignal.emit(msg)
             return

--- a/src/sas/qtgui/Perspectives/Fitting/FitThread.py
+++ b/src/sas/qtgui/Perspectives/Fitting/FitThread.py
@@ -13,10 +13,20 @@ def map_getattr(classInstance, classFunc, *args):
     Take an instance of a class and a function name as a string.
     Execute class.function and return result
     """
-    return  getattr(classInstance, classFunc)(*args)
+    try:
+        return_value = getattr(classInstance, classFunc)(*args)
+    except Exception as ex:
+        logger.error("Fitting failed: %s", traceback.format_exc())
+        return None
+    return  return_value
 
 def map_apply(arguments):
-    return arguments[0](*arguments[1:])
+    try:
+        return_value = arguments[0](*arguments[1:])
+    except Exception as ex:
+        logger.error("Fitting failed: %s", traceback.format_exc())
+        return None
+    return return_value
 
 class FitThread(CalcThread):
     """Thread performing the fit """

--- a/src/sas/qtgui/Perspectives/Fitting/FittingWidget.py
+++ b/src/sas/qtgui/Perspectives/Fitting/FittingWidget.py
@@ -2108,9 +2108,11 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         #re-enable the Fit button
         self.enableInteractiveElements()
 
-        if len(result) == 0:
+        if result is None or len(result) == 0 or result[0] is None or len(result[0]) == 0 or result[0][0] is None or len(result[0][0]) == 0:
             msg = "Fitting failed."
             self.communicate.statusBarUpdateSignal.emit(msg)
+            # reload the kernel_module in case it's corrupted
+            self.kernel_module = copy.deepcopy(self.kernel_module_copy)
             return
 
         # Don't recalculate chi2 - it's in res.fitness already

--- a/src/sas/qtgui/Perspectives/Fitting/FittingWidget.py
+++ b/src/sas/qtgui/Perspectives/Fitting/FittingWidget.py
@@ -2108,7 +2108,7 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         #re-enable the Fit button
         self.enableInteractiveElements()
 
-        if result is None or len(result) == 0 or result[0] is None or len(result[0]) == 0 or result[0][0] is None or len(result[0][0]) == 0:
+        if not result or not result[0] or not result[0][0]:
             msg = "Fitting failed."
             self.communicate.statusBarUpdateSignal.emit(msg)
             # reload the kernel_module in case it's corrupted


### PR DESCRIPTION
## Description

Added guards against bad results returned by bumps in case fitting is canceled.

Fixes #3147

## How Has This Been Tested?

Local testing on win10

## Review Checklist:

[if using the editor, use `[x]` in place of `[ ]` to check a box]

**Documentation** (check at least one)
- [X] There is **nothing** that needs documenting
- [ ] Documentation changes are **in this PR**
- [ ] There is an **issue** open for the documentation (link?)

**Installers**
- [ ] There is a chance this will affect the **installers**, if so
  - [ ] **Windows** installer (GH artifact) has been tested (installed and worked) 
  - [ ] **MacOSX** installer (GH artifact) has been tested (installed and worked) 

**Licencing** (untick if necessary)
- [x] The introduced changes comply with SasView license (BSD 3-Clause)

