### PR TITLE
Removing macOS-13 from the regular build

### DIFF
--- a/.github/workflows/matrix.py
+++ b/.github/workflows/matrix.py
@@ -29,7 +29,6 @@ os_release_list = [
     'ubuntu-20.04',
     'ubuntu-22.04',
     'windows-latest',
-    'macos-13',
     'macos-latest',
 ]
 


### PR DESCRIPTION
## Description

As decided at the contributor camp in Lund, we will only build macos-latest in the regular builds and the macOS-13 only for the release. 

Fixes # (issue/issues)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

## Review Checklist:

[if using the editor, use `[x]` in place of `[ ]` to check a box]

**Documentation** (check at least one)
- [x] There is **nothing** that needs documenting
- [ ] Documentation changes are **in this PR**
- [ ] There is an **issue** open for the documentation (link?)

**Installers**
- [ ] There is a chance this will affect the **installers**, if so
  - [ ] **Windows** installer (GH artifact) has been tested (installed and worked) 
  - [x] **MacOSX** installer (GH artifact) has been tested (installed and worked) 

**Licencing** (untick if necessary)
- [x] The introduced changes comply with SasView license (BSD 3-Clause)

