### PR TITLE
Cherry pick of 3164 for release 6.0.1 - OSX Notarization

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -268,7 +268,7 @@ jobs:
           primary-bundle-id: "org.sasview.SasView6"
           appstore-connect-username: ${{ secrets.NOTARIZATION_USERNAME }}
           appstore-connect-password: ${{ secrets.NOTARIZATION_PASSWORD }}
-          appstore-connect-team-id: W2AG9MPZ43
+          appstore-connect-team-id: 8CX8K63BQM
           verbose: True
 
       - name: Staple Release Build (OSX)


### PR DESCRIPTION
## Description

This is a cherry-pick from #3164 to update the OSX notarization group ID. This should help the Mac builds get past the notarization step, but #3134 still applies so this step may still time out.

## How Has This Been Tested?
Tested as part of the previous PR and using the CI to see if the OSX builds are successful.

