### PR TITLE
3178 status bar message does not clear on gsc exit - against 6.0.1

### DIFF
--- a/src/sas/qtgui/Calculators/GenericScatteringCalculator.py
+++ b/src/sas/qtgui/Calculators/GenericScatteringCalculator.py
@@ -1532,6 +1532,8 @@ class GenericScatteringCalculator(QtWidgets.QDialog, Ui_GenericScatteringCalcula
         Overwrite the close event and hide the window instead of closing it
         """
         self.hideWindow()
+        # Clear the status bar
+        self.communicator.statusBarClearSignal.emit("")
         event.ignore()
 
     def update_file_name(self):


### PR DESCRIPTION
## Description

This PR addresses the issue with the status bar not clearing on GSC calculator exit

Fixes #3178 

This is the same PR as #3179 but reparented to `release_6.0.1`.
Subsequent merge of `release_6.0.1` into main will place this fix in it, so the original #3179 will be deleted.

## How Has This Been Tested?

Local testing on Win10

## Review Checklist:

[if using the editor, use `[x]` in place of `[ ]` to check a box]

**Documentation** (check at least one)
- [X] There is **nothing** that needs documenting
- [ ] Documentation changes are **in this PR**
- [ ] There is an **issue** open for the documentation (link?)

**Installers**
- [ ] There is a chance this will affect the **installers**, if so
  - [ ] **Windows** installer (GH artifact) has been tested (installed and worked) 
  - [ ] **MacOSX** installer (GH artifact) has been tested (installed and worked) 

**Licencing** (untick if necessary)
- [x] The introduced changes comply with SasView license (BSD 3-Clause)

