### PR TITLE
2868 call the system default csv viewer not excel

### DIFF
--- a/src/sas/qtgui/Utilities/GridPanel.py
+++ b/src/sas/qtgui/Utilities/GridPanel.py
@@ -13,7 +13,7 @@ from sas.qtgui.Utilities.UI.GridPanelUI import Ui_GridPanelUI
 
 class BatchOutputPanel(QtWidgets.QMainWindow, Ui_GridPanelUI):
     """
-    Class for stateless grid-like printout of model parameters for mutiple models
+    Class for stateless grid-like printout of model parameters for multiple models
     """
     ERROR_COLUMN_CAPTION = " (Err)"
     IS_WIN = (sys.platform == 'win32')
@@ -242,13 +242,13 @@ class BatchOutputPanel(QtWidgets.QMainWindow, Ui_GridPanelUI):
             excel_app.Workbooks.Open(self.grid_filename)
             excel_app.Visible = 1
         except Exception as ex:
-            msg = "Error occured when calling Excel.\n"
+            msg = "Error occurred when calling Excel.\n"
             msg += ex
             self.parent.communicate.statusBarUpdateSignal.emit(msg)
 
     def actionSaveFile(self):
         """
-        Generate a .csv file and dump it do disk
+        Generate a .csv file and dump it to disk
         """
         t = time.localtime(time.time())
         time_str = time.strftime("%b %d %H %M of %Y", t)

--- a/src/sas/qtgui/Utilities/GridPanel.py
+++ b/src/sas/qtgui/Utilities/GridPanel.py
@@ -5,6 +5,8 @@ import logging
 import webbrowser
 
 from PySide6 import QtCore, QtWidgets, QtGui
+from PySide6.QtCore import QMimeType, QMimeDatabase, QUrl
+from PySide6.QtGui import QDesktopServices
 
 import sas.qtgui.Utilities.GuiUtils as GuiUtils
 from sas.qtgui.Plotting.PlotterData import Data1D
@@ -38,10 +40,6 @@ class BatchOutputPanel(QtWidgets.QMainWindow, Ui_GridPanelUI):
 
         # save state
         self.data_dict = {}
-
-        # System dependent menu items
-        if not self.IS_WIN:
-            self.actionOpen_with_Excel.setVisible(False)
 
         # list of QTableWidgets, indexed by tab number
         self.tables = []
@@ -236,15 +234,15 @@ class BatchOutputPanel(QtWidgets.QMainWindow, Ui_GridPanelUI):
             self.writeBatchToFile(data=data, tmpfile=tmpfile, details=details)
             tmpfile.close()
 
-        try:
-            from win32com.client import Dispatch
-            excel_app = Dispatch('Excel.Application')
-            excel_app.Workbooks.Open(self.grid_filename)
-            excel_app.Visible = 1
-        except Exception as ex:
-            msg = "Error occurred when calling Excel.\n"
-            msg += ex
-            self.parent.communicate.statusBarUpdateSignal.emit(msg)
+        mime_type = QMimeDatabase().mimeTypeForFile(self.grid_filename)
+
+        if mime_type.isValid():
+            url = QUrl.fromLocalFile(self.grid_filename)
+
+            if QDesktopServices.openUrl(url):
+                print("File opened successfully.")
+            else:
+                print("Failed to open file.")
 
     def actionSaveFile(self):
         """

--- a/src/sas/qtgui/Utilities/GridPanel.py
+++ b/src/sas/qtgui/Utilities/GridPanel.py
@@ -240,9 +240,12 @@ class BatchOutputPanel(QtWidgets.QMainWindow, Ui_GridPanelUI):
             url = QUrl.fromLocalFile(self.grid_filename)
 
             if QDesktopServices.openUrl(url):
-                print("File opened successfully.")
+                self.parent.communicate.statusBarUpdateSignal.emit("Success: "
+                "The batch results CSV file successfully opened in your system CSV viewer.")
             else:
-                print("Failed to open file.")
+                self.parent.communicate.statusBarUpdateSignal.emit("Failure: A CSV viewer "
+                    "is required to view the batch results. Please set one in your default "
+                    "app settings to change this behavior.")
 
     def actionSaveFile(self):
         """

--- a/src/sas/qtgui/Utilities/UI/GridPanelUI.ui
+++ b/src/sas/qtgui/Utilities/UI/GridPanelUI.ui
@@ -118,7 +118,7 @@
   </action>
   <action name="actionOpen_with_Excel">
    <property name="text">
-    <string>Open with Excel</string>
+    <string>Open in CSV Viewer</string>
    </property>
   </action>
   <action name="actionSave">


### PR DESCRIPTION
## Description

Batch Fit Results table now has the option to open as a spreadsheet regardless of OS and opens to default system CSV viewer instead of only Excel. The button to do this is still labeled 'Open with Excel', though this would not be difficult to change - the only question is what to.

Fixes # 2868

## How Has This Been Tested?

Tested manually by opening a set of fit results on Mac and Linux. Confirmed that 'Open with Excel' button is visible and opens to default CSV viewer.

Have not tested whether this works on Windows, or that data is correct - though nothing about generating the csv to open has changed, so this should be fine. I just don't know how to get actual batch fit results.

## Review Checklist:

**Documentation** (check at least one)
- [x] There is **nothing** that needs documenting
- [ ] Documentation changes are **in this PR**
- [ ] There is an **issue** open for the documentation (link?)

**Installers**
- [ ] There is a chance this will affect the **installers**, if so
  - [ ] **Windows** installer (GH artifact) has been tested (installed and worked) 
  - [ ] **MacOSX** installer (GH artifact) has been tested (installed and worked) 

**Licencing** (untick if necessary)
- [x] The introduced changes comply with SasView license (BSD 3-Clause)

