### PR TITLE
Fix calls to set_xticklabels and set_yticklabels

### DIFF
--- a/src/sas/qtgui/Plotting/Plotter.py
+++ b/src/sas/qtgui/Plotting/Plotter.py
@@ -906,12 +906,12 @@ class PlotterWidget(PlotterBase):
             # self.ax.tick_params(axis='x', labelsize=fx.size, labelcolor=fx.color)
             from matplotlib.pyplot import gca
             a = gca()
-            a.set_xticklabels(a.get_xticks(), fx)
+            a.set_xticklabels(a.get_xticks(), **fx)
         if apply_y:
             # self.ay.tick_params(axis='y', labelsize=fy.size, labelcolor=fy.color)
             from matplotlib.pyplot import gca
             a = gca()
-            a.set_yticklabels(a.get_yticks(), fy)
+            a.set_yticklabels(a.get_yticks(), **fy)
         self.canvas.draw_idle()
 
     def onMplMouseDown(self, event):


### PR DESCRIPTION
## Description

Fixes #3189 

## How Has This Been Tested?

Followed the reproduction steps in the issue, and the error no longer appears.

@butlerpd can you please confirm that the intended behaviour now occurs? If you run SasView from this branch, please ignore any errors with 'NameError: name 'model_id' is not defined'; I have fixed these in a separate PR.

## Review Checklist:

**Documentation** (check at least one)
- [x] There is **nothing** that needs documenting
- [ ] Documentation changes are **in this PR**
- [ ] There is an **issue** open for the documentation (link?)

**Installers**
- [ ] There is a chance this will affect the **installers**, if so
  - [ ] **Windows** installer (GH artifact) has been tested (installed and worked) 
  - [ ] **MacOSX** installer (GH artifact) has been tested (installed and worked) 

**Licencing** (untick if necessary)
- [x] The introduced changes comply with SasView license (BSD 3-Clause)

