### PR TITLE
Remove bumps dependence from doc build.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,7 +112,6 @@ jobs:
         run: |
           git clone --depth=50 --branch=master https://github.com/SasView/sasdata.git ../sasdata
           git clone --depth=50 --branch=master https://github.com/SasView/sasmodels.git ../sasmodels
-          git clone --depth=50 --branch=v0.9.3 https://github.com/bumps/bumps.git ../bumps
 
       - name: Build and install sasdata
         run: |
@@ -125,13 +124,6 @@ jobs:
       - name: Build and install sasmodels
         run: |
           cd ../sasmodels
-          rm -rf build
-          rm -rf dist
-          python -m pip install --no-deps .
-
-      - name: Build and install bumps
-        run: |
-          cd ../bumps
           rm -rf build
           rm -rf dist
           python -m pip install --no-deps .
@@ -174,10 +166,10 @@ jobs:
 
       ### Build documentation (if enabled)
 
-      - name: Build sasmodels, sasdata, and bumps docs
+      - name: Build sasmodels and sasdata docs
         if: ${{ matrix.docs }}
         run: |
-          make -C ../bumps/doc html || true
+          # TODO: supress sasmodels cache for the doc build
           mkdir -p ~/.sasmodels/compiled_models
           make -j4 -C ../sasmodels/doc html || true
           make -C ../sasdata/docs html || true

--- a/docs/sphinx-docs/build_sphinx.py
+++ b/docs/sphinx-docs/build_sphinx.py
@@ -67,12 +67,6 @@ SASDATA_DEV_TARGET = joinpath(SPHINX_SOURCE, "dev", "sasdata-dev")
 SASDATA_GUIDE_SOURCE = joinpath(SASDATA_DOCS, "source", "user")
 SASDATA_GUIDE_TARGET = joinpath(SPHINX_SOURCE, "user", "data")
 
-# bumps paths
-BUMPS_DOCS = joinpath(SASVIEW_ROOT, "..", "bumps", "doc")
-BUMPS_SOURCE = joinpath(BUMPS_DOCS, "guide")
-BUMPS_TARGET = joinpath(SPHINX_PERSPECTIVES, "Fitting")
-
-
 run = SourceFileLoader('run', joinpath(SASVIEW_ROOT, 'run.py')).load_module()
 run.prepare()
 
@@ -166,33 +160,11 @@ def retrieve_user_docs():
 
 def retrieve_sasdata_docs():
     """
-        Copies select files from the bumps documentation into fitting perspective
+    Copies the sasdata documentation tree into sasview.
     """
     print("=== Sasdata Docs ===")
     copy_tree(SASDATA_DEV_SOURCE, SASDATA_DEV_TARGET)
     copy_tree(SASDATA_GUIDE_SOURCE, SASDATA_GUIDE_TARGET)
-
-
-def retrieve_bumps_docs():
-    """
-    Copies select files from the bumps documentation into fitting perspective
-    """
-    if exists(BUMPS_SOURCE):
-        print("=== Retrieve BUMPS Docs ===")
-        filenames = glob(joinpath(BUMPS_SOURCE, "dream-*.png"))
-        #filenames = [joinpath(BUMPS_SOURCE, "optimizer.rst")]
-        #filenames += glob(joinpath(BUMPS_SOURCE, "dream-*.png"))
-        #filenames += glob(joinpath(BUMPS_SOURCE, "fit-*.png"))
-        for f in filenames:
-            print("Copying file", f)
-            shutil.copy(f, BUMPS_TARGET)
-    else:
-        print("""
-======= Error =======
-missing directory %s
-The documentation will not include the optimizer selection section.
-Checkout the bumps source tree and rebuild the docs.
-""" % BUMPS_DOCS)
 
 
 def apidoc():
@@ -289,7 +261,6 @@ def rebuild():
     clean()
     setup_source_temp()
     retrieve_user_docs()
-    retrieve_bumps_docs()
     retrieve_sasdata_docs()
     apidoc()
     build()


### PR DESCRIPTION
## Description

The bumps tree is not required for doc build because the relevant files (optimizer.rst and dream-*.png) are already in the sasview repo. Remove references to bumps from the doc build and treat it as a normal third-party package in the CI.

Fixes #2673

## How Has This Been Tested?

Checking whether docs build without the bumps source tree.

## Review Checklist:

[if using the editor, use `[x]` in place of `[ ]` to check a box]

**Documentation** (check at least one)
- [ ] There is **nothing** that needs documenting
- [ ] Documentation changes are **in this PR**
- [ ] There is an **issue** open for the documentation (link?)

**Installers**
- [ ] There is a chance this will affect the **installers**, if so
  - [ ] **Windows** installer (GH artifact) has been tested (installed and worked) 
  - [ ] **MacOSX** installer (GH artifact) has been tested (installed and worked) 

**Licencing** (untick if necessary)
- [x] The introduced changes comply with SasView license (BSD 3-Clause)

