### PR TITLE
Start webfit

### DIFF
--- a/src/sas/cli.py
+++ b/src/sas/cli.py
@@ -110,7 +110,7 @@ def main(logging="production"):
 
     # I/O redirection for the windows console. Need to do this early so that
     # output will be displayed on the console. Presently not working for
-    # for production (it always opens the console even if it is not needed)
+    # production (it always opens the console even if it is not needed)
     # so require "sasview con ..." to open the console. Not an infamous
     # "temporary fix" I hope...
     if "-i" in sys.argv[1:] or "-o" in sys.argv[1:]:

--- a/src/sas/webfit/analyze/fitting/urls.py
+++ b/src/sas/webfit/analyze/fitting/urls.py
@@ -9,11 +9,11 @@ info_patterns = [
     path("", views.fit_info),
     path("status/", views.status, name = "get status using fit_id"),
     path("parameters/", views.view_parameters, name = "current parameters"),
-    #TODO impliment parameter trace
+    #TODO implement parameter trace
     #path("parameter_history/"),
     #TODO allow user to find specific parts of results
     path("results/", views.view_results, name = "current results"),
-    #TODO impliment results trace
+    #TODO implement results trace
     #path("results_history/")
 ]
 

--- a/src/sas/webfit/analyze/fitting/views.py
+++ b/src/sas/webfit/analyze/fitting/views.py
@@ -16,7 +16,7 @@ from sasmodels.bumps_model import Model, Experiment
 from sasmodels.direct_model import DirectModel
 from sas.sascalc.fit.models import ModelManager
 
-#TODO categoryinstallers should belong in SasView.Systen rather than in QTGUI
+#TODO categoryinstallers should belong in SasView.System rather than in QTGUI
 from sas.qtgui.Utilities.CategoryInstaller import CategoryInstaller
 
 from serializers import (

--- a/src/sas/webfit/analyze/models.py
+++ b/src/sas/webfit/analyze/models.py
@@ -20,7 +20,7 @@ class AnalysisBase(models.Model):
                                         help_text="use GPU rather than CPU")
     #TODO create gpu_used
 
-    time_recieved = models.DateTimeField(auto_now_add=True, 
+    time_received = models.DateTimeField(auto_now_add=True,
                                          help_text="analysis requested")
     #TODO write in view to start these
     time_started = models.DateTimeField(auto_now=False, blank=True, 

--- a/src/sas/webfit/data/models.py
+++ b/src/sas/webfit/data/models.py
@@ -18,7 +18,7 @@ class Data(models.Model):
 
     #imported data
     #user can either import a file path or actual file
-    #TODO upload_to should instead create a new directionry using user.id to name
+    #TODO upload_to should instead create a new directory using user.id to name
     file = models.FileField(blank=False, default=None, help_text="This is a file", 
                             upload_to="uploaded_files", storage=FileSystemStorage())
 
@@ -28,4 +28,4 @@ class Data(models.Model):
     is_public = models.BooleanField(default=False, 
                                     help_text= "opt in to submit your data into example pool")
 
-    #TODO add date,recieved, expiration_data, expired boolean, delete if expired
+    #TODO add date,received, expiration_data, expired boolean, delete if expired

--- a/src/sas/webfit/data/views.py
+++ b/src/sas/webfit/data/views.py
@@ -107,7 +107,7 @@ def download(request, data_id, version = None):
                 return HttpResponseBadRequest("data is private, must log in")
         #TODO add issues later
         try:
-            file = storage.open(serializer.file_name, 'rb')
+            file = storage.open(serializer.file.name, 'rb')
         except Exception as e:
             return HttpResponseBadRequest(str(e))
         if file is None:

--- a/src/sas/webfit/data/views.py
+++ b/src/sas/webfit/data/views.py
@@ -2,7 +2,7 @@ import os
 
 from django.shortcuts import get_object_or_404
 from django.http import HttpResponseBadRequest, HttpResponseForbidden, Http404
-from django.core.files.storage import FileSystemStorage 
+from django.core.files.storage import FileSystemStorage
 
 #TODO go over to see if token is needed for is_authenticated
 from rest_framework.authtoken.models import Token

--- a/src/sas/webfit/serializers.py
+++ b/src/sas/webfit/serializers.py
@@ -99,6 +99,6 @@ class FitParameterSerializer(ModelSerializer):
 
 class FitConstraintSerializer(ModelSerializer):
     class Meta:
-        model = FitConstriant
+        model = FitConstraint
         fields = "__all__"
 """

--- a/src/sas/webfit/settings.py
+++ b/src/sas/webfit/settings.py
@@ -214,7 +214,7 @@ USE_TZ = True
 STATIC_ROOT = os.path.join(BASE_DIR, 'static')
 STATIC_URL = '/static/'
 
-#instead of doing this, create a create a new media_root 
+#instead of doing this, create a new media_root
 MEDIA_ROOT = os.path.join(BASE_DIR, "media")
 MEDIA_URL = '/media/'
 

--- a/src/sas/webfit/settings.py
+++ b/src/sas/webfit/settings.py
@@ -49,6 +49,7 @@ INSTALLED_APPS = [
     "django.contrib.auth",
     "django.contrib.contenttypes",
     "django.contrib.messages",
+    "django.contrib.sessions",
     "django.contrib.staticfiles",
     'django.contrib.sites',
     "rest_framework",
@@ -75,6 +76,7 @@ MIDDLEWARE = [
     "django.contrib.auth.middleware.AuthenticationMiddleware",
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
+    "allauth.account.middleware.AccountMiddleware",
 ]
 
 ROOT_URLCONF = "urls"

--- a/src/sas/webfit/upload_example_data.py
+++ b/src/sas/webfit/upload_example_data.py
@@ -5,6 +5,7 @@ import json
 import logging
 import django
 from glob import glob
+from sasdata import example_data
 
 # Initialise the Django environment. This must be done before importing anything
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "settings")
@@ -14,7 +15,7 @@ from django.contrib.auth.models import User
 from django.core.files.uploadedfile import SimpleUploadedFile
 from data.models import Data
 
-EXAMPLE_DATA_DIR = os.environ.get("EXAMPLE_DATA_DIR", "../example_data")
+EXAMPLE_DATA_DIR = os.environ.get("EXAMPLE_DATA_DIR", os.path.dirname(example_data.__file__))
 
 def parse_1D():
     dir_1d = os.path.join(EXAMPLE_DATA_DIR, "1d_data")

--- a/src/sas/webfit/urls.py
+++ b/src/sas/webfit/urls.py
@@ -25,7 +25,7 @@ logger = logging.getLogger(__name__)
 #TO DO: finalize version control
 
 #base urls 
-# no urls for pluggins currently
+# no urls for plugins currently
 urlpatterns = [
     #admin page
     path("admin/", admin.site.urls, name = "admin page"),


### PR DESCRIPTION
## Description

Made changes to settings.py in webfit to address errors in running the server and  user authentication. I suspect the issues were due to using Django version 5.1 when webfit was originally written using 4.2. Also changed a reference to the example_data directory to access it from sasdata rather than its original location in sasview, and fixed some minor spelling errors.

## How Has This Been Tested?

Successfully started webfit locally using python manage.py runserver.

## Review Checklist:

[if using the editor, use `[x]` in place of `[ ]` to check a box]

**Documentation** (check at least one)
- [ ] There is **nothing** that needs documenting
- [ ] Documentation changes are **in this PR**
- [ ] There is an **issue** open for the documentation (link?)

**Installers**
- [ ] There is a chance this will affect the **installers**, if so
  - [ ] **Windows** installer (GH artifact) has been tested (installed and worked) 
  - [ ] **MacOSX** installer (GH artifact) has been tested (installed and worked) 

**Licencing** (untick if necessary)
- [x] The introduced changes comply with SasView license (BSD 3-Clause)

