### PR TITLE
remove need for old "six" library

### DIFF
--- a/build_tools/requirements.txt
+++ b/build_tools/requirements.txt
@@ -26,7 +26,6 @@ pytest-mock
 pytools
 qtconsole
 scipy
-six
 sphinx
 superqt
 tinycc

--- a/src/sas/sascalc/fit/models.py
+++ b/src/sas/sascalc/fit/models.py
@@ -13,8 +13,6 @@ import py_compile
 import shutil
 import io
 
-from six import reraise
-
 from sasmodels.sasview_model import load_custom_model, load_standard_models
 
 from sas.system.user import get_user_dir
@@ -139,7 +137,7 @@ class ReportProblem(object):
         type, value, tb = sys.exc_info()
         if type is not None and issubclass(type, py_compile.PyCompileError):
             print("Problem with", repr(value))
-            reraise(type, value, tb)
+            raise value
         return 1
 
 report_problem = ReportProblem()


### PR DESCRIPTION
## Description

This remove the last reference to a logn obsolete Python2+3 compatibility layer

## How Has This Been Tested?

I plan to include this patch in Debian
https://wiki.debian.org/Python3-six-removal

**Licencing** (untick if necessary)
- [x] The introduced changes comply with SasView license (BSD 3-Clause)

