### PR TITLE
3211: Fix for sasmodel doc build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -179,6 +179,8 @@ jobs:
 
       - name: Build sasmodels, sasdata, and bumps docs
         if: ${{ matrix.docs }}
+        env:
+          SAS_OPENCL: NONE
         run: |
           make -C ../bumps/doc html || true
           mkdir -p ~/.sasmodels/compiled_models

--- a/build_tools/requirements.txt
+++ b/build_tools/requirements.txt
@@ -24,6 +24,7 @@ pytest_qt
 pytest-mock
 pytools
 qtconsole
+siphash24
 six
 sphinx
 superqt


### PR DESCRIPTION
## Description

This disables OpenCL during the sasmodels doc generation to allow the model figures to be generated under Windows.

Fixes #3211

## How Has This Been Tested?

CI

## Review Checklist:

**Installers**
- [X] There is a chance this will affect the **installers**, if so
  - [ ] **Windows** installer (GH artifact) has been tested (installed and worked) 
  - [ ] **MacOSX** installer (GH artifact) has been tested (installed and worked) 

**Licencing** (untick if necessary)
- [x] The introduced changes comply with SasView license (BSD 3-Clause)

