### PR TITLE
Remove Ubuntu 20.04 from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -302,7 +302,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [ windows-latest, ubuntu-20.04 ]
+        os: [ windows-latest, ubuntu-22.04 ]
         python-version: [ 3.11 ]
       fail-fast: false
 

--- a/.github/workflows/matrix.py
+++ b/.github/workflows/matrix.py
@@ -26,7 +26,6 @@ jobs = []
 #   dynamically linked by pyinstaller.
 #   https://pyinstaller.readthedocs.io/en/stable/usage.html#making-gnu-linux-apps-forward-compatible
 os_release_list = [
-    'ubuntu-20.04',
     'ubuntu-22.04',
     'windows-latest',
     'macos-latest',


### PR DESCRIPTION
## Description

As discussed in an email exchange, Github are no longer going to be supporting their Ubuntu 20.04 runner image from 1st April. In my opinion, there is not much reason to build Ubuntu installers for this specific release. It is nearly 5 years old, and in May Ubuntu's 'standard support' for this version will end meaning further updates will require an Ubuntu Pro subscription. For users who, for whatever reason, cannot upgrade from Ubuntu 20.04, they can use the Flatpak to install SasView.

This branch also now tests the Ubuntu installer on 22.04 instead of 20.04.

## How Has This Been Tested?

After this PR is created, I'll check the CI to make sure we're not building any Ubuntu 20.04 installers. And of course check all the CI checks pass.

## Review Checklist:

**Documentation** (check at least one)
- [x] There is **nothing** that needs documenting
- [ ] Documentation changes are **in this PR**
- [ ] There is an **issue** open for the documentation (link?)

**Installers**
- [ ] There is a chance this will affect the **installers**, if so
  - [ ] **Windows** installer (GH artifact) has been tested (installed and worked) 
  - [ ] **MacOSX** installer (GH artifact) has been tested (installed and worked) 

**Licencing** (untick if necessary)
- [x] The introduced changes comply with SasView license (BSD 3-Clause)

