### PR TITLE
Remove bookmark button

### DIFF
--- a/src/sas/example_data/saved_states/fit_pr_and_invariant_project.svs
+++ b/src/sas/example_data/saved_states/fit_pr_and_invariant_project.svs
@@ -690,7 +690,6 @@
 					<fit_enable_low>False</fit_enable_low>
 				</state_6>
 			</history>
-			<bookmark/>
 		</invariant>
 	</SASentry>
 	<SASentry>

--- a/src/sas/example_data/saved_states/test.inv
+++ b/src/sas/example_data/saved_states/test.inv
@@ -1310,7 +1310,6 @@
 					</fit_enable_low>
 				</state_0>
 			</history>
-			<bookmark/>
 		</invariant>
 	</SASentry>
 </SASroot>

--- a/src/sas/qtgui/MainWindow/UI/MainWindowUI.ui
+++ b/src/sas/qtgui/MainWindow/UI/MainWindowUI.ui
@@ -194,7 +194,6 @@
    <addaction name="actionRedo"/>
    <addaction name="actionCopy"/>
    <addaction name="actionPaste"/>
-   <addaction name="actionBookmarks"/>
    <addaction name="separator"/>
    <addaction name="actionPrevious"/>
    <addaction name="actionNext"/>
@@ -287,18 +286,6 @@
   <action name="actionSaveParamsAs">
    <property name="text">
     <string>Save Params to File</string>
-   </property>
-  </action>
-  <action name="actionBookmarks">
-   <property name="checkable">
-    <bool>true</bool>
-   </property>
-   <property name="icon">
-    <iconset>
-     <normaloff>:/res/bookmark.png</normaloff>:/res/bookmark.png</iconset>
-   </property>
-   <property name="text">
-    <string>Bookmarks</string>
    </property>
   </action>
   <action name="actionPerspective">

--- a/src/sas/qtgui/Perspectives/Fitting/media/fitting_help.rst
+++ b/src/sas/qtgui/Perspectives/Fitting/media/fitting_help.rst
@@ -596,16 +596,6 @@ To *paste* parameters, either:
 If either operation is successful a message will appear in the info line at the
 bottom of the SasView window.
 
-Bookmark
-^^^^^^^^
-
-To *Bookmark* a *Fit Page* either:
-
-*  Select a *Fit Page* and then click on *Bookmark* in the tool bar, or
-*  Right-click and select the *Bookmark* in the popup menu.
-
-.. ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ
-
 .. _Status_bar:
 
 Status Bar & Log Explorer


### PR DESCRIPTION
## Description

Removed the bookmark button, and some other references to it. As discussed in #3213 , it doesn't appear to be implemented.

## How Has This Been Tested?

Ran SasView. The bookmark button no longer appears. I tried loading the save states that used to contain a tag for it but from what I can understand, they are all in the old format anyway. I was getting errors but I don't think those were caused by this branch.

## Review Checklist:

**Documentation** (check at least one)
- [ ] There is **nothing** that needs documenting
- [x] Documentation changes are **in this PR**
- [ ] There is an **issue** open for the documentation (link?)

**Installers**
- [ ] There is a chance this will affect the **installers**, if so
  - [ ] **Windows** installer (GH artifact) has been tested (installed and worked) 
  - [ ] **MacOSX** installer (GH artifact) has been tested (installed and worked) 

**Licencing** (untick if necessary)
- [x] The introduced changes comply with SasView license (BSD 3-Clause)

