### PR TITLE
3233: Fix for empty plugin model directory

### DIFF
--- a/src/sas/qtgui/Perspectives/Fitting/FittingWidget.py
+++ b/src/sas/qtgui/Perspectives/Fitting/FittingWidget.py
@@ -1900,7 +1900,7 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
             case 0:
                 # Look at the model and if set, pull out its help page
                 # TODO: Disable plugin model documentation generation until issues can be resolved
-                plugin_names = [name for name, enabled in self.master_category_dict[CATEGORY_CUSTOM]]
+                plugin_names = [name for name, enabled in self.master_category_dict.get(CATEGORY_CUSTOM, {})]
                 if (self.kernel_module is not None
                         and hasattr(self.kernel_module, 'name')
                         and self.kernel_module.id not in plugin_names


### PR DESCRIPTION
## Description

This fixes an issue where the model help wouldn't display if the plugin model directory was empty.

Fixes #3233

## Review Checklist:

**Documentation** (check at least one)
- [x] There is **nothing** that needs documenting
- [ ] Documentation changes are **in this PR**
- [ ] There is an **issue** open for the documentation (link?)

**Installers**
- [ ] There is a chance this will affect the **installers**, if so
  - [ ] **Windows** installer (GH artifact) has been tested (installed and worked) 
  - [ ] **MacOSX** installer (GH artifact) has been tested (installed and worked) 

**Licencing** (untick if necessary)
- [x] The introduced changes comply with SasView license (BSD 3-Clause)

