### PR TITLE
3226 whats new window also shows previous version information

### DIFF
--- a/src/sas/qtgui/MainWindow/GuiManager.py
+++ b/src/sas/qtgui/MainWindow/GuiManager.py
@@ -143,7 +143,7 @@ class GuiManager:
                                               "_downloads",
                                               "Tutorial.pdf"))
 
-        if self.WhatsNew.has_new_messages():
+        if self.WhatsNew.has_new_messages(): # Not a static method
             self.actionWhatsNew()
 
     def info(self, type, value, tb):

--- a/src/sas/qtgui/MainWindow/GuiManager.py
+++ b/src/sas/qtgui/MainWindow/GuiManager.py
@@ -679,7 +679,7 @@ class GuiManager:
         self.welcomePanel.show()
 
     def actionWhatsNew(self):
-        self.WhatsNew = WhatsNew(self._parent, strictly_newer=False)
+        self.WhatsNew = WhatsNew(self._parent, only_recent=False)
         self.WhatsNew.show()
 
     def showWelcomeMessage(self):

--- a/src/sas/qtgui/MainWindow/GuiManager.py
+++ b/src/sas/qtgui/MainWindow/GuiManager.py
@@ -144,7 +144,7 @@ class GuiManager:
                                               "Tutorial.pdf"))
 
         if self.WhatsNew.has_new_messages(): # Not a static method
-            self.actionWhatsNew()
+            self.WhatsNew.show()
 
     def info(self, type, value, tb):
         logger.error("".join(traceback.format_exception(type, value, tb)))

--- a/src/sas/qtgui/Utilities/WhatsNew/WhatsNew.py
+++ b/src/sas/qtgui/Utilities/WhatsNew/WhatsNew.py
@@ -119,6 +119,7 @@ class WhatsNew(QDialog):
         self.buttonBar.setLayout(self.buttonLayout)
 
         self.closeButton = QPushButton("Close")
+        self.prevButton = QPushButton("Prev")
         self.nextButton = QPushButton("Next")
 
         # Only show the show on startup checkbox if we're not up-to-date
@@ -135,6 +136,7 @@ class WhatsNew(QDialog):
 
         # other buttons
         self.buttonLayout.addSpacerItem(QtWidgets.QSpacerItem(40, 20, QtWidgets.QSizePolicy.Expanding, QtWidgets.QSizePolicy.Minimum))
+        self.buttonLayout.addWidget(self.prevButton)
         self.buttonLayout.addWidget(self.nextButton)
 
 
@@ -145,6 +147,7 @@ class WhatsNew(QDialog):
 
         # Callbacks
         self.closeButton.clicked.connect(self.close_me)
+        self.prevButton.clicked.connect(self.prev_file)
         self.nextButton.clicked.connect(self.next_file)
 
         # # Gather new files
@@ -169,6 +172,12 @@ class WhatsNew(QDialog):
         """ Show the next available file (increment counter, show)"""
         self.current_index += 1
         self.current_index %= self.max_index
+        self.show_file()
+
+    def prev_file(self):
+        self.current_index -= 1
+        if self.current_index < 0:
+            self.current_index = self.max_index - 1
         self.show_file()
 
     def show_file(self):

--- a/src/sas/qtgui/Utilities/WhatsNew/WhatsNew.py
+++ b/src/sas/qtgui/Utilities/WhatsNew/WhatsNew.py
@@ -164,6 +164,7 @@ class WhatsNew(QDialog):
         self.current_index = 0
 
         self.show_file()
+        self.set_enable_disable_prev_next()
 
         self.setFixedSize(800, 600)
         self.setModal(True)
@@ -173,12 +174,28 @@ class WhatsNew(QDialog):
         self.current_index += 1
         self.current_index %= self.max_index
         self.show_file()
+        self.set_enable_disable_prev_next()
 
     def prev_file(self):
+        """ Go to next file"""
         self.current_index -= 1
         if self.current_index < 0:
             self.current_index = self.max_index - 1
         self.show_file()
+        self.set_enable_disable_prev_next()
+
+    def set_enable_disable_prev_next(self):
+        """ Set the appropriate enable state on the navigation buttons"""
+
+        if self.current_index == 0:
+            self.prevButton.setEnabled(False)
+        else:
+            self.prevButton.setEnabled(True)
+
+        if self.current_index >= self.max_index - 1:
+            self.nextButton.setEnabled(False)
+        else:
+            self.nextButton.setEnabled(True)
 
     def show_file(self):
         """ Set the text of the window to the file with the current index"""

--- a/src/sas/qtgui/Utilities/WhatsNew/WhatsNew.py
+++ b/src/sas/qtgui/Utilities/WhatsNew/WhatsNew.py
@@ -150,10 +150,10 @@ class WhatsNew(QDialog):
         # # Gather new files
         new_messages = whats_new_messages(only_recent=only_recent)
         new_message_directories = [key for key in new_messages.keys()]
-        new_message_directories.sort(key=reduced_version)
+        new_message_directories.sort(key=reduced_version, reverse=True)
 
         self.all_messages = []
-        
+
         for version in new_message_directories:
             self.all_messages += new_messages[version]
 

--- a/src/sas/qtgui/Utilities/WhatsNew/WhatsNew.py
+++ b/src/sas/qtgui/Utilities/WhatsNew/WhatsNew.py
@@ -15,10 +15,10 @@ from sas.qtgui.Utilities.WhatsNew.newer import strictly_newer_than, reduced_vers
 
 
 
-def whats_new_messages(strictly_newer=True):
+def whats_new_messages(only_recent=True):
     """ Accumulate all files that are newer than the value in the config
 
-    :param strictly_newer: require strictly newer stuff, strictness is needed for showing new things
+    :param only_recent: require strictly newer stuff, strictness is needed for showing new things
                            when there is an update, non-strictness is needed for the menu access.
     """
 
@@ -31,11 +31,11 @@ def whats_new_messages(strictly_newer=True):
             newer = False
 
             try:
-                if strictly_newer:
+                if only_recent:
                     newer = strictly_newer_than(child_dir.name, config.LAST_WHATS_NEW_HIDDEN_VERSION)
                 else:
                     # Include current version
-                    newer = not strictly_newer_than(config.LAST_WHATS_NEW_HIDDEN_VERSION, child_dir.name)
+                    newer = strictly_newer_than(child_dir.name, "0.0.0")
 
             except ValueError:
                 pass
@@ -96,7 +96,7 @@ class WhatsNew(QDialog):
     To add new messages, just dump a (self-contained) html file into the appropriate folder
 
     """
-    def __init__(self, parent=None, strictly_newer=True):
+    def __init__(self, parent=None, only_recent=True):
         super().__init__(parent)
 
         self.setWindowTitle(f"What's New in SasView {sasview_version}")
@@ -148,13 +148,13 @@ class WhatsNew(QDialog):
         self.nextButton.clicked.connect(self.next_file)
 
         # # Gather new files
-        new_messages = whats_new_messages(strictly_newer=strictly_newer)
+        new_messages = whats_new_messages(only_recent=only_recent)
         new_message_directories = [key for key in new_messages.keys()]
         new_message_directories.sort(key=reduced_version)
 
         self.all_messages = []
-
-        for version in new_messages:
+        
+        for version in new_message_directories:
             self.all_messages += new_messages[version]
 
         self.max_index = len(self.all_messages)

--- a/src/sas/qtgui/Utilities/WhatsNew/WhatsNew.py
+++ b/src/sas/qtgui/Utilities/WhatsNew/WhatsNew.py
@@ -24,26 +24,26 @@ def whats_new_messages(strictly_newer=True):
 
     out = defaultdict(list)
     message_dir = resources.files("sas.qtgui.Utilities.WhatsNew.messages")
-    for message_dir in message_dir.iterdir():
+    for child_dir in message_dir.iterdir():
         # Get short filename
-        if message_dir.is_dir():
+        if child_dir.is_dir():
 
             newer = False
 
             try:
                 if strictly_newer:
-                    newer = strictly_newer_than(message_dir.name, config.LAST_WHATS_NEW_HIDDEN_VERSION)
+                    newer = strictly_newer_than(child_dir.name, config.LAST_WHATS_NEW_HIDDEN_VERSION)
                 else:
                     # Include current version
-                    newer = not strictly_newer_than(config.LAST_WHATS_NEW_HIDDEN_VERSION, message_dir.name)
+                    newer = not strictly_newer_than(config.LAST_WHATS_NEW_HIDDEN_VERSION, child_dir.name)
 
             except ValueError:
                 pass
 
             if newer:
-                for file in message_dir.iterdir():
+                for file in child_dir.iterdir():
                     if file.name.endswith(".html"):
-                        out[message_dir.name].append(file)
+                        out[child_dir.name].append(file)
 
 
     return out
@@ -166,11 +166,13 @@ class WhatsNew(QDialog):
         self.setModal(True)
 
     def next_file(self):
+        """ Show the next available file (increment counter, show)"""
         self.current_index += 1
         self.current_index %= self.max_index
         self.show_file()
 
     def show_file(self):
+        """ Set the text of the window to the file with the current index"""
         if len(self.all_messages) > 0:
             filename = self.all_messages[self.current_index]
             with open(filename, 'r') as fid:
@@ -180,6 +182,7 @@ class WhatsNew(QDialog):
             self.browser.setHtml("<html><body><h1>You should not see this!!!</h1></body></html>")
 
     def close_me(self):
+        """ Close action, needs to save the state for showing """
         if self.showAgain is not None:
             if not self.showAgain.isChecked():
                 # We choose the newest, for backwards compatability, i.e. we never reduce the last version


### PR DESCRIPTION
## Description

🦠🦗🐞🦋 - Fewer Bugs!!! - Fixed the problem with it showing old what's new messages. 

🔀📨📨📨 - Better Organisation!!! - Retained all what's new message in the help, but put them in a better order.

🏔️ 🏕️ 🏖️🚤- Better navigation!!! - Added a prev button, and some enabling/disabling.

Fixes #3225

## How Has This Been Tested?

Some manual testing

## Review Checklist:

[if using the editor, use `[x]` in place of `[ ]` to check a box]

**Documentation** (check at least one)
- [x] There is **nothing** that needs documenting
- [ ] Documentation changes are **in this PR**
- [ ] There is an **issue** open for the documentation (link?)

**Installers**
- [ ] There is a chance this will affect the **installers**, if so
  - [ ] **Windows** installer (GH artifact) has been tested (installed and worked) 
  - [ ] **MacOSX** installer (GH artifact) has been tested (installed and worked) 

**Licencing** (untick if necessary)
- [x] The introduced changes comply with SasView license (BSD 3-Clause)

