### PR TITLE
3250: Replace tinycc with tccbox

### DIFF
--- a/build_tools/requirements.txt
+++ b/build_tools/requirements.txt
@@ -31,7 +31,7 @@ scipy
 siphash24
 sphinx
 superqt
-tinycc
+tccbox
 twisted
 uncertainties
 unittest-xml-reporting

--- a/installers/sasview.spec
+++ b/installers/sasview.spec
@@ -38,10 +38,10 @@ import sasmodels
 add_data(sasmodels.data_files())
 
 try:
-    import tinycc
-    add_data(tinycc.data_files())
+    import tccbox
+    datas.append((os.path.join(PYTHON_PACKAGES, 'tccbox'), 'tccbox'))
 except ImportError:
-    warnings.warn("TinyCC package is not available and will not be included")
+    warnings.warn("TCCbox package is not available and will not be included")
 
 import periodictable
 add_data(periodictable.data_files())
@@ -67,6 +67,7 @@ hiddenimports = [
     'debugpy',
     'debugpy._vendored',
     'uncertainties',
+    'tccbox',
 ]
 
 if platform.system() == 'Windows':


### PR DESCRIPTION
## Description

Built binaries were having trouble compiling models ever since the change from tinycc to tccbox in sasmodels. This ensures developers testing the binaries are able to run fits.

Fixes #3250

## Review Checklist:

[if using the editor, use `[x]` in place of `[ ]` to check a box]

**Documentation** (check at least one)
- [x] There is **nothing** that needs documenting
- [ ] Documentation changes are **in this PR**
- [ ] There is an **issue** open for the documentation (link?)

**Installers**
- [x] There is a chance this will affect the **installers**, if so
  - [ ] **Windows** installer (GH artifact) has been tested (installed and worked) 
  - [ ] **MacOSX** installer (GH artifact) has been tested (installed and worked) 

**Licencing** (untick if necessary)
- [x] The introduced changes comply with SasView license (BSD 3-Clause)

