### PR TITLE
Include images icons and css in sasview package

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+recursive-include src/sas/qtgui *.png *.svg *.css


### PR DESCRIPTION
## Description

This PR adds a `MANIFEST.in` file at the root which controls which additional package data will be included in built wheels and pip installs of `sasview`

This fixes an issue where pip installing from source results in an unusable state, where `site-packages/sas/qtgui` is missing all the .png and .css files needed to run the application

## How Has This Been Tested?

I tried to start the sasview GUI from the command line after pip installing from source, and it failed.  Then I added this file, re-ran `pip install .`, and then tried starting the GUI, and it worked.

## Review Checklist:

[if using the editor, use `[x]` in place of `[ ]` to check a box]

**Documentation** (check at least one)
- [ ] There is **nothing** that needs documenting
- [x] Documentation changes are **in this PR**
- [ ] There is an **issue** open for the documentation (link?)

**Installers**
- [x] There is a chance this will affect the **installers**, if so
  - [ ] **Windows** installer (GH artifact) has been tested (installed and worked) 
  - [ ] **MacOSX** installer (GH artifact) has been tested (installed and worked) 

**Licencing** (untick if necessary)
- [x] The introduced changes comply with SasView license (BSD 3-Clause)

