### PR TITLE
Compatibility with bumps>=1.0.0b3

### DIFF
--- a/src/sas/sascalc/fit/BumpsFitting.py
+++ b/src/sas/sascalc/fit/BumpsFitting.py
@@ -423,7 +423,7 @@ def run_bumps(problem, handler, curr_thread):
     success = best is not None
     try:
         stderr = fitdriver.stderr() if success else None
-        if hasattr(fitdriver.fitter, 'state'):
+        if hasattr(fitdriver.fitter, 'state') and hasattr(fitdriver.fitter.state, 'draw'):
             x = fitdriver.fitter.state.draw().points
             n_parameters = x.shape[1]
             cov = np.cov(x.T, bias=True).reshape((n_parameters, n_parameters))

--- a/src/sas/sascalc/fit/BumpsFitting.py
+++ b/src/sas/sascalc/fit/BumpsFitting.py
@@ -340,9 +340,9 @@ class BumpsFit(FitEngine):
             # TODO: should scale stderr by sqrt(chisq/DOF) if dy is unknown
             fitting_result.success = result['success']
             fitting_result.convergence = result['convergence']
-            if result['uncertainty'] is not None:
-                fitting_result.uncertainty_state = result['uncertainty']
-
+            uncertainty = result['uncertainty']
+            if hasattr(uncertainty, "draw"):
+                fitting_result.uncertainty_state = uncertainty
             fitting_result.pvec = np.array([getattr(p.slot, 'n', p.slot) for p in pars])
             fitting_result.stderr = np.array([getattr(p.slot, 's', 0) for p in pars])
             DOF = max(1, fitness.numpoints() - len(fitness.fitted_pars))


### PR DESCRIPTION
## Description

In release 1.0.0b3, the class structure for `bumps.fitters.FitBase` changed so that the fit classes all have a `state` attribute, but it is `None` for all except `dream` and `de`.

The check in `sas.sascalc.fit.BumpsFitting` for fit results from `dream` is then broken without this PR, if using the most recent version of `bumps`.

## How Has This Been Tested?

I ran an `amoeba` fit with bumps==1.0.0b3 and got an error from this part of the code, as it tried to call `state.draw()` on the state from `SimplexFit`.

I made the change in this PR, and then was able to run both `amoeba` and `dream` fits, showing the results.

## Review Checklist:

[if using the editor, use `[x]` in place of `[ ]` to check a box]

**Documentation** (check at least one)
- [ ] There is **nothing** that needs documenting
- [x] Documentation changes are **in this PR**
- [ ] There is an **issue** open for the documentation (link?)

**Installers**
- [ ] There is a chance this will affect the **installers**, if so
  - [ ] **Windows** installer (GH artifact) has been tested (installed and worked) 
  - [ ] **MacOSX** installer (GH artifact) has been tested (installed and worked) 

**Licencing** (untick if necessary)
- [x] The introduced changes comply with SasView license (BSD 3-Clause)

