### PR TITLE
Refactor bumps result views

### DIFF
--- a/src/sas/qtgui/Utilities/PlotView.py
+++ b/src/sas/qtgui/Utilities/PlotView.py
@@ -2,206 +2,24 @@ from __future__ import with_statement, print_function
 
 # The Figure object is used to create backend-independent plot representations.
 from matplotlib.figure import Figure
-GUI_TOOLKIT = "qt5"
-from matplotlib.backends.qt_compat import QtCore, QtWidgets
+from matplotlib.backends.qt_compat import QtWidgets
+from PySide6.QtWidgets import QLabel, QComboBox
 
-class EmbeddedPylab(object):
-    """
-    Define a 'with' context manager that lets you use pylab commands to
-    plot on an embedded canvas.  This is useful for wrapping existing
-    scripts in a GUI, and benefits from being more familiar than the
-    underlying object oriented interface.
 
-    As a convenience, the pylab module is returned on entry.
+class FitResultView(QtWidgets.QWidget):
+    state = None
+    show_plot_selector = False
 
-    *Example*
-
-    The following example shows how to use the WxAgg backend in a wx panel::
-
-        from matplotlib.backends.backend_wxagg import FigureCanvasWxAgg as FigureCanvas
-        from matplotlib.backends.backend_wxagg import NavigationToolbar2WxAgg as Toolbar
-        from matplotlib.figure import Figure
-
-        class PlotPanel(wx.Panel):
-            def __init__(self, *args, **kw):
-                wx.Panel.__init__(self, *args, **kw)
-
-                figure = Figure(figsize=(1,1), dpi=72)
-                canvas = FigureCanvas(self, wx.ID_ANY, figure)
-                self.pylab_interface = EmbeddedPylab(canvas)
-
-                # Instantiate the matplotlib navigation toolbar and explicitly show it.
-                mpl_toolbar = Toolbar(canvas)
-                mpl_toolbar.Realize()
-
-                # Create a vertical box sizer to manage the widgets in the main panel.
-                sizer = wx.BoxSizer(wx.VERTICAL)
-                sizer.Add(canvas, 1, wx.EXPAND|wx.LEFT|wx.RIGHT, border=0)
-                sizer.Add(mpl_toolbar, 0, wx.EXPAND|wx.ALL, border=0)
-
-                # Associate the sizer with its container.
-                self.SetSizer(sizer)
-                sizer.Fit(self)
-
-            def plot(self, *args, **kw):
-                with self.pylab_interface as pylab:
-                    pylab.clf()
-                    pylab.plot(*args, **kw)
-
-    Similar patterns should work for the other backends.  Check the source code
-    in matplotlib.backend_bases.* for examples showing how to use matplotlib
-    with other GUI toolkits.
-    """
-    def __init__(self, canvas):
-        # delay loading pylab until matplotlib.use() is called
-        from matplotlib.backend_bases import FigureManagerBase
-        self.fm = FigureManagerBase(canvas, -1)
-    def __enter__(self):
-        # delay loading pylab until matplotlib.use() is called
-        import pylab
-        from matplotlib._pylab_helpers import Gcf
-        Gcf.set_active(self.fm)
-        return pylab
-    def __exit__(self, *args, **kw):
-        # delay loading pylab until matplotlib.use() is called
-        from matplotlib._pylab_helpers import Gcf
-        if hasattr(Gcf, '_activeQue'):  # CRUFT: MPL < 3.3.1
-            Gcf._activeQue = [f for f in Gcf._activeQue if f is not self.fm]
-            try:
-                del Gcf.figs[-1]
-            except KeyError:
-                pass
-        else:
-            Gcf.figs.pop(self.fm.num, None)
-
-class _PlotViewShared(object):
-    title = 'Plot'
-    default_size = (600, 400)
-    pylab_interface = None  # type: EmbeddedPylab
-    plot_state = None
-    model = None
-    _calculating = False
-    _need_plot =  False
-    _need_newmodel = False
-
-    def set_model(self, model):
-        self.model = model
-        if not self._is_shown():
-            self._need_newmodel = True
-        else:
-            self._redraw(newmodel=True)
-
-    def update_model(self, model):
-        #print "profile update model"
-        if self.model != model:  # ignore updates to different models
-            return
-
-        if not self._is_shown():
-            self._need_newmodel = True
-        else:
-            self._redraw(newmodel=True)
-
-    def update_parameters(self, model):
-        #print "profile update parameters"
-        if self.model != model:
-            return
-
-        if not self._is_shown():
-            self._need_plot = True
-        else:
-            self._redraw(newmodel=self._need_newmodel)
-
-    def _show(self):
-        #print "showing theory"
-        if self._need_newmodel:
-            self._redraw(newmodel=True)
-        elif self._need_plot:
-            self._redraw(newmodel=False)
-
-    def _redraw(self, newmodel=False):
-        self._need_newmodel = newmodel
-        if self._calculating:
-            # That means that I've entered the thread through a
-            # wx.Yield for the currently executing redraw.  I need
-            # to cancel the running thread and force it to start
-            # the calculation over.
-            self.cancel_calculation = True
-            #print "canceling calculation"
-            return
-
-        with self.pylab_interface as pylab:
-            self._calculating = True
-
-            #print "calling again"
-            while True:
-                #print "restarting"
-                # We are restarting the calculation, so clear the reset flag
-                self.cancel_calculation = False
-
-                if self._need_newmodel:
-                    self.newmodel()
-                    if self.cancel_calculation:
-                        continue
-                    self._need_newmodel = False
-                self.plot()
-                if self.cancel_calculation:
-                    continue
-                pylab.draw()
-                break
-        self._need_plot = False
-        self._calculating = False
-
-    def get_state(self):
-        #print "returning state",self.model,self.plot_state
-        return self.model, self.plot_state
-
-    def set_state(self, state):
-        self.model, self.plot_state = state
-        #print "setting state",self.model,self.plot_state
-        self.plot()
-
-    def menu(self):
-        """
-        Return a model specific menu
-        """
-        return None
-
-    def newmodel(self, model=None):
-        """
-        New or updated model structure.  Do any sort or precalculation you
-        need.  plot will be called separately when you are done.
-
-        For long calculations, periodically perform wx.YieldIfNeeded()
-        and then if self.cancel_calculation is True, return from the plot.
-        """
-        pass
-
-    def plot(self):
-        """
-        Plot to the current figure.  If model has a plot method,
-        just use that.
-
-        For long calculations, periodically perform wx.YieldIfNeeded()
-        and then if self.cancel_calculation is True, return from the plot.
-        """
-        if hasattr(self.model, 'plot'):
-            self.model.plot()
-        else:
-            raise NotImplementedError("PlotPanel needs a plot method")
-
-class PlotView(QtWidgets.QWidget, _PlotViewShared):
-    def __init__(self, *args, **kw):
-        QtWidgets.QWidget.__init__(self, *args, **kw)
-        #import matplotlib.backends.backend_qt4agg
-        #matplotlib.backends.backend_qt4agg.DEBUG = True
+    def __init__(self, **kw):
+        QtWidgets.QWidget.__init__(self, **kw)
         from matplotlib.backends.backend_qt5agg import FigureCanvasQTAgg as FigureCanvas
         from matplotlib.backends.backend_qt5agg import NavigationToolbar2QT as Toolbar
-
-        #QtWidgets.QWidget.__init__(self, *args, **kw)
 
         # Can specify name on
         if 'title' in kw:
             self.title = kw['title']
+
+        self.state = None
 
         # Instantiate a figure object that will contain our plots.
         figure = Figure(figsize=(10,10), dpi=72)
@@ -209,23 +27,91 @@ class PlotView(QtWidgets.QWidget, _PlotViewShared):
         # Initialize the figure canvas, mapping the figure object to the plot
         # engine backend.
         canvas = FigureCanvas(figure)
-
-        # Wx-Pylab magic ...
-        # Make our canvas an active figure manager for pylab so that when
-        # pylab plotting statements are executed they will operate on our
-        # canvas and not create a new frame and canvas for display purposes.
-        # This technique allows this application to execute code that uses
-        # pylab stataments to generate plots and embed these plots in our
-        # application window(s).  Use _activate_figure() to set.
-        self.pylab_interface = EmbeddedPylab(canvas)
+        self.canvas = canvas
+        self.figure = figure
 
         # Instantiate the matplotlib navigation toolbar and explicitly show it.
         mpl_toolbar = Toolbar(canvas, self, False)
 
         layout = QtWidgets.QVBoxLayout()
+        if self.show_plot_selector:
+            label = QLabel("Select plot:")
+            layout.addWidget(label)
+            self.dropdown = QComboBox()
+            layout.addWidget(self.dropdown)
+            self.dropdown.currentIndexChanged.connect(self.plot)
+
         layout.addWidget(canvas)
         layout.addWidget(mpl_toolbar)
         self.setLayout(layout)
+    
+    def update(self, state):
+        self.state = state
+        self.plot()
+        self.canvas.draw_idle()
 
-    def _is_shown(self):
-        return IS_MAC or self.IsShown()
+    def plot(self):
+        raise NotImplementedError("PlotView needs a plot method... subclass it")
+
+
+class ConvergenceView(FitResultView):
+    def plot(self):
+        best, pop = self.state.convergence[:, 0], self.state.convergence[:, 1:]
+        plot_convergence(pop, best, self.figure)
+
+
+class CorrelationView(FitResultView):
+    def plot(self):
+        from bumps.dream.views import plot_corrmatrix
+
+        draw = self.state.uncertainty_state.draw()
+        self.figure.clear()
+        plot_corrmatrix(draw=draw, fig=self.figure)
+        self.canvas.draw_idle()
+
+
+class UncertaintyView(FitResultView):
+    def plot(self):
+        from bumps.dream.varplot import plot_vars
+        from bumps.dream.stats import var_stats
+
+        draw = self.state.uncertainty_state.draw()
+        stats = var_stats(draw)
+        self.figure.clear()
+        plot_vars(draw, stats, fig=self.figure)
+        self.canvas.draw_idle()
+
+
+class TraceView(FitResultView):
+    show_plot_selector = True
+
+    def update(self, state):
+        self.state = state
+        vars = state.uncertainty_state.labels
+        self.dropdown.clear()
+        self.dropdown.addItems(vars)
+        self.figure.clear()
+        self.plot()
+
+    def plot(self):
+        from bumps.dream.views import plot_trace
+        var = self.dropdown.currentIndex()
+        self.figure.clear()
+        plot_trace(self.state.uncertainty_state, var=var, fig=self.figure)
+        self.canvas.draw_idle()
+
+
+def plot_convergence(pop, best, fig):
+    import numpy as np
+    ni, npop = pop.shape
+    iternum = np.arange(1, ni + 1)
+    tail = int(0.25 * ni)
+    axes = fig.add_subplot(111)
+    if npop == 5:
+        axes.fill_between(iternum[tail:], pop[tail:, 1], pop[tail:, 3], color="lightgreen", label="20% to 80% range")
+        axes.plot(iternum[tail:], pop[tail:, 2], label="median", color="green", alpha=0.5)
+        axes.plot(iternum[tail:], pop[tail:, 0], label="population best", linestyle="dashed", color="green")
+    axes.plot(iternum[tail:], best[tail:], label="best", color="red")
+    axes.set_xlabel("iteration number")
+    axes.set_ylabel("chisq")
+    axes.legend()


### PR DESCRIPTION
## Description

Summary: Use locally-defined FitResultView (QtWidget), no more import from bumps.gui or monkey-patching

Fixes #3252
Requires `bumps>=1.0.0b4` (for the plotting functions)
Also requires #3268 (for compatibility with latest bumps)

### Removes:

- all imports of wxPanel classes from `bumps.gui` (e.g. `bumps.gui.uncertainty_view.UncertaintyView`)
- monkey-patching of `bumps.gui.plot_view`
  - including `_PlotViewShared` wrapper for mocking wxPanel from `sas.qtgui.Utilities.PlotView`
- `EmbeddedPylab` class; we are now using functions that can plot directly to the `FigureCanvas` provided

### Adds

- imports of plotting functions directly from `bumps.dream.views` and `bumps.dream.var_plot`
- **parameter selector for "Parameter Trace" panel!**

Example: 
![image](https://github.com/user-attachments/assets/391822dd-80c5-4096-b2cd-2317de3204e1)

Labels and plot formatting changed for convergence plot, with more legend items:
![image](https://github.com/user-attachments/assets/0490b519-fd46-4844-b478-45cef4363c43)


## How Has This Been Tested?

Ran amoeba and dream fits on a test dataset, generated plots, exercised the selector for fit parameters
in the Trace view.

## Review Checklist:

[if using the editor, use `[x]` in place of `[ ]` to check a box]

**Documentation** (check at least one)
- [ ] There is **nothing** that needs documenting
- [x] Documentation changes are **in this PR**
- [ ] There is an **issue** open for the documentation (link?)

**Installers**
- [ ] There is a chance this will affect the **installers**, if so
  - [ ] **Windows** installer (GH artifact) has been tested (installed and worked) 
  - [ ] **MacOSX** installer (GH artifact) has been tested (installed and worked) 

**Licencing** (untick if necessary)
- [x] The introduced changes comply with SasView license (BSD 3-Clause)

