### PR TITLE
3322: Shape2SAS imports

### DIFF
--- a/src/sas/qtgui/Calculators/Shape2SAS/Constraints.py
+++ b/src/sas/qtgui/Calculators/Shape2SAS/Constraints.py
@@ -10,7 +10,7 @@ from PySide6.QtCore import Qt
 from PySide6.QtWidgets import QPushButton
 
 #Global SasView
-from sas.qtgui.Utilities.ModelEditor import ModelEditor
+from sas.qtgui.Utilities.ModelEditors.TabbedEditor.ModelEditor import ModelEditor
 
 #Local Perspectives
 from sas.qtgui.Calculators.Shape2SAS.UI.ConstraintsUI import Ui_Constraints

--- a/src/sas/qtgui/Calculators/Shape2SAS/DesignWindow.py
+++ b/src/sas/qtgui/Calculators/Shape2SAS/DesignWindow.py
@@ -8,7 +8,7 @@ from PySide6.QtCore import Qt
 from PySide6.QtWidgets import QPushButton, QCheckBox, QFrame, QLineEdit, QSizePolicy
 
 # Local SasView
-from sas.qtgui.Utilities.TabbedModelEditor import TabbedModelEditor
+from sas.qtgui.Utilities.ModelEditors.TabbedEditor.TabbedModelEditor import TabbedModelEditor
 from sas.qtgui.Perspectives.perspective import Perspective
 from sas.qtgui.Utilities.GuiUtils import createModelItemWithPlot
 from sas.qtgui.Plotting.PlotterData import Data1D


### PR DESCRIPTION
## Description

This updates the Shape2SAS imports related to the model editors.

Fixes #3322

## How Has This Been Tested?

CI should now succeed for the Ubuntu builds

## Review Checklist:

**Documentation** (check at least one)
- [x] There is **nothing** that needs documenting
- [ ] Documentation changes are **in this PR**
- [ ] There is an **issue** open for the documentation (link?)

**Installers**
- [x] There is a chance this will affect the **installers**, if so
  - [ ] **Windows** installer (GH artifact) has been tested (installed and worked) 
  - [ ] **MacOSX** installer (GH artifact) has been tested (installed and worked) 

**Licencing** (untick if necessary)
- [x] The introduced changes comply with SasView license (BSD 3-Clause)

