### PR TITLE
Fix MacOS Test Runner Issue

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -478,7 +478,7 @@ jobs:
       - name: Try running the installation (macOS)
         if: ${{ startsWith(matrix.os, 'macOS' )}}
         run: |
-          hdiutil attach $DL_PATH/SasView6.dmg
+          hdiutil attach $DL_PATH/SasView6-${{ matrix.os }}.dmg
           # Testing scripting interface by running simple model generation through sasmodels compare
           /Volumes/SasView6/SasView6.app/Contents/MacOS/sasview -m sasmodels.compare cylinder -noplot
 


### PR DESCRIPTION
## Description

The dmg file has a Mac release-specific name that wasn't accounted for in one of the test runners.

## How Has This Been Tested?

The MacOS CI succeeded in the push test. **The push test runner for Ubuntu should fail**, but the pull request test runner should succeed now that #3323 is merged into main.

## Review Checklist:

[if using the editor, use `[x]` in place of `[ ]` to check a box]

**Documentation** (check at least one)
- [x] There is **nothing** that needs documenting
- [ ] Documentation changes are **in this PR**
- [ ] There is an **issue** open for the documentation (link?)

**Licencing** (untick if necessary)
- [x] The introduced changes comply with SasView license (BSD 3-Clause)

