### PR TITLE
clear convergence plot before plotting new result

### DIFF
--- a/src/sas/qtgui/Utilities/PlotView.py
+++ b/src/sas/qtgui/Utilities/PlotView.py
@@ -56,8 +56,10 @@ class FitResultView(QtWidgets.QWidget):
 
 class ConvergenceView(FitResultView):
     def plot(self):
+        self.figure.clear()
         best, pop = self.state.convergence[:, 0], self.state.convergence[:, 1:]
         plot_convergence(pop, best, self.figure)
+        self.canvas.draw_idle()
 
 
 class CorrelationView(FitResultView):


### PR DESCRIPTION
## Description

Fixes a bug where convergence plot is not cleared between fits, leading to old axis labels and ticks not being removed (and accumulating making the plot unusable) 

## How Has This Been Tested?

Local testing - ran multiple fits without fix, seeing garbled axes on convergence plot.
After fix, convergence plot is cleared (like all other result plots) correctly.

## Review Checklist:

[if using the editor, use `[x]` in place of `[ ]` to check a box]

**Documentation** (check at least one)
- [x] There is **nothing** that needs documenting
- [ ] Documentation changes are **in this PR**
- [ ] There is an **issue** open for the documentation (link?)

**Installers**
- [ ] There is a chance this will affect the **installers**, if so
  - [ ] **Windows** installer (GH artifact) has been tested (installed and worked) 
  - [ ] **MacOSX** installer (GH artifact) has been tested (installed and worked) 

**Licencing** (untick if necessary)
- [x] The introduced changes comply with SasView license (BSD 3-Clause)

