### PR TITLE
Documentation viewer/regeneration, wheels, importlib.resources

### DIFF
--- a/docs/sphinx-docs/Makefile
+++ b/docs/sphinx-docs/Makefile
@@ -5,7 +5,7 @@
 SPHINXOPTS    =
 SPHINXBUILD   = sphinx-build
 PAPER         =
-BUILDDIR      = build
+BUILDDIR      = ../../build/doc/
 
 # User-friendly check for sphinx-build
 ifeq ($(shell which $(SPHINXBUILD) >/dev/null 2>&1; echo $$?), 1)

--- a/docs/sphinx-docs/extract-module-resource.py
+++ b/docs/sphinx-docs/extract-module-resource.py
@@ -6,7 +6,7 @@ This utility extracts all the resources under a source name and saves the
 hierarchy to the nominated directory.
 
 Usage:
-    fetch-doc-source.py module source dest
+    extract-module-resource.py module source dest
 
 where
     module: the Python name of the module
@@ -67,7 +67,7 @@ def allowed(name: str):
 
 if __name__ == "__main__":
     if len(sys.argv) < 4:
-        print("Usage: fetch-doc-source.py module source dest")
+        print("Usage: extract-module-resource.py module source dest")
         sys.exit(1)
 
     modname = sys.argv[1]

--- a/run.py
+++ b/run.py
@@ -83,11 +83,6 @@ def prepare():
     #    with cd(root):
     #        subprocess.call((sys.executable, "setup.py", "build"), shell=False)
 
-    # Notify the help menu that the Sphinx documentation is in a different
-    # place than it otherwise would be.
-    docpath = joinpath(root, 'docs', 'sphinx-docs', '_build', 'html')
-    os.environ['SASVIEW_DOC_PATH'] = docpath
-
 import multiprocessing
 if __name__ == "__main__":
     multiprocessing.freeze_support()

--- a/src/sas/__pyinstaller/hook-sas.py
+++ b/src/sas/__pyinstaller/hook-sas.py
@@ -23,8 +23,6 @@ try:
         ('sas/qtgui/Utilities/WhatsNew/messages', 'sas/qtgui/Utilities/WhatsNew/messages'),
         ('sas/qtgui/Utilities/WhatsNew/css/style.css', 'sas/qtgui/Utilities/WhatsNew/css'),
         ('sas/qtgui/Utilities/About/images', 'sas/qtgui/Utilities/About/images'),
-        ('sas/docs', 'doc/build'),
-        ('sas/docs-source', 'doc/source')
     ]:
         datas.append((str((base / f).absolute()), t))
 

--- a/src/sas/__pyinstaller/hook-sas.py
+++ b/src/sas/__pyinstaller/hook-sas.py
@@ -16,7 +16,6 @@ try:
         ('sas/qtgui/images', 'images'),
         ('sas/qtgui/images', "sas/qtgui/images"),
         ('sas/sasview/media', 'media'),
-        ('sas/example_data', 'example_data'),
         ('sas/sascalc/calculator/ausaxs/lib', 'sas/sascalc/calculator/ausaxs/lib'),
         ('sas/qtgui/Utilities/Reports/report_style.css', 'sas/qtgui/Utilities/Reports'),
         ('sas/qtgui/Perspectives/Fitting/plugin_models', 'plugin_models'),

--- a/src/sas/__pyinstaller/hook-sas.py
+++ b/src/sas/__pyinstaller/hook-sas.py
@@ -22,6 +22,7 @@ try:
         ('sas/qtgui/Utilities/WhatsNew/messages', 'sas/qtgui/Utilities/WhatsNew/messages'),
         ('sas/qtgui/Utilities/WhatsNew/css/style.css', 'sas/qtgui/Utilities/WhatsNew/css'),
         ('sas/qtgui/Utilities/About/images', 'sas/qtgui/Utilities/About/images'),
+        ('sas/docs-source/conf.py', 'sas/docs-source/'),
     ]:
         datas.append((str((base / f).absolute()), t))
 

--- a/src/sas/sascalc/doc_regen/makedocumentation.py
+++ b/src/sas/sascalc/doc_regen/makedocumentation.py
@@ -1,15 +1,15 @@
 """
 Creates documentation from .py files
 """
+import importlib.resources
 import logging
 import os
 import sys
 import subprocess
 import shutil
 
-from os.path import join, basename
 from pathlib import Path
-from typing import Union
+from typing import Sequence, Union
 
 from sas.sascalc.fit import models
 from sas.system.user import get_app_dir_versioned
@@ -17,7 +17,8 @@ from sas.system.user import get_app_dir_versioned
 from sasmodels.core import list_models
 
 
-PATH_LIKE = Union[Path, str, os.PathLike]
+PATH_LIKE = Union[Path, str, os.PathLike[str]]
+
 
 # Path constants related to the directories and files used in documentation regeneration processes
 APP_DIRECTORY = Path(get_app_dir_versioned())
@@ -34,26 +35,149 @@ PLUGIN_PY_SRC = Path(models.find_plugins_dir())
 HELP_DIRECTORY_LOCATION = MAIN_BUILD_SRC / "html"
 RECOMPILE_DOC_LOCATION = HELP_DIRECTORY_LOCATION
 IMAGES_DIRECTORY_LOCATION = HELP_DIRECTORY_LOCATION / "_images"
-SAS_DIR = Path(sys.argv[0]).parent
-
-# Find the original documentation location, depending on where the files originate from
-if os.path.exists(SAS_DIR / "doc"):
-    # This is the directory structure for the installed version of SasView (primary for times when both exist)
-    BASE_DIR = SAS_DIR / "doc"
-    ORIGINAL_DOCS_SRC = BASE_DIR / "source"
-elif os.path.exists(SAS_DIR / '..' / 'Frameworks' / 'doc'):
-    # In the MacOS bundle, the executable and packages are in parallel directories
-    BASE_DIR = SAS_DIR / '..' / 'Frameworks' / 'doc'
-    ORIGINAL_DOCS_SRC = BASE_DIR / "source"
-else:
-    # This is the directory structure for developers
-    BASE_DIR = SAS_DIR / "docs" / "sphinx-docs"
-    ORIGINAL_DOCS_SRC = BASE_DIR / "source-temp"
-
-ORIGINAL_DOC_BUILD = BASE_DIR / "build"
 
 
-def create_user_files_if_needed():
+# logging.debug("""
+# APP_DIRECTORY = %s
+# USER_DOC_BASE = %s
+# USER_DOC_SRC = %s
+# USER_DOC_LOG = %s
+# DOC_LOG = %s
+# MAIN_DOC_SRC = %s
+# MAIN_BUILD_SRC = %s
+# MAIN_PY_SRC = %s
+# ABSOLUTE_TARGET_MAIN = %s
+# PLUGIN_PY_SRC = %s
+# HELP_DIRECTORY_LOCATION = %s
+# RECOMPILE_DOC_LOCATION = %s
+# IMAGES_DIRECTORY_LOCATION = %s
+# """,
+#     APP_DIRECTORY,
+#     USER_DOC_BASE,
+#     USER_DOC_SRC,
+#     USER_DOC_LOG,
+#     DOC_LOG,
+#     MAIN_DOC_SRC,
+#     MAIN_BUILD_SRC,
+#     MAIN_PY_SRC,
+#     ABSOLUTE_TARGET_MAIN,
+#     PLUGIN_PY_SRC,
+#     HELP_DIRECTORY_LOCATION,
+#     RECOMPILE_DOC_LOCATION,
+#     IMAGES_DIRECTORY_LOCATION,
+# )
+
+def copy_resources() -> None:
+    """Find the original documentation location (source and built)
+
+    The source and built docs for SasView could be in a number of locations.
+    Search for them in the following locations:
+    1. installed within the module
+    2. unpacked next to the source
+    3. in legacy paths from older installation approaches
+
+    Installed versions are prioritised over uninstalled versions to make sure
+    that inconveniently named local directories don't cause issues.
+    """
+    # Fast path out - everything already exists
+    if MAIN_DOC_SRC.exists() and MAIN_BUILD_SRC.exists():
+        return
+
+    if copy_module_resources():
+        return
+
+    source_dir, build_dir = locate_unpacked_resources()
+    if not MAIN_DOC_SRC.exists():
+        if source_dir.exists():
+            shutil.copytree(source_dir, MAIN_DOC_SRC)
+        else:
+            logging.error("Could not find source for documentation")
+
+    if not MAIN_BUILD_SRC.exists():
+        if build_dir.exists():
+            shutil.copytree(build_dir, MAIN_BUILD_SRC)
+        else:
+            logging.error("Could not find pre-built documentation")
+
+
+def copy_module_resources() -> bool:
+    """Obtain the source and build output from within the installed sas module"""
+
+    # Look in the module for the resources. We know that there is a conf.py
+    # for sphinx so check that it exists; checking that the file exists and
+    # not just the directory protects against empty directories
+    if importlib.resources.files("sas").joinpath("docs-source/conf.py").is_file():
+        logging.info("Extracting docs from sas module")
+        if not MAIN_DOC_SRC.exists():
+            module_copytree("sas", "docs-source", MAIN_DOC_SRC)
+        if not MAIN_BUILD_SRC.exists():
+            module_copytree("sas", "docs", MAIN_BUILD_SRC / "html")
+        return True
+
+    return False
+
+
+def locate_unpacked_resources() -> tuple[Path, Path]:
+    """Locate the resources unpacked on disk"""
+    # Look near where sasview executable sits - if it's from the pyinstaller
+    # bundle or from run.py then the doc source will be close by. Note that
+    # this won't be true for POSIX-like installations where the executable
+    # is in /usr/bin, ~/.local/bin, or .../venv/bin.
+    exe_dir = Path(sys.argv[0]).parent
+
+    if (exe_dir / "doc").exists():
+        # This is the directory structure for the installed version of SasView
+        # such as when installed from the pyinstaller bundle prior to v6.1
+        source_dir = exe_dir / "doc" / "source"
+        build_dir = exe_dir / "doc" / "build"
+
+    elif (exe_dir.parent / "Frameworks" / "doc").exists():
+        # In the MacOS bundle, the executable and packages are in parallel directories
+        source_dir = exe_dir.parent / "Frameworks" / "doc" / "source"
+        build_dir = exe_dir.parent / "Frameworks" / "doc" / "build"
+
+    else:
+        # This is the directory structure for developers
+        source_dir = exe_dir / "docs" / "sphinx-docs" / "source-temp"
+        build_dir = exe_dir / "build" / "doc"
+
+    logging.info(
+        "Extracting docs from on-disk locations: source=%s, build=%s",
+        source_dir, build_dir
+    )
+    return source_dir, build_dir
+
+
+def module_copytree(module: str, src: PATH_LIKE, dest: PATH_LIKE) -> None:
+    """Copy the tree from a module to the specified directory
+
+    module: name of the Python module (the "anchor" for importlib.resources)
+    src: source name of the resource inside the module
+    dest: destination directory for the resources to be copied into; will be
+        created if it doesn't exist
+    """
+    spth = Path(src)
+    src = str(spth)
+
+    dpth = Path(dest)
+    dpth.mkdir(exist_ok=True, parents=True)
+
+    for resource in importlib.resources.files(module).joinpath(src).iterdir():
+        if "__pycache__" in resource.name:
+            continue
+
+        if resource.is_dir():
+            # recurse into the directory
+            module_copytree(module, spth / resource.name, dpth / resource.name)
+        elif resource.is_file():
+            logging.debug("Copied: %s", spth / resource.name)
+            with open(dpth / resource.name, "wb") as dh:
+                dh.write(resource.read_bytes())
+        else:
+            logging.warning("Skipping %s (unknown type)", spth / resource.name)
+
+
+def create_user_files_if_needed() -> None:
     """Create user documentation directories if necessary and copy built docs there."""
     if not USER_DOC_BASE.exists():
         os.mkdir(USER_DOC_BASE)
@@ -65,13 +189,10 @@ def create_user_files_if_needed():
         with open(DOC_LOG, "wb") as f:
             # Write an empty file to eliminate any potential future file creation conflicts
             pass
-    if not MAIN_DOC_SRC.exists() and ORIGINAL_DOCS_SRC.exists():
-        shutil.copytree(ORIGINAL_DOCS_SRC, MAIN_DOC_SRC)
-    if not MAIN_BUILD_SRC.exists() and ORIGINAL_DOC_BUILD.exists():
-        shutil.copytree(ORIGINAL_DOC_BUILD, MAIN_BUILD_SRC)
+    copy_resources()
 
 
-def get_py(directory: PATH_LIKE) -> list[PATH_LIKE]:
+def get_py(directory: Path) -> list[Path]:
     """Find all python files within a directory that are meant for sphinx and return those file-paths as a list.
 
     :param directory: A file path-like object to find all python files contained there-in.
@@ -79,28 +200,29 @@ def get_py(directory: PATH_LIKE) -> list[PATH_LIKE]:
     """
     for root, dirs, files in os.walk(directory):
         # Only include python files not starting in '_' (pycache not included)
-        py_files = [join(directory, string) for string in files if not string.startswith("_") and string.endswith(".py")]
+        py_files = [Path(directory) / string for string in files if not string.startswith("_") and string.endswith(".py")]
         return py_files
+    return []
 
 
-def get_main_docs() -> list[PATH_LIKE]:
+def get_main_docs() -> list[Path]:
     """Generates a list of all .py files to be passed into compiling functions found in the main source code, as well as
     in the user plugin model directory.
 
     :return: A list of python files """
     # The order in which these are added is important. if ABSOLUTE_TARGET_PLUGINS goes first, then we're not compiling the .py file stored in .sasview/plugin_models
     targets = get_py(MAIN_PY_SRC) + get_py(PLUGIN_PY_SRC)
-    base_targets = [basename(string) for string in targets]
+    base_targets = [p.name for p in targets]
 
     # Removes duplicate instances of the same file copied from plugins folder to source-temp/user/models/src/
-    for file in targets:
-        if base_targets.count(basename(file)) >= 2:
-            targets.remove(file)
-            base_targets.remove(basename(file))
+    for p in targets:
+        if base_targets.count(p.name) >= 2:
+            targets.remove(p)
+            base_targets.remove(p.name)
 
     return targets
 
-def sync_plugin_models():
+def sync_plugin_models() -> list[Path]:
     """
     Remove deleted plugin models from source-temp/user/models/src/
     """
@@ -113,7 +235,7 @@ def sync_plugin_models():
             removed_files.append(file)
     return removed_files
 
-def call_regenmodel(filepaths: list[PATH_LIKE]):
+def call_regenmodel(filepaths: Sequence[PATH_LIKE]) -> list[Path]:
     """Runs regenmodel.py or regentoc.py (specified in parameter regen_py) with all found PY_FILES.
 
     :param filepath: A file-path like object or list of file-path like objects to regenerate.
@@ -122,13 +244,13 @@ def call_regenmodel(filepaths: list[PATH_LIKE]):
     """
     create_user_files_if_needed()
     from sas.sascalc.doc_regen.regenmodel import process_model
-    filepaths = [Path(path) for path in filepaths]
+    paths = [Path(path) for path in filepaths]
     removed_files = sync_plugin_models()
-    for py_file in filepaths:
+    for py_file in paths:
         process_model(py_file, True)
     return removed_files
 
-def generate_html(single_files: Union[PATH_LIKE, list[PATH_LIKE]] = "", rst: bool = False, output_path: PATH_LIKE = ""):
+def generate_html(single_files: Union[PATH_LIKE, list[PATH_LIKE]] = "", rst: bool = False, output_path: PATH_LIKE = "") -> subprocess.Popen[bytes]:
     """Generates HTML from an RST using a subprocess. Based off of syntax provided in Makefile found in /sasmodels/doc/
 
     :param single_file: A file name that needs the html regenerated.
@@ -145,18 +267,18 @@ def generate_html(single_files: Union[PATH_LIKE, list[PATH_LIKE]] = "", rst: boo
     doctrees = MAIN_BUILD_SRC / "doctrees"
 
     # Process the single_files parameter into a list of Path objects referring to rst files
+    paths: list[Path] = []
     if isinstance(single_files, str) and single_files:
         # User has passed in a single file as a string
-        single_files = [Path(single_files)]
+        paths = [Path(single_files)]
     elif rst is False and isinstance(single_files, list):
         # User has passed in a list of python pathnames: we need to pass in the corresponding .rst file
-        single_files = [MAIN_DOC_SRC / "user" / "models" / single_file.name.replace('.py', '.rst') for single_file in single_files]
+        paths = [(MAIN_DOC_SRC / "user" / "models" / single_file).with_suffix(".rst") for single_file in single_files]
     elif not single_files:
         # User wants a complete regeneration of documentation
         force_rebuild = "-E"
-        single_files = None
     os.environ['SAS_NO_HIGHLIGHT'] = '1'
-    command = [
+    command: list[str | Path] = [
         sys.executable,
         "-m",
         "sphinx",
@@ -168,9 +290,9 @@ def generate_html(single_files: Union[PATH_LIKE, list[PATH_LIKE]] = "", rst: boo
         MAIN_DOC_SRC,
         html_directory,
     ]
-    if single_files:
+    if paths:
         # If the user has passed in a single file, we only want to regenerate that file
-        command.extend(single_files)
+        command.extend(paths)
     # Try removing empty arguments
     command = [arg for arg in command if arg]
     with open(DOC_LOG, "wb") as f:
@@ -178,7 +300,7 @@ def generate_html(single_files: Union[PATH_LIKE, list[PATH_LIKE]] = "", rst: boo
     return runner
 
 
-def call_all_files():
+def call_all_files() -> None:
     """A master method to regenerate all known documentation."""
     from sas.sascalc.doc_regen.regentoc import generate_toc
     targets = get_main_docs()
@@ -193,7 +315,7 @@ def call_all_files():
     generate_toc(targets)
 
 
-def call_one_file(file: PATH_LIKE):
+def call_one_file(file: PATH_LIKE) -> None:
     """A master method to regenerate a single file that is passed to the method.
 
     :param file: A file name that needs the html regenerated.
@@ -203,10 +325,10 @@ def call_one_file(file: PATH_LIKE):
     model_target = MAIN_PY_SRC / file
     plugin_target = PLUGIN_PY_SRC / file
     # Determines if a model's source .py file from /user/models/src/ should be used or if the file from /plugin-models/ should be used
-    if os.path.exists(model_target) and os.path.exists(plugin_target):
+    if model_target.exists() and plugin_target.exists():
         # Model name collision between built-in models and plugin models: Choose the most recent
-        file_call_path = model_target if os.path.getmtime(plugin_target) < os.path.getmtime(model_target) else plugin_target
-    elif not os.path.exists(plugin_target):
+        file_call_path = model_target if plugin_target.stat().st_mtime < model_target.stat().st_mtime else plugin_target
+    elif not plugin_target.exists():
         file_call_path = model_target
     else:
         file_call_path = plugin_target
@@ -218,10 +340,11 @@ def call_one_file(file: PATH_LIKE):
             targets.remove(filename)
 
     # Generate the TOC
+    breakpoint()
     generate_toc(targets)
 
 
-def make_documentation(target: PATH_LIKE = ".") -> subprocess.Popen:
+def make_documentation(target: PATH_LIKE = ".") -> subprocess.Popen[bytes]:
     """Similar to call_one_file, but will fall back to calling all files and regenerating everything if an error occurs.
 
     :param target: A file name that needs the html regenerated.
@@ -232,8 +355,7 @@ def make_documentation(target: PATH_LIKE = ".") -> subprocess.Popen:
         with open(DOC_LOG, "rb+") as f:
             f.truncate(0)
     # Ensure target is a path object
-    if target:
-        target = Path(target)
+    target = Path(target)
     try:
         if ".rst" in target.name:
             # Generate only HTML if passed in file is an RST

--- a/src/sas/sascalc/doc_regen/regenmodel.py
+++ b/src/sas/sascalc/doc_regen/regenmodel.py
@@ -57,14 +57,11 @@ from sasmodels import generate, core
 from sasmodels.direct_model import DirectModel, call_profile
 from sasmodels.data import empty_data1D, empty_data2D
 
-from sas.sascalc.doc_regen.makedocumentation import MAIN_DOC_SRC, generate_html
+from sas.sascalc.doc_regen.makedocumentation import MAIN_DOC_SRC, generate_html, PATH_LIKE
 
 from typing import Any, Dict, Union
 from sasmodels.kernel import KernelModel
 from sasmodels.modelinfo import ModelInfo
-
-
-PATH_LIKE = Union[Path, str, os.PathLike[str]]
 
 
 # Destination directory for model docs

--- a/src/sas/sascalc/doc_regen/regenmodel.py
+++ b/src/sas/sascalc/doc_regen/regenmodel.py
@@ -59,9 +59,13 @@ from sasmodels.data import empty_data1D, empty_data2D
 
 from sas.sascalc.doc_regen.makedocumentation import MAIN_DOC_SRC, generate_html
 
-from typing import Dict, Any
+from typing import Any, Dict, Union
 from sasmodels.kernel import KernelModel
 from sasmodels.modelinfo import ModelInfo
+
+
+PATH_LIKE = Union[Path, str, os.PathLike[str]]
+
 
 # Destination directory for model docs
 TARGET_DIR = MAIN_DOC_SRC / "user" / "models"
@@ -335,7 +339,7 @@ def copy_file(src: str, dst: str):
         shutil.copy2(src, dst)
 
 
-def process_model(py_file: str, force=False) -> str:
+def process_model(py_file: PATH_LIKE, force=False) -> str:
     """Generate doc file and image file for the given model definition file.
 
     Does nothing if the corresponding rst file is newer than *py_file*.
@@ -349,7 +353,7 @@ def process_model(py_file: str, force=False) -> str:
     :param force: Regardless of the ReST file age, relative to the python file, force the regeneration.
     """
     py_file = Path(py_file)
-    rst_file = TARGET_DIR / py_file.name.replace('.py', '.rst')
+    rst_file = (TARGET_DIR / py_file.name).with_suffix(".rst")
     if not (force or newer(py_file, rst_file) or newer(__file__, rst_file)):
         #print("skipping", rst_file)
         return rst_file

--- a/src/sas/sascalc/doc_regen/regentoc.py
+++ b/src/sas/sascalc/doc_regen/regentoc.py
@@ -7,11 +7,9 @@ from os import mkdir
 from os.path import basename, exists, join as joinpath
 from pathlib import Path
 from sasmodels.core import load_model_info
-from sas.sascalc.doc_regen.makedocumentation import MAIN_DOC_SRC
+from sas.sascalc.doc_regen.makedocumentation import MAIN_DOC_SRC, PATH_LIKE
 
 from typing import Optional, IO, BinaryIO, Union
-
-PATH_LIKE = Union[Path, str, os.PathLike[str]]
 
 
 TEMPLATE = """\


### PR DESCRIPTION
## Description

Finding resources inside the module should be done with `importlib.resources` wherever possible, and not using file paths. Calculating locations using file paths fails when modules are inside zip files, wheels, manipulated by pyinstaller. The resources can even end up in different locations depending on the operating system and installation 'style' (all in one directory vs separate `/usr/bin` or `.../.venv/bin/` etc). 

The current code for locating the documentation makes incorrect assumptions about the proximity of the documentation files to the executable.

This PR adds code to obtain the documentation files firstly from the module using `importlib.resources` and then other locations as a fallback. 

Fixes # (I thought there were several bugs?)

This PR is needed in both the `release-6.1.0` branch and in `main`; I'm assuming that it will end up in `main` on its own via a merge, but please let me know if you'd like a parallel PR for `main` to help it land earlier.

## How Has This Been Tested?

Documentation locating, copying, and viewing code works from:

- unpacked source on linux with run.py
- pyinstaller on linux
- installed wheel on linux

The document generation code (manually calling `makedocumentation.py` was tested with

- unpacked source on linux
- installed wheel on linux

In principle this work is making the code more portable and so that should be enough... but it would be good to hear that the different sort of pyinstaller unpacking that happens on windows and macos works. When testing, you should delete your existing local cache of doc source and build to ensure that the relevant code is actually used. 

## Review Checklist:

**Documentation** (check at least one)
- [x] There is **nothing** that needs documenting
- [ ] Documentation changes are **in this PR**
- [ ] There is an **issue** open for the documentation (link?)

**Installers**
- [x] There is a chance this will affect the **installers**, if so
  - [ ] **Windows** installer (GH artifact) has been tested (installed and worked) 
  - [ ] **MacOSX** installer (GH artifact) has been tested (installed and worked) 

**Licencing** (untick if necessary)
- [x] The introduced changes comply with SasView license (BSD 3-Clause)

