### PR TITLE
Improvements in sasview version handling - internal version and versioned directory

### DIFF
--- a/src/sas/system/user.py
+++ b/src/sas/system/user.py
@@ -1,8 +1,12 @@
 import os
+from packaging.version import Version
 import shutil
 from pathlib import Path
 from platformdirs import PlatformDirs
-from sas.system.version import __version__ as sasview_version
+from sas.system.version import __version__
+
+
+sasview_version = Version(__version__).base_version
 
 # Create separate versioned and unversioned file locations
 PLATFORM_DIRS_VERSIONED = PlatformDirs("SasView", "sasview", version=sasview_version)

--- a/src/sas/system/version.py
+++ b/src/sas/system/version.py
@@ -1,5 +1,5 @@
 try:
-    from _version import __version__
+    from ._version import __version__
 except ImportError:
     __version__ = "6.1.0a1"
 


### PR DESCRIPTION
## Description

A minor bugfix and a small improvement to do with sasview version handling:

- The import of `_version` from the hatch-vcs automation was incorrect - trivial fix to bring it in. 
- The versioned directory for config/cache should be only dependent on the base version (x.y.z) component and not on development markers (alpha, beta, dev).

This PR is aimed against `release-6.1.0` branch but is also needed in `main`. Please let me know if duplicating the PR is desired to get this fix synced sooner rather than later.

## How Has This Been Tested?

`run.py`:

- check the version string in title bar and logs 
- check what directory it wants to use when run

## Review Checklist:

[if using the editor, use `[x]` in place of `[ ]` to check a box]

**Documentation** (check at least one)
- [x] There is **nothing** that needs documenting
- [ ] Documentation changes are **in this PR**
- [ ] There is an **issue** open for the documentation (link?)

**Installers**
- [ ] There is a chance this will affect the **installers**, if so
  - [ ] **Windows** installer (GH artifact) has been tested (installed and worked) 
  - [ ] **MacOSX** installer (GH artifact) has been tested (installed and worked) 

**Licencing** (untick if necessary)
- [x] The introduced changes comply with SasView license (BSD 3-Clause)

