### PR TITLE
Update PR and Bug templates 

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -29,5 +29,8 @@ If applicable, add screenshots to help explain your problem.
 **Operating system (please complete the following information):**
  - OS: [e.g. Windows 10]
 
+**Installation method (please complete the following information):**
+ - Installed: [e.g. Windows installer, pip, pipenv, git checkout]
+
 **Additional context**
 Add any other context about the problem here.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -23,6 +23,6 @@ Please describe the tests that you ran to verify your changes. Provide instructi
   - [ ] **MacOSX** installer (GH artifact) has been tested (installed and worked)
   - [ ] **Wheels** installer (GH artifact) has been tested (installed and worked)
 
-**Licencing** (untick if necessary)
+**Licensing** (untick if necessary)
 - [x] The introduced changes comply with SasView license (BSD 3-Clause)
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -20,7 +20,8 @@ Please describe the tests that you ran to verify your changes. Provide instructi
 **Installers**
 - [ ] There is a chance this will affect the **installers**, if so
   - [ ] **Windows** installer (GH artifact) has been tested (installed and worked) 
-  - [ ] **MacOSX** installer (GH artifact) has been tested (installed and worked) 
+  - [ ] **MacOSX** installer (GH artifact) has been tested (installed and worked)
+  - [ ] **Wheels** installer (GH artifact) has been tested (installed and worked)
 
 **Licencing** (untick if necessary)
 - [x] The introduced changes comply with SasView license (BSD 3-Clause)


### PR DESCRIPTION
## Description

- Include information about how sasview was installed in the bug report template. It's useful to know if this is form a git checkout, the windows installer, pip install, etc.
- Include testing wheels as an installer route that can be checked in the course of testing a PR

(this should be in both `main` and `release-6.1.0` branches - let me know if you want a second PR for that)

## How Has This Been Tested?

n/a
## Review Checklist:

[if using the editor, use `[x]` in place of `[ ]` to check a box]

**Documentation** (check at least one)
- [x] There is **nothing** that needs documenting
- [ ] Documentation changes are **in this PR**
- [ ] There is an **issue** open for the documentation (link?)

**Installers**
- [ ] There is a chance this will affect the **installers**, if so
  - [ ] **Windows** installer (GH artifact) has been tested (installed and worked) 
  - [ ] **MacOSX** installer (GH artifact) has been tested (installed and worked) 

**Licencing** (untick if necessary)
- [x] The introduced changes comply with SasView license (BSD 3-Clause)

