### PR TITLE
Update tarball name in nightly flow to match CI.yml

### DIFF
--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -36,7 +36,7 @@ jobs:
           for file in $(ls *.dmg); do
               mv $file ${file/SasView6-/SasView-nightly-MacOSX-}
           done
-          mv SasView-Installer-ubuntu*/sasview6.tar.gz ./SasView-nightly-Linux.tar.gz
+          mv SasView-Installer-ubuntu*/SasView6.tar.gz ./SasView-nightly-Linux.tar.gz
 
       - name: Upload Nightly Build Installer to GitHub releases
         uses: ncipollo/release-action@v1


### PR DESCRIPTION
## Description

Somewhere in the process of updating CI.yml, the tarball filename changed for the linux installer bundle. This PR updates the filename.

Fixes #3328 

## How Has This Been Tested?

CI - tarball found and uploaded

## Review Checklist:

[if using the editor, use `[x]` in place of `[ ]` to check a box]

**Documentation** (check at least one)
- [x] There is **nothing** that needs documenting
- [ ] Documentation changes are **in this PR**
- [ ] There is an **issue** open for the documentation (link?)

**Installers**
- [ ] There is a chance this will affect the **installers**, if so
  - [ ] **Windows** installer (GH artifact) has been tested (installed and worked) 
  - [ ] **MacOSX** installer (GH artifact) has been tested (installed and worked) 

**Licencing** (untick if necessary)
- [x] The introduced changes comply with SasView license (BSD 3-Clause)

