### PR TITLE
Publish wheels along side other installers in nightly-builds action

### DIFF
--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -32,7 +32,13 @@ jobs:
       - name: Display structure of downloaded files
         run: ls -R
         working-directory: .
-          
+
+      - name: Bundle up wheels
+        run: |
+          cp sasview-wheel-*/* sasview-wheel/
+          cd sasview-wheel
+          zip ../SasView-nightly-wheels.zip *
+
       - name: Rename artifacts
         run: |
           mv SasView-Installer-windows*/setupSasView.exe ./setupSasView-nightly-Win64.exe
@@ -54,7 +60,7 @@ jobs:
           allowUpdates: true
           replacesArtifacts: true
           token: ${{ secrets.GITHUB_TOKEN }}
-          artifacts: "setupSasView-nightly-Win64.exe, SasView-nightly-MacOSX-*.dmg, SasView-nightly-Linux.tar.gz"
+          artifacts: "setupSasView-nightly-Win64.exe, SasView-nightly-MacOSX-*.dmg, SasView-nightly-Linux.tar.gz, SasView-nightly-wheels.zip"
           body: "Nightly build of main SasView branch"
           name: "nightly-build"
           tag: "nightly-build"


### PR DESCRIPTION
## Description

Wheels are now generated for sasview as part of the build process, and if prerelease versions of sasmodels, sasdata, and bumps are needed, these wheels are also generated. This PR publishes a zip of the wheels and the sasview sdist alongside the nightly builds of the other installers.

(This PR also contains the change from #3334 to allow the actions to pass)

## How Has This Been Tested?

CI of nightly - https://github.com/llimeht/sasview/releases/tag/nightly-build (CI on the PR is likely to fail due to lack of secrets to sign the installer at an earlier stage of the action; that's a separate bug to fix)

![image](https://github.com/user-attachments/assets/536bda79-509a-4dd4-9473-5f72de6b4588)

## Review Checklist:

[if using the editor, use `[x]` in place of `[ ]` to check a box]

**Documentation** (check at least one)
- [x] There is **nothing** that needs documenting
- [ ] Documentation changes are **in this PR**
- [ ] There is an **issue** open for the documentation (link?)

**Installers**
- [ ] There is a chance this will affect the **installers**, if so
  - [ ] **Windows** installer (GH artifact) has been tested (installed and worked) 
  - [ ] **MacOSX** installer (GH artifact) has been tested (installed and worked) 

**Licencing** (untick if necessary)
- [x] The introduced changes comply with SasView license (BSD 3-Clause)

