### PR TITLE
Clean out nightly files

### DIFF
--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -21,6 +21,10 @@ jobs:
         os: [ ubuntu-latest]
     needs: reuse_main_ci
 
+    env:
+      GH_REPO: ${{ github.repository }}
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
     steps:
       - name: Retrieve saved artifacts
         uses: actions/download-artifact@v4
@@ -38,6 +42,10 @@ jobs:
           done
           mv SasView-Installer-ubuntu*/SasView6.tar.gz ./SasView-nightly-Linux.tar.gz
 
+      - name: Clean out old release
+        run: |
+          gh release delete nightly-build --cleanup-tag --yes || true
+
       - name: Upload Nightly Build Installer to GitHub releases
         uses: ncipollo/release-action@v1
         with:
@@ -50,3 +58,4 @@ jobs:
           body: "Nightly build of main SasView branch"
           name: "nightly-build"
           tag: "nightly-build"
+          commit: ${{ github.sha }}

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -36,7 +36,7 @@ jobs:
           for file in $(ls *.dmg); do
               mv $file ${file/SasView6-/SasView-nightly-MacOSX-}
           done
-          mv SasView-Installer-ubuntu*/sasview6.tar.gz ./SasView-nightly-Linux.tar.gz
+          mv SasView-Installer-ubuntu*/SasView6.tar.gz ./SasView-nightly-Linux.tar.gz
 
       - name: Upload Nightly Build Installer to GitHub releases
         uses: ncipollo/release-action@v1


### PR DESCRIPTION
## Description

The nightly-build output contains updated installers but still contains the old source. The source is linked to the git tag `nightly-build` which is isn't changing, and so the source tarballs continue to point to wherever that tag pointed.

The approach here is to delete the release and the tag and recreate it, meaning that not only does the tarball get updated but the date for the release gets updated too, rather than remaining at some time in 2023.

(Note that this PR also contains the change from #3334 otherwise the CI can't pass; cross-fork CI is likely to fail with permissions issues)

Fixes #2648

## How Has This Been Tested?

CI https://github.com/llimeht/sasview/actions/runs/14773162725

![image](https://github.com/user-attachments/assets/854d106a-c300-45d4-9b73-0f1250173a37)


## Review Checklist:

[if using the editor, use `[x]` in place of `[ ]` to check a box]

**Documentation** (check at least one)
- [x] There is **nothing** that needs documenting
- [ ] Documentation changes are **in this PR**
- [ ] There is an **issue** open for the documentation (link?)

**Installers**
- [ ] There is a chance this will affect the **installers**, if so
  - [ ] **Windows** installer (GH artifact) has been tested (installed and worked) 
  - [ ] **MacOSX** installer (GH artifact) has been tested (installed and worked) 

**Licencing** (untick if necessary)
- [x] The introduced changes comply with SasView license (BSD 3-Clause)

