### PR TITLE
Fix mousemove warning in matplotlib plots

### DIFF
--- a/src/sas/qtgui/Plotting/Binder.py
+++ b/src/sas/qtgui/Plotting/Binder.py
@@ -3,7 +3,6 @@ Extension to MPL to support the binding of artists to key/mouse events.
 """
 import sys
 import logging
-import warnings
 
 class Selection(object):
     """

--- a/src/sas/qtgui/Plotting/Binder.py
+++ b/src/sas/qtgui/Plotting/Binder.py
@@ -3,6 +3,7 @@ Extension to MPL to support the binding of artists to key/mouse events.
 """
 import sys
 import logging
+import warnings
 
 class Selection(object):
     """
@@ -238,20 +239,21 @@ class BindArtist(object):
         """
         # TODO: sort by zorder of axes then by zorder within axes
         found = Selection()
-        self._artists.sort(key=lambda x: x.zorder, reverse=True)
-        for artist in self._artists:
-            # TODO: should contains() return false if invisible?
-            if not artist.get_visible():
-                continue
-            # TODO: optimization - exclude artists not inaxes
-            try:
-                inside, prop = artist.contains(event)
-            except:
-                # Probably an old version of matplotlib
-                inside = False
-            if inside:
-                found.artist, found.prop = artist, prop
-                break
+        inaxes = event.inaxes
+        if inaxes is not None:
+            self._artists.sort(key=lambda x: x.zorder, reverse=True)
+            for artist in self._artists:
+                # TODO: should contains() return false if invisible?
+                if not artist.get_visible() or inaxes != artist.axes:
+                    continue
+                try:
+                    inside, prop = artist.contains(event)
+                except:
+                    # Probably an old version of matplotlib
+                    inside = False
+                if inside:
+                    found.artist, found.prop = artist, prop
+                    break
 
         # TODO: how to check if prop is equal?
         if found != self._current:


### PR DESCRIPTION
## Description

This removes warnings when mousing over plots (for certain platforms and OS?)
This PR does two things, in the handler that checks if a mouse event is contained within an artist:

1. checks if mouse event is associated with _any_ axes before trying to determine if an artist contains it (`event.inaxes is not None`)
2. if the first check passes, check if the axes associated with an event match the axes associated with the artist before running `artist.contains()`

Fixes #3145

## How Has This Been Tested?

Warnings appear when mousing over fit plot before fix.  They are gone after fix.

## Review Checklist:

[if using the editor, use `[x]` in place of `[ ]` to check a box]

**Documentation** (check at least one)
- [x] There is **nothing** that needs documenting
- [ ] Documentation changes are **in this PR**
- [ ] There is an **issue** open for the documentation (link?)

**Installers**
- [ ] There is a chance this will affect the **installers**, if so
  - [ ] **Windows** installer (GH artifact) has been tested (installed and worked) 
  - [ ] **MacOSX** installer (GH artifact) has been tested (installed and worked) 

**Licencing** (untick if necessary)
- [x] The introduced changes comply with SasView license (BSD 3-Clause)

