### PR TITLE
3276 parent data needs to be removed from size distribution perspective results plot

### DIFF
--- a/src/sas/qtgui/MainWindow/DataExplorer.py
+++ b/src/sas/qtgui/MainWindow/DataExplorer.py
@@ -1128,7 +1128,7 @@ class DataExplorerWindow(DroppableDataLoadWidget):
 
         append = False
         plot_to_append_to = None
-        for plot_to_show in plots_to_show:
+        for idx, plot_to_show in enumerate(plots_to_show):
             # Check if this plot already exists
             shown = self.updatePlot(plot_to_show)
             # Retain append status throughout loop
@@ -1159,8 +1159,15 @@ class DataExplorerWindow(DroppableDataLoadWidget):
                 self.appendOrUpdatePlot(self, plot_to_show, plot_to_append_to)
             else:
                 # Plots with main data points on the same chart
-                # Get the main data plot unless data is 2D which is plotted earlier
-                if main_data is not None and not isinstance(main_data, Data2D) and role is not DataRole.ROLE_SIZE_DISTRIBUTION:
+                # If this is the first plot in the list (and ONLY if the first)
+                # get the main data plot unless data is 2D which is plotted earlier
+                # or the DataRole is ROLE_SIZE_DISTRIBUTION
+                if (
+                    idx == 0
+                    and main_data is not None
+                    and not isinstance(main_data, Data2D)
+                    and role != DataRole.ROLE_SIZE_DISTRIBUTION
+                ):
                     new_plots.append((plot_item, main_data))
                 new_plots.append((plot_item, plot_to_show))
 

--- a/src/sas/qtgui/MainWindow/DataExplorer.py
+++ b/src/sas/qtgui/MainWindow/DataExplorer.py
@@ -1160,7 +1160,7 @@ class DataExplorerWindow(DroppableDataLoadWidget):
             else:
                 # Plots with main data points on the same chart
                 # Get the main data plot unless data is 2D which is plotted earlier
-                if main_data is not None and not isinstance(main_data, Data2D):
+                if main_data is not None and not isinstance(main_data, Data2D) and role is not DataRole.ROLE_SIZE_DISTRIBUTION:
                     new_plots.append((plot_item, main_data))
                 new_plots.append((plot_item, plot_to_show))
 
@@ -1229,7 +1229,8 @@ class DataExplorerWindow(DroppableDataLoadWidget):
                     plot_set.xtransform = 'log10(x)'
                 if (plot_set.plot_role in [
                     DataRole.ROLE_POLYDISPERSITY, DataRole.ROLE_RESIDUAL, DataRole.ROLE_RESIDUAL_SESANS,
-                    DataRole.ROLE_ANGULAR_SLICE, DataRole.ROLE_STAND_ALONE] or plot_set.isSesans):
+                    DataRole.ROLE_ANGULAR_SLICE, DataRole.ROLE_STAND_ALONE,
+                    DataRole.ROLE_SIZE_DISTRIBUTION] or plot_set.isSesans):
                     plot_set.ytransform = 'y'
                 else:
                     plot_set.ytransform = 'log10(y)'

--- a/src/sas/qtgui/Perspectives/SizeDistribution/SizeDistributionLogic.py
+++ b/src/sas/qtgui/Perspectives/SizeDistribution/SizeDistributionLogic.py
@@ -174,7 +174,7 @@ class SizeDistributionLogic:
         dy = result.bin_err
         new_plot = Data1D(x=x, y=y, dy=dy)
         new_plot.is_data = False
-        # new_plot.plot_role = DataRole.ROLE_STAND_ALONE
+        new_plot.plot_role = DataRole.ROLE_SIZE_DISTRIBUTION
         # new_plot.symbol = "Line"
 
         new_plot.id = SIZE_DISTR_LABEL
@@ -188,12 +188,13 @@ class SizeDistributionLogic:
 
         # Create vertical lines for trusted range
         x_trust = self.computeTrustRange(qmin, qmax)
-        y_max_trust = np.full_like(x_trust, 1.0)  # lines start at 0.0 and end at y
+        y_max_trust = np.full_like(x_trust, max(y))  # lines start at 0.0 and end at y
         trust_plot = Data1D(x=x_trust, y=y_max_trust)
         trust_plot.is_data = False
         trust_plot.symbol = "Vline"
         trust_plot.xaxis("\\rm{Diameter}", "A")
         trust_plot.yaxis("\\rm{VolumeDistribution}", "")
+        trust_plot.plot_role = DataRole.ROLE_SIZE_DISTRIBUTION
 
         trust_plot.id = TRUST_RANGE_LABEL
         trust_plot.group_id = GROUP_ID_SIZE_DISTR_FIT

--- a/src/sas/qtgui/Plotting/PlotterData.py
+++ b/src/sas/qtgui/Plotting/PlotterData.py
@@ -35,6 +35,9 @@ class DataRole(Enum):
     ROLE_POLYDISPERSITY = auto()
     # ANGULAR_SLICE role is to ensure angular slices from 2D plots are on linear scale
     ROLE_ANGULAR_SLICE = auto()
+    # SIZE_DISTRIBUTION role is to allow for plotting the vol fraction results on a lin-log scale
+    # without plotting the parent data
+    ROLE_SIZE_DISTRIBUTION = auto()
 
 
 class Data1D(PlottableData1D, LoadData1D):


### PR DESCRIPTION
## Description
This fixes the issue in #3276 by adding a new role, `DataRole.ROLE_SIZE_DISTRIBUTION` and making it an exception to the rule that ALL plots that are not standalone get plotted with the main data in the same chart.  In principle one could also try a direct call to `plotData` instead of `displayData` (assuming there is a sgnal for that which is unclear). This is what the `create New` graph button does for example but it is not clear that all the logic we want for these plots will work doing that?

in the process also fixed issue #3344 by adding an index to the for loop and only running the if statement for the first iteration.

Fixes #3276
Fixes #3344

## How Has This Been Tested?

Checked by running locally in dev environment and for 3344 tested with both Invariant and the new sizedistribution

## Review Checklist:

[if using the editor, use `[x]` in place of `[ ]` to check a box]

**Documentation** (check at least one)
- [X] There is **nothing** that needs documenting
- [ ] Documentation changes are **in this PR**
- [ ] There is an **issue** open for the documentation (link?)

**Installers**
- [ ] There is a chance this will affect the **installers**, if so
  - [ ] **Windows** installer (GH artifact) has been tested (installed and worked) 
  - [ ] **MacOSX** installer (GH artifact) has been tested (installed and worked) 

None of the changes should affect the installers as far as I know

**Licencing** (untick if necessary)
- [x] The introduced changes comply with SasView license (BSD 3-Clause)

