### PR TITLE
Error when sending 2D data to Size Distribution perspective

### DIFF
--- a/src/sas/qtgui/Perspectives/SizeDistribution/SizeDistributionPerspective.py
+++ b/src/sas/qtgui/Perspectives/SizeDistribution/SizeDistributionPerspective.py
@@ -435,13 +435,15 @@ class SizeDistributionWindow(QtWidgets.QDialog, Ui_SizeDistribution, Perspective
             raise AttributeError(msg)
 
         self._model_item = data_item[0]
-        self.logic.data = GuiUtils.dataFromItem(self._model_item)
-        self.model.item(WIDGETS.W_NAME).setData(self._model_item.text())
-        self.updateBackground()
+        logic_data = GuiUtils.dataFromItem(self._model_item)
 
-        if not isinstance(self.logic.data, Data1D):
+        if not isinstance(logic_data, Data1D):
             msg = "Size Distribution cannot be computed with 2D data."
             raise ValueError(msg)
+
+        self.logic.data = logic_data
+        self.model.item(WIDGETS.W_NAME).setData(self._model_item.text())
+        self.updateBackground()
 
         try:
             name = self.logic.data.name


### PR DESCRIPTION
## Description

There was an uninformative error when sending 2D data to the Size Distribution perspective, because the check for 2D data came too late in the logic. This change moves the check for 2D data. Now, there is a more informative error message that tells the user that the Size Distribution perspective cannot handle 2D data.

Fixes #3341 

## How Has This Been Tested?

Tested in the local dev environment that sending 2D data results in the error message below and sending 1D data works as expected.

![image](https://github.com/user-attachments/assets/4dce7686-6e7a-44ac-821e-54adb9c50465)

## Review Checklist:

[if using the editor, use `[x]` in place of `[ ]` to check a box]

**Documentation** (check at least one)
- [ ] There is **nothing** that needs documenting
- [ ] Documentation changes are **in this PR**
- [ ] There is an **issue** open for the documentation (link?)

**Installers**
- [ ] There is a chance this will affect the **installers**, if so
  - [ ] **Windows** installer (GH artifact) has been tested (installed and worked) 
  - [ ] **MacOSX** installer (GH artifact) has been tested (installed and worked) 

**Licencing** (untick if necessary)
- [x] The introduced changes comply with SasView license (BSD 3-Clause)

