### PR TITLE
Set compression level on windows installer to speed up generation

### DIFF
--- a/installers/installer.iss
+++ b/installers/installer.iss
@@ -35,8 +35,10 @@ SetupIconFile=../src/sas/qtgui/images/ball.ico
 ; Uncomment the following line to run in non administrative install mode (install for current user only.)
 ;PrivilegesRequired=lowest
 PrivilegesRequiredOverridesAllowed=dialog
-Compression=lzma
+Compression=lzma2/normal
 SolidCompression=yes
+LZMAUseSeparateProcess=yes
+LZMANumBlockThreads=4
 WizardStyle=modern
 
 [Languages]


### PR DESCRIPTION
## Description

Creating the windows installer is currently the slowest step along the slowest path on CI - the windows installer creation step is approx 7 min slower than the other jobs that are run in parallel.

One of the slow parts of the the windows installer CI job is assembling all the files into a compressed archive. To speed this up, we can (a) tweak the compression settings, and (b) reduce the size and number of files being compressed. This PR looks at (a) and I'll look at (b) next.

I have thrashed CI running the `iscc` installer in a loop to measure the time taken to create the windows installer and the size of the output. Times are simply measured using the unix utility `time` (`real` time is sufficient here); they are quite reproducible within any given CI run but as the CI workers themselves do vary a bit, they can differ between runs by as much as 25%. Using the compressor as embedded within `iscc` on the hardware that we care about with the data that will be used is important — compressor performance is very sensitive to what is being compressed and tuning the compressor needs to match the capabilities of the hardware.

The installer currently uses `lzma` compression; as expected, my experiments showed that `zip` is faster than `lzma` (about 78% faster) but it resulted in a 27% increase in the size of the image. That's worth considering at least during the development phase. 

Working on the assumption that we don't want to end up with that big jump in installer size, we can look at other compressors within `iscc`, namely tuning the `lzma` or switching to the newer `lzma2`. To compare these, I looked at the following settings ([reference documentation](https://jrsoftware.org/ishelp/index.php?topic=setup_compression)):

 - `Compression`: `lzma` vs `lzma2`; we currently use `lzma`
 - Compressor level: `fast`, `normal`, `max`, `ultra`; we currently use the default, `max`
 - `LZMANumBlockThreads` compressor block threads: 1, 2, 4, 6, 8, 16; we currently use the default 1
 - `LZMAUseSeparateProcess`: `yes` vs `no` to select running the compressor in an external process or internally within `iscc`; we currently use the default `no` (i.e. internal)
 
![installer-compression-lzma-threads](https://github.com/user-attachments/assets/6d03f1ea-2949-415c-a9f3-e32471e9105a)

The first group of 3 measurements are with the internal compressor (`LZMAUseSeparateProcess=no`) and different numbers of block threads; the second group is with the **ext**ernal compressor.

In the experiments, there was no improvement with more than 4 threads so the data are truncated there. The `ultra` level of compressor is much slower again and ran out of memory on more than one occasion so was omitted from the experiments. The `fast` compressor level produces much larger image sizes (+20%).

Based on these data, this PR sets:

```
Compression=lzma2/normal
LZMAUseSeparateProcess=yes
LZMANumBlockThreads=4
```

which achieves a 62% speed up in the `iscc` step at the expense of a 6% increase in the windows installer size. The CI runs are then 2-3ish min faster with this in place (noting the variability between CI runs as opposed to measurements within one).

This PR is pointed at the `release-6.1.0` branch on the assumption that this is something that is desirable to land in CI as soon as possible. Please let me know if you'd rather it just went to `main` at this stage.

For future reference, `zip/4` and `lzma2/fast` (with NBT=4) produced similar speeds and output sizes - running with that throughout the development cycle up until the beta releases is a reasonable discussion for the future.

## How Has This Been Tested?

CI tests that the installer can be installed, which is the only potential place for breakage.

## Review Checklist:

[if using the editor, use `[x]` in place of `[ ]` to check a box]

**Documentation** (check at least one)
- [x] There is **nothing** that needs documenting
- [ ] Documentation changes are **in this PR**
- [ ] There is an **issue** open for the documentation (link?)

**Installers**
- [x] There is a chance this will affect the **installers**, if so
  - [ ] **Windows** installer (GH artifact) has been tested (installed and worked) 
  - [ ] **MacOSX** installer (GH artifact) has been tested (installed and worked) 

**Licencing** (untick if necessary)
- [x] The introduced changes comply with SasView license (BSD 3-Clause)

