### PR TITLE
Suppress signature errors when CI run on PRs from forks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,7 +90,7 @@ jobs:
     env:
       MACOS_DMG_NAME: SasView6-${{ matrix.os }}.dmg
       # Only sign/notarize if the secrets will be available
-      SIGN_INSTALLER: ${{ (github.repository == 'SasView/sasview') && 'true' || '' }}
+      SIGN_INSTALLER: ${{ (! github.event.repository.fork && ! github.event.pull_request.head.repo.fork) && 'true' || '' }}
 
     name: "${{ matrix.job_name }}"
 


### PR DESCRIPTION
## Description

CI already knows not to try to sign/notarise the installers when running on push within a fork. This change ensures that the sign/notarise steps only happen when a PR comes from the `sasview/sasview.git` repository and not from a fork. This will suppress spurious errors about signing keys not being available in PRs.

Anyone using the unsigned installers likely needs to jump though additional hoops to enable the unsigned code, but they can't currently even get to the unsigned installers because the job fails prior to upload.

## How Has This Been Tested?

CI on this PR - it doesn't fail :)

(Checking that signing still works for 'internal' PRs is still needed)

## Review Checklist:

[if using the editor, use `[x]` in place of `[ ]` to check a box]

**Documentation** (check at least one)
- [x] There is **nothing** that needs documenting
- [ ] Documentation changes are **in this PR**
- [ ] There is an **issue** open for the documentation (link?)

**Installers**
- [ ] There is a chance this will affect the **installers**, if so
  - [ ] **Windows** installer (GH artifact) has been tested (installed and worked) 
  - [ ] **MacOSX** installer (GH artifact) has been tested (installed and worked) 

**Licencing** (untick if necessary)
- [x] The introduced changes comply with SasView license (BSD 3-Clause)

