### PR TITLE
3359: Corfunc not accept Data1D

### DIFF
--- a/src/sas/qtgui/Perspectives/Corfunc/CorfuncPerspective.py
+++ b/src/sas/qtgui/Perspectives/Corfunc/CorfuncPerspective.py
@@ -454,9 +454,6 @@ class CorfuncWindow(QtWidgets.QDialog, Ui_CorfuncDialog, Perspective):
         Obtain a QStandardItem object and dissect it to get Data1D/2D
         Pass it over to the calculator
         """
-        if not isinstance(data_item, Data1D):
-            msg = "Invariant cannot be computed with 2D data."
-            raise ValueError(msg)
 
         if self.has_data:
             msg = "Data is already loaded into the Corfunc perspective. Sending a new data set "
@@ -471,6 +468,10 @@ class CorfuncWindow(QtWidgets.QDialog, Ui_CorfuncDialog, Perspective):
         data = GuiUtils.dataFromItem(model_item)
         self.data = data
         self._model_item = model_item
+
+        if not isinstance(self.data, Data1D):
+            msg = "Corfunc cannot be computed using 2D data."
+            raise ValueError(msg)
 
         self.model.itemChanged.disconnect(self.model_changed)
 


### PR DESCRIPTION
## Description

This moves the isinstance check for data objects in Corfunc to after the data extraction step. Also updated the wording to so the Corfunc error says Corfunc, not Invariant.

Fixes #3359 

## How Has This Been Tested?

Tested locally using run.py

## Review Checklist:

**Documentation** (check at least one)
- [x] There is **nothing** that needs documenting
- [ ] Documentation changes are **in this PR**
- [ ] There is an **issue** open for the documentation (link?)

**Installers**
- [ ] There is a chance this will affect the **installers**, if so
  - [ ] **Windows** installer (GH artifact) has been tested (installed and worked) 
  - [ ] **MacOSX** installer (GH artifact) has been tested (installed and worked) 

**Licencing** (untick if necessary)
- [x] The introduced changes comply with SasView license (BSD 3-Clause)

