### PR TITLE
Q range sliders reset after fitting

### DIFF
--- a/src/sas/qtgui/Plotting/QRangeSlider.py
+++ b/src/sas/qtgui/Plotting/QRangeSlider.py
@@ -155,7 +155,8 @@ class LineInteractor(BaseInteractor):
             self.setter = self._get_input_or_callback(setter)
             self.getter = self._get_input_or_callback(getter)
         self.connect_markers([self.line, self.inner_marker])
-        self.update(draw=True)
+        # Get the linked input and draw
+        self.inputChanged()
 
     @property
     def input(self):


### PR DESCRIPTION
## Description

When a `LineConnector` is created for Q range sliders in a plot, use the connected inputs (e.g. min Q text input) to initialize the position of the slider.

Fixes #3347

## How Has This Been Tested?

I have tested in the local dev environment that this fixes #3347. I have tested that other perspectives with Q range sliders are not affected by this change. The same bug (Q range sliders reset to the Q range of the data on plot update) is present in the P(r) Inversion perspective, but it is unfortunately not fixed by this change.

## Review Checklist:

[if using the editor, use `[x]` in place of `[ ]` to check a box]

**Documentation** (check at least one)
- [ ] There is **nothing** that needs documenting
- [ ] Documentation changes are **in this PR**
- [ ] There is an **issue** open for the documentation (link?)

**Installers**
- [ ] There is a chance this will affect the **installers**, if so
  - [ ] **Windows** installer (GH artifact) has been tested (installed and worked) 
  - [ ] **MacOSX** installer (GH artifact) has been tested (installed and worked) 

**Licencing** (untick if necessary)
- [x] The introduced changes comply with SasView license (BSD 3-Clause)

