### PR TITLE
Stop new version dialogue from appearing in test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -453,6 +453,7 @@ jobs:
         # If sasview has crashed on its own, then this should return an error
         run: |
           (
+            export https_proxy=https://127.0.0.1:9
             echo "## START SASVIEW"
             xvfb-run -a --server-args="-screen 0 1024x768x24" $RUN_SASVIEW 2>&1 |
             tee sasview-test.log


### PR DESCRIPTION
## Description

The "New version available" dialogue can appear during the test sequence. This halts sasview GUI startup and so breaks the very simple linux installer smoke test. Setting the https_proxy environment variable to a port that doesn't reply (the discard port) is a standard way of preventing network checks from running during tests - in this case, it means the test for the new version always fails, which is a non-fatal error in starting up sasview.

## How Has This Been Tested?

CI now passes for the linux installer test.

## Review Checklist:

[if using the editor, use `[x]` in place of `[ ]` to check a box]

**Documentation** (check at least one)
- [x] There is **nothing** that needs documenting
- [ ] Documentation changes are **in this PR**
- [ ] There is an **issue** open for the documentation (link?)

**Installers**
- [ ] There is a chance this will affect the **installers**, if so
  - [ ] **Windows** installer (GH artifact) has been tested (installed and worked) 
  - [ ] **MacOSX** installer (GH artifact) has been tested (installed and worked) 

**Licencing** (untick if necessary)
- [x] The introduced changes comply with SasView license (BSD 3-Clause)

