### PR TITLE
Simultaneous fitting issues

### DIFF
--- a/src/sas/qtgui/Perspectives/Fitting/ComplexConstraint.py
+++ b/src/sas/qtgui/Perspectives/Fitting/ComplexConstraint.py
@@ -53,7 +53,7 @@ class ComplexConstraint(QtWidgets.QDialog, Ui_ComplexConstraintUI):
         """
         Digs into self.tabs and pulls out relevant info
         """
-        self.tab_names = [tab.kernel_module.name for tab in self.tabs]
+        self.tab_names = [tab.logic.kernel_module.name for tab in self.tabs]
         self.params = [tab.getParamNames() for tab in self.tabs]
 
     def setupSignals(self):
@@ -105,10 +105,10 @@ class ComplexConstraint(QtWidgets.QDialog, Ui_ComplexConstraintUI):
         # Populate the left combobox parameter arbitrarily with the parameters
         # from the first tab if `All` option is selected
         if self.cbModel1.currentText() == "All":
-            items1 = self.tabs[1].main_params_to_fit + self.tabs[1].poly_params_to_fit
+            items1 = self.tabs[1].main_params_to_fit + self.tabs[1].polydispersity_widget.poly_params_to_fit
         else:
             tab_index1 = self.cbModel1.currentIndex()
-            items1 = self.tabs[tab_index1].main_params_to_fit + self.tabs[tab_index1].poly_params_to_fit
+            items1 = self.tabs[tab_index1].main_params_to_fit + self.tabs[tab_index1].polydispersity_widget.poly_params_to_fit
         self.cbParam1.addItems(items1)
         # Show the previously selected parameter if available
         if previous_param1 in items1:
@@ -180,7 +180,7 @@ class ComplexConstraint(QtWidgets.QDialog, Ui_ComplexConstraintUI):
             self.txtConstraint.setText(self.cbModel2.currentText() + "." + param2)
         # Check if any of the parameters are polydisperse
         params_list = [param1, param2]
-        all_pars = [tab.model_parameters for tab in self.tabs]
+        all_pars = [tab.logic.model_parameters for tab in self.tabs]
         is2Ds = [tab.is2D for tab in self.tabs]
         txt = self.redefining_warning
         for pars, is2D in zip(all_pars, is2Ds):
@@ -309,7 +309,7 @@ class ComplexConstraint(QtWidgets.QDialog, Ui_ComplexConstraintUI):
         if self.cbModel1.currentText() == "All":
             # exclude the tab on the lhs
             tabs = [tab for tab in self.tabs if
-                    tab.kernel_module.name != self.cbModel2.currentText()]
+                    tab.logic.kernel_module.name != self.cbModel2.currentText()]
             self.applyAcrossTabs(tabs, self.cbParam1.currentText(),
                                  self.txtConstraint.text())
             self.setupParamWidgets()
@@ -338,16 +338,16 @@ class ComplexConstraint(QtWidgets.QDialog, Ui_ComplexConstraintUI):
         """
         for tab in tabs:
             if hasattr(tab, "kernel_module"):
-                if (param in tab.kernel_module.params or
+                if (param in tab.logic.kernel_module.params or
                     param in tab.poly_params or
                     param in tab.magnet_params):
-                    value_ex = tab.kernel_module.name + "." +param
+                    value_ex = tab.logic.kernel_module.name + "." +param
                     constraint = Constraint(param=param,
                                             value=param,
                                             func=expr,
                                             value_ex=value_ex,
                                             operator="=")
-                    self.constraintReadySignal.emit((tab.kernel_module.name,
+                    self.constraintReadySignal.emit((tab.logic.kernel_module.name,
                                                      constraint))
 
     def onSetAll(self):
@@ -357,8 +357,8 @@ class ComplexConstraint(QtWidgets.QDialog, Ui_ComplexConstraintUI):
         # loop over parameters in constrained model
         index1 = self.cbModel1.currentIndex()
         index2 = self.cbModel2.currentIndex()
-        items1 = self.tabs[index1].main_params_to_fit + self.tabs[index1].poly_params_to_fit
-        items2 = self.tabs[index2].main_params_to_fit + self.tabs[index2].poly_params_to_fit
+        items1 = self.tabs[index1].main_params_to_fit + self.tabs[index1].polydispersity_widget.poly_params_to_fit
+        items2 = self.tabs[index2].main_params_to_fit + self.tabs[index2].polydispersity_widget.poly_params_to_fit
         # create an empty list to store redefined constraints
         redefined_constraints = []
         for item in items1:

--- a/src/sas/qtgui/Perspectives/Fitting/ConstraintWidget.py
+++ b/src/sas/qtgui/Perspectives/Fitting/ConstraintWidget.py
@@ -482,7 +482,7 @@ class ConstraintWidget(QtWidgets.QWidget, Ui_ConstraintWidgetUI):
             # Remove the key from the dictionaries
             self.available_tabs.pop(self.current_cell, None)
             # Change the model name
-            model = temp_tab.kernel_module
+            model = temp_tab.logic.kernel_module
             model.name = new_moniker
             # Replace constraint name
             temp_tab.replaceConstraintName(self.current_cell, new_moniker)
@@ -694,7 +694,7 @@ class ConstraintWidget(QtWidgets.QWidget, Ui_ConstraintWidgetUI):
                 # No such tab. removed while job was running
                 return
             # Make sure result and target objects are the same (same model moniker)
-            if tab_object.kernel_module.name == results[i].model.name:
+            if tab_object.logic.kernel_module.name == results[i].model.name:
                 tab_object.fitComplete(([[results[i]]], elapsed))
 
         msg = "Fitting completed successfully in: %s s.\n" % GuiUtils.formatNumber(elapsed)
@@ -935,7 +935,7 @@ class ConstraintWidget(QtWidgets.QWidget, Ui_ConstraintWidgetUI):
         Update a single line of the table widget with tab info
         """
         fit_page = ObjectLibrary.getObject(tab)
-        model = fit_page.kernel_module
+        model = fit_page.logic.kernel_module
 
         if model is None:
             logging.warning("No model selected")
@@ -1102,7 +1102,7 @@ class ConstraintWidget(QtWidgets.QWidget, Ui_ConstraintWidgetUI):
             object = ObjectLibrary.getObject(object_name)
             if isinstance(object, FittingWidget):
                 try:
-                    if object.kernel_module.name == name:
+                    if object.logic.kernel_module.name == name:
                         return object
                 except AttributeError:
                     # Disregard atribute errors - empty fit widgets

--- a/src/sas/qtgui/Perspectives/Fitting/UnitTesting/ComplexConstraintTest.py
+++ b/src/sas/qtgui/Perspectives/Fitting/UnitTesting/ComplexConstraintTest.py
@@ -54,14 +54,14 @@ class ComplexConstraintTest:
         model_index = tab2.cbModel.findText("barbell")
         tab2.cbModel.setCurrentIndex(model_index)
         # set tab2 model name to M2
-        tab2.kernel_module.name = "M2"
+        tab2.logic.kernel_module.name = "M2"
 
         category_index = tab3.cbCategory.findText("Cylinder")
         tab3.cbCategory.setCurrentIndex(category_index)
         model_index = tab3.cbModel.findText("barbell")
         tab3.cbModel.setCurrentIndex(model_index)
         # set tab2 model name to M2
-        tab3.kernel_module.name = "M3"
+        tab3.logic.kernel_module.name = "M3"
 
         tabs = [tab1, tab2, tab3]
         w = ComplexConstraint(parent=None, tabs=tabs)

--- a/src/sas/qtgui/Perspectives/Fitting/UnitTesting/ConstraintWidgetTest.py
+++ b/src/sas/qtgui/Perspectives/Fitting/UnitTesting/ConstraintWidgetTest.py
@@ -128,7 +128,7 @@ class ConstraintWidgetTest:
         ''' tab checks for consistency '''
         test_tab = MagicMock(spec=FittingWidget)
         test_tab.data_is_loaded = False
-        test_tab.kernel_module = None
+        test_tab.logic.kernel_module = None
         mocker.patch.object(ObjectLibrary, 'getObject', return_value=test_tab)
 
         assert not widget.isTabImportable(None)
@@ -165,7 +165,7 @@ class ConstraintWidgetTest:
         test_tab = MagicMock(spec=FittingWidget)
         test_tab.data_is_loaded = False
         mocker.patch.object(test_tab, 'kernel_module', create=True)
-        test_tab.kernel_module.name = "M1"
+        test_tab.logic.kernel_module.name = "M1"
         mocker.patch.object(ObjectLibrary, 'getObject', return_value=test_tab)
 
         # Add a tab without an constraint
@@ -190,7 +190,7 @@ class ConstraintWidgetTest:
         assert widget.tblConstraints.item(0, 0).checkState() == 2
         # Check the text
         assert widget.tblConstraints.item(0, 0).text() == \
-                         test_tab.kernel_module.name + \
+                         test_tab.logic.kernel_module.name + \
                          ":scale = " + \
                          self.constraint1.func
         # Add a tab with a non active constraint
@@ -283,7 +283,7 @@ class ConstraintWidgetTest:
         # test a successful fit
         result.success = True
         test_tab = MagicMock()
-        test_tab.kernel_module.name = 'M1'
+        test_tab.logic.kernel_module.name = 'M1'
         mocker.patch.object(test_tab, 'fitComplete')
         result.model.name = 'M1'
         widget.tabs_for_fitting = {"test_tab": test_tab}
@@ -328,7 +328,7 @@ class ConstraintWidgetTest:
         test_tab = MagicMock(spec=FittingWidget)
         test_tab.data_is_loaded = False
         mocker.patch.object(test_tab, 'kernel_module', create=True)
-        test_tab.kernel_module.name = "M1"
+        test_tab.logic.kernel_module.name = "M1"
         mocker.patch.object(ObjectLibrary, 'getObject', return_value=test_tab)
 
         # Add a tab with an active constraint
@@ -360,7 +360,7 @@ class ConstraintWidgetTest:
         test_tab = MagicMock(spec=FittingWidget)
         test_tab.data_is_loaded = False
         mocker.patch.object(test_tab, 'kernel_module', create=True)
-        test_tab.kernel_module.name = "M1"
+        test_tab.logic.kernel_module.name = "M1"
         mocker.patch.object(test_tab, 'getRowFromName', return_value=0)
         mocker.patch.object(ObjectLibrary, 'getObject', return_value=test_tab)
 

--- a/src/sas/qtgui/Perspectives/Fitting/UnitTesting/FitPageTest.py
+++ b/src/sas/qtgui/Perspectives/Fitting/UnitTesting/FitPageTest.py
@@ -27,7 +27,7 @@ class FitPageTest:
         assert not page.data_is_loaded
         assert page.name == ""
         assert page.data is None
-        assert page.kernel_module is None
+        assert page.logic.kernel_module is None
         assert page.parameters_to_fit == []
 
     def testSave(self):

--- a/src/sas/qtgui/Perspectives/Fitting/UnitTesting/FittingWidgetTest.py
+++ b/src/sas/qtgui/Perspectives/Fitting/UnitTesting/FittingWidgetTest.py
@@ -551,11 +551,11 @@ class FittingWidgetTest:
         assert widget.poly_params_to_fit == ['radius_bell.width', 'length.width']
 
         # Change the min/max values
-        assert widget.kernel_module.details['radius_bell.width'][1] == 0.0
+        assert widget.logic.kernel_module.details['radius_bell.width'][1] == 0.0
         widget._poly_model.item(0,2).setText("1.0")
-        assert widget.kernel_module.details['radius_bell.width'][1] == 1.0
+        assert widget.logic.kernel_module.details['radius_bell.width'][1] == 1.0
         # Check that changing the polydispersity min/max value doesn't affect the paramer min/max
-        assert widget.kernel_module.details['radius_bell'][1] == 0.0
+        assert widget.logic.kernel_module.details['radius_bell'][1] == 0.0
 
         #widget.show()
         #QtWidgets.QApplication.exec_()
@@ -565,14 +565,14 @@ class FittingWidgetTest:
         widget._poly_model.item(0,4).setText("22")
         assert widget.poly_params['radius_bell.npts'] == 22
         # test that sasmodel is updated with the new value
-        assert widget.kernel_module.getParam('radius_bell.npts') == 22
+        assert widget.logic.kernel_module.getParam('radius_bell.npts') == 22
 
         # Change the pd value
         assert widget.poly_params['radius_bell.width'] == 0.0
         widget._poly_model.item(0,1).setText("0.8")
         assert widget.poly_params['radius_bell.width'] == pytest.approx(0.8, abs=1e-7)
         # Test that sasmodel is updated with the new value
-        assert widget.kernel_module.getParam('radius_bell.width') == pytest.approx(0.8, abs=1e-7)
+        assert widget.logic.kernel_module.getParam('radius_bell.width') == pytest.approx(0.8, abs=1e-7)
 
         # Uncheck pd in the fitting widget
         widget.chkPolydispersity.setCheckState(2)
@@ -580,7 +580,7 @@ class FittingWidgetTest:
         # Should not change the value of the qt model
         assert widget.poly_params['radius_bell.width'] == pytest.approx(0.8, abs=1e-7)
         # sasmodel should be set to 0
-        assert widget.kernel_module.getParam('radius_bell.width') == pytest.approx(0.0, abs=1e-7)
+        assert widget.logic.kernel_module.getParam('radius_bell.width') == pytest.approx(0.0, abs=1e-7)
 
         # try something stupid
         widget._poly_model.item(0,4).setText("butt")
@@ -610,8 +610,8 @@ class FittingWidgetTest:
         # call method with default settings
         widget.onPolyComboIndexChange('gaussian', 0)
         # check values
-        assert widget.kernel_module.getParam('radius_bell.npts') == 35
-        assert widget.kernel_module.getParam('radius_bell.nsigmas') == 3
+        assert widget.logic.kernel_module.getParam('radius_bell.npts') == 35
+        assert widget.logic.kernel_module.getParam('radius_bell.nsigmas') == 3
         # Change the index
         widget.onPolyComboIndexChange('rectangle', 0)
         # check values
@@ -1203,10 +1203,10 @@ class FittingWidgetTest:
 
         # check that the value has been modified in kernel_module
         assert new_value == \
-                         str(widget.kernel_module.params[name_modified_param])
+                         str(widget.logic.kernel_module.params[name_modified_param])
 
         # check that range of variation for this parameter has NOT been changed
-        assert new_value not in widget.kernel_module.details[name_modified_param]
+        assert new_value not in widget.logic.kernel_module.details[name_modified_param]
 
     def testModelContextMenu(self, widget):
         """

--- a/src/sas/sascalc/fit/BumpsFitting.py
+++ b/src/sas/sascalc/fit/BumpsFitting.py
@@ -343,13 +343,13 @@ class BumpsFit(FitEngine):
             uncertainty = result['uncertainty']
             if hasattr(uncertainty, "draw"):
                 fitting_result.uncertainty_state = uncertainty
-            fitting_result.pvec = np.array([getattr(p.slot, 'n', p.slot) for p in pars])
-            fitting_result.stderr = np.array([getattr(p.slot, 's', 0) for p in pars])
+            fitting_result.pvec = np.array([getattr(p.slot, 'n', p.slot) for p in pars if hasattr(p, 'slot')])
+            fitting_result.stderr = np.array([getattr(p.slot, 's', 0) for p in pars if hasattr(p, 'slot')])
             DOF = max(1, fitness.numpoints() - len(fitness.fitted_pars))
             fitting_result.fitness = np.sum(fitting_result.residuals ** 2) / DOF
 
             # Warn user about any parameter that is not an uncertainty object
-            miss_uncertainty = [p for p in pars if not isinstance(p.slot,
+            miss_uncertainty = [p for p in pars if hasattr(p, 'slot') and not isinstance(p.slot,
                                 (uncertainties.core.Variable, uncertainties.core.AffineScalarFunc))]
             if miss_uncertainty:
                 uncertainty_warning = True


### PR DESCRIPTION
## Description

Refactoring of the Fitting widget left some dangling references to old methods, which now reside on separate objects.
This got fixed.

Fixes #3343

## How Has This Been Tested?

Local Windows 10 tests

## Review Checklist:

[if using the editor, use `[x]` in place of `[ ]` to check a box]

**Documentation** (check at least one)
- [X] There is **nothing** that needs documenting
- [ ] Documentation changes are **in this PR**
- [ ] There is an **issue** open for the documentation (link?)

**Installers**
- [ ] There is a chance this will affect the **installers**, if so
  - [ ] **Windows** installer (GH artifact) has been tested (installed and worked) 
  - [ ] **MacOSX** installer (GH artifact) has been tested (installed and worked) 

**Licencing** (untick if necessary)
- [x] The introduced changes comply with SasView license (BSD 3-Clause)

