### PR TITLE
removed unused method, updated unit tests

### DIFF
--- a/src/sas/qtgui/MainWindow/DataExplorer.py
+++ b/src/sas/qtgui/MainWindow/DataExplorer.py
@@ -1853,26 +1853,6 @@ class DataExplorerWindow(DroppableDataLoadWidget):
         self.model.clear()
         self.theory_model.clear()
 
-    def deleteSelectedItem(self):
-        """
-        Delete the current item
-        """
-        # Assure this is indeed wanted
-        delete_msg = "This operation will remove the selected data sets " +\
-                     "and all the dependents from SasView." +\
-                     "\nDo you want to continue?"
-        reply = QtWidgets.QMessageBox.question(self,
-                                               'Warning',
-                                               delete_msg,
-                                               QtWidgets.QMessageBox.Yes,
-                                               QtWidgets.QMessageBox.No)
-
-        if reply == QtWidgets.QMessageBox.No:
-            return
-
-        indices = self.current_view.selectedIndexes()
-        self.deleteIndices(indices)
-
     def deleteIndices(self, indices):
         """
         Delete model idices from the current view

--- a/src/sas/qtgui/MainWindow/UnitTesting/DataExplorerTest.py
+++ b/src/sas/qtgui/MainWindow/UnitTesting/DataExplorerTest.py
@@ -1064,7 +1064,7 @@ class DataExplorerTest:
         form.current_view.selectionModel().select(select_index, QtCore.QItemSelectionModel.Rows)
 
         # Attempt at deleting
-        form.deleteSelectedItem()
+        form.deleteFile()
 
         # Test the warning dialog called once
         assert QMessageBox.question.called
@@ -1078,7 +1078,7 @@ class DataExplorerTest:
         # Select the newly created item
         form.current_view.selectionModel().select(select_index, QtCore.QItemSelectionModel.Rows)
         # delete it. now for good
-        form.deleteSelectedItem()
+        form.deleteFile()
 
         # Test the warning dialog called once
         assert QMessageBox.question.called


### PR DESCRIPTION
## Description

#3236 set the delete dataset action to a single method (there were two separate methods before, executed depending on the context). The unused method was left to make sure things don't break with the new setup.
They seem not to, so the additional, unused method has been removed now.

Fixes #3238 

## How Has This Been Tested?

Local Win10 dev build

## Review Checklist:


**Documentation** (check at least one)
- [X] There is **nothing** that needs documenting
- [ ] Documentation changes are **in this PR**
- [ ] There is an **issue** open for the documentation (link?)

**Installers**
- [ ] There is a chance this will affect the **installers**, if so
  - [ ] **Windows** installer (GH artifact) has been tested (installed and worked) 
  - [ ] **MacOSX** installer (GH artifact) has been tested (installed and worked) 

**Licencing** (untick if necessary)
- [x] The introduced changes comply with SasView license (BSD 3-Clause)

