### PR TITLE
Fix bumps constrained fit

### DIFF
--- a/src/sas/qtgui/Perspectives/Fitting/FittingWidget.py
+++ b/src/sas/qtgui/Perspectives/Fitting/FittingWidget.py
@@ -1850,10 +1850,11 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         Given the fit results structure, pull out optimized parameters and return them as nicely
         formatted dict
         """
+        pvec = [float(p) for p in results.pvec]
         if results.fitness is None or \
             not np.isfinite(results.fitness) or \
-            np.any(results.pvec is None) or \
-            not np.all(np.isfinite(results.pvec)):
+            np.any(pvec is None) or \
+            not np.all(np.isfinite(pvec)):
             msg = "Fitting did not converge!"
             self.communicate.statusBarUpdateSignal.emit(msg)
             msg += results.mesg
@@ -1864,7 +1865,7 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
             logger.warning(results.mesg)
 
         param_list = results.param_list # ['radius', 'radius.width']
-        param_values = results.pvec     # array([ 0.36221662,  0.0146783 ])
+        param_values = pvec             # array([ 0.36221662,  0.0146783 ])
         param_stderr = results.stderr   # array([ 1.71293015,  1.71294233])
         params_and_errors = list(zip(param_values, param_stderr))
         param_dict = dict(zip(param_list, params_and_errors))

--- a/src/sas/sascalc/fit/BumpsFitting.py
+++ b/src/sas/sascalc/fit/BumpsFitting.py
@@ -36,6 +36,9 @@ from sas.sascalc.fit.AbstractFitEngine import FitEngine
 from sas.sascalc.fit.AbstractFitEngine import FResult
 from sas.sascalc.fit.expression import compile_constraints
 
+# patch uncertainties.core.AffineScalarFunc to work with float() conversion
+uncertainties.core.AffineScalarFunc.__float__ = lambda self: float(self.nominal_value)
+
 class Progress(object):
     def __init__(self, history, max_step, pars, dof):
         remaining_time = int(history.time[0]*(float(max_step)/history.step[0]-1))

--- a/src/sas/sascalc/fit/expression.py
+++ b/src/sas/sascalc/fit/expression.py
@@ -240,9 +240,22 @@ def compile_constraints(symtab, exprs, context={}):
     return retfn
 
 # Simple parameter class for checking constraints
-class _Parameter:
+class _Variable:
     def __init__(self, value=0):
         self.value = value
+
+class _Parameter:
+    slot = None
+    def __init__(self, value=0):
+        self.slot = _Variable(value)
+
+    @property
+    def value(self):
+        return self.slot.value
+    
+    @value.setter
+    def value(self, value):
+        self.slot.value = value
 
 def check_constraints(symtab, exprs, context={}, html=False):
     """
@@ -313,7 +326,7 @@ def _compile_constraints(symtab, exprs, context={}, html=False):
     # of the parameter in the expression.
     names = list(sorted(symtab.keys()))
     parameters = dict(('P%d'%i, symtab[k]) for i, k in enumerate(names))
-    mapping = dict((k, 'P%d.value'%i) for i, k in enumerate(names))
+    mapping = dict((k, 'P%d.slot'%i) for i, k in enumerate(names))
 
     # Add the parameters to the global context
     global_context = standard_symbols(context)


### PR DESCRIPTION
## Description

Allows running constrained fits with new bumps version >= 1.0.0b6
Fixes #3370

## How Has This Been Tested?

Ran a test constraint fit with the fix, and it works without the error described in #3370 
**NOTE**: the convergence plot doesn't seem to work when running a consrtrained fit, which is I think a different issue.

## Review Checklist:

[if using the editor, use `[x]` in place of `[ ]` to check a box]

**Documentation** (check at least one)
- [x] There is **nothing** that needs documenting
- [ ] Documentation changes are **in this PR**
- [ ] There is an **issue** open for the documentation (link?)

**Installers**
- [ ] There is a chance this will affect the **installers**, if so
  - [ ] **Windows** installer (GH artifact) has been tested (installed and worked) 
  - [ ] **MacOSX** installer (GH artifact) has been tested (installed and worked) 

**Licencing** (untick if necessary)
- [x] The introduced changes comply with SasView license (BSD 3-Clause)

