### PR TITLE
3288: Allow reparameterized parameters to be edited

### DIFF
--- a/src/sas/qtgui/Utilities/ModelEditors/ReparamEditor/ReparameterizationEditor.py
+++ b/src/sas/qtgui/Utilities/ModelEditors/ReparamEditor/ReparameterizationEditor.py
@@ -198,12 +198,11 @@ class ReparameterizationEditor(QtWidgets.QDialog, Ui_ReparameterizationEditor):
         
         # Find the parameter item by using param_to_open and format as a dictionary
         param_properties = self.getParamProperties(param_to_open)
-        param_properties['highlighted_property'] = highlighted_property
         self.onAddParam()
         # Populate the editor with the parameter values
         if self.param_editor:
             self.param_editor.properties = param_properties
-            self.param_editor.qtree_item = selected_item
+            self.param_editor.qtree_item = param_to_open # Item to edit is always the parent of the selected_item!
             self.param_editor.onLoad()
             self.param_editor.returnEditedParamSignal.connect(self.updateParam)
     
@@ -586,10 +585,10 @@ class ReparameterizationEditor(QtWidgets.QDialog, Ui_ReparameterizationEditor):
         if (self.loaded_model_name is not None
                 and self.loaded_model_name not in list(self.model_selector.custom_models.values())):
             tree_location = tree_base + f"{self.loaded_model_name}.html"
+            self.parent.showHelp(tree_location)
         else:
             logging.info("No model detected to have been loaded. Showing default help page.")
             self.onHelp()
-        self.parent.showHelp(tree_location)
 
     ### CLASS METHODS ###
 


### PR DESCRIPTION
## Description

This populates the parameter editor widget when selecting edit parameter and updating the widget in the reparameterization editor.

Fixes #3288

## How Has This Been Tested?

Tested locally. Seems to work for all values in the window.

## Review Checklist:

[if using the editor, use `[x]` in place of `[ ]` to check a box]

**Documentation** (check at least one)
- [x] There is **nothing** that needs documenting
- [ ] Documentation changes are **in this PR**
- [ ] There is an **issue** open for the documentation (link?)

**Installers**
- [x] There is a chance this will affect the **installers**, if so
  - [ ] **Windows** installer (GH artifact) has been tested (installed and worked) 
  - [ ] **MacOSX** installer (GH artifact) has been tested (installed and worked) 

**Licencing** (untick if necessary)
- [x] The introduced changes comply with SasView license (BSD 3-Clause)

