### PR TITLE
Use python instead of python3 for UI generation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -113,7 +113,7 @@ artifacts = [
 [[tool.hatch.build.targets.wheel.hooks.build-scripts.scripts]]
 # Perform Qt UI conversion steps (uic, rcc etc)
 commands = [
-    "python3 src/sas/qtgui/convertUI.py",
+    "python src/sas/qtgui/convertUI.py",
 ]
 # out_dir = "GUI-output"
 artifacts = [


### PR DESCRIPTION
## Description

Some windows developers are having issues building sasview with the latest move to pyproject. The build stops with the error:

> Command 'python3 src/sas/qtgui/convertUI.py' returned non-zero exit status 9009

This is resolved by removing the number 3 (python3->python).

Fixes # (issue/issues)

## How Has This Been Tested?

Tested locally using my development system.

## Review Checklist:

**Documentation** (check at least one)
- [x] There is **nothing** that needs documenting
- [ ] Documentation changes are **in this PR**
- [ ] There is an **issue** open for the documentation (link?)

**Installers**
- [x] There is a chance this will affect the **installers**, if so
  - [ ] **Windows** installer (GH artifact) has been tested (installed and worked) 
  - [ ] **MacOSX** installer (GH artifact) has been tested (installed and worked) 

**Licencing** (untick if necessary)
- [x] The introduced changes comply with SasView license (BSD 3-Clause)

