### PR TITLE
Fix for documentation window crashes

### DIFF
--- a/src/sas/qtgui/MainWindow/MainWindow.py
+++ b/src/sas/qtgui/MainWindow/MainWindow.py
@@ -77,7 +77,9 @@ def get_highdpi_scaling():
     return 1.0
 
 def run_sasview():
-    # Force software rendering and disable GPU
+    # Disable GPU. This is a workaround for the issue with the QtWebEngine on some Win 10 systems
+    # https://github.com/SasView/sasview/issues/3384
+    # TODO: remove when the issue is fixed in QtWebEngine
     os.environ["QTWEBENGINE_CHROMIUM_FLAGS"] = "--disable-gpu"
 
     # Check for updates

--- a/src/sas/qtgui/MainWindow/MainWindow.py
+++ b/src/sas/qtgui/MainWindow/MainWindow.py
@@ -77,6 +77,8 @@ def get_highdpi_scaling():
     return 1.0
 
 def run_sasview():
+    # Force software rendering and disable GPU
+    os.environ["QTWEBENGINE_CHROMIUM_FLAGS"] = "--disable-gpu"
 
     # Check for updates
     maybe_prompt_new_version_download()


### PR DESCRIPTION
## Description

Removed GPU rendering in the QtWebWidget, which was causing issues with some graphics cards on Win10.

Fixes #3384

## How Has This Been Tested?

Running docs in SasView installed from the installer.

## Review Checklist:

[if using the editor, use `[x]` in place of `[ ]` to check a box]

**Documentation** (check at least one)
- [X] There is **nothing** that needs documenting
- [ ] Documentation changes are **in this PR**
- [ ] There is an **issue** open for the documentation (link?)

**Installers**
- [ ] There is a chance this will affect the **installers**, if so
  - [ ] **Windows** installer (GH artifact) has been tested (installed and worked) 
  - [ ] **MacOSX** installer (GH artifact) has been tested (installed and worked) 

**Licencing** (untick if necessary)
- [x] The introduced changes comply with SasView license (BSD 3-Clause)

