### PR TITLE
Deduplicate the windows installer artifact

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -323,10 +323,10 @@ jobs:
         with:
           name: SasView-Installer-${{ matrix.os }}-${{ matrix.python-version }}
           path: |
-            installers/dist/setupSasView*.exe
+            installers/dist/setupSasView.exe
             installers/dist/SasView6-macos-13.dmg
             installers/dist/SasView6-macos-latest.dmg
-            installers/dist/SasView*.tar.gz
+            installers/dist/SasView6.tar.gz
           if-no-files-found: ignore
 
 


### PR DESCRIPTION
## Description

As noted in #3383 by @rozyczko, the windows installer artifact also contains a tarball of the files prior to going into the installer. This wasn't intended - it's just one of the perverse things than happens in case-insensitive file systems. It's easy to fix by getting rid of the globs and making the filenames more specific.

## How Has This Been Tested?

CI

## Review Checklist:

[if using the editor, use `[x]` in place of `[ ]` to check a box]

**Documentation** (check at least one)
- [x] There is **nothing** that needs documenting
- [ ] Documentation changes are **in this PR**
- [ ] There is an **issue** open for the documentation (link?)

**Installers**
- [ ] There is a chance this will affect the **installers**, if so
  - [ ] **Windows** installer (GH artifact) has been tested (installed and worked) 
  - [ ] **MacOSX** installer (GH artifact) has been tested (installed and worked) 

**Licencing** (untick if necessary)
- [x] The introduced changes comply with SasView license (BSD 3-Clause)

