### PR TITLE
Second try at fixing custom labels

### DIFF
--- a/src/sas/qtgui/Plotting/Plotter.py
+++ b/src/sas/qtgui/Plotting/Plotter.py
@@ -5,6 +5,7 @@ import functools
 import copy
 import math
 import matplotlib as mpl
+import matplotlib.ticker as ticker
 import numpy as np
 import textwrap
 from matplotlib.font_manager import FontProperties
@@ -907,6 +908,15 @@ class PlotterWidget(PlotterBase):
             from matplotlib.pyplot import gca
             a = gca()
             a.set_yticklabels(a.get_yticks(), **fy)
+        if self.ax.xaxis.get_scale() == "log":
+            self.ax.xaxis.set_major_formatter(ticker.LogFormatterSciNotation(labelOnlyBase=True))
+        else:
+            self.ax.xaxis.set_major_formatter(ticker.ScalarFormatter(useMathText=True))
+        if self.ax.yaxis.get_scale() == "log":
+            self.ax.yaxis.set_major_formatter(ticker.LogFormatterSciNotation(labelOnlyBase=True))
+        else:
+            self.ax.yaxis.set_major_formatter(ticker.ScalarFormatter(useMathText=True))
+
         self.canvas.draw_idle()
 
     def onMplMouseDown(self, event):


### PR DESCRIPTION
This is a second attempt at fixing the problem reported in #3197. As discussed in PR #3386 comments, it turns out that using the log formatter should automatically take care of the issue with the tick labels on log scale. It also turns out that the linear scale has a similar problem. This is fixed by using the scaler formatter as in PR #3386.

## Description

This is a much simpler fix that implemented in PR #3386. It just adds the tick label formatting to the `onCustomizeLabel` method.
 
Fixes #3197

## How Has This Been Tested?

tested in the local dev environment of windows 10 machine. tried both x and y, both linear and log scales.

## Review Checklist:

[if using the editor, use `[x]` in place of `[ ]` to check a box]

**Documentation** (check at least one)
- [x] There is **nothing** that needs documenting
- [ ] Documentation changes are **in this PR**
- [ ] There is an **issue** open for the documentation (link?)

**Installers**
- [ ] There is a chance this will affect the **installers**, if so
  - [ ] **Windows** installer (GH artifact) has been tested (installed and worked) 
  - [ ] **MacOSX** installer (GH artifact) has been tested (installed and worked) 

**Licencing** (untick if necessary)
- [x] The introduced changes comply with SasView license (BSD 3-Clause)

