### PR TITLE
Add text boxes to size distribution output box and add/fix units

### DIFF
--- a/src/sas/qtgui/Perspectives/SizeDistribution/SizeDistributionPerspective.py
+++ b/src/sas/qtgui/Perspectives/SizeDistribution/SizeDistributionPerspective.py
@@ -759,22 +759,20 @@ class SizeDistributionWindow(QtWidgets.QDialog, Ui_SizeDistribution, Perspective
         else:
             converge_msg = "Not converged"
         self.lblConvergence.setText(converge_msg)
-        self.lblChiSq.setText(f"ChiSq: {result.chisq:.5g}")
+        self.txtChiSq.setText(f"{result.chisq:.5g}")
         stats = result.statistics
-        self.lblVolume.setText(
-            f"Volume of scatterers: {stats['volume']:.5g} +/- {stats['volume_err']:.5g}"
-        )
-        self.lblDiameterMean.setText(f"Mean diameter: {stats['mean']:.5g} \u212b")
-        self.lblDiameterMode.setText(f"Median diameter: {stats['median']:.5g} \u212b")
-        self.lblDiameterMedian.setText(f"Mode diameter: {stats['mode']:.5g} \u212b")
+        self.txtVolume.setText(f"{stats['volume']:.5g} +/- {stats['volume_err']:.5g}")
+        self.txtDiameterMean.setText(f"{stats['mean']:.5g}")
+        self.txtDiameterMedian.setText(f"{stats['median']:.5g}")
+        self.txtDiameterMode.setText(f"{stats['mode']:.5g}")
 
     def clearStatistics(self):
         """
         Clear the output box
         """
         self.lblConvergence.setText("")
-        self.lblChiSq.setText("")
-        self.lblVolume.setText("")
-        self.lblDiameterMean.setText("")
-        self.lblDiameterMode.setText("")
-        self.lblDiameterMedian.setText("")
+        self.txtChiSq.setText("")
+        self.txtVolume.setText("")
+        self.txtDiameterMean.setText("")
+        self.txtDiameterMode.setText("")
+        self.txtDiameterMedian.setText("")

--- a/src/sas/qtgui/Perspectives/SizeDistribution/UI/SizeDistributionUI.ui
+++ b/src/sas/qtgui/Perspectives/SizeDistribution/UI/SizeDistributionUI.ui
@@ -152,8 +152,7 @@
           <item row="0" column="2">
            <widget class="QLabel" name="label_2">
             <property name="text">
-             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Å&lt;span
-              style=&quot; vertical-align:super;&quot;&gt;-1&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;
+             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Å&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;
              </string>
             </property>
            </widget>
@@ -175,8 +174,7 @@
           <item row="0" column="5">
            <widget class="QLabel" name="label_3">
             <property name="text">
-             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Å&lt;span
-              style=&quot; vertical-align:super;&quot;&gt;-1&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;
+             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Å&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;
              </string>
             </property>
            </widget>
@@ -225,36 +223,157 @@
             </property>
            </widget>
           </item>
+          <item row="4" column="2">
+           <widget class="QLabel" name="label_4">
+            <property name="text">
+             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;10&lt;span
+              style=&quot; vertical-align:super;&quot;&gt;-6&lt;/span&gt;/Å&lt;span
+              style=&quot; vertical-align:super;&quot;&gt;-2&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;
+             </string>
+            </property>
+           </widget>
+          </item>
          </layout>
         </widget>
        </item>
-       <item row="3" column="0">
+       <item row="3" column="0" alignment="Qt::AlignTop">
         <widget class="QGroupBox" name="boxOutput">
          <property name="title">
           <string>Output</string>
          </property>
          <layout class="QGridLayout" name="gridLayout_8">
-          <item row="0" column="0">
+          <item row="0" column="0" colspan="4">
            <widget class="QLabel" name="lblConvergence">
             <property name="text">
-             <string></string>
+             <string/>
             </property>
            </widget>
           </item>
           <item row="1" column="0">
-           <widget class="QLabel" name="lblChiSq"/>
+           <widget class="QLabel" name="lblChiSq">
+            <property name="text">
+             <string>ChiSq: </string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="1">
+           <widget class="QLineEdit" name="txtChiSq">
+            <property name="enabled">
+             <bool>true</bool>
+            </property>
+            <property name="readOnly">
+             <bool>true</bool>
+            </property>
+           </widget>
           </item>
           <item row="2" column="0">
-           <widget class="QLabel" name="lblVolume"/>
+           <widget class="QLabel" name="lblVolume">
+            <property name="text">
+             <string>Total volume fraction: </string>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="1">
+           <widget class="QLineEdit" name="txtVolume">
+            <property name="enabled">
+             <bool>true</bool>
+            </property>
+            <property name="readOnly">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="2">
+           <widget class="QLabel" name="label_5">
+            <property name="text">
+             <string>%</string>
+            </property>
+           </widget>
           </item>
           <item row="3" column="0">
-           <widget class="QLabel" name="lblDiameterMean"/>
+           <widget class="QLabel" name="lblDiameterMean">
+            <property name="text">
+             <string>Mean diameter:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="1">
+           <widget class="QLineEdit" name="txtDiameterMean">
+            <property name="enabled">
+             <bool>true</bool>
+            </property>
+            <property name="readOnly">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="2">
+           <widget class="QLabel" name="label_6">
+            <property name="text">
+             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Å&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+            </property>
+           </widget>
           </item>
           <item row="4" column="0">
-           <widget class="QLabel" name="lblDiameterMode"/>
+           <widget class="QLabel" name="lblDiameterMedian">
+            <property name="text">
+             <string>Median diameter:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="4" column="1">
+           <widget class="QLineEdit" name="txtDiameterMedian">
+            <property name="enabled">
+             <bool>true</bool>
+            </property>
+            <property name="readOnly">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+          <item row="4" column="2">
+           <widget class="QLabel" name="label_19">
+            <property name="text">
+             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Å&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+            </property>
+           </widget>
           </item>
           <item row="5" column="0">
-           <widget class="QLabel" name="lblDiameterMedian"/>
+           <widget class="QLabel" name="lblDiameterMode">
+            <property name="text">
+             <string>Mode diameter:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="5" column="1">
+           <widget class="QLineEdit" name="txtDiameterMode">
+            <property name="enabled">
+             <bool>true</bool>
+            </property>
+            <property name="readOnly">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+          <item row="5" column="2">
+           <widget class="QLabel" name="label_20">
+            <property name="text">
+             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Å&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="3" rowspan="5">
+           <spacer name="horizontalSpacer_7">
+            <property name="orientation">
+             <enum>Qt::Horizontal</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>200</width>
+              <height>20</height>
+             </size>
+            </property>
+           </spacer>
           </item>
          </layout>
         </widget>
@@ -466,7 +585,6 @@
             </property>
            </spacer>
           </item>
-
          </layout>
         </widget>
        </item>


### PR DESCRIPTION
## Description

This changes the output box to show labels and empty text boxes for the outputs so that users can see what the expected output is.

Fixes #3392

## How Has This Been Tested?

Tested that the output text boxes are populated after a successful fit and that they are reset to empty when data is deleted.

## Review Checklist:

[if using the editor, use `[x]` in place of `[ ]` to check a box]

**Documentation** (check at least one)
- [x] There is **nothing** that needs documenting
- [ ] Documentation changes are **in this PR**
- [ ] There is an **issue** open for the documentation (link?)

**Installers**
- [ ] There is a chance this will affect the **installers**, if so
  - [ ] **Windows** installer (GH artifact) has been tested (installed and worked) 
  - [ ] **MacOSX** installer (GH artifact) has been tested (installed and worked) 

**Licencing** (untick if necessary)
- [x] The introduced changes comply with SasView license (BSD 3-Clause)

