### PR TITLE
3309: Shape2SAS plotting enhancements

### DIFF
--- a/src/sas/qtgui/Calculators/Shape2SAS/ViewerModel.py
+++ b/src/sas/qtgui/Calculators/Shape2SAS/ViewerModel.py
@@ -44,10 +44,10 @@ class ViewerModel(QWidget):
         self.dict_series = {"Red": self.seriesRed, "Green": self.seriesGreen, "Blue": self.seriesBlue}
        
         self.scatterContainer = QWidget.createWindowContainer(self.scatter)
-        self.scatterContainer.setFixedHeight(200)
-        self.scatterContainer.setFixedWidth(271)
+        self.scatter.setMinimumSize(QSize(271, 271))
         self.scatter.setHorizontalAspectRatio(1.0)
         self.scatter.setAspectRatio(1.0)
+        self.scatterContainer.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Expanding)
 
         self.initialiseAxis()
 
@@ -64,8 +64,8 @@ class ViewerModel(QWidget):
 
         #2D plot of P(q)
         self.scattering = QGraphicsView()
-        self.scattering.setMinimumSize(QSize(271, 250))  
-        self.scattering.setSizePolicy(QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Fixed)
+        self.scattering.setMinimumSize(QSize(271, 271))
+        self.scattering.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Expanding)
         self.scattering.setBackgroundBrush(QColor(255, 255, 255))
         self.scene = QGraphicsScene()
         self.scattering.setScene(self.scene)
@@ -74,7 +74,7 @@ class ViewerModel(QWidget):
         layout = QVBoxLayout()
         layout.setContentsMargins(0, 10, 0, 0)#remove margins
 
-        spacer = QSpacerItem(271, 20, QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Expanding)
+        spacer = QSpacerItem(271, 20, QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Fixed)
         subunitTableLabel = QLabel("Scattering of P(q)")
 
         layout.addWidget(self.scatterContainer)
@@ -85,11 +85,9 @@ class ViewerModel(QWidget):
         layout.addWidget(self.scattering)
 
         self.setLayout(layout)
-        self.setFixedWidth(271)
 
         self.Viewmodel_modul = QWidget()
         self.Viewmodel_modul.setLayout(layout)
-        self.Viewmodel_modul.setFixedWidth(271)
 
     def setScatteringPlot(self, theo: TheoreticalScattering):
         """Set the scattering plot"""

--- a/src/sas/qtgui/Calculators/Shape2SAS/ViewerModel.py
+++ b/src/sas/qtgui/Calculators/Shape2SAS/ViewerModel.py
@@ -46,6 +46,8 @@ class ViewerModel(QWidget):
         self.scatterContainer = QWidget.createWindowContainer(self.scatter)
         self.scatterContainer.setFixedHeight(200)
         self.scatterContainer.setFixedWidth(271)
+        self.scatter.setHorizontalAspectRatio(1.0)
+        self.scatter.setAspectRatio(1.0)
 
         self.initialiseAxis()
 


### PR DESCRIPTION
## Description

This fixes the issue related to the 3D plot in the Shape2SAS window where spheres looked liked ellipsoids. I also added a few tweaks to the plots, mostly to allow them to expand as the window is expanded.

Fixes #3309

## How Has This Been Tested?

Locally, the aspect ratios for all of the 3D plot axis remains the same.

## Review Checklist:

**Documentation** (check at least one)
- [x] There is **nothing** that needs documenting
- [ ] Documentation changes are **in this PR**
- [ ] There is an **issue** open for the documentation (link?)

**Installers**
- [x] There is a chance this will affect the **installers**, if so
  - [ ] **Windows** installer (GH artifact) has been tested (installed and worked) 
  - [ ] **MacOSX** installer (GH artifact) has been tested (installed and worked) 

**Licencing** (untick if necessary)
- [x] The introduced changes comply with SasView license (BSD 3-Clause)

