### PR TITLE
3378: Ensure python model is selected when window opens

### DIFF
--- a/src/sas/qtgui/Utilities/ModelEditors/TabbedEditor/PluginDefinition.py
+++ b/src/sas/qtgui/Utilities/ModelEditors/TabbedEditor/PluginDefinition.py
@@ -122,6 +122,8 @@ class PluginDefinition(QtWidgets.QDialog, Ui_PluginDefinition):
         self.highlightFunction = PythonHighlighter(self.txtFunction.document())
         self.highlightFormVolumeFunction = PythonHighlighter(self.txtFormVolumeFunction.document())
 
+        self.setModelTypeCheckBoxEnabledState("")
+
     def initializeModel(self):
         """
         Define the dictionary for internal data representation
@@ -288,11 +290,7 @@ class PluginDefinition(QtWidgets.QDialog, Ui_PluginDefinition):
         self.model['gen_c'] = self.chkGenC.isChecked()
         self.modelModified.emit()
 
-    def checkPyModelExists(self, filename: str) -> bool:
-        """
-        Checks if a Python model exists in the user plugin directory and forces enabling Python checkbox if not
-        :param filename: name of the file (without extension)
-        """
+    def setModelTypeCheckBoxEnabledState(self, filename: str):
         if not os.path.exists(os.path.join(find_plugins_dir(), filename + '.py')):
             # If the user has not yet created a Python file for a specific filename, then force them to create one
             self.chkGenPython.setChecked(True)
@@ -302,6 +300,13 @@ class PluginDefinition(QtWidgets.QDialog, Ui_PluginDefinition):
         else:
             self.infoLabel.setVisible(False)
             self.chkGenPython.setEnabled(True)
+
+    def checkPyModelExists(self, filename: str) -> bool:
+        """
+        Checks if a Python model exists in the user plugin directory and forces enabling Python checkbox if not
+        :param filename: name of the file (without extension)
+        """
+        self.setModelTypeCheckBoxEnabledState(filename)
         return os.path.exists(os.path.join(find_plugins_dir(), filename + '.py'))
 
     def updateParamTableFromEditor(self, param_list: []):


### PR DESCRIPTION
## Description

This ensures the python model creation check box is selected anytime the model name given does not already exist.

Fixes #3378

## Review Checklist:

**Documentation** (check at least one)
- [ ] There is **nothing** that needs documenting
- [ ] Documentation changes are **in this PR**
- [x] There is an **issue** open for the documentation (link?)

**Installers**
- [x] There is a chance this will affect the **installers**, if so
  - [ ] **Windows** installer (GH artifact) has been tested (installed and worked) 
  - [ ] **MacOSX** installer (GH artifact) has been tested (installed and worked) 

**Licencing** (untick if necessary)
- [x] The introduced changes comply with SasView license (BSD 3-Clause)

