### PR TITLE
3299: Include effective radius modes in model template

### DIFF
--- a/src/sas/qtgui/Utilities/ModelEditors/TabbedEditor/TabbedModelEditor.py
+++ b/src/sas/qtgui/Utilities/ModelEditors/TabbedEditor/TabbedModelEditor.py
@@ -1002,6 +1002,12 @@ description = """{description}"""
 ER_VR_TEMPLATE = '''\
 # NOTE: If you want to couple this model with structure factors (S(Q)), please uncomment this section. This
 #     function will need to return a meaningful value to enable full structure factor compatibility.
+# 
+# The modes in which the effective radius can be applied. This list allows arbitrary values, but the index of the mode
+#    will be passed to the calculation, not the text. Ensure the radius_effective method reutrns the correct value
+#    based on the index.
+# radius_effective_modes = ["equivalent volume sphere", "radius", "half length", "half total length",]
+#
 # def ER({args}):
 #     """
 #     Effective radius of particles to be used when computing structure factors.


### PR DESCRIPTION
## Description

This adds the list for `radius_effective_modes` to the python plugin model template to allow for different ER calculations.

Fixes #3299

## Review Checklist:

**Documentation** (check at least one)
- [ ] There is **nothing** that needs documenting
- [x] Documentation changes are **in this PR**
- [ ] There is an **issue** open for the documentation (link?)

**Licencing** (untick if necessary)
- [x] The introduced changes comply with SasView license (BSD 3-Clause)

