### PR TITLE
Size distribution should do what it says with uncertainties

### DIFF
--- a/src/sas/qtgui/Perspectives/SizeDistribution/SizeDistributionPerspective.py
+++ b/src/sas/qtgui/Perspectives/SizeDistribution/SizeDistributionPerspective.py
@@ -38,6 +38,7 @@ POWER_LOW_Q = 4
 SCALE_LOW_Q = 1.0
 NUM_ITERATIONS = 100
 WEIGHT_FACTOR = 1.0
+WEIGHT_PERCENT = 1.0
 
 logger = logging.getLogger(__name__)
 
@@ -214,6 +215,7 @@ class SizeDistributionWindow(QtWidgets.QDialog, Ui_SizeDistribution, Perspective
 
         # Weighting
         self.mapper.addMapping(self.txtWgtFactor, WIDGETS.W_WEIGHT_FACTOR)
+        self.mapper.addMapping(self.txtWgtPercent, WIDGETS.W_WEIGHT_PERCENT)
 
         self.mapper.toFirst()
 
@@ -268,10 +270,13 @@ class SizeDistributionWindow(QtWidgets.QDialog, Ui_SizeDistribution, Perspective
         # Weighting
         item = QtGui.QStandardItem(str(WEIGHT_FACTOR))
         self.model.setItem(WIDGETS.W_WEIGHT_FACTOR, item)
+        item = QtGui.QStandardItem(str(WEIGHT_PERCENT))
+        self.model.setItem(WIDGETS.W_WEIGHT_PERCENT, item)
 
     def setupWindow(self):
         """Initialize base window state on init"""
         self.enableButtons()
+        self.rbWeighting2.setChecked(True)
         self.txtPowerLowQ.setEnabled(False)
         self.txtScaleLowQ.setEnabled(False)
 
@@ -288,6 +293,7 @@ class SizeDistributionWindow(QtWidgets.QDialog, Ui_SizeDistribution, Perspective
         self.txtPowerLowQ.setValidator(GuiUtils.DoubleValidator())
         self.txtScaleLowQ.setValidator(GuiUtils.DoubleValidator())
         self.txtWgtFactor.setValidator(GuiUtils.DoubleValidator())
+        self.txtWgtPercent.setValidator(GuiUtils.DoubleValidator())
         self.txtBackgdQMin.setValidator(GuiUtils.DoubleValidator())
         self.txtBackgdQMax.setValidator(GuiUtils.DoubleValidator())
 
@@ -308,12 +314,8 @@ class SizeDistributionWindow(QtWidgets.QDialog, Ui_SizeDistribution, Perspective
         # Weighting controls
         if self.logic.di_flag:
             self.rbWeighting2.setEnabled(True)
-            self.rbWeighting2.setChecked(True)
-            # self.onWeightingChoice(self.rbWeighting2)
         else:
             self.rbWeighting2.setEnabled(False)
-            self.rbWeighting1.setChecked(True)
-            # self.onWeightingChoice(self.rbWeighting1)
         self.cmdFitFlatBackground.setEnabled(self.logic.data_is_loaded)
         self.cmdFitPowerLaw.setEnabled(
             self.logic.data_is_loaded and self.chkLowQ.isChecked()
@@ -677,7 +679,7 @@ class SizeDistributionWindow(QtWidgets.QDialog, Ui_SizeDistribution, Perspective
             self.rbWeighting1: WeightType.NONE,
             self.rbWeighting2: WeightType.DI,
             self.rbWeighting3: WeightType.SQRT_I,
-            self.rbWeighting4: WeightType.I,
+            self.rbWeighting4: WeightType.PERCENT_I,
         }
         for button, weight_type in weight_type_map.items():
             if button.isChecked():
@@ -699,6 +701,7 @@ class SizeDistributionWindow(QtWidgets.QDialog, Ui_SizeDistribution, Perspective
             sky_background=float(self.txtSkyBackgd.text()),
             max_iterations=int(self.txtIterations.text()),
             weight_factor=float(self.txtWgtFactor.text()),
+            weight_percent=float(self.txtWgtPercent.text()),
             weight_type=self.getWeightType(),
         )
 

--- a/src/sas/qtgui/Perspectives/SizeDistribution/SizeDistributionThread.py
+++ b/src/sas/qtgui/Perspectives/SizeDistribution/SizeDistributionThread.py
@@ -55,6 +55,7 @@ class SizeDistributionThread(CalcThread):
         sd.useWeights = True
         sd.weightType = self.params.weight_type
         sd.weightFactor = self.params.weight_factor
+        sd.weightPercent = self.params.weight_percent
         sd.nbins = self.params.num_bins
 
         trim_data, intensities, init_bins_back, sigma = sd.prep_maxEnt(

--- a/src/sas/qtgui/Perspectives/SizeDistribution/SizeDistributionUtils.py
+++ b/src/sas/qtgui/Perspectives/SizeDistribution/SizeDistributionUtils.py
@@ -23,14 +23,15 @@ WIDGETS = enum(
     "W_SCALE_LOW_Q",
     "W_NUM_ITERATIONS",
     "W_WEIGHT_FACTOR",
+    "W_WEIGHT_PERCENT",
 )
 
 
 class WeightType(StrEnum):
     NONE = "None"
     DI = "dI"
-    SQRT_I = "sqrtI"
-    I = "I"
+    SQRT_I = "sqrt(I Data)"
+    PERCENT_I = "percentI"
 
 
 @dataclass
@@ -49,6 +50,7 @@ class MaxEntParameters:
     use_weights: bool = True
     weight_type: WeightType = WeightType.DI
     weight_factor: float = 1.0
+    weight_percent: float = 1.0
     full_fit: bool = True
 
 

--- a/src/sas/qtgui/Perspectives/SizeDistribution/UI/SizeDistributionUI.ui
+++ b/src/sas/qtgui/Perspectives/SizeDistribution/UI/SizeDistributionUI.ui
@@ -528,8 +528,8 @@
          </property>
          <layout class="QGridLayout" name="gridLayout_20">
           <item row="0" column="0">
-           <layout class="QVBoxLayout" name="verticalLayout">
-            <item>
+           <layout class="QGridLayout" name="verticalLayout">
+            <item row="0" column="0">
              <widget class="QRadioButton" name="rbWeighting1">
               <property name="text">
                <string>None</string>
@@ -539,26 +539,29 @@
               </property>
              </widget>
             </item>
-            <item>
+            <item row="1" column="0">
              <widget class="QRadioButton" name="rbWeighting2">
               <property name="text">
                <string>Use dI Data</string>
               </property>
              </widget>
             </item>
-            <item>
+            <item row="2" column="0">
              <widget class="QRadioButton" name="rbWeighting3">
               <property name="text">
                <string>Use |sqrt(I Data)|</string>
               </property>
              </widget>
             </item>
-            <item>
+            <item row="3" column="0">
              <widget class="QRadioButton" name="rbWeighting4">
               <property name="text">
-               <string>Use |I Data|</string>
+               <string>Use % |I Data|</string>
               </property>
              </widget>
+            </item>
+            <item row="3" column="1">
+             <widget class="QLineEdit" name="txtWgtPercent"/>
             </item>
            </layout>
           </item>

--- a/src/sas/sascalc/size_distribution/SizeDistribution.py
+++ b/src/sas/sascalc/size_distribution/SizeDistribution.py
@@ -196,6 +196,7 @@ class sizeDistribution():
         self._useWeights = True
         self._weightType = 'dI'  
         self._weightFactor = 1.0
+        self._weightPercent = 1.0
         self._weights = self.data.dy
 
         ## Return Values after the MaxEnt should 
@@ -393,7 +394,15 @@ class sizeDistribution():
     @weightFactor.setter
     def weightFactor(self, value):
         self._weightFactor = value
-        
+
+    @property
+    def weightPercent(self):
+        return self._weightPercent
+
+    @weightPercent.setter
+    def weightPercent(self, value):
+        self._weightPercent = value
+
     @property
     def weightType(self):
         return self._weightType
@@ -407,7 +416,7 @@ class sizeDistribution():
     def weights(self):
         return self._weights
     
-    def update_weights(self, sigma=None, percent_value=0.01):
+    def update_weights(self, sigma=None):
 
         if sigma is None:
             wdata = self.data
@@ -423,12 +432,9 @@ class sizeDistribution():
             elif (self.weightType == 'sqrt(I Data)'):
                 self._weights = 1/np.sqrt(wdata.y)
 
-            elif (self.weightType == 'abs(I Data)'):
-                self._weights = 1/np.abs(wdata.y)
-
             elif self.weightType == 'percentI':
-                self._useWeights=False
-                self._weights = 1/np.abs(percent_value*wdata.y)
+                weight_fraction = self.weightPercent / 100.0
+                self._weights = 1/np.abs(weight_fraction*wdata.y)
             else:
                 logger.error("weightType doesn't match the possible strings for weight selection.\n Please check the value entered or use 'dI'.")
         


### PR DESCRIPTION
## Description

This fixes a bug where the weight type was always reset to "dI" when the user clicked one of the fit buttons. There was also a mismatch between the weight type strings in the GUI code and the calculation code (we should change this to define a weight type enum in the calculation code that the GUI code can import, but that's cleanup for later). The weight type option "I" is replaced with "% I" in the GUI.

Fixes #3394

## How Has This Been Tested?

Tested locally. The "% I" option gives different results depending on the input percentage, although the results are always worse than when using "dI". The "sqrt(I)" option also gives different (bad) results.

## Review Checklist:

[if using the editor, use `[x]` in place of `[ ]` to check a box]

**Documentation** (check at least one)
- [ ] There is **nothing** that needs documenting
- [ ] Documentation changes are **in this PR**
- [ ] There is an **issue** open for the documentation (link?)

**Installers**
- [ ] There is a chance this will affect the **installers**, if so
  - [ ] **Windows** installer (GH artifact) has been tested (installed and worked) 
  - [ ] **MacOSX** installer (GH artifact) has been tested (installed and worked) 

**Licencing** (untick if necessary)
- [x] The introduced changes comply with SasView license (BSD 3-Clause)

