### PR TITLE
Fix error multiplier

### DIFF
--- a/src/sas/sascalc/size_distribution/SizeDistribution.py
+++ b/src/sas/sascalc/size_distribution/SizeDistribution.py
@@ -371,7 +371,7 @@ class sizeDistribution():
         elif self.weightType == 'percentI':
             weight_fraction = self.weightPercent / 100.0
             self._weights = np.abs(weight_fraction*wdata.y)
-         else:
+        else:
             logger.error("weightType doesn't match the possible strings for weight selection.\n Please check the value entered or use 'dI'.")
         
         return None

--- a/src/sas/sascalc/size_distribution/SizeDistribution.py
+++ b/src/sas/sascalc/size_distribution/SizeDistribution.py
@@ -142,8 +142,7 @@ class sizeDistribution():
         #advanced parameters for MaxEnt 
         self._iterMax = 5000
         self._skyBackground = 1e-6
-        self._useWeights = True
-        self._weightType = 'dI'  
+        self._weightType = 'dI'
         self._weightFactor = 1.0
         self._weightPercent = 1.0
         self._weights = self.data.dy
@@ -328,15 +327,6 @@ class sizeDistribution():
         self._skyBackground = value   
 
     @property
-    def useWeights(self):
-        return self._useWeights
-        
-    @useWeights.setter
-    def useWeights(self, value:bool):
-        self._useWeights = value
-        self.update_weights()
-
-    @property
     def weightFactor(self):
         return self._weightFactor
         
@@ -372,20 +362,17 @@ class sizeDistribution():
         else:
             wdata = sigma
         
-        if self._useWeights == False:
+        if self.weightType == 'None':
             self._weights = np.ones_like(wdata.y)
-        else:
-            if (self.weightType == 'dI'):
-                self._weights = 1/np.array(wdata.dy)
-
-            elif (self.weightType == 'sqrt(I Data)'):
-                self._weights = 1/np.sqrt(wdata.y)
-
-            elif self.weightType == 'percentI':
-                weight_fraction = self.weightPercent / 100.0
-                self._weights = 1/np.abs(weight_fraction*wdata.y)
-            else:
-                logger.error("weightType doesn't match the possible strings for weight selection.\n Please check the value entered or use 'dI'.")
+        elif (self.weightType == 'dI'):
+            self._weights = np.array(wdata.dy)
+        elif (self.weightType == 'sqrt(I Data)'):
+            self._weights = np.sqrt(wdata.y)
+        elif self.weightType == 'percentI':
+            weight_fraction = self.weightPercent / 100.0
+            self._weights = np.abs(weight_fraction*wdata.y)
+         else:
+            logger.error("weightType doesn't match the possible strings for weight selection.\n Please check the value entered or use 'dI'.")
         
         return None
 
@@ -501,7 +488,7 @@ class sizeDistribution():
 
         self.update_weights(trim_data)
         init_binsBack = np.ones_like(self.bins)*self.skyBackground*self.scale/self.contrast
-        sigma = self.scale/(self.weightFactor*self.weights)
+        sigma = self.weightFactor*self.weights
 
         return trim_data, intensities, init_binsBack, sigma
 
@@ -527,9 +514,9 @@ class sizeDistribution():
                 IMaxEnt.append(icalc)
                 convergence.append([converged, conv_iter])
                 if (not converged):
-                    logger.warning("Maximum Entropy did not converge. Try lowering the weight factor to increase the weighting effect.")
+                    logger.warning("Maximum Entropy did not converge. Try increasing the weight factor to increase the weighting effect.")
             except ZeroDivisionError as e:
-                logger.error("Divide by Zero Error occured in maximum entropy fitting. Try lowering the weight factor to increase the error weighting")
+                logger.error("Divide by Zero Error occured in maximum entropy fitting. Try increasing the weight factor to increase the error weighting")
             
 
 
@@ -566,11 +553,9 @@ class sizeDistribution():
                              ):
         
         maxent_cdf_array = integrate.cumulative_trapezoid(bin_mag/(2*self._binDiff), 2*self.bins, axis=1)
-        #print(maxent_cdf_array[:,-1])
         self.BinMag_numberDist = self.BinMagnitude_maxEnt/ellipse_volume(self.aspectRatio*self.bins, self.bins)
 
         rvdist = stats.rv_histogram((self.BinMagnitude_maxEnt, self._bin_edges*2)) ## volume fraction weighted
-        #print(rvdist.mean(), rvdist.median())
         number_cdf = integrate.cumulative_trapezoid(self.BinMag_numberDist, 2*self.bins)
         self.number_cdf = number_cdf/number_cdf[-1]
 


### PR DESCRIPTION
The error multiplier now multiplies the error bar rather than divide. The warnings have been updated to reflect the change. Also cleaned up some debugging print statements.

## Description

as described above. 
Fixes #3391 

## How Has This Been Tested?

tested locally in dev environment on windows. tried out all combos of weight types with standard data and a data set with no error bars. There are bugs discovered when running the later which are not part of this PR but will be turned into a new issue.  The values of the weights and the sigma were verified under several conditions using print statements and a calculator. 

## Review Checklist:

[if using the editor, use `[x]` in place of `[ ]` to check a box]

**Documentation** (check at least one)
- [x] There is **nothing** that needs documenting
- [ ] Documentation changes are **in this PR**
- [ ] There is an **issue** open for the documentation (link?)

**Installers**
- [ ] There is a chance this will affect the **installers**, if so
  - [ ] **Windows** installer (GH artifact) has been tested (installed and worked) 
  - [ ] **MacOSX** installer (GH artifact) has been tested (installed and worked) 

**Licencing** (untick if necessary)
- [x] The introduced changes comply with SasView license (BSD 3-Clause)

