### PR TITLE
Power law background estimation in Size Distribution

### DIFF
--- a/src/sas/qtgui/Perspectives/SizeDistribution/SizeDistributionLogic.py
+++ b/src/sas/qtgui/Perspectives/SizeDistribution/SizeDistributionLogic.py
@@ -1,3 +1,4 @@
+import logging
 from typing import List
 
 import numpy as np
@@ -14,6 +15,9 @@ GROUP_ID_SIZE_DISTR_DATA = "SizeDistrData"
 SIZE_DISTR_LABEL = "SizeDistrFit"
 GROUP_ID_SIZE_DISTR_FIT = "SizeDistrFit"
 TRUST_RANGE_LABEL = "SizeDistrTrustRange"
+
+
+logger = logging.getLogger(__name__)
 
 
 class SizeDistributionLogic:
@@ -96,7 +100,11 @@ class SizeDistributionLogic:
         :param power: if a float is given, the power is fixed; if None, the power is fitted
         :return: fit parameters; [scale] if power is fixed, or [scale, power] if power is fitted
         """
-        background, _ = background_fit(self.data, power, qmin, qmax)
+        try:
+            background, _ = background_fit(self.data, power, qmin, qmax)
+        except ValueError:
+            logger.exception("Fitting failed")
+            return None
         return background
 
     def newDataPlot(self):

--- a/src/sas/qtgui/Perspectives/SizeDistribution/SizeDistributionLogic.py
+++ b/src/sas/qtgui/Perspectives/SizeDistribution/SizeDistributionLogic.py
@@ -1,3 +1,5 @@
+from typing import List
+
 import numpy as np
 
 from sas.qtgui.Perspectives.SizeDistribution.SizeDistributionUtils import MaxEntResult
@@ -86,19 +88,16 @@ class SizeDistributionLogic:
         d_trust_max = 0.95 * np.pi / qmin
         return [d_trust_min, d_trust_max]
 
-    def fitBackgroundScale(self, power, qmin, qmax):
+    def fitBackground(
+        self, power: float | None, qmin: float, qmax: float
+    ) -> List[float]:
         """
-        Estimate the background scale
+        Estimate the background power law, scale * q^(power)
+        :param power: if a float is given, the power is fixed; if None, the power is fitted
+        :return: fit parameters; [scale] if power is fixed, or [scale, power] if power is fitted
         """
-        background, background_err = background_fit(self.data, power, qmin, qmax)
-        return np.exp(background)[0]
-    
-    def fitFlatBackground(self, qmin, qmax):
-        """
-        Estimate the flat background
-        """
-        #background, background_err = background_fit(self.data, 0, qmin, qmax)
-        return self.fitBackgroundScale(0, qmin, qmax)
+        background, _ = background_fit(self.data, power, qmin, qmax)
+        return background
 
     def newDataPlot(self):
         """

--- a/src/sas/qtgui/Perspectives/SizeDistribution/SizeDistributionPerspective.py
+++ b/src/sas/qtgui/Perspectives/SizeDistribution/SizeDistributionPerspective.py
@@ -395,8 +395,10 @@ class SizeDistributionWindow(QtWidgets.QDialog, Ui_SizeDistribution, Perspective
         Fit flat background and update plot
         """
         qmin, qmax = self.getFlatBackgroundRange()
-        fit_params = self.logic.fitBackground(power=0.0, qmin=qmin, qmax=qmax)
-        constant = fit_params[0]
+        fit_result = self.logic.fitBackground(power=0.0, qmin=qmin, qmax=qmax)
+        if fit_result is None:
+            return
+        constant = fit_result[0]
         self.txtBackgd.setText(f"{constant:5g}")
         self.updateBackground()
         self.plotData()
@@ -408,17 +410,20 @@ class SizeDistributionWindow(QtWidgets.QDialog, Ui_SizeDistribution, Perspective
         qmin, qmax = self.getPowerLawBackgroundRange()
         if self.rbFitPower.isChecked():
             # if the power should be fit, pass None
-            scale, power_fit = self.logic.fitBackground(
-                power=None, qmin=qmin, qmax=qmax
-            )
+            fit_result = self.logic.fitBackground(power=None, qmin=qmin, qmax=qmax)
+            if fit_result is None:
+                return
+            scale, power_fit = fit_result
             # by convention, the power is shown without a minus sign
             power = -1.0 * power_fit
             self.txtPowerLowQ.setText(f"{power:5g}")
         else:
             # if the power should be fixed, pass the value from the input box
             _, _, power_fixed = self.getBackgroundParams()
-            fit_params = self.logic.fitBackground(power_fixed, qmin, qmax)
-            scale = fit_params[0]
+            fit_result = self.logic.fitBackground(power_fixed, qmin, qmax)
+            if fit_result is None:
+                return
+            scale = fit_result[0]
         # update the scale
         self.txtScaleLowQ.setText(f"{scale:5g}")
         self.updateBackground()

--- a/src/sas/qtgui/Perspectives/SizeDistribution/UI/SizeDistributionUI.ui
+++ b/src/sas/qtgui/Perspectives/SizeDistribution/UI/SizeDistributionUI.ui
@@ -607,7 +607,7 @@
           <item row="0" column="1">
            <widget class="QLineEdit" name="txtBackgd"/>
           </item>
-          <item row="0" column="2">
+          <item row="0" column="2" colspan="2">
            <widget class="QLabel" name="label_8">
             <property name="text">
              <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;cm&lt;span style=&quot;
@@ -627,29 +627,66 @@
            </widget>
           </item>
           <item row="3" column="0" colspan="3">
-           <layout class="QHBoxLayout" name="horizontalLayout_6">
-            <item>
+           <layout class="QGridLayout" name="gridLayout_14">
+            <item row="0" column="0">
              <widget class="QLabel" name="lblPowerLowQ">
               <property name="text">
                <string>Power:</string>
               </property>
              </widget>
             </item>
-            <item>
+            <item row="0" column="1">
              <widget class="QLineEdit" name="txtPowerLowQ">
               <property name="toolTip">
                <string>Exponent to apply to the Power_law function.</string>
               </property>
              </widget>
             </item>
-            <item>
+            <item row="0" column="2">
+             <layout class="QHBoxLayout" name="horizontalLayout">
+              <item>
+               <widget class="QRadioButton" name="rbFixPower">
+                <property name="text">
+                 <string>Fix</string>
+                </property>
+                <property name="checked">
+                 <bool>true</bool>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="QRadioButton" name="rbFitPower">
+                <property name="text">
+                 <string>Fit</string>
+                </property>
+               </widget>
+              </item>
+             </layout>
+            </item>
+            <item row="0" column="3">
+             <spacer name="horizontalSpacer">
+              <property name="orientation">
+               <enum>Qt::Horizontal</enum>
+              </property>
+              <property name="sizeType">
+               <enum>QSizePolicy::Expanding</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>100</width>
+                <height>20</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+            <item row="1" column="0">
              <widget class="QLabel" name="lblScaleLowQ">
               <property name="text">
                <string>Scale:</string>
               </property>
              </widget>
             </item>
-            <item>
+            <item row="1" column="1">
              <widget class="QLineEdit" name="txtScaleLowQ">
               <property name="toolTip">
                <string>Scale to apply to the Power_law function.</string>

--- a/src/sas/sascalc/size_distribution/SizeDistribution.py
+++ b/src/sas/sascalc/size_distribution/SizeDistribution.py
@@ -65,9 +65,16 @@ def background_fit(data, power=None, qmin=None, qmax=None):
     if qmax is None:
         qmax = max(data.x)
 
+    if not qmax > qmin:
+        raise ValueError("Fit range Qmin must be smaller than Qmax")
+
     # Identify the bin range for the fit
     idx = (data.x >= qmin) & (data.x <= qmax)
-    
+
+    # Check that the fit range contains enough data points
+    if (power is None and sum(idx) < 2) or (power is not None and sum(idx) < 1):
+        raise ValueError("Need more data points than fitting parameters")
+
     fx = np.zeros(len(data.x))
 
     # Uncertainty

--- a/src/sas/sascalc/size_distribution/SizeDistribution.py
+++ b/src/sas/sascalc/size_distribution/SizeDistribution.py
@@ -98,14 +98,15 @@ def background_fit(data, power=None, qmin=None, qmax=None):
     param_result, pcov = optimize.curve_fit(fit_func, linearized_data.x, linearized_data.y, init_guess, sigma = linearized_data.dy)
     param_err = np.sqrt(np.diag(pcov))
 
-
-    if len(param_err) > 1: 
+    if len(param_err) > 1:
         param_err[0] = np.exp(param_result[0])*param_err[0]
     else:
         param_err[0] = np.exp(param_result[0])*param_err[0]
-    
-    
-    return param_result, param_err 
+
+    # transform scale back to non-linearized
+    param_result[0] = np.exp(param_result[0])
+
+    return param_result, param_err
 
 def ellipse_volume(rp, re):
     return (4*np.pi/3)*rp*re**2


### PR DESCRIPTION
## Description

Enable in the GUI fitting of the power in the power law background estimation.

Fixes #3279

## How Has This Been Tested?

Tested locally with `src/sas/sascalc/size_distribution/test_data/Alumina_usaxs_irena_input.csv`.

## Review Checklist:

[if using the editor, use `[x]` in place of `[ ]` to check a box]

**Documentation** (check at least one)
- [ ] There is **nothing** that needs documenting
- [ ] Documentation changes are **in this PR**
- [ ] There is an **issue** open for the documentation (link?)

**Installers**
- [ ] There is a chance this will affect the **installers**, if so
  - [ ] **Windows** installer (GH artifact) has been tested (installed and worked) 
  - [ ] **MacOSX** installer (GH artifact) has been tested (installed and worked) 

**Licencing** (untick if necessary)
- [x] The introduced changes comply with SasView license (BSD 3-Clause)

