### PR TITLE
Reset window when sending new data to the Size Distribution

### DIFF
--- a/src/sas/qtgui/Perspectives/SizeDistribution/SizeDistributionPerspective.py
+++ b/src/sas/qtgui/Perspectives/SizeDistribution/SizeDistributionPerspective.py
@@ -439,6 +439,10 @@ class SizeDistributionWindow(QtWidgets.QDialog, Ui_SizeDistribution, Perspective
             msg = "Incorrect type passed to the Size Distribution Perspective"
             raise AttributeError(msg)
 
+        if self.logic.data_is_loaded:
+            # remove existing data and reset GUI
+            self.resetWindow()
+
         self._model_item = data_item[0]
         logic_data = GuiUtils.dataFromItem(self._model_item)
 
@@ -525,9 +529,19 @@ class SizeDistributionWindow(QtWidgets.QDialog, Ui_SizeDistribution, Perspective
         """Remove the existing data reference from the Size Distribution Perspective"""
         if not data_list or self._model_item not in data_list:
             return
+        self.resetWindow()
+
+    def resetWindow(self):
+        """
+        Reset the state of input widgets and data structures
+        """
         self._data = None
         self._path = ""
         self.txtName.setText("")
+        self.txtPowerLawQMin.setText("")
+        self.txtPowerLawQMax.setText("")
+        self.txtBackgdQMin.setText("")
+        self.txtBackgdQMax.setText("")
         self._model_item = None
         self.logic.data = None
         self.logic.data_fit = None


### PR DESCRIPTION
## Description

Reset window when sending new data to the Size Distribution. The existing plots for the old data remain, is that the expected behavior?

Fixes #3423

## How Has This Been Tested?

Tested locally using the steps in issue #3423

## Review Checklist:

[if using the editor, use `[x]` in place of `[ ]` to check a box]

**Documentation** (check at least one)
- [ ] There is **nothing** that needs documenting
- [ ] Documentation changes are **in this PR**
- [ ] There is an **issue** open for the documentation (link?)

**Installers**
- [ ] There is a chance this will affect the **installers**, if so
  - [ ] **Windows** installer (GH artifact) has been tested (installed and worked) 
  - [ ] **MacOSX** installer (GH artifact) has been tested (installed and worked) 

**Licencing** (untick if necessary)
- [x] The introduced changes comply with SasView license (BSD 3-Clause)

