### PR TITLE
3422 default weighting for size distribution should be i if data has no dy

### DIFF
--- a/src/sas/qtgui/Perspectives/SizeDistribution/SizeDistributionLogic.py
+++ b/src/sas/qtgui/Perspectives/SizeDistribution/SizeDistributionLogic.py
@@ -60,6 +60,8 @@ class SizeDistributionLogic:
         """
         if self._data.dy is not None and np.any(self._data.dy):
             self.di_flag = True
+        else:
+            self.di_flag = False
 
     def computeDataRange(self):
         """

--- a/src/sas/qtgui/Perspectives/SizeDistribution/SizeDistributionPerspective.py
+++ b/src/sas/qtgui/Perspectives/SizeDistribution/SizeDistributionPerspective.py
@@ -276,7 +276,6 @@ class SizeDistributionWindow(QtWidgets.QDialog, Ui_SizeDistribution, Perspective
     def setupWindow(self):
         """Initialize base window state on init"""
         self.enableButtons()
-        self.rbWeighting2.setChecked(True)
         self.txtPowerLowQ.setEnabled(False)
         self.txtScaleLowQ.setEnabled(False)
         self.rbFixPower.setChecked(True)
@@ -312,11 +311,6 @@ class SizeDistributionWindow(QtWidgets.QDialog, Ui_SizeDistribution, Perspective
             self.logic.data_is_loaded and not self.is_calculating
         )
         self.boxWeighting.setEnabled(self.logic.data_is_loaded)
-        # Weighting controls
-        if self.logic.di_flag:
-            self.rbWeighting2.setEnabled(True)
-        else:
-            self.rbWeighting2.setEnabled(False)
         self.cmdFitFlatBackground.setEnabled(self.logic.data_is_loaded)
         self.cmdFitPowerLaw.setEnabled(
             self.logic.data_is_loaded and self.chkLowQ.isChecked()
@@ -489,6 +483,16 @@ class SizeDistributionWindow(QtWidgets.QDialog, Ui_SizeDistribution, Perspective
         self.model.item(WIDGETS.W_QMIN).setText(str(qmin))
         self.model.item(WIDGETS.W_QMAX).setText(str(qmax))
         self._path = self.logic.data.filename
+
+        # Set up default weighting controls
+        if self.logic.di_flag:
+            print('have dI')
+            self.rbWeighting2.setEnabled(True)
+            self.rbWeighting2.setChecked(True)
+        else:
+            print('no dI')
+            self.rbWeighting2.setEnabled(False)
+            self.rbWeighting4.setChecked(True)
 
         self.enableButtons()
 

--- a/src/sas/qtgui/Perspectives/SizeDistribution/SizeDistributionPerspective.py
+++ b/src/sas/qtgui/Perspectives/SizeDistribution/SizeDistributionPerspective.py
@@ -485,13 +485,9 @@ class SizeDistributionWindow(QtWidgets.QDialog, Ui_SizeDistribution, Perspective
         self._path = self.logic.data.filename
 
         # Set up default weighting controls
-        if self.logic.di_flag:
-            print('have dI')
-            self.rbWeighting2.setEnabled(True)
-            self.rbWeighting2.setChecked(True)
-        else:
-            print('no dI')
-            self.rbWeighting2.setEnabled(False)
+        self.rbWeighting2.setEnabled(self.logic.di_flag)
+        self.rbWeighting2.setChecked(self.logic.di_flag)
+        if not self.logic.di_flag:
             self.rbWeighting4.setChecked(True)
 
         self.enableButtons()


### PR DESCRIPTION
## Description

Enabling of the dI radio button checkbox 2 was moved from `enableButtons` and `setupWindow` to `setData` and which radio button is checked by default was added there. Those defaults depend on whether or not the new data set has dy or not and should not be changed every time a fit or other action is performed (besides loading new data), nor should they be set permanently at the start.

Also fixed a bug in logic where di_flag was not getting reset once set to "True". This could have been done in the main perspective on cleanup between data sets  (in `resetWindow`), but it seemed more general to fix at the source?

Fixes #3422 

## How Has This Been Tested?

Tested in the local environment on windows 10. Loaded both a the irena test data set (which contains dy) and the `cyl_400_20.txt` example data set (which does not contain dy). going back and forth between them several time now works, including manually changing from the default (dI to %I)

NOTE: a few other bugs to do with the swapping between data files was identified but are not relevant to this PR and will be addressed in a separate issue

## Review Checklist:

[if using the editor, use `[x]` in place of `[ ]` to check a box]

**Documentation** (check at least one)
- [x] There is **nothing** that needs documenting
- [ ] Documentation changes are **in this PR**
- [ ] There is an **issue** open for the documentation (link?)

**Installers**
- [ ] There is a chance this will affect the **installers**, if so
  - [ ] **Windows** installer (GH artifact) has been tested (installed and worked) 
  - [ ] **MacOSX** installer (GH artifact) has been tested (installed and worked) 

**Licencing** (untick if necessary)
- [x] The introduced changes comply with SasView license (BSD 3-Clause)

