### PR TITLE
minor fix for displaying Chi2 value in scientific notation.

### DIFF
--- a/src/sas/qtgui/Perspectives/Inversion/InversionWidget.py
+++ b/src/sas/qtgui/Perspectives/Inversion/InversionWidget.py
@@ -55,6 +55,11 @@ class InversionResult:
 def format_float(f: float):
     return f'{f:.3f}'
 
+def format_float_scientific(f: float):
+    """
+    Formats a float in scientific notation with 3 significant figures.
+    """
+    return f'{f:.3g}' if f != 0 else '0.0'  # Avoids showing '0e+00' for zero values
 
 # Default Values for inputs
 NUMBER_OF_TERMS = 10
@@ -272,7 +277,7 @@ class InversionWidget(QWidget, Ui_PrInversion):
             if current_calculator.est_bck:
                 self.backgroundInput.setText(format_float(out.background))
             self.computationTimeValue.setText(format_float(out.calc_time))
-            self.chiDofValue.setText(format_float(out.chi2[0]))
+            self.chiDofValue.setText(format_float_scientific(out.chi2[0]))
             self.oscillationValue.setText(format_float(out.oscillations))
             self.posFractionValue.setText(format_float(out.pos_frac))
             self.sigmaPosFractionValue.setText(format_float(out.pos_err))


### PR DESCRIPTION
## Description

Chi2 should be displayed in sci notation to avoid overflowing the text field when the error is large.

Fixes #3317

## How Has This Been Tested?

Local win10

## Review Checklist:

[if using the editor, use `[x]` in place of `[ ]` to check a box]

**Documentation** (check at least one)
- [X] There is **nothing** that needs documenting
- [ ] Documentation changes are **in this PR**
- [ ] There is an **issue** open for the documentation (link?)

**Installers**
- [ ] There is a chance this will affect the **installers**, if so
  - [ ] **Windows** installer (GH artifact) has been tested (installed and worked) 
  - [ ] **MacOSX** installer (GH artifact) has been tested (installed and worked) 

**Licencing** (untick if necessary)
- [x] The introduced changes comply with SasView license (BSD 3-Clause)

