### PR TITLE
Size distribution should report normalized chi^2

### DIFF
--- a/src/sas/qtgui/Perspectives/SizeDistribution/SizeDistributionPerspective.py
+++ b/src/sas/qtgui/Perspectives/SizeDistribution/SizeDistributionPerspective.py
@@ -794,7 +794,7 @@ class SizeDistributionWindow(QtWidgets.QDialog, Ui_SizeDistribution, Perspective
                 converge_msg = f"Full fit converged after on average {np.mean(result.num_iters):.1f} iterations"
             self.lblConvergence.setStyleSheet("color: black;")
         else:
-            converge_msg = "Not converged"
+            converge_msg = "Not converged! Try increasing the weight factor."
             self.lblConvergence.setStyleSheet("color: red; font-weight: bold;")
         self.lblConvergence.setText(converge_msg)
         self.txtChiSq.setText(f"{result.chisq:.5g}")

--- a/src/sas/qtgui/Perspectives/SizeDistribution/SizeDistributionPerspective.py
+++ b/src/sas/qtgui/Perspectives/SizeDistribution/SizeDistributionPerspective.py
@@ -792,8 +792,10 @@ class SizeDistributionWindow(QtWidgets.QDialog, Ui_SizeDistribution, Perspective
                 )
             else:
                 converge_msg = f"Full fit converged after on average {np.mean(result.num_iters):.1f} iterations"
+            self.lblConvergence.setStyleSheet("color: black;")
         else:
             converge_msg = "Not converged"
+            self.lblConvergence.setStyleSheet("color: red; font-weight: bold;")
         self.lblConvergence.setText(converge_msg)
         self.txtChiSq.setText(f"{result.chisq:.5g}")
         stats = result.statistics

--- a/src/sas/sascalc/size_distribution/maxEnt_method.py
+++ b/src/sas/sascalc/size_distribution/maxEnt_method.py
@@ -299,7 +299,7 @@ class maxEntMethod():
             if (abs(chisq/chizer-1.0) < CHI_SQR_LIMIT) and  (test < TEST_LIMIT):
                 print (' Convergence achieved.')
                 converged = True
-                return chisq, f, np.dot(f, Gqr.transpose()), converged, iter     # solution FOUND returns here
+                return chisq/chizer, f, np.dot(f, Gqr.transpose()), converged, iter     # solution FOUND returns here
         print (' No convergence! Try increasing Error multiplier.')
-        return chisq, f, np.dot(f, Gqr.transpose()), converged, iter             # no solution after IterMax iterations
+        return chisq/chizer, f, np.dot(f, Gqr.transpose()), converged, iter             # no solution after IterMax iterations
 


### PR DESCRIPTION
## Description

This changes the maximum entropy method to return the chi2 normalized by the number of bins. The style of the convergence message is changed to red and bold if the fit returned is not converged.

![image](https://github.com/user-attachments/assets/ec7b3f73-43f6-425c-8499-42596d3ee2fa)

![Screenshot from 2025-05-30 12-48-20](https://github.com/user-attachments/assets/24aaf0af-75c2-4f94-930f-d88691213e8e)

Fixes #3410

## How Has This Been Tested?

Tested locally what the message looks like with and without converged results. The converged results now has chi^2 close to 1.

## Review Checklist:

[if using the editor, use `[x]` in place of `[ ]` to check a box]

**Documentation** (check at least one)
- [ ] There is **nothing** that needs documenting
- [ ] Documentation changes are **in this PR**
- [ ] There is an **issue** open for the documentation (link?)

**Installers**
- [ ] There is a chance this will affect the **installers**, if so
  - [ ] **Windows** installer (GH artifact) has been tested (installed and worked) 
  - [ ] **MacOSX** installer (GH artifact) has been tested (installed and worked) 

**Licencing** (untick if necessary)
- [x] The introduced changes comply with SasView license (BSD 3-Clause)

