### PR TITLE
Label the Shape2SAS and MuMag tools as experimental

### DIFF
--- a/src/sas/qtgui/Calculators/Shape2SAS/DesignWindow.py
+++ b/src/sas/qtgui/Calculators/Shape2SAS/DesignWindow.py
@@ -78,6 +78,10 @@ class DesignWindow(QDialog, Ui_Shape2SAS, Perspective):
         self.plugin.setEnabled(False)
         self.modelTabButtonOptions.horizontalLayout_5.insertWidget(1, self.plugin)
 
+        # TODO: Remove these lines to enable the plugin model generation window - hidden for v6.1.0
+        self.line2.setHidden(True)
+        self.plugin.setHidden(True)
+
         #connect buttons
         self.modelTabButtonOptions.reset.clicked.connect(self.onSubunitTableReset)
         self.modelTabButtonOptions.closePage.clicked.connect(self.onClickingClose)

--- a/src/sas/qtgui/Calculators/Shape2SAS/DesignWindow.py
+++ b/src/sas/qtgui/Calculators/Shape2SAS/DesignWindow.py
@@ -42,7 +42,7 @@ class DesignWindow(QDialog, Ui_Shape2SAS, Perspective):
     def __init__(self, parent=None):
         super().__init__()
         self.setupUi(self)
-        self.setWindowTitle("Shape2SAS")
+        self.setWindowTitle("Shape2SAS (Experimental)")
         self.parent = parent
 
         self._manager = parent

--- a/src/sas/qtgui/MainWindow/UI/MainWindowUI.ui
+++ b/src/sas/qtgui/MainWindow/UI/MainWindowUI.ui
@@ -631,7 +631,7 @@
   </action>
   <action name="actionMuMag_Fitter">
    <property name="text">
-    <string>MuMag Fitter</string>
+    <string>MuMag Fitter (Experimental)</string>
       </property>
   </action>
   <action name="actionWhat_s_New">

--- a/src/sas/qtgui/MainWindow/UI/MainWindowUI.ui
+++ b/src/sas/qtgui/MainWindow/UI/MainWindowUI.ui
@@ -364,7 +364,7 @@
   </action>
   <action name="actionShape2SAS_Calculator">
    <property name="text">
-    <string>Shape2SAS Calculator</string>
+    <string>Shape2SAS Calculator (Experimental)</string>
    </property>
   </action>
   <action name="actionGeneric_Scattering_Calculator">

--- a/src/sas/qtgui/Utilities/MuMag/UI/MuMagUI.ui
+++ b/src/sas/qtgui/Utilities/MuMag/UI/MuMagUI.ui
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string>MuMagTool</string>
+   <string>MuMagTool (Experimental)</string>
   </property>
   <widget class="QWidget" name="centralwidget">
    <layout class="QHBoxLayout" name="horizontalLayout_6" stretch="1,2">


### PR DESCRIPTION
## Description

This adds labels to the Shape2SAS and MuMag tools labelling them as experimental. This also hides the plugin model generation button in the Shape2SAS tool.

## How Has This Been Tested?

Tested locally and what I say above seems true.

## Review Checklist:

[if using the editor, use `[x]` in place of `[ ]` to check a box]

**Documentation** (check at least one)
- [x] There is **nothing** that needs documenting
- [ ] Documentation changes are **in this PR**
- [ ] There is an **issue** open for the documentation (link?)

**Installers**
- [x] There is a chance this will affect the **installers**, if so
  - [ ] **Windows** installer (GH artifact) has been tested (installed and worked) 
  - [ ] **MacOSX** installer (GH artifact) has been tested (installed and worked) 

**Licencing** (untick if necessary)
- [x] The introduced changes comply with SasView license (BSD 3-Clause)

