### PR TITLE
Shape2SAS outstanding issues redux

### DIFF
--- a/src/sas/qtgui/Calculators/Shape2SAS/Constraints.py
+++ b/src/sas/qtgui/Calculators/Shape2SAS/Constraints.py
@@ -63,7 +63,7 @@ class Constraints(QWidget, Ui_Constraints):
 #Write libraries to be imported here.
 from numpy import inf
 
-#Modify fit parameteres here.
+#Modify fit parameters here.
 parameters = {constraints}
 
 #Set constraints here.

--- a/src/sas/qtgui/Calculators/Shape2SAS/DesignWindow.py
+++ b/src/sas/qtgui/Calculators/Shape2SAS/DesignWindow.py
@@ -150,6 +150,7 @@ class DesignWindow(QDialog, Ui_Shape2SAS, Perspective):
         self.constraint = Constraints()
         self.subunitTable.add.clicked.connect(self.addToVariableTable)
         self.subunitTable.deleteButton.clicked.connect(self.deleteFromVariableTable)
+        self.subunitTable.table.clicked.connect(self.updateDeleteButton)
         self.constraint.variableTable.setConstraints.clicked.connect(self.setConstraintsToTextEditor)
         self.constraint.createPlugin.clicked.connect(self.getPluginModel)
         self.constraint.buttonOptions.reset.clicked.connect(self.onConstraintReset)
@@ -267,6 +268,12 @@ class DesignWindow(QDialog, Ui_Shape2SAS, Perspective):
 
         #set variables in variable table
         self.constraint.variableTable.setVariableTableData(names, column)
+
+    def updateDeleteButton(self):
+        selection_model = self.subunitTable.table.selectionModel()
+        selected_indexes = selection_model.selectedIndexes()
+        column = selected_indexes[0].column()
+        self.subunitTable.selected.setValue(int(column) + 1)
 
     def deleteFromVariableTable(self):
         """Delete parameters from the variable table"""

--- a/src/sas/qtgui/Calculators/Shape2SAS/DesignWindow.py
+++ b/src/sas/qtgui/Calculators/Shape2SAS/DesignWindow.py
@@ -151,6 +151,7 @@ class DesignWindow(QDialog, Ui_Shape2SAS, Perspective):
         self.subunitTable.add.clicked.connect(self.addToVariableTable)
         self.subunitTable.deleteButton.clicked.connect(self.deleteFromVariableTable)
         self.subunitTable.table.clicked.connect(self.updateDeleteButton)
+        self.subunitTable.table.horizontalHeader().sectionClicked.connect(self.updateDeleteButton)
         self.constraint.variableTable.setConstraints.clicked.connect(self.setConstraintsToTextEditor)
         self.constraint.createPlugin.clicked.connect(self.getPluginModel)
         self.constraint.buttonOptions.reset.clicked.connect(self.onConstraintReset)

--- a/src/sas/qtgui/Calculators/Shape2SAS/DesignWindow.py
+++ b/src/sas/qtgui/Calculators/Shape2SAS/DesignWindow.py
@@ -625,7 +625,7 @@ class DesignWindow(QDialog, Ui_Shape2SAS, Perspective):
         #Write file to plugin model folder
         TabbedModelEditor.writeFile(full_path, model_str)
         self.communicator.customModelDirectoryChanged.emit()
-        logger.info(f"Succefully generated model {modelName}!")
+        logger.info(f"Successfully generated model {modelName}!")
 
     def onCheckingInput(self, input: str, default: str) -> str:
         """Check if the input not None. Otherwise, return default value"""

--- a/src/sas/qtgui/Calculators/Shape2SAS/Tables/subunitTable.py
+++ b/src/sas/qtgui/Calculators/Shape2SAS/Tables/subunitTable.py
@@ -142,8 +142,8 @@ class OptionLayout(ExtendedEnum):
         """Return the hollow sphere dimensions"""
         name = {self.x: "R", self.y: "r"}
         units = {self.x: "Å", self.y: "Å"}
-        types = {self.x: "volume"}
-        bounds = {self.x: [0, inf]}
+        types = {self.x: "volume", self.y: "volume"}
+        bounds = {self.x: [0, inf], self.y: [0, inf]}
         tooltip = {self.x: "Outer radius of the hollow sphere",
                    self.y: "Inner radius of the hollow sphere"}
         defaultVal = {self.x: 50.0, self.y: 25.0}

--- a/src/sas/qtgui/Calculators/Shape2SAS/Tables/subunitTable.py
+++ b/src/sas/qtgui/Calculators/Shape2SAS/Tables/subunitTable.py
@@ -535,6 +535,7 @@ class SubunitTable(QWidget, Ui_SubunitTableController):
         self.model.insertColumn(numcolumn, items)
         self.model.setData(self.model.index(0, numcolumn), self.subunit.currentText())
         self.setSubunitRestriction(subunitName.keys())
+        self.table.resizeColumnsToContents()
         self.setButtonSpinboxBounds()
 
 

--- a/src/sas/qtgui/Calculators/Shape2SAS/ViewerModel.py
+++ b/src/sas/qtgui/Calculators/Shape2SAS/ViewerModel.py
@@ -166,10 +166,25 @@ class ViewerModel(QWidget):
            data = []
            series.dataProxy().resetArray(data)
 
+        # Check if we have any data at all
+        if not distr.x or len(distr.x) == 0:
+            return
+
         minx, maxx = min(distr.x[0]), max(distr.x[0])
         miny, maxy = min(distr.y[0]), max(distr.y[0])
         minz, maxz = min(distr.z[0]), max(distr.z[0])
+
         for subunit in range(len(colours)):
+            # Skip empty subunits - handle numpy arrays properly
+            try:
+                if (subunit >= len(distr.x)
+                        or not hasattr(distr.x[subunit], '__len__')
+                        or len(distr.x[subunit]) == 0):
+                    continue
+            except (ValueError, TypeError):
+                # Handle numpy array comparison issues
+                continue
+
             series = self.dict_series[colours[subunit]]
             data = []
             for index in range(len(distr.x[subunit])):


### PR DESCRIPTION
## Description

This PR replaces #3444. It fixes the same issues as the previous PR, but removes some of the original changes that were in question.

Fixes https://github.com/SasView/sasview/issues/3413 - When a column or series of columns is selected, the first column in the selection is set as the one to be deleted.
Fixes https://github.com/SasView/sasview/issues/3441 - If one or more shapes are completely within other shapes and overlap is excluded, errors are no longer thrown.
Fixes https://github.com/SasView/sasview/issues/3442 - A couple of typos are fixed in the tool.
No issue - Fixes an issue with the hollow sphere where certain parameters were not being calculated.

## Review Checklist:

**Documentation** (check at least one)
- [x] There is **nothing** that needs documenting
- [ ] Documentation changes are **in this PR**
- [ ] There is an **issue** open for the documentation (link?)

**Installers**
- [x] There is a chance this will affect the **installers**, if so
  - [ ] **Windows** installer (GH artifact) has been tested (installed and worked) 
  - [ ] **MacOSX** installer (GH artifact) has been tested (installed and worked) 

**Licencing** (untick if necessary)
- [x] The introduced changes comply with SasView license (BSD 3-Clause)

