### PR TITLE
Fix version strings in release-branch builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -163,7 +163,10 @@ jobs:
       - name: Build sasview
         run: |
           python -m build --no-isolation --sdist --wheel
-          python -m pip install dist/sasview*whl
+
+      - name: Install sasview wheel
+        run: |
+          python -m pip install --no-deps dist/sasview*whl
 
       - name: Publish sdist and wheel package
         uses: actions/upload-artifact@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,6 +90,13 @@ jobs:
       MACOS_DMG_NAME: SasView6-${{ matrix.os }}.dmg
       # Only sign/notarize if the secrets will be available
       SIGN_INSTALLER: ${{ (github.repository == 'SasView/sasview') && 'true' || '' }}
+      RELEASE_BRANCH_BUILD: ${{
+          (
+            (github.event_name == 'push' && contains(github.ref, 'release')) ||
+            (github.event_name == 'push' && contains(github.ref, 'tags/v6.1')) ||
+            (github.event_name == 'pull_request' && contains(github.base_ref, 'release-6.1'))
+          ) && 'true' || ''
+        }}
 
     name: "${{ matrix.job_name }}"
 
@@ -136,19 +143,18 @@ jobs:
           python -m pip install dist/*whl
 
       - name: Install Python dependencies
-        if: "(github.event_name == 'push' && !contains(github.ref, 'release')) || (github.event_name == 'pull_request' && !contains(github.base_ref, 'release-6.1.0'))"
+        if: ${{ ! env.RELEASE_BRANCH_BUILD }}
         run: |
           # Don't try to reinstall sibling packages if already at right version
-          # (macos really doesn't like "sed -i" for this task,)
-          grep -v -e sasdata < build_tools/requirements.txt > build_tools/tmp.txt
-          mv build_tools/tmp.txt build_tools/requirements.txt
-          grep -v -e sasmodels < build_tools/requirements.txt > build_tools/tmp.txt
-          mv build_tools/tmp.txt build_tools/requirements.txt
-          python -m pip install -r build_tools/requirements.txt -r build_tools/requirements-dev.txt
+          # Comment out the 'grep' below when not needed
+          cp  build_tools/requirements.txt build_tools/tmp.txt
+          grep -v -e sasdata -e sasmodels < build_tools/requirements.txt > build_tools/tmp.txt
+          python -m pip install -r build_tools/tmp.txt -r build_tools/requirements-dev.txt
 
       ### For pull_requests with the release branch as the base -or- branches with the name *release*
+
       - name: Install Python dependencies for release branches
-        if: "(github.event_name == 'push' && contains(github.ref, 'release')) || (github.event_name == 'pull_request' && contains(github.base_ref, 'release-6.1.0'))"
+        if: ${{ env.RELEASE_BRANCH_BUILD }}
         run: |
           python -m pip install --no-deps -r build_tools/requirements-release-${{ matrix.os }}.txt
 


### PR DESCRIPTION

## Description

Two issues were spotted in the 6.1.0b1 builds:
- the pinned versions of the dependencies were not installed in the CI build for the tag
- the generated package had an ugly version string (`6.1.0b2.dev0+gd5f5c0082.d20250603` rather than `6.1.0b1`)

Unpacking this version string, it's a development version that would be leading towards `6.1.0b2` that is currently `0` commits past the previous tag, it is at the expected git hash (`d5f5c0082`), with an uncommitted modification that was spotted on that date (`20250603`). The cause of this ugly version string is that git tracked files were modified during build which the versioning then spots and tracks in the string — that's the perfect version string for a regular CI build, but a terrible version string for a release. 

The changes here:
- include tags in the logic for whether to use pinned dependencies
- avoid changing git tracked files so as to ensure that the generated versions are correct

## How Has This Been Tested?

- Look at which "Install Python dependencies" step runs.
- Look at [CI runs for a fake tag](https://github.com/llimeht/sasview/actions/runs/15458470279) (in my fork - you don't want fake tags in the sasview repo!); check the version of the sasview package in the filename for the wheel artifact and in the CI steps that handle the wheel, for example "Install sasview wheel".

These changes seem to be enough to get the CI run for the tag to have the correct version. 

A partial test of this will be on CI of this PR against the `release-6.1.0` branch - checking that "Install Python dependencies for release branches runs" and the version doesn't have a local modification indication in it.

The real test of this will be at 6.1.0b2.

## Review Checklist:

[if using the editor, use `[x]` in place of `[ ]` to check a box]

**Documentation** (check at least one)
- [x] There is **nothing** that needs documenting
- [ ] Documentation changes are **in this PR**
- [ ] There is an **issue** open for the documentation (link?)

**Installers**
- [ ] There is a chance this will affect the **installers**, if so
  - [ ] **Windows** installer (GH artifact) has been tested (installed and worked) 
  - [ ] **MacOSX** installer (GH artifact) has been tested (installed and worked) 

**Licencing** (untick if necessary)
- [x] The introduced changes comply with SasView license (BSD 3-Clause)

