### PR TITLE
3452 mumag help button doesn't

### DIFF
--- a/src/sas/qtgui/Utilities/MuMag/MuMag.py
+++ b/src/sas/qtgui/Utilities/MuMag/MuMag.py
@@ -25,6 +25,7 @@ class MuMag(QtWidgets.QMainWindow, Ui_MuMagTool):
     def __init__(self, parent=None):
         super().__init__()
 
+        self.parent = parent
         self.setupUi(self)
 
         # Callbacks
@@ -322,9 +323,8 @@ class MuMag(QtWidgets.QMainWindow, Ui_MuMagTool):
             MuMagLib.save_data(self.fit_data, directory)
 
     def onHelp(self):
-        from sas.qtgui.MainWindow.GuiManager import GuiManager
         url = "/user/qtgui/Utilities/MuMag/mumag_help.html"
-        GuiManager.showHelp(url)
+        self.parent.showHelp(url)
 
 def main():
     """ Show a demo of the slider """

--- a/src/sas/qtgui/Utilities/MuMag/MuMag.py
+++ b/src/sas/qtgui/Utilities/MuMag/MuMag.py
@@ -322,7 +322,9 @@ class MuMag(QtWidgets.QMainWindow, Ui_MuMagTool):
             MuMagLib.save_data(self.fit_data, directory)
 
     def onHelp(self):
-        webbrowser.open("https://www.sasview.org/docs/user/qtgui/Utilities/MuMag/mumag_help.html")
+        from sas.qtgui.MainWindow.GuiManager import GuiManager
+        url = "/user/qtgui/Utilities/MuMag/mumag_help.html"
+        GuiManager.showHelp(url)
 
 def main():
     """ Show a demo of the slider """


### PR DESCRIPTION
## Description

Changed the `onHelp` call from a webbrowser call to a non-existent sasview.org webpage to the standard help page within the internal documents using the `GuiManager.showHelp` method 

Fixes #3452 

## How Has This Been Tested?

Checked on the dev environment of windows 10 machine. Prior to change a 404 as with installer, after the fix the proper page comes up

## Review Checklist:

[if using the editor, use `[x]` in place of `[ ]` to check a box]

**Documentation** (check at least one)
- [x] There is **nothing** that needs documenting
- [ ] Documentation changes are **in this PR**
- [ ] There is an **issue** open for the documentation (link?)

**Installers**
- [ ] There is a chance this will affect the **installers**, if so
  - [ ] **Windows** installer (GH artifact) has been tested (installed and worked) 
  - [ ] **MacOSX** installer (GH artifact) has been tested (installed and worked) 

**Licencing** (untick if necessary)
- [x] The introduced changes comply with SasView license (BSD 3-Clause)

