### PR TITLE
Extend pyinstaller data for sas module to include all of sphinx output

### DIFF
--- a/src/sas/__pyinstaller/hook-sas.py
+++ b/src/sas/__pyinstaller/hook-sas.py
@@ -1,11 +1,19 @@
 # hook for pyinstaller to find all the extra parts of sas
 
+import os
 from pathlib import Path
 
 try:
     from PyInstaller.utils.hooks import collect_data_files
 
-    datas = collect_data_files('sas')
+    datas = collect_data_files(
+        'sas',
+        excludes=[
+            # handle the documentation trees manually
+            'docs/',
+            'docs-source/',
+            ],
+        )
 
     # add in additional data files
     base = Path(__file__).parent.parent.parent
@@ -22,13 +30,42 @@ try:
         ('sas/qtgui/Utilities/WhatsNew/messages', 'sas/qtgui/Utilities/WhatsNew/messages'),
         ('sas/qtgui/Utilities/WhatsNew/css/style.css', 'sas/qtgui/Utilities/WhatsNew/css'),
         ('sas/qtgui/Utilities/About/images', 'sas/qtgui/Utilities/About/images'),
-        ('sas/docs-source/conf.py', 'sas/docs-source/'),
     ]:
         datas.append((str((base / f).absolute()), t))
 
-    print(f"SasView added datas: {datas}")
+    # Handle documentation trees separately:
+    # There's a range of files here (html, css, js, json, png, py); the .py
+    # files need particular care because they should be included in the documentation
+    # tree even though pyinstaller would not normally include them. At the same
+    # time, the __pycache__ and .pyc files should not included
+    def append_data_files(src: Path):
+        # CRUFT: Path.walk() needs Python 3.12 or later
+        # for root, _, files in (base / src).walk():
+        for root, _, files in os.walk(base / src):
+            root = Path(root)
+            if root.name == "__pycache__":
+                continue
+
+            for f in files:
+                if f.endswith(".pyc"):
+                    continue
+                src = root / f
+                dst = src.relative_to(base).parent
+                datas.append((str(src), str(dst)))
+
+    append_data_files("sas/docs-source")
+    append_data_files("sas/docs")
+
+    datas.sort()
+    print(f"SasView added datas:")
+    for s, d in datas:
+        print(f"  {s}")
+        print(f"  > {d}")
 
     hiddenimports = [
+        "OpenGL",
+        "OpenGL.platform.egl",
+        "PyOpenGL",
         "pyopencl",
         'uncertainties',
     ]


### PR DESCRIPTION
## Description

pyinstaller needs to be told what files to bundle with the module - this PR adds some more files to what pyinstaller will keep with the `sas` module.

Fixes #3455

## How Has This Been Tested?

Checked file list from pyinstaller output from CI. Installers not otherwise tested - those with the right hardware need to do that!

## Review Checklist:

[if using the editor, use `[x]` in place of `[ ]` to check a box]

**Documentation** (check at least one)
- [x] There is **nothing** that needs documenting
- [ ] Documentation changes are **in this PR**
- [ ] There is an **issue** open for the documentation (link?)

**Installers**
- [x] There is a chance this will affect the **installers**, if so
  - [ ] **Windows** installer (GH artifact) has been tested (installed and worked) 
  - [ ] **MacOSX** installer (GH artifact) has been tested (installed and worked) 

**Licencing** (untick if necessary)
- [x] The introduced changes comply with SasView license (BSD 3-Clause)

