### PR TITLE
Only process the download event that produced the trigger

### DIFF
--- a/src/sas/qtgui/Utilities/DocViewWidget.py
+++ b/src/sas/qtgui/Utilities/DocViewWidget.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from typing import Optional
 
 from PySide6 import QtCore, QtWidgets, QtWebEngineCore
+from PySide6.QtGui import QCloseEvent
 from twisted.internet import threads
 
 from .UI.DocViewWidgetUI import Ui_DocViewerWindow
@@ -153,8 +154,11 @@ class DocViewWindow(QtWidgets.QDialog, Ui_DocViewerWindow):
         self.show()
 
     def onDownload(self, download_item):
-        download_item.accept()
-        download_item.isFinishedChanged.connect(lambda: self.onDownloadFinished(download_item))
+        # There may be several active webEngineViewers. Only process the
+        # actual caller
+        if download_item.page() == self.webEngineViewer.page():
+            download_item.accept()
+            download_item.isFinishedChanged.connect(lambda: self.onDownloadFinished(download_item))
 
     def onDownloadFinished(self, item):
         _filename = item.downloadFileName()


### PR DESCRIPTION
## Description

wrapped the `onDownlaod` code behind an if statement.


Fixes #3463 

## How Has This Been Tested?

Tested locally on windows developer machine

## Review Checklist:

[if using the editor, use `[x]` in place of `[ ]` to check a box]

**Documentation** (check at least one)
- [x] There is **nothing** that needs documenting
- [ ] Documentation changes are **in this PR**
- [ ] There is an **issue** open for the documentation (link?)

**Installers**
- [ ] There is a chance this will affect the **installers**, if so
  - [ ] **Windows** installer (GH artifact) has been tested (installed and worked) 
  - [ ] **MacOSX** installer (GH artifact) has been tested (installed and worked) 

**Licencing** (untick if necessary)
- [x] The introduced changes comply with SasView license (BSD 3-Clause)

