### PR TITLE
Fix newly appeared SyntaxWarnings

### DIFF
--- a/src/sas/qtgui/Utilities/MuMag/MuMag.py
+++ b/src/sas/qtgui/Utilities/MuMag/MuMag.py
@@ -232,7 +232,7 @@ class MuMag(QtWidgets.QMainWindow, Ui_MuMagTool):
 
         self.chi_squared_axes.set_xlim([min(sweep_data.exchange_A_checked * 1e12), max(sweep_data.exchange_A_checked * 1e12)])
         self.chi_squared_axes.set_xlabel('$A$ [pJ/m]')
-        self.chi_squared_axes.set_ylabel('$\chi^2$')
+        self.chi_squared_axes.set_ylabel(r'$\chi^2$')
 
         # Residual intensity plot
         self.residual_axes.plot(q, refined.I_residual, label='fit')
@@ -240,7 +240,7 @@ class MuMag(QtWidgets.QMainWindow, Ui_MuMagTool):
         self.residual_axes.set_xscale('log')
         self.residual_axes.set_xlim([min(q), max(q)])
         self.residual_axes.set_xlabel('$q$ [1/nm]')
-        self.residual_axes.set_ylabel('$I_{\mathrm{res}}$')
+        self.residual_axes.set_ylabel(r'$I_{\mathrm{res}}$')
 
         # S_H parameter
         self.s_h_axes.plot(q, refined.S_H, label='fit')

--- a/src/sas/sascalc/size_distribution/maxEnt_method.py
+++ b/src/sas/sascalc/size_distribution/maxEnt_method.py
@@ -128,7 +128,7 @@ class decision_helper():
     
 class maxEntMethod():
     def MaxEntMove(self,fSum, blank, chisq, chizer, c1, c2, s1, s2):
-        '''
+        r'''
         Implementing the maximum entropy move for feature size distribution
         The goal of this function is to calculate distance and choose the next
         target $\chi^2$ and to move beta one step closer towards the solution
@@ -174,7 +174,7 @@ class maxEntMethod():
         return w, chtarg, loop, a_new, fx, beta
 
     def MaxEnt_SB(self,Iq,sigma,Gqr,first_bins,IterMax=5000,report=True):
-        '''
+        r'''
         This function does the complete Maximum Entropy algorithm of Skilling
         and Bryan
          


### PR DESCRIPTION
## Description

As a regression on #3163, 4 new SyntaxWarning have appeared:

```
$ find -name \*pyc -delete; py3compile ./src
.../src/sas/qtgui/Utilities/MuMag/MuMag.py:235: SyntaxWarning: invalid escape sequence '\c'
  self.chi_squared_axes.set_ylabel('$\chi^2$')
.../src/sas/qtgui/Utilities/MuMag/MuMag.py:243: SyntaxWarning: invalid escape sequence '\m'
  self.residual_axes.set_ylabel('$I_{\mathrm{res}}$')
.../src/sas/sascalc/size_distribution/maxEnt_method.py:134: SyntaxWarning: invalid escape sequence '\c'
  target $\chi^2$ and to move beta one step closer towards the solution
.../src/sas/sascalc/size_distribution/maxEnt_method.py:185: SyntaxWarning: invalid escape sequence '\D'
  I_{Q}=|\Delta\rho^2|\int|F(Q,r)^2|(V(r))^2N_{P}(r)dr
```

## How Has This Been Tested?

None needed

## Review Checklist:

[if using the editor, use `[x]` in place of `[ ]` to check a box]

**Documentation** (check at least one)
- [x] There is **nothing** that needs documenting
- [ ] Documentation changes are **in this PR**
- [ ] There is an **issue** open for the documentation (link?)

**Installers**
- [ ] There is a chance this will affect the **installers**, if so
  - [ ] **Windows** installer (GH artifact) has been tested (installed and worked) 
  - [ ] **MacOSX** installer (GH artifact) has been tested (installed and worked) 

**Licencing** (untick if necessary)
- [x] The introduced changes comply with SasView license (BSD 3-Clause)

