### PR TITLE
Updates to the release automation script

### DIFF
--- a/build_tools/release_automation.py
+++ b/build_tools/release_automation.py
@@ -7,6 +7,7 @@ import datetime
 import sys
 import os
 from pathlib import Path
+from csv import DictReader
 
 from sas.system.legal import legal
 
@@ -141,20 +142,18 @@ def generate_sasview_data() -> dict:
         contributors = []
         creators = []
         with open(CONTRIBUTORS_FILE) as f:
-            # Rear in the lines and ignore the first line
-            lines = f.readlines()[1:]
-            for line in lines:
-                values = line.split('\t')
-                record = {"name": values[0], "affiliation": values[1]}
-                if len(values) > 5 and values[5]:
-                    record['orcid'] = values[5]
-                if values[2]:
+            reader = DictReader(f)
+            for row in reader:
+                record = {"name": row["Name"], "affiliation": row["Affiliation"]}
+                if 'ORCID' in row:
+                    record['orcid'] = row['ORCID']
+                if row['Creator']:
                     creators.append(record)
-                elif len(values) > 3 and values[3]:
-                    record['type'] = "Producer"
+                elif row['Producer']:
+                    record['type'] = 'Producer'
                     contributors.append(record)
-                elif len(values) > 4 and values[4]:
-                    record['type'] = "Other"
+                else:
+                    record['type'] == 'Other'
                     contributors.append(record)
         return {"creators": creators, "contributors": contributors}
     else:

--- a/build_tools/release_automation.py
+++ b/build_tools/release_automation.py
@@ -142,7 +142,7 @@ def generate_sasview_data() -> dict:
         contributors = []
         creators = []
         with open(CONTRIBUTORS_FILE) as f:
-            reader = DictReader(f)
+            reader = DictReader(f, delimiter="\t")
             for row in reader:
                 record = {"name": row["Name"], "affiliation": row["Affiliation"]}
                 if 'ORCID' in row:

--- a/build_tools/release_automation.py
+++ b/build_tools/release_automation.py
@@ -153,7 +153,7 @@ def generate_sasview_data() -> dict:
                     record['type'] = 'Producer'
                     contributors.append(record)
                 else:
-                    record['type'] == 'Other'
+                    record['type'] = 'Other'
                     contributors.append(record)
         return {"creators": creators, "contributors": contributors}
     else:

--- a/build_tools/release_automation.py
+++ b/build_tools/release_automation.py
@@ -346,12 +346,9 @@ def main(args=None):
 
     # Pull the license from a know location
     license_line = legal.copyright
-    subpackages = [SASMODELS_PATH, SASDATA_PATH, SASVIEW_PATH]
-    for subpackage in subpackages:
-        license_file = subpackage / 'LICENSE.txt'
-        update_file(license_file, license_line, 0)
-    license_file = SASVIEW_PATH / 'installers' / 'license.txt'
-    update_file(license_file, license_line, -1)
+    update_file(SASMODELS_PATH / 'LICENSE.txt', license_line, 0)
+    update_file(SASDATA_PATH / 'LICENSE.TXT', license_line, 0)
+    update_file(SASVIEW_PATH / 'installers' / 'license.txt', license_line, -1)
 
     sasview_issues_list = args.sasview_list
     sasmodels_issues_list = args.sasmodels_list

--- a/build_tools/release_automation.py
+++ b/build_tools/release_automation.py
@@ -37,8 +37,8 @@ zenodo_url = "https://zenodo.org"
 # Should import release notes from git repo, for now will need to cut and paste
 sasview_data = {
 'metadata': {
-    'title': f'SasView version 6.1.0',
-    'description': f'6.1.0 release',
+    'title': 'SasView version 6.1.0',
+    'description': '6.1.0 release',
     'related_identifiers': [{'identifier': 'https://github.com/SasView/sasview/releases/tag/v6.1.0-alpha-1',
                         'relation': 'isAlternateIdentifier', 'scheme': 'url'}],
     'contributors': [


### PR DESCRIPTION
## Description

There are two main changes

- The script now uses the Python `csv` module, rather than parsing the `tsv` file manually. This means that quotations in the file will be handled properly.
- Some of the script broke on Linux (and presumably on macOS as well) because of how Unix file systems are case sensitive, as opposed to the Windows file system which is case insensitive. I've fixed this.

## How Has This Been Tested?

I ran the script, and pretty printed the contributors dictionary which came out as expected. I haven't tested the upload to Zenodo, however.=

## Review Checklist:

[if using the editor, use `[x]` in place of `[ ]` to check a box]

**Documentation** (check at least one)
- [x] There is **nothing** that needs documenting
- [ ] Documentation changes are **in this PR**
- [ ] There is an **issue** open for the documentation (link?)

**Installers**
- [ ] There is a chance this will affect the **installers**, if so
  - [ ] **Windows** installer (GH artifact) has been tested (installed and worked) 
  - [ ] **MacOSX** installer (GH artifact) has been tested (installed and worked) 

**Licencing** (untick if necessary)
- [x] The introduced changes comply with SasView license (BSD 3-Clause)

