### PR TITLE
Use the new data loaders in the refactored data explorer. 

### DIFF
--- a/src/ascii_dialog/dialog.py
+++ b/src/ascii_dialog/dialog.py
@@ -65,6 +65,9 @@ class AsciiDialog(QDialog):
         self.dataset_label = QLabel("Dataset Type")
         self.dataset_combobox = QComboBox()
         for name in dataset_types:
+            # TODO: Temporarily exclude SESANS until that's been fixed.
+            if name == 'SESANS':
+                continue
             self.dataset_combobox.addItem(name)
         self.dataset_layout.addWidget(self.dataset_label)
         self.dataset_layout.addWidget(self.dataset_combobox)

--- a/src/sas/data_explorer_menu.py
+++ b/src/sas/data_explorer_menu.py
@@ -35,3 +35,4 @@ class DataExplorerMenu(QMenu):
                 new_action.setData(DataExplorerMenuAction("send_to", perspective))
                 send_to_menu.addAction(new_action)
         self.addAction(remove_data)
+        self.addAction(view_data)

--- a/src/sas/data_explorer_menu.py
+++ b/src/sas/data_explorer_menu.py
@@ -6,12 +6,14 @@ from sas.data_manager import NewDataManager
 from src.sas.refactored import Perspective
 from dataclasses import dataclass
 
+
 # TODO: Could we perhaps enforce that, if the action is send_to, the action_data
 # should not be None?
 @dataclass
-class DataExplorerMenuAction():
-    action: Literal['remove', 'send_to']
+class DataExplorerMenuAction:
+    action: Literal["remove", "send_to"]
     action_data: Perspective | None = None
+
 
 class DataExplorerMenu(QMenu):
     def __init__(self, parent: QWidget, data_manager: NewDataManager, send_to: bool):
@@ -19,7 +21,7 @@ class DataExplorerMenu(QMenu):
 
         remove_data = QAction("Remove", parent)
         # remove_data.setData('remove')
-        remove_data.setData(DataExplorerMenuAction('remove'))
+        remove_data.setData(DataExplorerMenuAction("remove"))
         # TODO: There will be loads more
 
         if send_to:
@@ -27,6 +29,6 @@ class DataExplorerMenu(QMenu):
 
             for perspective in data_manager.all_perspectives:
                 new_action = QAction(perspective.formatName, parent)
-                new_action.setData(DataExplorerMenuAction('send_to', perspective))
+                new_action.setData(DataExplorerMenuAction("send_to", perspective))
                 send_to_menu.addAction(new_action)
         self.addAction(remove_data)

--- a/src/sas/data_explorer_menu.py
+++ b/src/sas/data_explorer_menu.py
@@ -11,7 +11,7 @@ from dataclasses import dataclass
 # should not be None?
 @dataclass
 class DataExplorerMenuAction:
-    action: Literal["remove", "send_to"]
+    action: Literal["remove", "send_to", "view_data"]
     action_data: Perspective | None = None
 
 
@@ -22,6 +22,9 @@ class DataExplorerMenu(QMenu):
         remove_data = QAction("Remove", parent)
         # remove_data.setData('remove')
         remove_data.setData(DataExplorerMenuAction("remove"))
+
+        view_data = QAction("View Data", parent)
+        view_data.setData(DataExplorerMenuAction("view_data"))
         # TODO: There will be loads more
 
         if send_to:

--- a/src/sas/data_explorer_tree.py
+++ b/src/sas/data_explorer_tree.py
@@ -34,6 +34,7 @@ class DataExplorerTree(QTreeWidget):
         self._data_manager = data_manager
         _ = self._data_manager.new_data.connect(self.addToTable)
         _ = self._data_manager.data_removed.connect(self.removeFromTable)
+        _ = self.view_data_activated.connect(self.showViewData)
 
         self.setContextMenuPolicy(Qt.ContextMenuPolicy.CustomContextMenu)
         self.setSelectionMode(QAbstractItemView.SelectionMode.ExtendedSelection)

--- a/src/sas/data_explorer_tree.py
+++ b/src/sas/data_explorer_tree.py
@@ -1,12 +1,19 @@
 from typing_extensions import cast
 from PySide6.QtCore import Qt, Signal
 from PySide6.QtGui import QCursor
-from PySide6.QtWidgets import QAbstractItemView, QMessageBox, QTreeWidget, QTreeWidgetItem, QWidget
+from PySide6.QtWidgets import (
+    QAbstractItemView,
+    QMessageBox,
+    QTreeWidget,
+    QTreeWidgetItem,
+    QWidget,
+)
 from sasdata.data import SasData
 from sas.data_manager import NewDataManager as DataManager, TrackedData
 from sas.refactored import Perspective
 from src.sas.data_explorer_error_message import DataExplorerErrorMessage
 from src.sas.data_explorer_menu import DataExplorerMenu, DataExplorerMenuAction
+
 
 # TODO: Is this the right place for this?
 def tracked_data_name(data: TrackedData) -> str:
@@ -15,10 +22,13 @@ def tracked_data_name(data: TrackedData) -> str:
     else:
         return data.formatName
 
+
 class DataExplorerTree(QTreeWidget):
     current_datum_removed = Signal()
 
-    def __init__(self, data_manager: DataManager, parent: QWidget | None = None) -> None:
+    def __init__(
+        self, data_manager: DataManager, parent: QWidget | None = None
+    ) -> None:
         super().__init__(parent)
         self._data_manager = data_manager
         _ = self._data_manager.new_data.connect(self.addToTable)
@@ -55,13 +65,17 @@ class DataExplorerTree(QTreeWidget):
         # TODO: Again, order.
         self.removeFromTable(datum2, root_datum=datum1)
 
-
     def addToTable(self, datum: TrackedData):
         item = QTreeWidgetItem([tracked_data_name(datum)])
         item.setData(0, Qt.ItemDataRole.UserRole, datum)
         self.addTopLevelItem(item)
 
-    def removeFromTable(self, datum: TrackedData, starting_root: QTreeWidgetItem | None = None, root_datum: TrackedData | None = None):
+    def removeFromTable(
+        self,
+        datum: TrackedData,
+        starting_root: QTreeWidgetItem | None = None,
+        root_datum: TrackedData | None = None,
+    ):
         """The root_datum param is needed when you want to delete something from the tree that has a certain root item.
         This is mostly useful for getting rid of associations."""
         root = self.invisibleRootItem() if starting_root is None else starting_root
@@ -71,7 +85,10 @@ class DataExplorerTree(QTreeWidget):
         for i in range(root.childCount()):
             item = root.child(i)
             item_datum = cast(TrackedData, item.data(0, Qt.ItemDataRole.UserRole))
-            if item_datum == datum and (not root_datum is None or root_datum == root.data(0, Qt.ItemDataRole.UserRole)):
+            if item_datum == datum and (
+                not root_datum is None
+                or root_datum == root.data(0, Qt.ItemDataRole.UserRole)
+            ):
                 # Need to defer this to later so we don't delete data while we're doing a for loop over it.
                 to_remove.append(item)
             elif item.childCount() != 0:
@@ -89,10 +106,10 @@ class DataExplorerTree(QTreeWidget):
         result: DataExplorerMenuAction = action.data()
         errors: list[ValueError] = []
         match result.action:
-            case 'remove':
+            case "remove":
                 # TODO: Work for all data.
                 self.current_datum_removed.emit()
-            case 'send_to':
+            case "send_to":
                 # TODO: This cast might not be necessary.
                 to_perspective = cast(Perspective, result.action_data)
                 # TODO: I'm a bit worried about potential repetition if there are more actions here. Will need to
@@ -121,7 +138,9 @@ class DataExplorerTree(QTreeWidget):
 
     # Annoyingly, there is no way to get all the items in a tree. So we have to
     # do this recursively instead.
-    def setCurrentTrackedDatum(self, datum: TrackedData, root: QTreeWidgetItem | None = None):
+    def setCurrentTrackedDatum(
+        self, datum: TrackedData, root: QTreeWidgetItem | None = None
+    ):
         if root is None:
             root = self.invisibleRootItem()
         for i in range(root.childCount()):

--- a/src/sas/data_explorer_tree.py
+++ b/src/sas/data_explorer_tree.py
@@ -3,7 +3,6 @@ from PySide6.QtCore import Qt, Signal
 from PySide6.QtGui import QCursor
 from PySide6.QtWidgets import (
     QAbstractItemView,
-    QMessageBox,
     QTreeWidget,
     QTreeWidgetItem,
     QWidget,

--- a/src/sas/data_explorer_tree.py
+++ b/src/sas/data_explorer_tree.py
@@ -12,6 +12,7 @@ from sas.data_manager import NewDataManager as DataManager, TrackedData
 from sas.refactored import Perspective
 from src.sas.data_explorer_error_message import DataExplorerErrorMessage
 from src.sas.data_explorer_menu import DataExplorerMenu, DataExplorerMenuAction
+from sas.qtgui.MainWindow.DataViewer import DataViewer
 
 
 # TODO: Is this the right place for this?
@@ -24,6 +25,7 @@ def tracked_data_name(data: TrackedData) -> str:
 
 class DataExplorerTree(QTreeWidget):
     current_datum_removed = Signal()
+    view_data_activated = Signal()
 
     def __init__(
         self, data_manager: DataManager, parent: QWidget | None = None
@@ -108,6 +110,8 @@ class DataExplorerTree(QTreeWidget):
             case "remove":
                 # TODO: Work for all data.
                 self.current_datum_removed.emit()
+            case "view_data":
+                self.view_data_activated.emit()
             case "send_to":
                 # TODO: This cast might not be necessary.
                 to_perspective = cast(Perspective, result.action_data)
@@ -121,6 +125,10 @@ class DataExplorerTree(QTreeWidget):
         if len(errors):
             box = DataExplorerErrorMessage(self, errors)
             box.show()
+
+    def showViewData(self):
+        viewer = DataViewer(self.currentTrackkedDatum)
+        viewer.exec()
 
     @property
     def currentTrackedDatum(self) -> TrackedData | None:

--- a/src/sas/data_explorer_tree.py
+++ b/src/sas/data_explorer_tree.py
@@ -128,7 +128,7 @@ class DataExplorerTree(QTreeWidget):
             box.show()
 
     def showViewData(self):
-        viewer = DataViewer(self.currentTrackkedDatum)
+        viewer = DataViewer(self.currentTrackedDatum)
         viewer.exec()
 
     @property

--- a/src/sas/qtgui/MainWindow/DataViewer.py
+++ b/src/sas/qtgui/MainWindow/DataViewer.py
@@ -8,5 +8,5 @@ class DataViewer(QDialog):
         self.to_view = to_view
         self.layout = QGridLayout()
 
-        self.filenameLabel = QLabel(f"Name: {self.to_view}")
-        self.layout.addWidget(self.filenameLabel, 0, 0, 1, 1)
+        self.nameLabel = QLabel(f"Name: {self.to_view}")
+        self.layout.addWidget(self.nameLabel, 0, 0, 1, 1)

--- a/src/sas/qtgui/MainWindow/DataViewer.py
+++ b/src/sas/qtgui/MainWindow/DataViewer.py
@@ -8,5 +8,5 @@ class DataViewer(QDialog):
         self.to_view = to_view
         self.layout = QGridLayout(self)
 
-        self.nameLabel = QLabel(f"Name: {self.to_view}")
+        self.nameLabel = QLabel(f"Name: {self.to_view.name}")
         self.layout.addWidget(self.nameLabel, 0, 0, 1, 1)

--- a/src/sas/qtgui/MainWindow/DataViewer.py
+++ b/src/sas/qtgui/MainWindow/DataViewer.py
@@ -1,4 +1,4 @@
-from PySide6.QtWidgets import QDialog
+from PySide6.QtWidgets import QDialog, QLabel, QGridLayout
 from sasdata.data import SasData
 
 
@@ -6,3 +6,7 @@ class DataViewer(QDialog):
     def __init__(self, to_view: SasData):
         super().__init__()
         self.to_view = to_view
+        self.layout = QGridLayout()
+
+        self.filenameLabel = QLabel(f"Name: {self.to_view}")
+        self.layout.addWidget(self.filenameLabel, 0, 0, 1, 1)

--- a/src/sas/qtgui/MainWindow/DataViewer.py
+++ b/src/sas/qtgui/MainWindow/DataViewer.py
@@ -1,0 +1,8 @@
+from PySide6.QtWidgets import QDialog
+from sasdata.data import SasData
+
+
+class DataViewer(QDialog):
+    def __init__(self, to_view: SasData):
+        super().__init__()
+        self.to_view = to_view

--- a/src/sas/qtgui/MainWindow/DataViewer.py
+++ b/src/sas/qtgui/MainWindow/DataViewer.py
@@ -6,7 +6,7 @@ class DataViewer(QDialog):
     def __init__(self, to_view: SasData):
         super().__init__()
         self.to_view = to_view
-        self.layout = QGridLayout()
+        self.layout = QGridLayout(self)
 
         self.nameLabel = QLabel(f"Name: {self.to_view}")
         self.layout.addWidget(self.nameLabel, 0, 0, 1, 1)

--- a/src/sas/qtgui/MainWindow/DataViewer.py
+++ b/src/sas/qtgui/MainWindow/DataViewer.py
@@ -44,4 +44,4 @@ class DataViewer(QDialog):
         self.dataTable.setHorizontalHeaderLabels(columns)
         for i, data in enumerate(self.to_view._data_contents.values()):
             for j, datum in enumerate(data.value):
-                self.dataTable.setItem(j, i, QTableWidgetItem(datum))
+                self.dataTable.setItem(j, i, QTableWidgetItem(str(datum)))

--- a/src/sas/qtgui/MainWindow/DataViewer.py
+++ b/src/sas/qtgui/MainWindow/DataViewer.py
@@ -33,7 +33,7 @@ class DataViewer(QDialog):
 
     def buildTable(self):
         # Make the table readonly
-        self.table.setEditTriggers(QTableWidget.EditTrigger.NoEditTriggers)
+        self.dataTable.setEditTriggers(QTableWidget.EditTrigger.NoEditTriggers)
         columns = self.to_view._data_contents.keys()
         self.dataTable.setColumnCount(len(columns))
         # NOTE: Assumes each column has the same amount of rows, which should be

--- a/src/sas/qtgui/MainWindow/DataViewer.py
+++ b/src/sas/qtgui/MainWindow/DataViewer.py
@@ -1,4 +1,11 @@
-from PySide6.QtWidgets import QDialog, QLabel, QGridLayout, QPushButton, QTableWidget
+from PySide6.QtWidgets import (
+    QDialog,
+    QLabel,
+    QGridLayout,
+    QPushButton,
+    QTableWidget,
+    QTableWidgetItem,
+)
 from sasdata.data import SasData
 
 
@@ -13,7 +20,8 @@ class DataViewer(QDialog):
         self.dataTypeLabel = QLabel(
             f"Type: {self.to_view.dataset_type.name}"
         )  # TODO: Probably a better way of printing this
-        self.dataTable = QTableWidget()  # TODO: Fill.
+        self.dataTable = QTableWidget()
+        self.buildTable()
         self.closeButton = QPushButton("Close")
         self.closeButton.clicked.connect(self.close)
 
@@ -22,3 +30,24 @@ class DataViewer(QDialog):
         self.layout.addWidget(self.dataTypeLabel, 1, 0, 1, 1)
         self.layout.addWidget(self.dataTable, 2, 0, 1, 2)
         self.layout.addWidget(self.closeButton, 3, 0, 1, 2)
+
+    def buildTable(self):
+        self.dataTable.setHorizontalHeaderLabels(self.to_view._data_contents.keys())
+        for i, data in enumerate(self.to_view._data_contents.values()):
+            for j, datum in enumerate(data):
+                self.dataTable.setItem(j, i, QTableWidgetItem(datum))
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/src/sas/qtgui/MainWindow/DataViewer.py
+++ b/src/sas/qtgui/MainWindow/DataViewer.py
@@ -16,3 +16,6 @@ class DataViewer(QDialog):
         self.dataTable = QTableWidget()  # TODO: Fill.
 
         self.layout.addWidget(self.nameLabel, 0, 0, 1, 1)
+        self.layout.addWidget(self.viewMetadataButton, 0, 1, 1, 1)
+        self.layout.addWidget(self.dataTypeLabel, 1, 0, 1, 1)
+        self.layout.addWidget(self.dataTable, 2, 0, 1, 1)

--- a/src/sas/qtgui/MainWindow/DataViewer.py
+++ b/src/sas/qtgui/MainWindow/DataViewer.py
@@ -6,6 +6,7 @@ from PySide6.QtWidgets import (
     QTableWidget,
     QTableWidgetItem,
     QAbstractScrollArea,
+    QHeaderView,
 )
 from sasdata.data import SasData
 
@@ -35,10 +36,6 @@ class DataViewer(QDialog):
     def buildTable(self):
         # Make the table readonly
         self.dataTable.setEditTriggers(QTableWidget.EditTrigger.NoEditTriggers)
-        # The table's width will always resize to fit the amount of space it has.
-        self.dataTable.setSizeAdjustPolicy(
-            QAbstractScrollArea.SizeAdjustPolicy.AdjustToContents
-        )
         columns = self.to_view._data_contents.keys()
         self.dataTable.setColumnCount(len(columns))
         # NOTE: Assumes each column has the same amount of rows, which should be
@@ -47,6 +44,9 @@ class DataViewer(QDialog):
             len(next(iter(self.to_view._data_contents.values())).value)
         )
         self.dataTable.setHorizontalHeaderLabels(columns)
+        self.dataTable.horizontalHeader().setSectionResizeMode(
+            QHeaderView.ResizeMode.Stretch
+        )
         for i, data in enumerate(self.to_view._data_contents.values()):
             for j, datum in enumerate(data.value):
                 self.dataTable.setItem(j, i, QTableWidgetItem(str(datum)))

--- a/src/sas/qtgui/MainWindow/DataViewer.py
+++ b/src/sas/qtgui/MainWindow/DataViewer.py
@@ -5,6 +5,7 @@ from PySide6.QtWidgets import (
     QPushButton,
     QTableWidget,
     QTableWidgetItem,
+    QAbstractScrollArea,
 )
 from sasdata.data import SasData
 
@@ -34,6 +35,10 @@ class DataViewer(QDialog):
     def buildTable(self):
         # Make the table readonly
         self.dataTable.setEditTriggers(QTableWidget.EditTrigger.NoEditTriggers)
+        # The table's width will always resize to fit the amount of space it has.
+        self.dataTable.setSizeAdjustPolicy(
+            QAbstractScrollArea.SizeAdjustPolicy.AdjustToContents
+        )
         columns = self.to_view._data_contents.keys()
         self.dataTable.setColumnCount(len(columns))
         # NOTE: Assumes each column has the same amount of rows, which should be

--- a/src/sas/qtgui/MainWindow/DataViewer.py
+++ b/src/sas/qtgui/MainWindow/DataViewer.py
@@ -36,7 +36,9 @@ class DataViewer(QDialog):
         self.dataTable.setColumnCount(len(columns))
         # NOTE: Assumes each column has the same amount of rows, which should be
         # the case, although perhaps we should validate this.
-        self.dataTable.setRowCount(len(self.to_view._data_contents.values()[0].value))
+        self.dataTable.setRowCount(
+            len(next(iter(self.to_view._data_contents.values())).value)
+        )
         self.dataTable.setHorizontalHeaderLabels(columns)
         for i, data in enumerate(self.to_view._data_contents.values()):
             for j, datum in enumerate(data.value):

--- a/src/sas/qtgui/MainWindow/DataViewer.py
+++ b/src/sas/qtgui/MainWindow/DataViewer.py
@@ -18,4 +18,4 @@ class DataViewer(QDialog):
         self.layout.addWidget(self.nameLabel, 0, 0, 1, 1)
         self.layout.addWidget(self.viewMetadataButton, 0, 1, 1, 1)
         self.layout.addWidget(self.dataTypeLabel, 1, 0, 1, 1)
-        self.layout.addWidget(self.dataTable, 2, 0, 1, 1)
+        self.layout.addWidget(self.dataTable, 2, 0, 1, 2)

--- a/src/sas/qtgui/MainWindow/DataViewer.py
+++ b/src/sas/qtgui/MainWindow/DataViewer.py
@@ -14,8 +14,11 @@ class DataViewer(QDialog):
             f"Type: {self.to_view.dataset_type.name}"
         )  # TODO: Probably a better way of printing this
         self.dataTable = QTableWidget()  # TODO: Fill.
+        self.closeButton = QPushButton("Close")
+        self.closeButton.clicked.connect(self.close)
 
         self.layout.addWidget(self.nameLabel, 0, 0, 1, 1)
         self.layout.addWidget(self.viewMetadataButton, 0, 1, 1, 1)
         self.layout.addWidget(self.dataTypeLabel, 1, 0, 1, 1)
         self.layout.addWidget(self.dataTable, 2, 0, 1, 2)
+        self.layout.addWidget(self.closeButton, 3, 0, 1, 2)

--- a/src/sas/qtgui/MainWindow/DataViewer.py
+++ b/src/sas/qtgui/MainWindow/DataViewer.py
@@ -11,7 +11,7 @@ class DataViewer(QDialog):
         self.nameLabel = QLabel(f"Name: {self.to_view.name}")
         self.viewMetadataButton = QPushButton("View Metadata")
         self.dataTypeLabel = QLabel(
-            f"Type: {self.to_view.dataset_type}"
+            f"Type: {self.to_view.dataset_type.name}"
         )  # TODO: Probably a better way of printing this
         self.dataTable = QTableWidget()  # TODO: Fill.
 

--- a/src/sas/qtgui/MainWindow/DataViewer.py
+++ b/src/sas/qtgui/MainWindow/DataViewer.py
@@ -9,6 +9,7 @@ from PySide6.QtWidgets import (
     QHeaderView,
 )
 from sasdata.data import SasData
+from sas.qtgui.MainWindow.MetadataExplorer import MetadataExplorer
 
 
 class DataViewer(QDialog):
@@ -19,6 +20,7 @@ class DataViewer(QDialog):
 
         self.nameLabel = QLabel(f"Name: {self.to_view.name}")
         self.viewMetadataButton = QPushButton("View Metadata")
+        self.viewMetadataButton.clicked.connect(self.openMetadataExplorer)
         self.dataTypeLabel = QLabel(
             f"Type: {self.to_view.dataset_type.name}"
         )  # TODO: Probably a better way of printing this
@@ -50,3 +52,7 @@ class DataViewer(QDialog):
         for i, data in enumerate(self.to_view._data_contents.values()):
             for j, datum in enumerate(data.value):
                 self.dataTable.setItem(j, i, QTableWidgetItem(str(datum)))
+
+    def openMetadataExplorer(self):
+        explorer = MetadataExplorer(self.to_view.metadata, self.to_view.name)
+        explorer.exec()

--- a/src/sas/qtgui/MainWindow/DataViewer.py
+++ b/src/sas/qtgui/MainWindow/DataViewer.py
@@ -32,6 +32,8 @@ class DataViewer(QDialog):
         self.layout.addWidget(self.closeButton, 3, 0, 1, 2)
 
     def buildTable(self):
+        # Make the table readonly
+        self.table.setEditTriggers(QTableWidget.EditTrigger.NoEditTriggers)
         columns = self.to_view._data_contents.keys()
         self.dataTable.setColumnCount(len(columns))
         # NOTE: Assumes each column has the same amount of rows, which should be

--- a/src/sas/qtgui/MainWindow/DataViewer.py
+++ b/src/sas/qtgui/MainWindow/DataViewer.py
@@ -34,20 +34,5 @@ class DataViewer(QDialog):
     def buildTable(self):
         self.dataTable.setHorizontalHeaderLabels(self.to_view._data_contents.keys())
         for i, data in enumerate(self.to_view._data_contents.values()):
-            for j, datum in enumerate(data):
+            for j, datum in enumerate(data.value):
                 self.dataTable.setItem(j, i, QTableWidgetItem(datum))
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/src/sas/qtgui/MainWindow/DataViewer.py
+++ b/src/sas/qtgui/MainWindow/DataViewer.py
@@ -1,4 +1,4 @@
-from PySide6.QtWidgets import QDialog, QLabel, QGridLayout
+from PySide6.QtWidgets import QDialog, QLabel, QGridLayout, QPushButton, QTableWidget
 from sasdata.data import SasData
 
 
@@ -9,4 +9,10 @@ class DataViewer(QDialog):
         self.layout = QGridLayout(self)
 
         self.nameLabel = QLabel(f"Name: {self.to_view.name}")
+        self.viewMetadataButton = QPushButton("View Metadata")
+        self.dataTypeLabel = QLabel(
+            f"Type: {self.to_view.dataset_type}"
+        )  # TODO: Probably a better way of printing this
+        self.dataTable = QTableWidget()  # TODO: Fill.
+
         self.layout.addWidget(self.nameLabel, 0, 0, 1, 1)

--- a/src/sas/qtgui/MainWindow/DataViewer.py
+++ b/src/sas/qtgui/MainWindow/DataViewer.py
@@ -32,7 +32,12 @@ class DataViewer(QDialog):
         self.layout.addWidget(self.closeButton, 3, 0, 1, 2)
 
     def buildTable(self):
-        self.dataTable.setHorizontalHeaderLabels(self.to_view._data_contents.keys())
+        columns = self.to_view._data_contents.keys()
+        self.dataTable.setColumnCount(len(columns))
+        # NOTE: Assumes each column has the same amount of rows, which should be
+        # the case, although perhaps we should validate this.
+        self.dataTable.setRowCount(len(self.to_view._data_contents.values()[0].value))
+        self.dataTable.setHorizontalHeaderLabels(columns)
         for i, data in enumerate(self.to_view._data_contents.values()):
             for j, datum in enumerate(data.value):
                 self.dataTable.setItem(j, i, QTableWidgetItem(datum))

--- a/src/sas/qtgui/MainWindow/GuiManager.py
+++ b/src/sas/qtgui/MainWindow/GuiManager.py
@@ -282,8 +282,11 @@ class GuiManager:
 
     @Slot(QDialog)
     def removed_perspective(self, to_remove: QDialog):
-        # Need to find the subwindow that contains the perspective so we can remove that. for sub_window in self._workspace.workspace.subWindowList(): if sub_window.widget() == to_remove: self._workspace.workspace.removeSubWindow(sub_window) break @Slot(QMdiSubWindow) def current_window_perspective_changed(self, perspective_window: QMdiSubWindow | None): if isinstance(perspective_window.widget(), NewPerspective):
-        pass
+        # Need to find the subwindow that contains the perspective so we can remove that.
+        for sub_window in self._workspace.workspace.subWindowList():
+            if sub_window.widget() == to_remove:
+                self._workspace.workspace.removeSubWindow(sub_window)
+                break
 
     @Slot(QMdiSubWindow)
     def current_window_perspective_changed(self, perspective_window: QMdiSubWindow | None):

--- a/src/sas/qtgui/MainWindow/GuiManager.py
+++ b/src/sas/qtgui/MainWindow/GuiManager.py
@@ -190,6 +190,7 @@ class GuiManager:
         # self.filesWidget = DataExplorerWindow(self._parent, self, manager=self._data_manager)
         # TODO: Is this a good opportunity to change this name? dataExplorer would be better I think.
         self.filesWidget = NewDataExplorer(self._data_manager ,self._parent)
+        self.filesWidget.new_perspective.connect(self.new_perspective)
         ObjectLibrary.addObject('DataExplorer', self.filesWidget)
 
         self.dockedFilesWidget = QDockWidget("Data Explorer", self._workspace)
@@ -281,15 +282,7 @@ class GuiManager:
 
     @Slot(QDialog)
     def removed_perspective(self, to_remove: QDialog):
-        # Need to find the subwindow that contains the perspective so we can remove that.
-        for sub_window in self._workspace.workspace.subWindowList():
-            if sub_window.widget() == to_remove:
-                self._workspace.workspace.removeSubWindow(sub_window)
-                break
-
-    @Slot(QMdiSubWindow)
-    def current_window_perspective_changed(self, perspective_window: QMdiSubWindow | None):
-        if isinstance(perspective_window.widget(), NewPerspective):
+        # Need to find the subwindow that contains the perspective so we can remove that. for sub_window in self._workspace.workspace.subWindowList(): if sub_window.widget() == to_remove: self._workspace.workspace.removeSubWindow(sub_window) break @Slot(QMdiSubWindow) def current_window_perspective_changed(self, perspective_window: QMdiSubWindow | None): if isinstance(perspective_window.widget(), NewPerspective):
             perspective = cast(Perspective, perspective_window.widget())
             self.filesWidget.tree_view.setCurrentTrackedDatum(perspective)
 

--- a/src/sas/qtgui/MainWindow/GuiManager.py
+++ b/src/sas/qtgui/MainWindow/GuiManager.py
@@ -779,6 +779,7 @@ class GuiManager:
 
         # File
         self._workspace.actionLoadData.triggered.connect(self.actionLoadData)
+        self._workspace.actionAdvanced_Load.triggered.connect(self.actionAdvancedLoad)
         self._workspace.actionLoad_Data_Folder.triggered.connect(self.actionLoad_Data_Folder)
         self._workspace.actionOpen_Project.triggered.connect(self.actionOpen_Project)
         self._workspace.actionOpen_Analysis.triggered.connect(self.actionOpen_Analysis)
@@ -869,6 +870,9 @@ class GuiManager:
         Menu File/Load Data File(s)
         """
         self.filesWidget.loadFile()
+
+    def actionAdvancedLoad(self):
+        self.filesWidget.onAdvancedLoad()
 
     def actionLoad_Data_Folder(self):
         """

--- a/src/sas/qtgui/MainWindow/GuiManager.py
+++ b/src/sas/qtgui/MainWindow/GuiManager.py
@@ -283,8 +283,7 @@ class GuiManager:
     @Slot(QDialog)
     def removed_perspective(self, to_remove: QDialog):
         # Need to find the subwindow that contains the perspective so we can remove that. for sub_window in self._workspace.workspace.subWindowList(): if sub_window.widget() == to_remove: self._workspace.workspace.removeSubWindow(sub_window) break @Slot(QMdiSubWindow) def current_window_perspective_changed(self, perspective_window: QMdiSubWindow | None): if isinstance(perspective_window.widget(), NewPerspective):
-            perspective = cast(Perspective, perspective_window.widget())
-            self.filesWidget.tree_view.setCurrentTrackedDatum(perspective)
+        pass
 
     @Slot(QMdiSubWindow)
     def current_window_perspective_changed(self, perspective_window: QMdiSubWindow | None):

--- a/src/sas/qtgui/MainWindow/GuiManager.py
+++ b/src/sas/qtgui/MainWindow/GuiManager.py
@@ -286,6 +286,12 @@ class GuiManager:
             perspective = cast(Perspective, perspective_window.widget())
             self.filesWidget.tree_view.setCurrentTrackedDatum(perspective)
 
+    @Slot(QMdiSubWindow)
+    def current_window_perspective_changed(self, perspective_window: QMdiSubWindow | None):
+        if isinstance(perspective_window.widget(), NewPerspective):
+            perspective = cast(Perspective, perspective_window.widget())
+            self.filesWidget.tree_view.setCurrentTrackedDatum(perspective)
+
     @Slot()
     def current_index_perspective_changed(self):
         new_selected  = self.filesWidget.tree_view.currentTrackedDatum

--- a/src/sas/qtgui/MainWindow/MetadataExplorer.py
+++ b/src/sas/qtgui/MainWindow/MetadataExplorer.py
@@ -20,7 +20,9 @@ def metadata_as_dict(to_convert: object):
     easier to iterate over.
 
     """
-    if isinstance(to_convert, list) and all([hasattr(item, '__dict__') for item in to_convert]):
+    if isinstance(to_convert, list) and all(
+        [hasattr(item, "__dict__") for item in to_convert]
+    ):
         converted_dicts: list[dict[str, object]] = []
         for item in to_convert:
             converted_dicts.append(item.__dict__)

--- a/src/sas/qtgui/MainWindow/MetadataExplorer.py
+++ b/src/sas/qtgui/MainWindow/MetadataExplorer.py
@@ -28,7 +28,7 @@ def convert_raw_to_dict(to_convert: MetaNode, converted: dict = None) -> dict:
 
 def metadata_as_dict(to_convert: object):
     converted = to_convert.__dict__
-    converted["raw"] = convert_raw_to_dict(to_convert["raw"])
+    converted["raw"] = convert_raw_to_dict(converted["raw"])
     return converted
 
 

--- a/src/sas/qtgui/MainWindow/MetadataExplorer.py
+++ b/src/sas/qtgui/MainWindow/MetadataExplorer.py
@@ -13,36 +13,23 @@ from sasdata.metadata import MetaNode, Metadata
 from sasdata.temp_xml_reader import load_data
 
 
-def metadata_as_dict(to_convert: object):
-    """This is a custom implementation of asdict from dataclasses. The key
-    difference is that MetaNode class objects are preserved (as well as other
-    leaf nodes), but everything else is converted into a dict. This makes it
-    easier to iterate over.
+def convert_raw_to_dict(to_convert: MetaNode, converted: dict = None) -> dict:
+    if converted is None:
+        converted = {}
+    converted[to_convert.name] = {}
+    for raw_content in to_convert.contents:
+        if raw_content is MetaNode:
+            to_add = convert_raw_to_dict(to_convert, converted)
+        else:
+            to_add = raw_content
+        converted[to_convert.name][to_add.name] = to_add
+    return converted
 
-    """
-    if isinstance(to_convert, list) and all(
-        [hasattr(item, "__dict__") for item in to_convert]
-    ):
-        converted_dicts: list[dict[str, object]] = []
-        for item in to_convert:
-            converted_dicts.append(item.__dict__)
-    elif hasattr(to_convert, "__dict__"):
-        converted_dicts = [to_convert.__dict__]
-    else:
-        return to_convert
-    for single_dict in converted_dicts:
-        for key, value in single_dict.items():
-            # This if statement looks for a meta node that is a child node, and leaves it as is (i.e. it doesn't turn it
-            # into a dict). Some meta nodes contain other meta nodes, so we need to add a condition for this.
-            if not (
-                value is dict
-                or (
-                    isinstance(value, MetaNode)
-                    and [isinstance(content, MetaNode) for content in value.contents]
-                )
-            ):
-                single_dict[key] = metadata_as_dict(value)
-        return converted_dicts[0] if len(converted_dicts) == 0 else converted_dicts
+
+def metadata_as_dict(to_convert: object):
+    converted = to_convert.__dict__
+    converted["raw"] = convert_raw_to_dict(to_convert["raw"])
+    return converted
 
 
 class MetadataExplorer(QDialog):

--- a/src/sas/qtgui/MainWindow/MetadataExplorer.py
+++ b/src/sas/qtgui/MainWindow/MetadataExplorer.py
@@ -18,11 +18,11 @@ def convert_raw_to_dict(to_convert: MetaNode, converted: dict = None) -> dict:
         converted = {}
     converted[to_convert.name] = {}
     for raw_content in to_convert.contents:
-        if raw_content is MetaNode:
-            to_add = convert_raw_to_dict(to_convert, converted[to_convert.name])
+        if isinstance(raw_content, MetaNode):
+            to_add = convert_raw_to_dict(raw_content, converted[to_convert.name])
         else:
             to_add = raw_content
-        converted[to_convert.name][to_add.name] = to_add
+        converted[to_convert.name] = to_add
     return converted
 
 

--- a/src/sas/qtgui/MainWindow/MetadataExplorer.py
+++ b/src/sas/qtgui/MainWindow/MetadataExplorer.py
@@ -19,7 +19,7 @@ def convert_raw_to_dict(to_convert: MetaNode, converted: dict = None) -> dict:
     converted[to_convert.name] = {}
     for raw_content in to_convert.contents:
         if raw_content is MetaNode:
-            to_add = convert_raw_to_dict(to_convert, converted)
+            to_add = convert_raw_to_dict(to_convert, converted[to_convert.name])
         else:
             to_add = raw_content
         converted[to_convert.name][to_add.name] = to_add

--- a/src/sas/qtgui/MainWindow/MetadataExplorer.py
+++ b/src/sas/qtgui/MainWindow/MetadataExplorer.py
@@ -13,17 +13,15 @@ from sasdata.metadata import MetaNode, Metadata
 from sasdata.temp_xml_reader import load_data
 
 
-def convert_raw_to_dict(to_convert: MetaNode, converted: dict = None) -> dict:
-    if converted is None:
-        converted = {}
-    converted[to_convert.name] = {}
-    for raw_content in to_convert.contents:
-        if isinstance(raw_content, MetaNode):
-            to_add = convert_raw_to_dict(raw_content, converted[to_convert.name])
-        else:
-            to_add = raw_content
-        converted[to_convert.name] = to_add
-    return converted
+def convert_raw_to_dict(to_convert: MetaNode) -> dict:
+    # converted = {to_convert.name: to_convert.contents}
+    if isinstance(to_convert.contents, str):
+        return {to_convert.name: to_convert.contents}
+    value = {}
+    # We can now assume that every content is a MetaNode as per the typing.
+    for content in to_convert.contents:
+        value = value | convert_raw_to_dict(content)
+    return {to_convert.name: value}
 
 
 def metadata_as_dict(to_convert: object):

--- a/src/sas/qtgui/MainWindow/MetadataExplorer.py
+++ b/src/sas/qtgui/MainWindow/MetadataExplorer.py
@@ -84,7 +84,10 @@ class MetadataExplorer(QDialog):
             dicts = [current_item]
         for single_dict in dicts:
             for key, value in single_dict.items():
-                if isinstance(value, dict) or (isinstance(value, list) and any([isinstance(member, dict) for member in value])):
+                if isinstance(value, dict) or (
+                    isinstance(value, list)
+                    and any([isinstance(member, dict) for member in value])
+                ):
                     dict_root = QTreeWidgetItem([key])
                     table_root.addChild(dict_root)
                     self.buildTree(dict_root, value)

--- a/src/sas/qtgui/MainWindow/UI/MainWindowUI.ui
+++ b/src/sas/qtgui/MainWindow/UI/MainWindowUI.ui
@@ -24,7 +24,7 @@
      <x>0</x>
      <y>0</y>
      <width>915</width>
-     <height>20</height>
+     <height>22</height>
     </rect>
    </property>
    <widget class="QMenu" name="menu_File">
@@ -32,6 +32,7 @@
      <string>&amp;File</string>
     </property>
     <addaction name="actionLoadData"/>
+    <addaction name="actionAdvanced_Load"/>
     <addaction name="actionLoad_Data_Folder"/>
     <addaction name="separator"/>
     <addaction name="actionOpen_Project"/>
@@ -648,6 +649,11 @@
   <action name="actionDev_Tools">
    <property name="text">
     <string>Dev Tools</string>
+   </property>
+  </action>
+  <action name="actionAdvanced_Load">
+   <property name="text">
+    <string>Advanced Load</string>
    </property>
   </action>
  </widget>

--- a/src/sas/refactored_data_explorer.py
+++ b/src/sas/refactored_data_explorer.py
@@ -141,7 +141,10 @@ class NewDataExplorer(QWidget):
             case "h5":
                 loaded_data = load_hdf5_data(filename)
             case "txt":
-                loaded_data = load_ascii_data(filename)
+                data_list = load_ascii_data(filename)
+                # Since we're only giving the load function one filename, we can
+                # assume only one data object is being loaded.
+                loaded_data = dict([(filename, data_list[0])])
             case _:
                 QMessageBox.critical(
                     self,

--- a/src/sas/refactored_data_explorer.py
+++ b/src/sas/refactored_data_explorer.py
@@ -19,6 +19,7 @@ from sas.data_explorer_tree import DataExplorerTree
 from sas.dummy_perspective import DummyPerspective
 from sas.refactored import Perspective
 from sas.data_manager import NewDataManager as DataManager
+from ascii_dialog.dialog import AsciiDialog
 from src.sas.data_explorer_error_message import DataExplorerErrorMessage
 
 # TODO: Eventually, the values (should) never be None.
@@ -156,3 +157,9 @@ class NewDataExplorer(QWidget):
 
         for _, datum in loaded_data.items():
             self._data_manager.add_data(datum)
+
+    @Slot()
+    def onAdvancedLoad(self):
+        dialog = AsciiDialog()
+        dialog.exec()
+        # TODO: Actually do something with this return.

--- a/src/sas/refactored_data_explorer.py
+++ b/src/sas/refactored_data_explorer.py
@@ -12,14 +12,13 @@ from PySide6.QtWidgets import (
 )
 from sasdata.temp_xml_reader import load_data as load_xml_data
 from sasdata.temp_hdf5_reader import load_data as load_hdf5_data
-from sasdata.temp_ascii_reader import load_data as load_ascii_data
+from sasdata.temp_ascii_reader import load_data_default_params as load_ascii_data
 
 from sas.data_explorer_tree import DataExplorerTree
 from sas.dummy_perspective import DummyPerspective
 from sas.refactored import Perspective
 from sas.data_manager import NewDataManager as DataManager
 from src.sas.data_explorer_error_message import DataExplorerErrorMessage
-from ascii_dialog.dialog import AsciiDialog
 
 # TODO: Eventually, the values (should) never be None.
 # FIXME: Linter is complaining about DummyPew
@@ -142,12 +141,7 @@ class NewDataExplorer(QWidget):
             case "h5":
                 loaded_data = load_hdf5_data(filename)
             case "txt":
-                dialog = AsciiDialog()
-                status = dialog.exec()
-                if status != 1:
-                    # User closed the dialog without accepting the data.
-                    return
-                loaded_data = load_ascii_data(dialog.params)
+                loaded_data = load_ascii_data(filename)
             case _:
                 QMessageBox.critical(
                     self,

--- a/src/sas/refactored_data_explorer.py
+++ b/src/sas/refactored_data_explorer.py
@@ -13,6 +13,7 @@ from PySide6.QtWidgets import (
 from sasdata.temp_xml_reader import load_data as load_xml_data
 from sasdata.temp_hdf5_reader import load_data as load_hdf5_data
 from sasdata.temp_ascii_reader import load_data_default_params as load_ascii_data
+from sasdata.temp_ascii_reader import load_data as load_advanced_ascii_data
 from os.path import basename
 
 from sas.data_explorer_tree import DataExplorerTree
@@ -161,5 +162,8 @@ class NewDataExplorer(QWidget):
     @Slot()
     def onAdvancedLoad(self):
         dialog = AsciiDialog()
-        dialog.exec()
-        # TODO: Actually do something with this return.
+        status = dialog.exec()
+        if status == 1:
+            loaded = load_advanced_ascii_data(dialog.params)
+            for datum in loaded:
+                self._data_manager.add_data(datum)

--- a/src/sas/refactored_data_explorer.py
+++ b/src/sas/refactored_data_explorer.py
@@ -27,7 +27,7 @@ from PySide6.QtWidgets import QLabel, QVBoxLayout, QWidget
 # TODO: Just using the word 'new' to avoid conflicts. The final version
 # shouldn't have that name.
 class NewDataExplorer(QWidget):
-    def __init__(self, data_manager: DataManager, parent: QWidget | None = ...) -> None:
+    def __init__(self, parent: QWidget | None = ...) -> None:
         super().__init__(parent)
         self._data_manager = data_manager
 
@@ -92,6 +92,7 @@ class NewDataExplorer(QWidget):
         # TODO: Placeholder
         new_perspective_dialog = perspectives[to_add](self._data_manager)
         self._data_manager.add_data(new_perspective_dialog)
+        self.new_perspective.emit(self)
         logging.info(to_add)
         self.add_perspective_button.setCurrentIndex(0)
 

--- a/src/sas/refactored_data_explorer.py
+++ b/src/sas/refactored_data_explorer.py
@@ -22,6 +22,7 @@ perspectives: dict[str, None | Perspective] = {
     'Dummy': DummyPerspective,
     'Mumag': None
 }
+from PySide6.QtWidgets import QLabel, QVBoxLayout, QWidget
 
 # TODO: Just using the word 'new' to avoid conflicts. The final version
 # shouldn't have that name.

--- a/src/sas/refactored_data_explorer.py
+++ b/src/sas/refactored_data_explorer.py
@@ -16,6 +16,7 @@ from PySide6.QtWidgets import (
 from sasdata.data import Group, NamedQuantity, Quantity, SasData
 from sasdata.temp_xml_reader import load_data as load_xml_data
 from sasdata.temp_hdf5_reader import load_data as load_hdf5_data
+from sasdata.temp_ascii_reader import load_data as load_ascii_data
 from sasdata.dataset_types import one_dim
 import sasdata.quantities.units as units
 import numpy as np
@@ -25,6 +26,7 @@ from sas.dummy_perspective import DummyPerspective
 from sas.refactored import Perspective
 from sas.data_manager import NewDataManager as DataManager
 from src.sas.data_explorer_error_message import DataExplorerErrorMessage
+from ascii_dialog.dialog import AsciiDialog
 
 # TODO: Eventually, the values (should) never be None.
 # FIXME: Linter is complaining about DummyPew
@@ -147,6 +149,13 @@ class NewDataExplorer(QWidget):
                 loaded_data = load_xml_data(filename)
             case "h5":
                 loaded_data = load_hdf5_data(filename)
+            case ".txt":
+                dialog = AsciiDialog()
+                status = dialog.exec()
+                if status != 1:
+                    # User closed the dialog without accepting the data.
+                    return
+                loaded_data = load_ascii_data(dialog.params)
             case _:
                 QMessageBox.critical(
                     self,

--- a/src/sas/refactored_data_explorer.py
+++ b/src/sas/refactored_data_explorer.py
@@ -110,7 +110,6 @@ class NewDataExplorer(QWidget):
         # TODO: Placeholder
         new_perspective_dialog = perspectives[to_add](self._data_manager)
         self._data_manager.add_data(new_perspective_dialog)
-        self.new_perspective.emit(self)
         logging.info(to_add)
         self.add_perspective_button.setCurrentIndex(0)
 

--- a/src/sas/refactored_data_explorer.py
+++ b/src/sas/refactored_data_explorer.py
@@ -42,7 +42,9 @@ from PySide6.QtWidgets import QLabel, QVBoxLayout, QWidget
 # TODO: Just using the word 'new' to avoid conflicts. The final version
 # shouldn't have that name.
 class NewDataExplorer(QWidget):
-    def __init__(self, parent: QWidget | None = ...) -> None:
+    new_perspective = Signal(object)
+
+    def __init__(self, data_manager: DataManager, parent: QWidget | None = ...) -> None:
         super().__init__(parent)
         self._data_manager = data_manager
 

--- a/src/sas/refactored_data_explorer.py
+++ b/src/sas/refactored_data_explorer.py
@@ -14,6 +14,8 @@ from PySide6.QtWidgets import (
     QWidget,
 )
 from sasdata.data import Group, NamedQuantity, Quantity, SasData
+from sasdata.temp_xml_reader import load_data as load_xml_data
+from sasdata.temp_hdf5_reader import load_data as load_hdf5_data
 from sasdata.dataset_types import one_dim
 import sasdata.quantities.units as units
 import numpy as np
@@ -133,4 +135,22 @@ class NewDataExplorer(QWidget):
             self,
             "Open Data File",
         )
+        # FIXME: This would probably break if there isn't an extension.
+
+        # TODO: The logic for deciding which reader to use is temporary. It
+        # won't work for all file extensions, and ultimately this logic probably
+        # needs to be moved in sasdata.
+        file_extension = filename.split(".")[-1].lower()
+        match file_extension:
+            case "xml":
+                loaded_data = load_xml_data(filename)
+            case "h5":
+                loaded_data = load_hdf5_data(filename)
+            case _:
+                QMessageBox.critical(
+                    self,
+                    "Data Loading Error",
+                    f"Error loading {filename}. Extension not recognised.",
+                )
+
         print(filename)

--- a/src/sas/refactored_data_explorer.py
+++ b/src/sas/refactored_data_explorer.py
@@ -1,6 +1,18 @@
 import logging
 from PySide6.QtCore import Signal, Slot
-from PySide6.QtWidgets import QComboBox, QDialog, QErrorMessage, QHBoxLayout, QLabel, QMessageBox, QPushButton, QTreeView, QVBoxLayout, QWidget
+from PySide6.QtWidgets import (
+    QComboBox,
+    QDialog,
+    QErrorMessage,
+    QFileDialog,
+    QHBoxLayout,
+    QLabel,
+    QMessageBox,
+    QPushButton,
+    QTreeView,
+    QVBoxLayout,
+    QWidget,
+)
 from sasdata.data import Group, NamedQuantity, Quantity, SasData
 from sasdata.dataset_types import one_dim
 import sasdata.quantities.units as units
@@ -15,14 +27,15 @@ from src.sas.data_explorer_error_message import DataExplorerErrorMessage
 # TODO: Eventually, the values (should) never be None.
 # FIXME: Linter is complaining about DummyPew
 perspectives: dict[str, None | Perspective] = {
-    'Corfunc': None,
-    'Fitting': None,
-    'Invariant': None,
-    'Inversion': None,
-    'Dummy': DummyPerspective,
-    'Mumag': None
+    "Corfunc": None,
+    "Fitting": None,
+    "Invariant": None,
+    "Inversion": None,
+    "Dummy": DummyPerspective,
+    "Mumag": None,
 }
 from PySide6.QtWidgets import QLabel, QVBoxLayout, QWidget
+
 
 # TODO: Just using the word 'new' to avoid conflicts. The final version
 # shouldn't have that name.
@@ -42,7 +55,7 @@ class NewDataExplorer(QWidget):
         # TODO: This list is temporary. We should have all the perspectives
         # registered somewhere so its easy to add a new one.
         self.add_perspective_button = QComboBox(self)
-        self.add_perspective_button.addItem('+ New Perspectives')
+        self.add_perspective_button.addItem("+ New Perspectives")
         for p in perspectives.keys():
             self.add_perspective_button.addItem(p)
         self.add_perspective_button.currentTextChanged.connect(self.add_perspective)
@@ -50,11 +63,13 @@ class NewDataExplorer(QWidget):
         self.add_data_row.addWidget(self.load_data_row)
         self.add_data_row.addWidget(self.add_perspective_button)
 
-        self.filter_label = QLabel('Filters')
+        self.filter_label = QLabel("Filters")
 
         self.filter_row = QHBoxLayout(self)
-        filter_names = ['Data', 'Perspective', 'Theory', 'Plot']
-        self.filter_buttons: dict[str, QPushButton] = {name: QPushButton(name, self) for name in filter_names}
+        filter_names = ["Data", "Perspective", "Theory", "Plot"]
+        self.filter_buttons: dict[str, QPushButton] = {
+            name: QPushButton(name, self) for name in filter_names
+        }
         for widget in self.filter_buttons.values():
             widget.setCheckable(True)
             self.filter_row.addWidget(widget)
@@ -67,14 +82,13 @@ class NewDataExplorer(QWidget):
         # TODO: Is there a better name for this?
         self.final_row = QHBoxLayout(self)
 
-        self.remove_button = QPushButton('Remove', self)
-        self.remove_button.setToolTip('Remove the selected data from SasView')
+        self.remove_button = QPushButton("Remove", self)
+        self.remove_button.setToolTip("Remove the selected data from SasView")
         self.remove_button.clicked.connect(self.onRemove)
-        self.plot_button = QPushButton('Plot', self)
+        self.plot_button = QPushButton("Plot", self)
 
         self.final_row.addWidget(self.remove_button)
         self.final_row.addWidget(self.plot_button)
-
 
         self.layout.addLayout(self.add_data_row)
         self.layout.addWidget(self.filter_label)
@@ -114,9 +128,9 @@ class NewDataExplorer(QWidget):
 
     @Slot()
     def onLoadFile(self):
-        # TODO: At the moment, the readers are not hooked up properly. Just create some random dummy data for now.
-        quantities: dict[str, Quantity] = {}
-        for column in ['Q', 'I']:
-            quantities[column] = Quantity(100 * np.random.rand(100), units.angstroms)
-        dummy = SasData('Dummy Data', quantities, one_dim, Group('root', {}))
-        self._data_manager.add_data(dummy)
+        # TODO: Probably want to add filters.
+        filename, _ = QFileDialog.getOpenFileName(
+            self,
+            "Open Data File",
+        )
+        print(filename)

--- a/src/sas/refactored_data_explorer.py
+++ b/src/sas/refactored_data_explorer.py
@@ -2,24 +2,17 @@ import logging
 from PySide6.QtCore import Signal, Slot
 from PySide6.QtWidgets import (
     QComboBox,
-    QDialog,
-    QErrorMessage,
     QFileDialog,
     QHBoxLayout,
     QLabel,
     QMessageBox,
     QPushButton,
-    QTreeView,
     QVBoxLayout,
     QWidget,
 )
-from sasdata.data import Group, NamedQuantity, Quantity, SasData
 from sasdata.temp_xml_reader import load_data as load_xml_data
 from sasdata.temp_hdf5_reader import load_data as load_hdf5_data
 from sasdata.temp_ascii_reader import load_data as load_ascii_data
-from sasdata.dataset_types import one_dim
-import sasdata.quantities.units as units
-import numpy as np
 
 from sas.data_explorer_tree import DataExplorerTree
 from sas.dummy_perspective import DummyPerspective
@@ -38,7 +31,6 @@ perspectives: dict[str, None | Perspective] = {
     "Dummy": DummyPerspective,
     "Mumag": None,
 }
-from PySide6.QtWidgets import QLabel, QVBoxLayout, QWidget
 
 
 # TODO: Just using the word 'new' to avoid conflicts. The final version

--- a/src/sas/refactored_data_explorer.py
+++ b/src/sas/refactored_data_explorer.py
@@ -149,7 +149,7 @@ class NewDataExplorer(QWidget):
                 loaded_data = load_xml_data(filename)
             case "h5":
                 loaded_data = load_hdf5_data(filename)
-            case ".txt":
+            case "txt":
                 dialog = AsciiDialog()
                 status = dialog.exec()
                 if status != 1:

--- a/src/sas/refactored_data_explorer.py
+++ b/src/sas/refactored_data_explorer.py
@@ -13,6 +13,7 @@ from PySide6.QtWidgets import (
 from sasdata.temp_xml_reader import load_data as load_xml_data
 from sasdata.temp_hdf5_reader import load_data as load_hdf5_data
 from sasdata.temp_ascii_reader import load_data_default_params as load_ascii_data
+from os.path import basename
 
 from sas.data_explorer_tree import DataExplorerTree
 from sas.dummy_perspective import DummyPerspective
@@ -144,7 +145,7 @@ class NewDataExplorer(QWidget):
                 data_list = load_ascii_data(filename)
                 # Since we're only giving the load function one filename, we can
                 # assume only one data object is being loaded.
-                loaded_data = dict([(filename, data_list[0])])
+                loaded_data = dict([(basename(filename), data_list[0])])
             case _:
                 QMessageBox.critical(
                     self,

--- a/src/sas/refactored_data_explorer.py
+++ b/src/sas/refactored_data_explorer.py
@@ -153,4 +153,5 @@ class NewDataExplorer(QWidget):
                     f"Error loading {filename}. Extension not recognised.",
                 )
 
-        print(filename)
+        for _, datum in loaded_data.items():
+            self._data_manager.add_data(datum)

--- a/src/sas/refactored_data_explorer.py
+++ b/src/sas/refactored_data_explorer.py
@@ -152,6 +152,7 @@ class NewDataExplorer(QWidget):
                     "Data Loading Error",
                     f"Error loading {filename}. Extension not recognised.",
                 )
+                return
 
         for _, datum in loaded_data.items():
             self._data_manager.add_data(datum)


### PR DESCRIPTION
Previously, the 'load button' just loaded dummy data into the data explorer, but this PR hooks up the new data loaders in sasdata.

It also:

- Provides a prototype data viewer which displays the data in a table
- Hooks up the metadata viewer, and also makes some changes to it so it displays the metadata for ASCII files properly.
- Implements the ASCII reader dialog as an 'advanced load' button in the File menu, as per [this discussion](https://github.com/orgs/SasView/discussions/3476)