### PR TITLE
Fixes fatal access violation in Windows tests

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,8 +1,18 @@
+import os
+import platform
+
+import pytest
+
 from run import prepare
+from src.sas.system import config
 
 prepare()
 
-from src.sas.system import config
-
 config.override_with_defaults()
 
+
+@pytest.fixture(scope="session", autouse=True)
+def set_env():
+    # pytest and numba do not play nicely together on windows, see: https://github.com/numba/numba/issues/8223#issuecomment-1175213066
+    if platform.system() == "Windows":
+        os.environ["SAS_NUMBA"] = "0"

--- a/test/utest_sasview.py
+++ b/test/utest_sasview.py
@@ -82,10 +82,10 @@ def run_tests(dirs=None, run_all=False):
                             failure_text.append("== %s std err ==\n%s"
                                                 % (module_name, std_out))
 
-                    m = re.search("FAILED \(.*errors=([0-9]+)", std_out)
+                    m = re.search("FAILED \\(.*errors=([0-9]+)", std_out)
                     if m is not None:
                         n_errors += int(m.group(1))
-                    m = re.search("FAILED \(.*failures=([0-9]+)", std_out)
+                    m = re.search("FAILED \\(.*failures=([0-9]+)", std_out)
                     if m is not None:
                         n_failures += int(m.group(1))
 


### PR DESCRIPTION
## Description

Pytest and numba cannot work together on Windows, so this PR introduces an autouse fixture to ensure the non-numba versions of routines are used when running pytest on Windows.

Fixes # (issue/issues)

Fixes #3491

## How Has This Been Tested?

Run both `python test/sascalculator/utest_sas_gen.py` and `pytest test/sascalculator/utest_sas_gen.py` on both linux (via WSL) and Windows. I have verified that the tests run without an access violation in all cases, and numba is used in each case except for the pytest run on Windows.

## Review Checklist:

[if using the editor, use `[x]` in place of `[ ]` to check a box]

**Documentation** (check at least one)
- [x] There is **nothing** that needs documenting
- [ ] Documentation changes are **in this PR**
- [ ] There is an **issue** open for the documentation (link?)

**Installers**
- [ ] There is a chance this will affect the **installers**, if so
  - [ ] **Windows** installer (GH artifact) has been tested (installed and worked) 
  - [ ] **MacOSX** installer (GH artifact) has been tested (installed and worked)
  - [ ] **Wheels** installer (GH artifact) has been tested (installed and worked)

**Licensing** (untick if necessary)
- [x] The introduced changes comply with SasView license (BSD 3-Clause)

