### PR TITLE
Various fixes to try to get sasview sphinx docs to build cleanly.

### DIFF
--- a/docs/sphinx-docs/source/_extensions/dollarmath.py
+++ b/docs/sphinx-docs/source/_extensions/dollarmath.py
@@ -30,18 +30,18 @@ def setup(app):
 
 
 def test_dollar():
-    assert replace_dollar(u"no dollar")==u"no dollar"
-    assert replace_dollar(u"$only$")==u":math:`only`"
-    assert replace_dollar(u"$first$ is good")==u":math:`first` is good"
-    assert replace_dollar(u"so is $last$")==u"so is :math:`last`"
-    assert replace_dollar(u"and $mid$ too")==u"and :math:`mid` too"
-    assert replace_dollar(u"$first$, $mid$, $last$")==u":math:`first`, :math:`mid`, :math:`last`"
-    assert replace_dollar(u"dollar\$ escape")==u"dollar$ escape"
-    assert replace_dollar(u"dollar \$escape\$ too")==u"dollar $escape$ too"
-    assert replace_dollar(u"emb\ $ed$\ ed")==u"emb\ :math:`ed`\ ed"
-    assert replace_dollar(u"$first$a")==u"$first$a"
-    assert replace_dollar(u"a$last$")==u"a$last$"
-    assert replace_dollar(u"a $mid$dle a")==u"a $mid$dle a"
+    assert replace_dollar("no dollar")=="no dollar"
+    assert replace_dollar("$only$")==":math:`only`"
+    assert replace_dollar("$first$ is good")==":math:`first` is good"
+    assert replace_dollar("so is $last$")=="so is :math:`last`"
+    assert replace_dollar("and $mid$ too")=="and :math:`mid` too"
+    assert replace_dollar("$first$, $mid$, $last$")==":math:`first`, :math:`mid`, :math:`last`"
+    assert replace_dollar(r"dollar\$ escape")=="dollar$ escape"
+    assert replace_dollar(r"dollar \$escape\$ too")=="dollar $escape$ too"
+    assert replace_dollar(r"emb\ $ed$\ ed")==r"emb\ :math:`ed`\ ed"
+    assert replace_dollar("$first$a")=="$first$a"
+    assert replace_dollar("a$last$")=="a$last$"
+    assert replace_dollar("a $mid$dle a")=="a $mid$dle a"
 
 if __name__ == "__main__":
     test_dollar()

--- a/docs/sphinx-docs/source/conf.py
+++ b/docs/sphinx-docs/source/conf.py
@@ -35,6 +35,7 @@ extensions = ['sphinx.ext.autodoc',
               #'mathjax',  # replacement mathjax that allows a list of paths
               'dollarmath',
               #'sphinx.ext.viewcode',
+              'matplotlib.sphinxext.roles',  # For mpltype in Plotting/Arrow3D.py
               ]
 
 no_highlight = os.environ.get('SAS_NO_HIGHLIGHT', '0') # Check if sphinx highlighting is disabled in this environment

--- a/docs/sphinx-docs/source/dev/dev.rst
+++ b/docs/sphinx-docs/source/dev/dev.rst
@@ -11,7 +11,6 @@ Contents
 
    SasView API <sasview-api/modules>
    sasmodels overview <sasmodels-dev/index>
-   sasmodels API <sasmodels-api/modules>
    sasdata overview <sasdata-dev/dev>
    OpenGL subsystem <gl/opengl.rst>
 

--- a/docs/sphinx-docs/source/user/RELEASE.rst
+++ b/docs/sphinx-docs/source/user/RELEASE.rst
@@ -28,7 +28,7 @@ New Features
 * A model reparameterization editor is now available from the fitting menu by @tsole0 in https://github.com/SasView/sasview/pull/3136
 
 Feature Enhancements
-^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^
 * P(r) analysis now allows multiple files and batch processing by @ru4en in https://github.com/SasView/sasview/pull/3137
 * Fitting widget refactor by @rozyczko in https://github.com/SasView/sasview/pull/3169
 * Initial implementation of the undelete mechanism for fitting tabs by @rozyczko in https://github.com/SasView/sasview/pull/3140
@@ -37,14 +37,14 @@ Feature Enhancements
 * Update model editor (rebase) by @krzywon in https://github.com/SasView/sasview/pull/3135
 
 Bug Fixes
-^^^^^^^^^^^^
+^^^^^^^^^
 * Fix LaTeX equation in corfunc docs by @llimeht in https://github.com/SasView/sasview/pull/3162
 * Allow webfit to run in Django v5.0 by @summerhenson in https://github.com/SasView/sasview/pull/3200
 * Bumps v1.* compatibility fixes by @krzywon in https://github.com/SasView/sasview/pull/3165 and @bmaranville in https://github.com/SasView/sasview/pull/3268
 * Whats new window no longer shows previous version information by @lucas-wilkins in https://github.com/SasView/sasview/pull/3261
 
 Infrastructure Changes
-^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^
 * Bump dawidd6/action-download-artifact from 2 to 6 in /.github/workflows by @dependabot in https://github.com/SasView/sasview/pull/3151
 * Renabling the Ubuntu installer test by @jamescrake-merani in https://github.com/SasView/sasview/pull/3174
 * Remove Ubuntu 20.04 from CI by @jamescrake-merani in https://github.com/SasView/sasview/pull/3214
@@ -57,7 +57,7 @@ Infrastructure Changes
 * Auto generate wheels by @llimeht in https://github.com/SasView/sasview/pull/3281
 
 Known Issues
-^^^^^^^^^
+^^^^^^^^^^^^
 All known bugs and feature requests can be found in the issues on github.
 
 `sasview issues <https://github.com/SasView/sasview/issues>`_ | `sasmodels issues <https://github.com/SasView/sasmodels/issues>`_ | `sasdata issues <https://github.com/SasView/sasdata/issues>`_
@@ -70,20 +70,20 @@ This is a bug fix release and the issues fixed for this release are described be
 This version of SasView is built with Sasmodels v1.0.9, Sasdata v0.9.0, and bumps v0.9.3.
 
 General GUI Fixes
-^^^^^^^^^
+^^^^^^^^^^^^^^^^^
 * Open a pop-up on start-up if a new version is available by @lucas-wilkins in https://github.com/SasView/sasview/pull/3216
 * Removed superfluous signal connection causing duplicate theories by @rozyczko in https://github.com/SasView/sasview/pull/3199
 * Removing data from the context menu now removes it from perspectives by @rozyczko in https://github.com/SasView/sasview/pull/3236
 
 Plotting Fixes
-^^^^^^^^^
+^^^^^^^^^^^^^^
 * Fix to ensure default plot scaling matches the plot type by @krzywon in https://github.com/SasView/sasview/pull/3184
 * Delete intermediate theory plots by tab id not model id. by @jamescrake-merani in https://github.com/SasView/sasview/pull/3160
 * Linear fit no longer causes graph rescaling by @krzywon in https://github.com/SasView/sasview/pull/3187
 * Fix for errors thrown when modifying tick labels by @jamescrake-merani in https://github.com/SasView/sasview/pull/3191
 
 Fitting and Other Perspective Fixes
-^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 * Status bar message does not clear on gsc exit by @rozyczko in https://github.com/SasView/sasview/pull/3185
 * Guard against bad fit results to ensure fit tabs can run new fits by @rozyczko in https://github.com/SasView/sasview/pull/3172
 * A number of model editor bug fixes by @tsole0 in https://github.com/SasView/sasview/pull/2901
@@ -91,19 +91,19 @@ Fitting and Other Perspective Fixes
 * Added OpenCL support for the Flatpak release by @jamescrake-merani in https://github.com/flathub/org.sasview.sasview/pull/4
 
 Other Fixes
-^^^^^^^^^
+^^^^^^^^^^^
 * Call the system default csv viewer to allow batch fit results output for any OS by @summerhenson in https://github.com/SasView/sasview/pull/3186
 * Remove a button that did nothing by @jamescrake-merani in https://github.com/SasView/sasview/pull/3217
 
 Infrastructure Fixes
-^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^
 * Fixes to the flatpak metadata by @jamescrake-merani in https://github.com/SasView/sasview/pull/3150
 * Replace the expired OSX Notarization key by @krzywon in https://github.com/SasView/sasview/pull/3183
 * Include new contributors in the contributor file by @krzywon in https://github.com/SasView/sasview/pull/3192
 * Fix for sasmodel doc build by @krzywon in https://github.com/SasView/sasview/pull/3212
 
 Known Issues
-^^^^^^^^^
+^^^^^^^^^^^^
 All known bugs and feature requests can be found in the issues on github.
 
 `sasview issues <https://github.com/SasView/sasview/issues>`_ | `sasmodels issues <https://github.com/SasView/sasmodels/issues>`_ | `sasdata issues <https://github.com/SasView/sasdata/issues>`_
@@ -200,7 +200,7 @@ ______________
 * Fixed sesans residuals plots to show in real space rather than q space by @caitwolf in https://github.com/SasView/sasview/pull/2338
 
 Fitting and Other Perspective Fixes
-_____________
+___________________________________
 * Fix model date format in the user model docstring by @mrakitin in https://github.com/SasView/sasview/pull/2713
 * Various Multiplicity Model Fixes by @krzywon in https://github.com/SasView/sasview/pull/2647
 * Fix model save error by @krzywon in https://github.com/SasView/sasview/pull/2864
@@ -1531,7 +1531,7 @@ New in Version 2.2.0
 
 
 Feature set from previous versions
------------------------------------
+----------------------------------
 Perspectives Available
 ^^^^^^^^^^^^^^^^^^^^^^
 * Invariant calculator: Calculates the invariant, volume fraction, and

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,6 +78,7 @@ include = [
   "build_tools",
   "build/lib/doc/build",
   "docs/sphinx-docs/source",
+  "docs/sphinx-docs/*.py",
   "src",
   "test",
 ]
@@ -120,6 +121,11 @@ artifacts = [
     # "**/UI/*py",
 ]
 
+[[tool.hatch.build.targets.wheel.hooks.build-scripts.scripts]]
+# Install sasview dependencies so that sphinx autodoc can run in source tree.
+commands = [
+    "python -m pip install -r build_tools/requirements.txt",
+]
 
 [[tool.hatch.build.targets.wheel.hooks.sphinx.tools]]
 tool = "custom"

--- a/src/sas/qtgui/Calculators/media/gsc_ex_customModel_data.rst
+++ b/src/sas/qtgui/Calculators/media/gsc_ex_customModel_data.rst
@@ -3,7 +3,7 @@
 .. _gsc_ex_customModel_data:
 
 Example: Fit the experimental data using the calculated $P(Q)$ from a PDB file 
-==================================
+==============================================================================
 
 (Pictures in this document were generated using SasView 6.0.0.) To calculate $P(Q)$ from a PDB file, use the Generic Scattering Calculator in the Tools menu. In this example, a PDB file for apoferritin was downloaded from the PDB data bank (https://www.rcsb.org/structure/6z6u). The custom model function, custom_apoferritinLong, was obtained from the scattering calculator using the Debye full avg. w/ $\beta(Q)$ option after loading the apoferritin PDB file (see print-screen below). Note that the q-range and the number of data points can be customized. The Export Model box should be checked to enable a file name for the custom plugin model that will be produced (custom_apoferritinLong). Clicking "Compute" launches the calculation of $P(Q)$ and $\beta(Q)$, and generate the file into the plugin model directory of the SasView. Once the computation is finished, the plugin model is ready to use to fit scattering data.
 

--- a/src/sas/qtgui/Calculators/media/sld_calculator_help.rst
+++ b/src/sas/qtgui/Calculators/media/sld_calculator_help.rst
@@ -17,7 +17,7 @@ This tool calculates the neutron and x-ray scattering length densities (SLD) and
 This SLD calculator utilizes the periodictable python package\ :sup:`1`, which is a periodic table populated with values useful for neutron and x-ray experiments.
 
 User Inputs
-----------------------------
+-----------
 **Molecular Formula**
     This field defines the material for which you are calculating the SLD. The section "`Specifying Materials or Mixtures in the Molecular Formula Field`_" offers further guidance on how to enter molecules, biomolecules, and more complex mixtures.
 
@@ -31,7 +31,7 @@ User Inputs
     Wavelength is used to calculate the x-ray scattering length density. It is required for x-ray calculations and entered in units of |Ang|.
 
 Calculator Output
-----------------------------
+-----------------
 **Neutron SLD** (|Ang^-2|)
    A measure of the neutron scattering power of the material, which is used for fitting data from neutron scattering experiments.
 
@@ -48,7 +48,7 @@ Calculator Output
     The sample thickness required to reduce the transmission to 36.8% (1/e).
 
 Specifying Materials or Mixtures in the Molecular Formula Field
-----------------------------
+---------------------------------------------------------------
 **Molecular formulas** can be entered intuitively with atoms being represented by their atomic symbol. For example, calcium carbonate (CaCO\ :sub:`3`):
 
     CaCO3

--- a/src/sas/qtgui/MainWindow/media/sasview_files.rst
+++ b/src/sas/qtgui/MainWindow/media/sasview_files.rst
@@ -29,7 +29,7 @@ of the `~/.sasview` directory.**
 .. _Config_Files:
 
 Configuration Files
---------------------
+-------------------
 SasView stores two types of config file on the user disk, a general configuration file for each major version of sasview,
 and a categories file that allows the end user to change how their models are organized in the fitting perspective. The
 general configuration file, config-<v>.json is a json file that stores a mapping of config variables to their updated values.
@@ -70,7 +70,7 @@ OS-specific file locations for plugin files:
 .. _Compiled_Files:
 
 Complied Model Files
-------------
+--------------------
 The fitting module, when a model is selected, compiles each model in an on-demand process. The compiled file will include
 all form factors and structure factors used to create the model, and will be compiled based on the GPU optimization
 currently in use. These models are stored in a parallel directory to the plugin models, but end users do not need to add

--- a/src/sas/qtgui/Plotting/Slicers/BoxSlicer.py
+++ b/src/sas/qtgui/Plotting/Slicers/BoxSlicer.py
@@ -377,16 +377,18 @@ class BoxInteractor(BaseInteractor, SlicerModel):
     def validate(self, param_name, param_value):
         """
         Validate input from user.
-        Values get checked at apply time.
-        * nbins cannot be zero or samller
-        * The full ROI should stay within the data. thus center_x and center_y
+
+        Values get checked at apply time:
+
+        * ``nbins`` cannot be zero or smaller
+        * The full ROI should stay within the data. Thus ``center_x`` and ``center_y``
           are restricted such that the center +/- width (or height) cannot be
-          greate or smaller than data max/min.
+          greater or smaller than data max/min.
         * The width/height should not be set so small as to leave no data in
           the ROI. Here we only make sure that the width/height is not zero
           as done when dragging the vertical or horizontal lines. We let the
-          call to _post_data capture the ValueError of no points in ROI
-          raised by manipulations.py, log the message and negate the entry
+          call to ``_post_data`` capture the ``ValueError`` of no points in ROI
+          raised by ``manipulations.py``, log the message and negate the entry
           at that point.
         """
         isValid = True

--- a/src/sas/qtgui/Utilities/ModelEditors/TabbedEditor/TabbedModelEditor.py
+++ b/src/sas/qtgui/Utilities/ModelEditors/TabbedEditor/TabbedModelEditor.py
@@ -950,7 +950,7 @@ class TabbedModelEditor(QtWidgets.QDialog, Ui_TabbedModelEditor):
         def visit_FunctionDef(self, node):
             """
             Extract the source code of the function with the given name.
-            NOTE: Do NOT change the name of this method-- visit_ is a prefix that ast.NodeVisitor uses
+            NOTE: Do NOT change the name of this method; ``visit_`` is a prefix that ast.NodeVisitor uses
             """
             if node.name == self.function_name:
                 body = node.body

--- a/src/sas/sascalc/doc_regen/makedocumentation.py
+++ b/src/sas/sascalc/doc_regen/makedocumentation.py
@@ -151,10 +151,12 @@ def locate_unpacked_resources() -> tuple[Path, Path]:
 def module_copytree(module: str, src: PATH_LIKE, dest: PATH_LIKE) -> None:
     """Copy the tree from a module to the specified directory
 
-    module: name of the Python module (the "anchor" for importlib.resources)
-    src: source name of the resource inside the module
-    dest: destination directory for the resources to be copied into; will be
-        created if it doesn't exist
+    *module* name of the Python module (the "anchor" for importlib.resources)
+
+    *src* source name of the resource inside the module
+
+    *dest* destination directory for the resources to be copied into; will be
+    created if it doesn't exist
     """
     spth = Path(src)
     src = str(spth)


### PR DESCRIPTION
## Description

Change pyproject.toml so that requirements are installed before sphinx, allowing autodoc to load sasview modules. Fixes various restructured text issues (though not yet all of them).

Fixes # (issue/issues)

## How Has This Been Tested?

Ran `python -m build` on mac with python 3.13.

## Review Checklist:

[if using the editor, use `[x]` in place of `[ ]` to check a box]

**Documentation** (check at least one)
- [ ] There is **nothing** that needs documenting
- [x] Documentation changes are **in this PR**
- [ ] There is an **issue** open for the documentation (link?)

**Installers**
- [x] There is a chance this will affect the **installers**, if so
  - [ ] **Windows** installer (GH artifact) has been tested (installed and worked) 
  - [ ] **MacOSX** installer (GH artifact) has been tested (installed and worked)
  - [ ] **Wheels** installer (GH artifact) has been tested (installed and worked)

**Licensing** (untick if necessary)
- [x] The introduced changes comply with SasView license (BSD 3-Clause)

