### PR TITLE
3500: Fix for PD plotting

### DIFF
--- a/src/sas/qtgui/Perspectives/Fitting/PolydispersityWidget.py
+++ b/src/sas/qtgui/Perspectives/Fitting/PolydispersityWidget.py
@@ -481,6 +481,14 @@ class PolydispersityWidget(QtWidgets.QWidget, Ui_PolydispersityWidgetUI):
             # Nsigs
             param_repr = GuiUtils.formatNumber(param_dict[param_name][5+ioffset], high=True)
             self.poly_model.item(row, 5+joffset).setText(param_repr)
+            # Function
+            param_repr = param_dict[param_name][6+ioffset]
+            self.poly_model.item(row, 6+joffset).setText(param_repr)
+            index = self.poly_model.index(row, 6+joffset)
+            widget = self.lstPoly.indexWidget(index)
+            if widget is not None and isinstance(widget, QtWidgets.QComboBox):
+                func_index = widget.findText(param_repr)
+                widget.setCurrentIndex(func_index)
 
             self.setFocus()
 

--- a/src/sas/qtgui/Perspectives/Fitting/PolydispersityWidget.py
+++ b/src/sas/qtgui/Perspectives/Fitting/PolydispersityWidget.py
@@ -157,8 +157,11 @@ class PolydispersityWidget(QtWidgets.QWidget, Ui_PolydispersityWidgetUI):
             # PD[ratio] -> width, npts -> npts, nsigs -> nsigmas
             if model_column not in delegate.columnDict():
                 return
-            self.poly_params[parameter_name_w] = value
-            self.logic.kernel_module.setParam(parameter_name_w, value)
+            # Map the column to the poly param that was changed
+            associations = {1: "width", delegate.poly_npts: "npts", delegate.poly_nsigs: "nsigmas"}
+            p_name = f"{parameter_name}.{associations.get(model_column, 'width')}"
+            self.poly_params[p_name] = value
+            self.logic.kernel_module.setParam(p_name, value)
 
             # Update plot
             self.updateDataSignal.emit()


### PR DESCRIPTION
## Description

This restores some of the code changed during the fitting widget refactor (#3169) to ensure the PD plots are correct when switching models, in any way. This 2nd commit (7c0569ccaadd12464add4a4846e15a113306d9ec) restores the PD function on model change, which wasn't present before.

Fixes #3500
(Possibly?) Fixes #3248 
(Possibly?) Fixes #2540 
(Possibly?) Fixes #2438
(Possibly?) Fixes #1587

## How Has This Been Tested?

I repeated the steps in #3500, selecting schultz and switching between sphere and core_shell_sphere. The PD distribution is nominally correct, and the PD function remains as schulz. I also added and changed the structure factor and the function remained schultz for each S(Q) change.

I have **NOT** tested loading a project, but this is the same method called during the project load process, so I am guessing this may also fix the issues related to that.

## Review Checklist:

[if using the editor, use `[x]` in place of `[ ]` to check a box]

**Documentation** (check at least one)
- [x] There is **nothing** that needs documenting
- [ ] Documentation changes are **in this PR**
- [ ] There is an **issue** open for the documentation (link?)

**Installers**
- [x] There is a chance this will affect the **installers**, if so
  - [ ] **Windows** installer (GH artifact) has been tested (installed and worked) 
  - [ ] **MacOSX** installer (GH artifact) has been tested (installed and worked)
  - [ ] **Wheels** installer (GH artifact) has been tested (installed and worked)

**Licensing** (untick if necessary)
- [x] The introduced changes comply with SasView license (BSD 3-Clause)

