### PR TITLE
Applies automatic fixes from the default ruff ruleset

### DIFF
--- a/docs/sphinx-docs/source/conf.py
+++ b/docs/sphinx-docs/source/conf.py
@@ -11,7 +11,9 @@
 # All configuration values have a default; values that are commented out
 # serve to show the default.
 
-import sys, os, datetime
+import sys
+import os
+import datetime
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the

--- a/src/sas/__pyinstaller/hook-sas.py
+++ b/src/sas/__pyinstaller/hook-sas.py
@@ -57,7 +57,7 @@ try:
     append_data_files("sas/docs")
 
     datas.sort()
-    print(f"SasView added datas:")
+    print("SasView added datas:")
     for s, d in datas:
         print(f"  {s}")
         print(f"  > {d}")

--- a/src/sas/qtgui/Calculators/DataOperationUtilityPanel.py
+++ b/src/sas/qtgui/Calculators/DataOperationUtilityPanel.py
@@ -3,8 +3,6 @@ import logging
 import re
 import copy
 
-from PySide6 import QtCore
-from PySide6 import QtGui
 from PySide6 import QtWidgets
 
 from sas.qtgui.Plotting.PlotterData import Data1D

--- a/src/sas/qtgui/Calculators/DensityPanel.py
+++ b/src/sas/qtgui/Calculators/DensityPanel.py
@@ -1,14 +1,10 @@
 # global
-import logging
-import functools
 from PySide6 import QtCore
 from PySide6 import QtGui
 from PySide6 import QtWidgets
 
 from periodictable import formula as Formula
 
-from sas.qtgui.Utilities.GuiUtils import FormulaValidator
-from sas.qtgui.UI import main_resources_rc
 
 # Local UI
 from sas.qtgui.Calculators.UI.DensityPanel import Ui_DensityPanel

--- a/src/sas/qtgui/Calculators/GenericScatteringCalculator.py
+++ b/src/sas/qtgui/Calculators/GenericScatteringCalculator.py
@@ -16,26 +16,21 @@ from PySide6 import QtCore
 from PySide6 import QtGui
 from PySide6 import QtWidgets
 
-from matplotlib.backends.backend_qt5agg import (FigureCanvas, NavigationToolbar2QT as NavigationToolbar)
+from matplotlib.backends.backend_qt5agg import (FigureCanvas)
 from mpl_toolkits.mplot3d.axes3d import Axes3D
-from matplotlib import __version__ as mpl_version
 
 from twisted.internet import threads
 
-import periodictable
 
 import sas.qtgui.Utilities.GuiUtils as GuiUtils
 from sas.qtgui.Utilities.ModelEditors.TabbedEditor.TabbedModelEditor import TabbedModelEditor
 from sas.qtgui.Utilities.GenericReader import GenReader
 from sasdata.dataloader.data_info import Detector, Source
-from sas.system.version import __version__
 from sas.sascalc.calculator import sas_gen
 from sas.sascalc.fit import models
 from sas.sascalc.calculator.geni import radius_of_gyration, create_beta_plot, f_of_q
 import sas.sascalc.calculator.gsc_model as gsc_model
 from sas.qtgui.Plotting.PlotterBase import PlotterBase
-from sas.qtgui.Plotting.Plotter2D import Plotter2D
-from sas.qtgui.Plotting.Plotter import Plotter
 from sas.qtgui.Plotting.Arrow3D import Arrow3D
 
 from sas.qtgui.Plotting.PlotterData import Data1D

--- a/src/sas/qtgui/Calculators/GenericScatteringCalculator.py
+++ b/src/sas/qtgui/Calculators/GenericScatteringCalculator.py
@@ -483,7 +483,7 @@ class GenericScatteringCalculator(QtWidgets.QDialog, Ui_GenericScatteringCalcula
             sender.setStyleSheet(self.TEXTBOX_ERROR_STYLESTRING)
         # If the LineEdit is an acceptable value according to the regex apply warnings
         # This functionality was previously found in check_value()
-        if not(sender in self.invalidLineEdits):
+        if sender not in self.invalidLineEdits:
             if sender == self.txtNoQBins :
                 xnodes = float(self.txtXnodes.text())
                 ynodes = float(self.txtYnodes.text())

--- a/src/sas/qtgui/Calculators/KiessigPanel.py
+++ b/src/sas/qtgui/Calculators/KiessigPanel.py
@@ -2,9 +2,7 @@ from PySide6 import QtCore
 from PySide6 import QtGui
 from PySide6 import QtWidgets
 
-from sas.qtgui.UI import main_resources_rc
 from .UI.KiessigPanel import Ui_KiessigPanel
-import sas.qtgui.Utilities.GuiUtils as GuiUtils
 
 # sas-global
 from sas.sascalc.calculator.kiessig_calculator import KiessigThicknessCalculator

--- a/src/sas/qtgui/Calculators/ResolutionCalculatorPanel.py
+++ b/src/sas/qtgui/Calculators/ResolutionCalculatorPanel.py
@@ -3,8 +3,6 @@ This object is a small tool to allow user to quickly
 determine the variance in q  from the
 instrumental parameters.
 """
-from PySide6 import QtCore
-from PySide6 import QtGui
 from PySide6 import QtWidgets
 
 from twisted.internet import threads

--- a/src/sas/qtgui/Calculators/SldPanel.py
+++ b/src/sas/qtgui/Calculators/SldPanel.py
@@ -1,18 +1,15 @@
 # global
 import numpy as np
-import logging
 from pyparsing.exceptions import ParseException
 from PySide6 import QtCore
 from PySide6 import QtGui
 from PySide6 import QtWidgets
 
-from periodictable import formula as Formula
-from periodictable.xsf import xray_energy, xray_sld
+from periodictable.xsf import xray_sld
 from periodictable.nsf import neutron_scattering
 
 import sas.qtgui.Utilities.GuiUtils as GuiUtils
 
-from sas.qtgui.UI import main_resources_rc
 
 # Local UI
 from sas.qtgui.Calculators.UI.SldPanel import Ui_SldPanel

--- a/src/sas/qtgui/Calculators/SlitSizeCalculator.py
+++ b/src/sas/qtgui/Calculators/SlitSizeCalculator.py
@@ -5,12 +5,8 @@ import os
 import sys
 import logging
 
-from PySide6 import QtCore
-from PySide6 import QtGui
 from PySide6 import QtWidgets
 
-from sas.qtgui.UI import main_resources_rc
-import sas.qtgui.Utilities.GuiUtils as GuiUtils
 
 from .UI.SlitSizeCalculator import Ui_SlitSizeCalculator
 from sasdata.dataloader.loader import Loader

--- a/src/sas/qtgui/Calculators/UnitTesting/DataOperationUtilityTest.py
+++ b/src/sas/qtgui/Calculators/UnitTesting/DataOperationUtilityTest.py
@@ -1,17 +1,10 @@
-import sys
-import time
-import numpy
-import logging
-import webbrowser
 
-from PySide6 import QtGui, QtWidgets
-from PySide6 import QtCore
+from PySide6 import QtWidgets
 from PySide6.QtTest import QTest
 from PySide6.QtCore import Qt
 
 import pytest
 
-from twisted.internet import threads
 
 from sas.qtgui.Calculators.DataOperationUtilityPanel import DataOperationUtilityPanel
 from sas.qtgui.Utilities.GuiUtils import *

--- a/src/sas/qtgui/Calculators/UnitTesting/DensityCalculatorTest.py
+++ b/src/sas/qtgui/Calculators/UnitTesting/DensityCalculatorTest.py
@@ -1,15 +1,12 @@
-import sys
-import webbrowser
 import pytest
 
-from PySide6 import QtGui, QtWidgets
+from PySide6 import QtWidgets
 from PySide6.QtTest import QTest
 from PySide6 import QtCore
 
 # Local
 from sas.qtgui.Calculators.DensityPanel import DensityPanel, MODEL
 from sas.qtgui.Calculators.DensityPanel import toMolarMass
-from sas.qtgui.Utilities.GuiUtils import FormulaValidator
 
 
 class ToMolarMassTest:

--- a/src/sas/qtgui/Calculators/UnitTesting/GenericScatteringCalculatorTest.py
+++ b/src/sas/qtgui/Calculators/UnitTesting/GenericScatteringCalculatorTest.py
@@ -1,4 +1,3 @@
-import sys
 import time
 import numpy
 
@@ -10,14 +9,11 @@ from PySide6.QtCore import Qt
 from unittest.mock import MagicMock
 
 from mpl_toolkits.mplot3d import Axes3D
-from sas.qtgui.UnitTesting.TestUtils import QtSignalSpy
 from matplotlib.backends.backend_qt5agg import FigureCanvasQTAgg as FigureCanvas
 from sas.qtgui.Calculators.GenericScatteringCalculator import GenericScatteringCalculator
 from sas.qtgui.Calculators.GenericScatteringCalculator import Plotter3D
 from sas.qtgui.Plotting.PlotterBase import PlotHelper
 
-from sas.qtgui.MainWindow.DataManager import DataManager
-from sas.qtgui.MainWindow.GuiManager import GuiManager
 from sas.qtgui.Utilities.GuiUtils import *
 from sas.sascalc.calculator import sas_gen
 

--- a/src/sas/qtgui/Calculators/UnitTesting/KiessigCalculatorTest.py
+++ b/src/sas/qtgui/Calculators/UnitTesting/KiessigCalculatorTest.py
@@ -1,7 +1,6 @@
-import sys
 
 import pytest
-from PySide6 import QtGui, QtWidgets
+from PySide6 import QtWidgets
 from PySide6.QtTest import QTest
 from PySide6.QtCore import Qt
 

--- a/src/sas/qtgui/Calculators/UnitTesting/ResolutionCalculatorPanelTest.py
+++ b/src/sas/qtgui/Calculators/UnitTesting/ResolutionCalculatorPanelTest.py
@@ -1,10 +1,6 @@
-import sys
-import time
-import numpy
-import logging
 import pytest
 
-from PySide6 import QtGui, QtWidgets
+from PySide6 import QtWidgets
 from PySide6 import QtCore
 from PySide6.QtTest import QTest
 from PySide6.QtCore import Qt

--- a/src/sas/qtgui/Calculators/UnitTesting/SLDCalculatorTest.py
+++ b/src/sas/qtgui/Calculators/UnitTesting/SLDCalculatorTest.py
@@ -1,18 +1,14 @@
-import sys
-import webbrowser
 
 import pytest
-from PySide6 import QtGui, QtWidgets
+from PySide6 import QtWidgets
 from PySide6.QtTest import QTest
 from PySide6 import QtCore
-from unittest.mock import MagicMock
 
 
 # Local
 #from sas.qtgui.Calculators.SldPanel import SldResult
 from sas.qtgui.Calculators.SldPanel import SldPanel
-from sas.qtgui.Calculators.SldPanel import neutronSldAlgorithm, xraySldAlgorithm
-from sas.qtgui.Utilities.GuiUtils import FormulaValidator
+from sas.qtgui.Calculators.SldPanel import neutronSldAlgorithm
 
 class SldAlgorithmTest:
     """ Test the periodictable wrapper """

--- a/src/sas/qtgui/Calculators/UnitTesting/SlitSizeCalculatorTest.py
+++ b/src/sas/qtgui/Calculators/UnitTesting/SlitSizeCalculatorTest.py
@@ -1,9 +1,8 @@
-import sys
 import logging
 
 import pytest
 
-from PySide6 import QtGui, QtWidgets
+from PySide6 import QtWidgets
 from PySide6.QtTest import QTest
 from PySide6.QtCore import Qt
 

--- a/src/sas/qtgui/GL/color.py
+++ b/src/sas/qtgui/GL/color.py
@@ -6,7 +6,6 @@ import matplotlib as mpl
 from enum import Enum
 from dataclasses import dataclass
 
-from OpenGL.GL import glColor4f
 
 "Helper classes for dealing with colours"
 

--- a/src/sas/qtgui/GL/cone.py
+++ b/src/sas/qtgui/GL/cone.py
@@ -1,4 +1,4 @@
-from typing import Optional, Union, Sequence, List, Tuple
+from typing import Optional, List, Tuple
 
 import numpy as np
 

--- a/src/sas/qtgui/GL/cube.py
+++ b/src/sas/qtgui/GL/cube.py
@@ -1,4 +1,4 @@
-from typing import Optional, Union, Sequence
+from typing import Optional
 
 from sas.qtgui.GL.models import FullModel
 from sas.qtgui.GL.color import ColorSpecification

--- a/src/sas/qtgui/GL/icosahedron.py
+++ b/src/sas/qtgui/GL/icosahedron.py
@@ -1,4 +1,4 @@
-from typing import Optional, Union, Sequence
+from typing import Optional
 
 import numpy as np
 

--- a/src/sas/qtgui/GL/renderable.py
+++ b/src/sas/qtgui/GL/renderable.py
@@ -1,4 +1,4 @@
-from abc import ABC, abstractmethod
+from abc import ABC
 
 import logging
 

--- a/src/sas/qtgui/GL/scene.py
+++ b/src/sas/qtgui/GL/scene.py
@@ -1,9 +1,9 @@
-from typing import Optional, Tuple, List, Callable
+from typing import List, Callable
 import numpy as np
 
 # from PyQt5 import QtWidgets, Qt, QtGui, QtOpenGL, QtCore
 from PySide6 import QtGui, QtCore
-from PySide6 import QtWidgets, QtOpenGL, QtOpenGLWidgets 
+from PySide6 import QtWidgets, QtOpenGLWidgets 
 
 from OpenGL.GL import *
 from OpenGL.GLU import *

--- a/src/sas/qtgui/GL/sphere.py
+++ b/src/sas/qtgui/GL/sphere.py
@@ -1,4 +1,4 @@
-from typing import Optional, Union, Sequence
+from typing import Optional
 
 import numpy as np
 

--- a/src/sas/qtgui/GL/visual_checks/primitive_library.py
+++ b/src/sas/qtgui/GL/visual_checks/primitive_library.py
@@ -6,7 +6,7 @@ from PySide6 import QtWidgets
 
 from sas.qtgui.GL.scene import Scene
 from sas.qtgui.GL.models import ModelBase
-from sas.qtgui.GL.color import uniform_coloring, mesh_coloring, vertex_coloring
+from sas.qtgui.GL.color import uniform_coloring, mesh_coloring
 from sas.qtgui.GL.surface import Surface
 from sas.qtgui.GL.cone import Cone
 from sas.qtgui.GL.cube import Cube

--- a/src/sas/qtgui/GL/visual_checks/primitive_library.py
+++ b/src/sas/qtgui/GL/visual_checks/primitive_library.py
@@ -29,7 +29,9 @@ def mesh_example():
 def primative_library():
     """ Shows all the existing primitives that can be rendered, press a key to go through them"""
 
-    import sys, os, traceback
+    import sys
+    import os
+    import traceback
     def excepthook(exc_type, exc_value, exc_tb):
         tb = "".join(traceback.format_exception(exc_type, exc_value, exc_tb))
         print("error catched!:")

--- a/src/sas/qtgui/MainWindow/Acknowledgements.py
+++ b/src/sas/qtgui/MainWindow/Acknowledgements.py
@@ -1,5 +1,4 @@
-import functools
-from PySide6 import QtWidgets, QtCore
+from PySide6 import QtWidgets
 from PySide6.QtCore import QSize
 from PySide6.QtGui import QIcon
 

--- a/src/sas/qtgui/MainWindow/DataExplorer.py
+++ b/src/sas/qtgui/MainWindow/DataExplorer.py
@@ -22,7 +22,7 @@ import sas.qtgui.Plotting.PlotHelper as PlotHelper
 from sas.qtgui.Plotting.PlotterData import Data1D
 from sas.qtgui.Plotting.PlotterData import Data2D
 from sas.qtgui.Plotting.PlotterData import DataRole
-from sas.qtgui.Plotting.Plotter import Plotter, PlotterWidget
+from sas.qtgui.Plotting.Plotter import PlotterWidget
 from sas.qtgui.Plotting.Plotter2D import Plotter2D, Plotter2DWidget
 from sas.qtgui.Plotting.MaskEditor import MaskEditor
 

--- a/src/sas/qtgui/MainWindow/DataManager.py
+++ b/src/sas/qtgui/MainWindow/DataManager.py
@@ -37,7 +37,6 @@ from sas.qtgui.Plotting.Plottables import View
 
 from sas.qtgui.Utilities import GuiUtils
 from sas.qtgui.MainWindow.DataState import DataState
-import sasdata.dataloader.data_info as DataInfo
 
 # used for import/export
 from sasdata.dataloader.data_info import Sample, Source, Vector

--- a/src/sas/qtgui/MainWindow/DroppableDataLoadWidget.py
+++ b/src/sas/qtgui/MainWindow/DroppableDataLoadWidget.py
@@ -1,11 +1,9 @@
 # global
 import os
 from PySide6 import QtCore
-from PySide6 import QtGui
 from PySide6 import QtWidgets
 
 # UI
-from sas.qtgui.UI import main_resources_rc
 from sas.qtgui.MainWindow.UI.DataExplorerUI import Ui_DataLoadWidget
 
 class DroppableDataLoadWidget(QtWidgets.QTabWidget, Ui_DataLoadWidget):

--- a/src/sas/qtgui/MainWindow/GuiManager.py
+++ b/src/sas/qtgui/MainWindow/GuiManager.py
@@ -12,10 +12,8 @@ from PySide6.QtWidgets import *
 from PySide6.QtGui import *
 from PySide6.QtCore import Qt, QLocale
 
-import matplotlib as mpl
 
 import sas.system.version
-from sas.qtgui.Utilities.NewVersion.NewVersionAvailable import maybe_prompt_new_version_download
 
 #mpl.use("Qt5Agg")
 

--- a/src/sas/qtgui/MainWindow/MainWindow.py
+++ b/src/sas/qtgui/MainWindow/MainWindow.py
@@ -8,13 +8,12 @@ from PySide6.QtWidgets import QMainWindow
 from PySide6.QtWidgets import QMdiArea
 from PySide6.QtWidgets import QSplashScreen
 from PySide6.QtWidgets import QApplication
-from PySide6.QtGui import QPixmap, QGuiApplication, QCursor
+from PySide6.QtGui import QPixmap, QGuiApplication
 from PySide6.QtCore import Qt, QTimer
 
 from importlib import resources
 
 # Local UI
-from sas.qtgui.UI import main_resources_rc
 from .UI.MainWindowUI import Ui_SasView
 from ..Utilities.NewVersion.NewVersionAvailable import maybe_prompt_new_version_download
 

--- a/src/sas/qtgui/MainWindow/NameChanger.py
+++ b/src/sas/qtgui/MainWindow/NameChanger.py
@@ -1,6 +1,6 @@
 import os
 
-from PySide6 import QtWidgets, QtCore
+from PySide6 import QtWidgets
 
 from sas.qtgui.Utilities import GuiUtils
 

--- a/src/sas/qtgui/MainWindow/PackageGatherer.py
+++ b/src/sas/qtgui/MainWindow/PackageGatherer.py
@@ -235,6 +235,6 @@ class PackageGatherer:
                 pass
             # Append module to output_list
             else:
-                output_dict[module_name] = f"Unknown: Version number could not be found"
+                output_dict[module_name] = "Unknown: Version number could not be found"
 
         return output_dict

--- a/src/sas/qtgui/MainWindow/UnitTesting/DataExplorerTest.py
+++ b/src/sas/qtgui/MainWindow/UnitTesting/DataExplorerTest.py
@@ -1,4 +1,3 @@
-import sys
 import time
 import random
 import pytest
@@ -9,7 +8,6 @@ from PySide6.QtWidgets import *
 from PySide6.QtTest import QTest
 from PySide6.QtCore import *
 
-from mpl_toolkits.mplot3d import Axes3D
 
 # Local
 from sas.qtgui.Plotting.PlotterData import Data1D, Data2D, DataRole
@@ -17,7 +15,6 @@ from sasdata.dataloader.loader import Loader
 from sas.qtgui.MainWindow.DataManager import DataManager
 
 from sas.qtgui.MainWindow.DataExplorer import DataExplorerWindow
-from sas.qtgui.MainWindow.GuiManager import GuiManager
 from sas.qtgui.Utilities.GuiUtils import *
 from sas.qtgui.UnitTesting.TestUtils import QtSignalSpy
 from sas.qtgui.Plotting.Plotter import Plotter

--- a/src/sas/qtgui/MainWindow/UnitTesting/DroppableDataLoadWidgetTest.py
+++ b/src/sas/qtgui/MainWindow/UnitTesting/DroppableDataLoadWidgetTest.py
@@ -1,7 +1,6 @@
 import pytest
 
 from PySide6.QtWidgets import QApplication
-from PySide6.QtTest import QTest
 from PySide6 import QtCore
 
 from sas.qtgui.MainWindow.DroppableDataLoadWidget import DroppableDataLoadWidget

--- a/src/sas/qtgui/MainWindow/UnitTesting/GuiManagerTest.py
+++ b/src/sas/qtgui/MainWindow/UnitTesting/GuiManagerTest.py
@@ -6,7 +6,6 @@ import pytest
 
 from PySide6.QtGui import *
 from PySide6.QtWidgets import *
-from PySide6.QtTest import QTest
 from PySide6 import QtCore
 
 # Local

--- a/src/sas/qtgui/MainWindow/UnitTesting/MainWindowTest.py
+++ b/src/sas/qtgui/MainWindow/UnitTesting/MainWindowTest.py
@@ -2,7 +2,7 @@ import sys
 
 import pytest
 
-from PySide6 import QtGui, QtWidgets
+from PySide6 import QtWidgets
 from PySide6.QtGui import *
 from PySide6.QtTest import QTest
 from PySide6 import QtCore
@@ -11,7 +11,7 @@ from PySide6 import QtCore
 from sas.qtgui.MainWindow.MainWindow import MainSasViewWindow
 from sas.qtgui.MainWindow.MainWindow import SplashScreen
 from sas.qtgui.Perspectives.Fitting import FittingPerspective
-from sas.qtgui.Utilities.HidableDialog import HidableDialog, ShowAgainResult
+from sas.qtgui.Utilities.HidableDialog import HidableDialog
 
 from sas.system import config
 class MainWindowTest:

--- a/src/sas/qtgui/MainWindow/UnitTesting/WelcomePanelTest.py
+++ b/src/sas/qtgui/MainWindow/UnitTesting/WelcomePanelTest.py
@@ -1,8 +1,7 @@
-import sys
 
 import pytest
 
-from PySide6 import QtGui, QtWidgets
+from PySide6 import QtWidgets
 
 # Local
 from sas.qtgui.MainWindow.WelcomePanel import WelcomePanel

--- a/src/sas/qtgui/MainWindow/WelcomePanel.py
+++ b/src/sas/qtgui/MainWindow/WelcomePanel.py
@@ -3,7 +3,6 @@ from PySide6 import QtWidgets
 import sas.sasview
 import sas.system.version
 
-from sas import config
 from sas.system import legal
 
 from sas.qtgui.MainWindow.UI.WelcomePanelUI import Ui_WelcomePanelUI

--- a/src/sas/qtgui/Perspectives/Corfunc/CorfuncPerspective.py
+++ b/src/sas/qtgui/Perspectives/Corfunc/CorfuncPerspective.py
@@ -6,10 +6,9 @@ import math
 from PySide6.QtGui import QStandardItem, QDoubleValidator
 from matplotlib.backends.backend_qt5agg import NavigationToolbar2QT
 
-from numpy.linalg.linalg import LinAlgError
 
 
-from typing import Optional, List, Tuple, Callable
+from typing import Optional, List, Callable
 
 import logging
 

--- a/src/sas/qtgui/Perspectives/Corfunc/SaveExtrapolatedPopup.py
+++ b/src/sas/qtgui/Perspectives/Corfunc/SaveExtrapolatedPopup.py
@@ -1,6 +1,5 @@
 import numpy as np
 
-from PySide6 import QtCore
 from PySide6.QtWidgets import QDialog, QFileDialog, QMessageBox
 
 

--- a/src/sas/qtgui/Perspectives/Corfunc/UnitTesting/CorfuncTest.py
+++ b/src/sas/qtgui/Perspectives/Corfunc/UnitTesting/CorfuncTest.py
@@ -1,5 +1,4 @@
 import os
-import sys
 
 import pytest
 
@@ -10,7 +9,6 @@ from PySide6.QtTest import QTest
 from sas.qtgui.Perspectives.Corfunc.CorfuncPerspective import CorfuncWindow
 from sas.qtgui.Plotting.PlotterData import Data1D
 from sasdata.dataloader.loader import Loader
-from sas.qtgui.MainWindow.DataManager import DataManager
 import sas.qtgui.Utilities.GuiUtils as GuiUtils
 
 

--- a/src/sas/qtgui/Perspectives/Corfunc/util.py
+++ b/src/sas/qtgui/Perspectives/Corfunc/util.py
@@ -1,4 +1,3 @@
-from typing import Callable
 from sas.qtgui.Utilities.GuiUtils import enum
 
 WIDGETS = enum( 'W_QMIN',

--- a/src/sas/qtgui/Perspectives/Fitting/AssociatedComboBox.py
+++ b/src/sas/qtgui/Perspectives/Fitting/AssociatedComboBox.py
@@ -1,4 +1,4 @@
-from PySide6 import QtGui, QtWidgets
+from PySide6 import QtWidgets
 
 
 class AssociatedComboBox(QtWidgets.QComboBox):

--- a/src/sas/qtgui/Perspectives/Fitting/ComplexConstraint.py
+++ b/src/sas/qtgui/Perspectives/Fitting/ComplexConstraint.py
@@ -1,19 +1,15 @@
 """
 Widget for multi-model constraints.
 """
-import os
 
 # numpy methods required for the validator! Don't remove.
 # pylint: disable=unused-import,unused-wildcard-import,redefined-builtin
 from numpy import *
 
 from PySide6 import QtCore
-from PySide6 import QtGui
 from PySide6 import QtWidgets
-import webbrowser
 
 from sas.qtgui.Perspectives.Fitting import FittingUtilities
-import sas.qtgui.Utilities.GuiUtils as GuiUtils
 from sas.qtgui.Perspectives.Fitting.Constraint import Constraint
 
 #ALLOWED_OPERATORS = ['=','<','>','>=','<=']

--- a/src/sas/qtgui/Perspectives/Fitting/ConstraintWidget.py
+++ b/src/sas/qtgui/Perspectives/Fitting/ConstraintWidget.py
@@ -773,7 +773,7 @@ class ConstraintWidget(QtWidgets.QWidget, Ui_ConstraintWidgetUI):
         Determines if the tab can be imported and included in the widget
         """
         if not isinstance(tab, str): return False
-        if not self.currentType in tab: return False
+        if self.currentType not in tab: return False
         object = ObjectLibrary.getObject(tab)
         if not isinstance(object, FittingWidget): return False
         if not object.data_is_loaded : return False
@@ -1189,7 +1189,7 @@ class ConstraintWidget(QtWidgets.QWidget, Ui_ConstraintWidgetUI):
         Update the page with passed parameter values
         """
         # checked models
-        if not 'checked_models' in parameters:
+        if 'checked_models' not in parameters:
             return
         models = parameters['checked_models'][0]
         for model, check_state in models.items():
@@ -1204,7 +1204,7 @@ class ConstraintWidget(QtWidgets.QWidget, Ui_ConstraintWidgetUI):
                 else:
                     self.tblTabList.item(row,0).setCheckState(QtCore.Qt.Checked)
 
-        if not 'checked_constraints' in parameters:
+        if 'checked_constraints' not in parameters:
             return
         # checked constraints
         models = parameters['checked_constraints'][0]

--- a/src/sas/qtgui/Perspectives/Fitting/FitThread.py
+++ b/src/sas/qtgui/Perspectives/Fitting/FitThread.py
@@ -1,6 +1,4 @@
-import sys
 import time
-import copy
 import traceback
 import logging
 

--- a/src/sas/qtgui/Perspectives/Fitting/FitThread.py
+++ b/src/sas/qtgui/Perspectives/Fitting/FitThread.py
@@ -13,7 +13,7 @@ def map_getattr(classInstance, classFunc, *args):
     """
     try:
         return_value = getattr(classInstance, classFunc)(*args)
-    except Exception as ex:
+    except Exception:
         logger.error("Fitting failed: %s", traceback.format_exc())
         return None
     return  return_value
@@ -21,7 +21,7 @@ def map_getattr(classInstance, classFunc, *args):
 def map_apply(arguments):
     try:
         return_value = arguments[0](*arguments[1:])
-    except Exception as ex:
+    except Exception:
         logger.error("Fitting failed: %s", traceback.format_exc())
         return None
     return return_value

--- a/src/sas/qtgui/Perspectives/Fitting/FittingOptions.py
+++ b/src/sas/qtgui/Perspectives/Fitting/FittingOptions.py
@@ -1,8 +1,5 @@
 # global
-import sys
-import os
 import types
-import webbrowser
 
 from PySide6 import QtCore
 from PySide6 import QtGui

--- a/src/sas/qtgui/Perspectives/Fitting/FittingPerspective.py
+++ b/src/sas/qtgui/Perspectives/Fitting/FittingPerspective.py
@@ -1,6 +1,5 @@
 import numpy
 import copy
-import re
 
 from typing import Optional
 

--- a/src/sas/qtgui/Perspectives/Fitting/GPUOptions.py
+++ b/src/sas/qtgui/Perspectives/Fitting/GPUOptions.py
@@ -1,9 +1,6 @@
 # global
-import os
-import sys
 import json
 import platform
-import webbrowser
 import logging
 from twisted.internet import threads
 from twisted.internet import reactor
@@ -13,8 +10,7 @@ import sasmodels.model_test
 import sasmodels.kernelcl
 from sasmodels.generate import F32, F64
 
-import sas.qtgui.Utilities.GuiUtils as GuiUtils
-from PySide6 import QtGui, QtCore, QtWidgets
+from PySide6 import QtCore, QtWidgets
 from sas.qtgui.Perspectives.Fitting.UI.GPUOptionsUI import Ui_GPUOptions
 from sas.qtgui.Perspectives.Fitting.UI.GPUTestResultsUI import Ui_GPUTestResults
 from sas.qtgui.Utilities.Preferences.PreferencesWidget import PreferencesWidget

--- a/src/sas/qtgui/Perspectives/Fitting/MultiConstraint.py
+++ b/src/sas/qtgui/Perspectives/Fitting/MultiConstraint.py
@@ -9,7 +9,6 @@ import webbrowser
 from numpy import *
 
 from PySide6 import QtWidgets
-from PySide6 import QtCore
 
 import sas.qtgui.Utilities.GuiUtils as GuiUtils
 

--- a/src/sas/qtgui/Perspectives/Fitting/ReportPageLogic.py
+++ b/src/sas/qtgui/Perspectives/Fitting/ReportPageLogic.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 import base64
 import datetime
-import re
 import sys
 
 from typing import List

--- a/src/sas/qtgui/Perspectives/Fitting/SmearingWidget.py
+++ b/src/sas/qtgui/Perspectives/Fitting/SmearingWidget.py
@@ -405,18 +405,18 @@ class SmearingWidget(QtWidgets.QWidget, Ui_SmearingWidgetUI):
         q_max = max(self.data.x)
         smearing_error_flag = False
         if d_length < d_width:
-            msg = f'Length specified which is less than width. \n' \
-                  f'This is not slit-smearing, probably you switched the two parameters? \n' \
-                  f'I am internally using the smaller parameter as the width and larger as the length. \n' \
-                  f'This is the only mathematically valid version of this.'
+            msg = 'Length specified which is less than width. \n' \
+                  'This is not slit-smearing, probably you switched the two parameters? \n' \
+                  'I am internally using the smaller parameter as the width and larger as the length. \n' \
+                  'This is the only mathematically valid version of this.'
             smearing_error_flag = True
             temp = d_length
             d_length = d_width
             d_width = temp
         elif d_length < 10 * d_width:
-            msg = f'Slit length specified which is less than 10 x slit width. ' \
-                  f'This is not slit-smearing (at least not in the form we implement). \n' \
-                  f'Use pinhole smearing instead.'
+            msg = 'Slit length specified which is less than 10 x slit width. ' \
+                  'This is not slit-smearing (at least not in the form we implement). \n' \
+                  'Use pinhole smearing instead.'
             smearing_error_flag = True
         # elif d_length < q_max:
         #     msg = f'Length specified which is less than q_max for the data. \n' \

--- a/src/sas/qtgui/Perspectives/Fitting/UnitTesting/ComplexConstraintTest.py
+++ b/src/sas/qtgui/Perspectives/Fitting/UnitTesting/ComplexConstraintTest.py
@@ -1,10 +1,9 @@
-import sys
 import numpy as np
 import webbrowser
 
 import pytest
 
-from PySide6 import QtGui, QtWidgets, QtCore, QtTest
+from PySide6 import QtWidgets, QtCore, QtTest
 
 from sas.qtgui.Perspectives.Fitting import FittingUtilities
 from sas.qtgui.Perspectives.Fitting.Constraint import Constraint

--- a/src/sas/qtgui/Perspectives/Fitting/UnitTesting/ConstraintWidgetTest.py
+++ b/src/sas/qtgui/Perspectives/Fitting/UnitTesting/ConstraintWidgetTest.py
@@ -1,5 +1,3 @@
-import sys
-import numpy as np
 from unittest.mock import MagicMock
 import pytest
 
@@ -8,8 +6,6 @@ from PySide6.QtTest import QTest, QSignalSpy
 
 import sas.qtgui.Utilities.ObjectLibrary as ObjectLibrary
 import sas.qtgui.Utilities.GuiUtils as GuiUtils
-from sas.qtgui.Perspectives.Fitting import FittingUtilities
-from sas.qtgui.Plotting.PlotterData import Data1D
 
 from sas.qtgui.MainWindow.GuiManager import GuiManager
 

--- a/src/sas/qtgui/Perspectives/Fitting/UnitTesting/FitPageTest.py
+++ b/src/sas/qtgui/Perspectives/Fitting/UnitTesting/FitPageTest.py
@@ -1,4 +1,3 @@
-import sys
 
 import pytest
 

--- a/src/sas/qtgui/Perspectives/Fitting/UnitTesting/FittingLogicTest.py
+++ b/src/sas/qtgui/Perspectives/Fitting/UnitTesting/FittingLogicTest.py
@@ -1,4 +1,3 @@
-import sys
 
 import pytest
 

--- a/src/sas/qtgui/Perspectives/Fitting/UnitTesting/FittingOptionsTest.py
+++ b/src/sas/qtgui/Perspectives/Fitting/UnitTesting/FittingOptionsTest.py
@@ -1,4 +1,3 @@
-import sys
 import webbrowser
 
 import pytest

--- a/src/sas/qtgui/Perspectives/Fitting/UnitTesting/FittingPerspectiveTest.py
+++ b/src/sas/qtgui/Perspectives/Fitting/UnitTesting/FittingPerspectiveTest.py
@@ -1,11 +1,7 @@
-import sys
-import webbrowser
 import pytest
 
 from PySide6 import QtGui
 from PySide6 import QtWidgets
-from PySide6 import QtTest
-from PySide6 import QtCore
 
 # Local
 import sas.qtgui.Utilities.GuiUtils as GuiUtils

--- a/src/sas/qtgui/Perspectives/Fitting/UnitTesting/FittingUtilitiesTest.py
+++ b/src/sas/qtgui/Perspectives/Fitting/UnitTesting/FittingUtilitiesTest.py
@@ -1,4 +1,3 @@
-import sys
 
 import pytest
 
@@ -7,7 +6,6 @@ from PySide6 import QtGui, QtCore
 from sas.qtgui.Plotting.PlotterData import Data1D
 from sas.qtgui.Plotting.PlotterData import Data2D
 
-from sas.qtgui.UnitTesting.TestUtils import WarningTestNotImplemented
 
 from sasmodels import generate
 from sasmodels import modelinfo

--- a/src/sas/qtgui/Perspectives/Fitting/UnitTesting/FittingWidgetTest.py
+++ b/src/sas/qtgui/Perspectives/Fitting/UnitTesting/FittingWidgetTest.py
@@ -1,8 +1,6 @@
-import sys
 import time
 import logging
 import os
-import inspect
 import glob
 import pytest
 
@@ -11,7 +9,7 @@ from PySide6 import QtWidgets
 from PySide6 import QtTest
 from PySide6 import QtCore
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 from twisted.internet import threads
 
 # Local
@@ -19,7 +17,6 @@ from sas.qtgui.Utilities.GuiUtils import *
 from sas.qtgui.Perspectives.Fitting.FittingWidget import *
 from sas.qtgui.Perspectives.Fitting.Constraint import Constraint
 from sas.qtgui.UnitTesting.TestUtils import QtSignalSpy
-from sas.qtgui.Perspectives.Fitting.ModelThread import Calc1D
 from sas.qtgui.Perspectives.Fitting.ModelThread import Calc2D
 
 from sas.qtgui.Plotting.PlotterData import Data1D

--- a/src/sas/qtgui/Perspectives/Fitting/UnitTesting/MultiConstraintTest.py
+++ b/src/sas/qtgui/Perspectives/Fitting/UnitTesting/MultiConstraintTest.py
@@ -5,7 +5,7 @@ import pytest
 
 import numpy as np
 
-from PySide6 import QtGui, QtWidgets
+from PySide6 import QtWidgets
 
 # Local
 from sas.qtgui.Perspectives.Fitting.MultiConstraint import MultiConstraint

--- a/src/sas/qtgui/Perspectives/Fitting/ViewDelegate.py
+++ b/src/sas/qtgui/Perspectives/Fitting/ViewDelegate.py
@@ -58,7 +58,7 @@ class ModelViewDelegate(QtWidgets.QStyledItemDelegate):
 
             # delete the original content
             options.text = ""
-            style.drawControl(QtWidgets.QStyle.CE_ItemViewItem, options, painter, options.widget);
+            style.drawControl(QtWidgets.QStyle.CE_ItemViewItem, options, painter, options.widget)
 
             context = QtGui.QAbstractTextDocumentLayout.PaintContext()
             textRect = style.subElementRect(QtWidgets.QStyle.SE_ItemViewItemText, options)
@@ -202,7 +202,7 @@ class PolyViewDelegate(QtWidgets.QStyledItemDelegate):
 
             # delete the original content
             options.text = ""
-            style.drawControl(QtWidgets.QStyle.CE_ItemViewItem, options, painter, options.widget);
+            style.drawControl(QtWidgets.QStyle.CE_ItemViewItem, options, painter, options.widget)
 
             context = QtGui.QAbstractTextDocumentLayout.PaintContext()
             textRect = style.subElementRect(QtWidgets.QStyle.SE_ItemViewItemText, options)
@@ -285,7 +285,7 @@ class MagnetismViewDelegate(QtWidgets.QStyledItemDelegate):
 
             # delete the original content
             options.text = ""
-            style.drawControl(QtWidgets.QStyle.CE_ItemViewItem, options, painter, options.widget);
+            style.drawControl(QtWidgets.QStyle.CE_ItemViewItem, options, painter, options.widget)
 
             context = QtGui.QAbstractTextDocumentLayout.PaintContext()
             textRect = style.subElementRect(QtWidgets.QStyle.SE_ItemViewItemText, options)

--- a/src/sas/qtgui/Perspectives/Fitting/plugin_models/plugin_structure_template.py
+++ b/src/sas/qtgui/Perspectives/Fitting/plugin_models/plugin_structure_template.py
@@ -27,7 +27,6 @@ Authorship and Verification
 * **Last Reviewed by:** Reviewer Name Here **Date:** Date Here
 """
 
-import numpy as np
 from numpy import inf
 
 name = "plugin_structure_template"

--- a/src/sas/qtgui/Perspectives/Fitting/plugin_models/plugin_template.py
+++ b/src/sas/qtgui/Perspectives/Fitting/plugin_models/plugin_template.py
@@ -27,7 +27,6 @@ Authorship and Verification
 * **Last Reviewed by:** Reviewer Name Here **Date:** Date Here
 """
 
-import numpy as np
 from numpy import inf
 
 name = "plugin_template"

--- a/src/sas/qtgui/Perspectives/Invariant/InvariantDetails.py
+++ b/src/sas/qtgui/Perspectives/Invariant/InvariantDetails.py
@@ -1,7 +1,4 @@
-import sys
-import os
-from PySide6 import QtCore
-from PySide6 import QtGui, QtWidgets
+from PySide6 import QtWidgets
 
 # local
 from .UI.InvariantDetailsUI import Ui_Dialog

--- a/src/sas/qtgui/Perspectives/Invariant/UnitTesting/InvariantPerspectiveTest.py
+++ b/src/sas/qtgui/Perspectives/Invariant/UnitTesting/InvariantPerspectiveTest.py
@@ -1,16 +1,13 @@
-import sys
 import logging
 import pytest
 
 from PySide6 import QtGui, QtWidgets
-from PySide6 import QtCore
 from PySide6.QtTest import QTest
 from PySide6.QtCore import Qt
 
 from twisted.internet import threads
 
 from sas.qtgui.Perspectives.Invariant.InvariantPerspective import InvariantWindow
-from sas.qtgui.Perspectives.Invariant.InvariantDetails import DetailsDialog
 from sas.qtgui.Perspectives.Invariant.InvariantUtils import WIDGETS
 from sas.qtgui.Plotting.PlotterData import Data1D
 

--- a/src/sas/qtgui/Perspectives/ParticleEditor/AngularSamplingMethodSelector.py
+++ b/src/sas/qtgui/Perspectives/ParticleEditor/AngularSamplingMethodSelector.py
@@ -1,4 +1,3 @@
-from typing import List, Tuple
 
 from PySide6.QtWidgets import QWidget, QVBoxLayout, QFormLayout, QComboBox, QDoubleSpinBox
 

--- a/src/sas/qtgui/Perspectives/ParticleEditor/CodeToolBar.py
+++ b/src/sas/qtgui/Perspectives/ParticleEditor/CodeToolBar.py
@@ -2,7 +2,6 @@ from PySide6 import QtWidgets, QtGui
 
 from sas.qtgui.Perspectives.ParticleEditor.UI.CodeToolBarUI import Ui_CodeToolBar
 
-import sas.qtgui.Perspectives.ParticleEditor.UI.icons_rc
 class CodeToolBar(QtWidgets.QWidget, Ui_CodeToolBar):
     def __init__(self, parent=None):
         super().__init__()

--- a/src/sas/qtgui/Perspectives/ParticleEditor/OutputViewer.py
+++ b/src/sas/qtgui/Perspectives/ParticleEditor/OutputViewer.py
@@ -2,7 +2,6 @@
 from PySide6 import QtWidgets
 from PySide6.QtGui import QFont
 
-from sas.qtgui.Perspectives.ParticleEditor.syntax_highlight import PythonHighlighter
 from sas.system.version import __version__ as version
 
 initial_text = f"<p><b>Particle Editor Log - SasView {version}</b></p>"

--- a/src/sas/qtgui/Perspectives/ParticleEditor/PythonViewer.py
+++ b/src/sas/qtgui/Perspectives/ParticleEditor/PythonViewer.py
@@ -1,6 +1,6 @@
 
-from PySide6 import QtWidgets, QtGui
-from PySide6.QtCore import Qt, Signal, QObject
+from PySide6 import QtWidgets
+from PySide6.QtCore import Qt, Signal
 from PySide6.QtGui import QFont
 
 

--- a/src/sas/qtgui/Perspectives/ParticleEditor/calculations/debye.py
+++ b/src/sas/qtgui/Perspectives/ParticleEditor/calculations/debye.py
@@ -1,20 +1,14 @@
-from typing import Optional, Tuple
-import time
+from typing import Optional
 
 import numpy as np
-from scipy.interpolate import interp1d
-from scipy.special import jv as bessel
-from scipy.spatial.distance import cdist
 
 from sas.qtgui.Perspectives.ParticleEditor.datamodel.calculation import (
-    ScatteringCalculation, ScatteringOutput, OrientationalDistribution, SamplingDistribution,
-    QSpaceScattering, QSpaceCalcDatum, RealSpaceScattering,
-    SLDDefinition, MagnetismDefinition, SpatialSample, QSample, CalculationParameters)
+    SLDDefinition, MagnetismDefinition, QSample, CalculationParameters)
 
 from sas.qtgui.Perspectives.ParticleEditor.sampling.chunking import SingleChunk, pairwise_chunk_iterator
 from sas.qtgui.Perspectives.ParticleEditor.sampling.points import SpatialDistribution
 
-from sas.qtgui.Perspectives.ParticleEditor.calculations.run_function import run_sld, run_magnetism
+from sas.qtgui.Perspectives.ParticleEditor.calculations.run_function import run_sld
 
 def debye(
         sld_definition: SLDDefinition,

--- a/src/sas/qtgui/Perspectives/ParticleEditor/calculations/fq.py
+++ b/src/sas/qtgui/Perspectives/ParticleEditor/calculations/fq.py
@@ -1,18 +1,13 @@
-from typing import Optional, Tuple
-import time
+from typing import Optional
 
 import numpy as np
-from scipy.interpolate import interp1d
-from scipy.special import jv as bessel
-from scipy.spatial.distance import cdist
 
 from sas.qtgui.Perspectives.ParticleEditor.datamodel.calculation import (
     SLDDefinition, MagnetismDefinition, AngularDistribution, QSample, CalculationParameters)
 
-from sas.qtgui.Perspectives.ParticleEditor.sampling.chunking import SingleChunk, pairwise_chunk_iterator
 from sas.qtgui.Perspectives.ParticleEditor.sampling.points import SpatialDistribution, PointGeneratorStepper
 
-from sas.qtgui.Perspectives.ParticleEditor.calculations.run_function import run_sld, run_magnetism
+from sas.qtgui.Perspectives.ParticleEditor.calculations.run_function import run_sld
 
 def scattering_via_fq(
         sld_definition: SLDDefinition,

--- a/src/sas/qtgui/Perspectives/ParticleEditor/sampling/angles.py
+++ b/src/sas/qtgui/Perspectives/ParticleEditor/sampling/angles.py
@@ -36,7 +36,7 @@ class ZDelta(AngularDistribution):
         return []
 
     def __repr__(self):
-        return f"ZDelta()"
+        return "ZDelta()"
 
 
 class Uniform(AngularDistribution):

--- a/src/sas/qtgui/Perspectives/ParticleEditor/sampling/chunking.py
+++ b/src/sas/qtgui/Perspectives/ParticleEditor/sampling/chunking.py
@@ -35,7 +35,6 @@ Something like this
 
 from typing import Tuple, Sequence, Any
 
-import math
 
 from sas.qtgui.Perspectives.ParticleEditor.sampling.points import SpatialDistribution
 from sas.qtgui.Perspectives.ParticleEditor.datamodel.types import VectorComponents3

--- a/src/sas/qtgui/Perspectives/ParticleEditor/syntax_highlight.py
+++ b/src/sas/qtgui/Perspectives/ParticleEditor/syntax_highlight.py
@@ -7,7 +7,6 @@ It's not great, should all really be implemented as a finite state machine with 
 
 """
 
-import sys
 from PySide6.QtCore import QRegularExpression, QRegularExpressionMatchIterator
 from PySide6.QtGui import QColor, QTextCharFormat, QFont, QSyntaxHighlighter
 

--- a/src/sas/qtgui/Perspectives/ParticleEditor/tests/test_angles.py
+++ b/src/sas/qtgui/Perspectives/ParticleEditor/tests/test_angles.py
@@ -1,4 +1,3 @@
-import pytest
 from pytest import mark
 import numpy as np
 

--- a/src/sas/qtgui/Perspectives/ParticleEditor/vectorise.py
+++ b/src/sas/qtgui/Perspectives/ParticleEditor/vectorise.py
@@ -1,5 +1,5 @@
 import traceback
-from typing import List, Union, Callable
+from typing import Callable
 import numpy as np
 
 test_n = 7

--- a/src/sas/qtgui/Plotting/AddText.py
+++ b/src/sas/qtgui/Plotting/AddText.py
@@ -1,10 +1,8 @@
-from PySide6 import QtCore
 from PySide6 import QtGui
 from PySide6 import QtWidgets
 from PySide6.QtCore import QSize
 from PySide6.QtGui import QIcon
 
-import sas.sasview
 
 from sas.qtgui.Plotting.UI.AddTextUI import Ui_AddText
 

--- a/src/sas/qtgui/Plotting/BoxSum.py
+++ b/src/sas/qtgui/Plotting/BoxSum.py
@@ -8,7 +8,6 @@ from PySide6 import QtWidgets
 import sas.qtgui.Utilities.GuiUtils as GuiUtils
 
 # Local UI
-from sas.qtgui.UI import main_resources_rc
 from sas.qtgui.Plotting.UI.BoxSumUI import Ui_BoxSumUI
 
 class BoxSum(QtWidgets.QDialog, Ui_BoxSumUI):

--- a/src/sas/qtgui/Plotting/ColorMap.py
+++ b/src/sas/qtgui/Plotting/ColorMap.py
@@ -17,7 +17,6 @@ from superqt import QDoubleRangeSlider
 DEFAULT_MAP = 'jet'
 
 # Local UI
-from sas.qtgui.UI import main_resources_rc
 from sas.qtgui.Plotting.UI.ColorMapUI import Ui_ColorMapUI
 
 class ColorMap(QtWidgets.QDialog, Ui_ColorMapUI):

--- a/src/sas/qtgui/Plotting/MaskEditor.py
+++ b/src/sas/qtgui/Plotting/MaskEditor.py
@@ -2,12 +2,11 @@ from functools import partial
 import copy
 import numpy as np
 
-from PySide6 import QtWidgets, QtCore
+from PySide6 import QtWidgets
 
 from sas.qtgui.Plotting.PlotterData import Data2D
 
 # Local UI
-from sas.qtgui.UI import main_resources_rc
 from sas.qtgui.Plotting.UI.MaskEditorUI import Ui_MaskEditorUI
 from sas.qtgui.Plotting.Plotter2D import Plotter2DWidget
 

--- a/src/sas/qtgui/Plotting/PlotLabelProperties.py
+++ b/src/sas/qtgui/Plotting/PlotLabelProperties.py
@@ -1,4 +1,3 @@
-from PySide6 import QtCore
 from PySide6 import QtWidgets
 
 from sas.qtgui.Plotting.PlotUtilities import COLORS, COLORS_LETTER, WEIGHTS, FONTS

--- a/src/sas/qtgui/Plotting/PlotProperties.py
+++ b/src/sas/qtgui/Plotting/PlotProperties.py
@@ -1,4 +1,3 @@
-from PySide6 import QtCore
 from PySide6 import QtWidgets
 
 from sas.qtgui.Plotting.PlotUtilities import COLORS, SHAPES

--- a/src/sas/qtgui/Plotting/PlotUtilities.py
+++ b/src/sas/qtgui/Plotting/PlotUtilities.py
@@ -293,7 +293,7 @@ def getValidColor(color):
     elif isinstance(color, str):
         # This could be a one letter code
         if len(color) == 1:
-            if not color in list (COLORS_LETTER.keys()):
+            if color not in list (COLORS_LETTER.keys()):
                 raise AttributeError
         elif color in list(COLORS.keys()):
             # or the full word

--- a/src/sas/qtgui/Plotting/PlotUtilities.py
+++ b/src/sas/qtgui/Plotting/PlotUtilities.py
@@ -1,4 +1,3 @@
-import sys
 import numpy
 import string
 

--- a/src/sas/qtgui/Plotting/Plottables.py
+++ b/src/sas/qtgui/Plotting/Plottables.py
@@ -205,7 +205,7 @@ class Graph(object):
     def add(self, plottable, color=None):
         """Add a new plottable to the graph"""
         # record the colour associated with the plottable
-        if not plottable in self.plottables:
+        if plottable not in self.plottables:
             if color is not None:
                 self.plottables[plottable] = color
             else:

--- a/src/sas/qtgui/Plotting/Plottables.py
+++ b/src/sas/qtgui/Plotting/Plottables.py
@@ -226,7 +226,7 @@ class Graph(object):
         for p in self.plottables:
             if p.hidden == True:
                 continue
-            if not p.x is None:
+            if p.x is not None:
                 for x_i in p.x:
                     if min_value is None or x_i < min_value:
                         min_value = x_i
@@ -561,8 +561,8 @@ class Plottable(object):
         """
         Returns True if there is no data stored in the plottable
         """
-        if not self.x is None and len(self.x) == 0 \
-            and not self.y is None and len(self.y) == 0:
+        if self.x is not None and len(self.x) == 0 \
+            and self.y is not None and len(self.y) == 0:
             return True
         return False
 
@@ -682,7 +682,7 @@ class View(object):
         has_err_y = not (dy is None or len(dy) == 0)
 
         if(x is not None) and (y is not None):
-            if not dx is None and not len(dx) == 0 and not len(x) == len(dx):
+            if dx is not None and not len(dx) == 0 and not len(x) == len(dx):
                 msg = "Plottable.View: Given x and dx are not"
                 msg += " of the same length"
                 raise ValueError(msg)
@@ -692,7 +692,7 @@ class View(object):
                 msg += "and x are not of the same length"
                 raise ValueError(msg)
 
-            if not dy is None and not len(dy) == 0 and not len(y) == len(dy):
+            if dy is not None and not len(dy) == 0 and not len(y) == len(dy):
                 msg = "Plottable.View: Given y and dy are not of the same "
                 msg += "length: len(y)=%s, len(dy)=%s" % (len(y), len(dy))
                 raise ValueError(msg)

--- a/src/sas/qtgui/Plotting/Plottables.py
+++ b/src/sas/qtgui/Plotting/Plottables.py
@@ -383,7 +383,7 @@ class Transform(object):
         user, along with an indication of which plottable was at fault.
 
         """
-        raise NotImplemented("Not a valid transform")
+        raise NotImplementedError("Not a valid transform")
 
     # Related issues
     # ==============

--- a/src/sas/qtgui/Plotting/Plotter.py
+++ b/src/sas/qtgui/Plotting/Plotter.py
@@ -4,12 +4,10 @@ from PySide6 import QtWidgets
 import functools
 import copy
 import math
-import matplotlib as mpl
 import matplotlib.ticker as ticker
 import numpy as np
 import textwrap
 from matplotlib.font_manager import FontProperties
-from packaging import version
 
 from sas.qtgui.Plotting.PlotterData import Data1D, DataRole
 from sas.qtgui.Plotting.PlotterBase import PlotterBase

--- a/src/sas/qtgui/Plotting/PlotterBase.py
+++ b/src/sas/qtgui/Plotting/PlotterBase.py
@@ -1,4 +1,3 @@
-import numpy
 
 from PySide6 import QtCore
 from PySide6 import QtGui

--- a/src/sas/qtgui/Plotting/QRangeSlider.py
+++ b/src/sas/qtgui/Plotting/QRangeSlider.py
@@ -1,8 +1,5 @@
 """Double slider interactor for setting the Q range for a fit or function"""
 import numpy as np
-from typing import Union
-from PySide6.QtCore import QEvent
-from PySide6.QtWidgets import QLineEdit, QTextEdit
 
 from sas.qtgui.Plotting.PlotterData import Data1D
 from sas.qtgui.Plotting.Slicers.BaseInteractor import BaseInteractor

--- a/src/sas/qtgui/Plotting/ScaleProperties.py
+++ b/src/sas/qtgui/Plotting/ScaleProperties.py
@@ -1,8 +1,5 @@
-from PySide6 import QtCore
-from PySide6 import QtGui
 from PySide6 import QtWidgets
 
-from sas.qtgui.UI import main_resources_rc
 from sas.qtgui.Plotting.UI.ScalePropertiesUI import Ui_scalePropertiesUI
 
 x_values = ["x", "x^(2)", "x^(4)", "ln(x)", "log10(x)", "log10(x^(4))"]

--- a/src/sas/qtgui/Plotting/SetGraphRange.py
+++ b/src/sas/qtgui/Plotting/SetGraphRange.py
@@ -1,14 +1,11 @@
 """
 Allows users to change the range of the current graph
 """
-from PySide6 import QtCore
-from PySide6 import QtGui
 from PySide6 import QtWidgets
 
 import sas.qtgui.Utilities.GuiUtils as GuiUtils
 
 # Local UI
-from sas.qtgui.UI import main_resources_rc
 from sas.qtgui.Plotting.UI.SetGraphRangeUI import Ui_setGraphRangeUI
 
 class SetGraphRange(QtWidgets.QDialog, Ui_setGraphRangeUI):

--- a/src/sas/qtgui/Plotting/Slicers/AnnulusSlicer.py
+++ b/src/sas/qtgui/Plotting/Slicers/AnnulusSlicer.py
@@ -3,7 +3,6 @@ import numpy
 import sas.qtgui.Utilities.GuiUtils as GuiUtils
 from .BaseInteractor import BaseInteractor
 from sas.qtgui.Plotting.PlotterData import Data1D, DataRole
-from sas.qtgui.Utilities.GuiUtils import formatNumber
 from sas.qtgui.Plotting.SlicerModel import SlicerModel
 
 class AnnulusInteractor(BaseInteractor, SlicerModel):

--- a/src/sas/qtgui/Plotting/Slicers/BaseInteractor.py
+++ b/src/sas/qtgui/Plotting/Slicers/BaseInteractor.py
@@ -1,4 +1,3 @@
-import logging
 
 interface_color = 'black'
 disable_color = 'gray'

--- a/src/sas/qtgui/Plotting/Slicers/BoxSum.py
+++ b/src/sas/qtgui/Plotting/Slicers/BoxSum.py
@@ -6,7 +6,6 @@ from sas.qtgui.Utilities.GuiUtils import formatNumber, toDouble
 from sas.qtgui.Plotting.Slicers.BaseInteractor import BaseInteractor
 from sasdata.data_util.manipulations import Boxavg, Boxsum
 
-from sas.qtgui.Plotting.SlicerModel import SlicerModel
 
 
 class BoxSumCalculator(BaseInteractor):

--- a/src/sas/qtgui/Plotting/Slicers/SectorSlicer.py
+++ b/src/sas/qtgui/Plotting/Slicers/SectorSlicer.py
@@ -1,5 +1,4 @@
 import numpy
-import logging
 
 from sas.qtgui.Plotting.Slicers.BaseInteractor import BaseInteractor
 from sas.qtgui.Plotting.PlotterData import Data1D

--- a/src/sas/qtgui/Plotting/UnitTesting/AddTextTest.py
+++ b/src/sas/qtgui/Plotting/UnitTesting/AddTextTest.py
@@ -1,4 +1,3 @@
-import sys
 
 import pytest
 

--- a/src/sas/qtgui/Plotting/UnitTesting/BoxSumTest.py
+++ b/src/sas/qtgui/Plotting/UnitTesting/BoxSumTest.py
@@ -1,8 +1,6 @@
-import sys
 import pytest
 
 from PySide6 import QtGui,QtWidgets
-from PySide6 import QtCore
 
 # Local
 from sas.qtgui.Plotting.BoxSum import BoxSum

--- a/src/sas/qtgui/Plotting/UnitTesting/ColorMapTest.py
+++ b/src/sas/qtgui/Plotting/UnitTesting/ColorMapTest.py
@@ -1,5 +1,3 @@
-import sys
-import numpy
 
 from PySide6 import QtGui, QtWidgets
 import pytest
@@ -10,7 +8,6 @@ mpl.use("Qt5Agg")
 
 from sas.qtgui.Plotting.PlotterData import Data2D
 import sas.qtgui.Plotting.Plotter2D as Plotter2D
-from sas.qtgui.UnitTesting.TestUtils import WarningTestNotImplemented
 from sas.qtgui.UnitTesting.TestUtils import QtSignalSpy
 
 # Local

--- a/src/sas/qtgui/Plotting/UnitTesting/LinearFitTest.py
+++ b/src/sas/qtgui/Plotting/UnitTesting/LinearFitTest.py
@@ -1,11 +1,10 @@
-import sys
 import numpy
 import pytest
 
 import matplotlib as mpl
 mpl.use("Qt5Agg")
 
-from PySide6 import QtGui, QtWidgets
+from PySide6 import QtWidgets
 
 from sas.qtgui.UnitTesting.TestUtils import QtSignalSpy
 

--- a/src/sas/qtgui/Plotting/UnitTesting/PlotPropertiesTest.py
+++ b/src/sas/qtgui/Plotting/UnitTesting/PlotPropertiesTest.py
@@ -1,4 +1,3 @@
-import sys
 
 import pytest
 

--- a/src/sas/qtgui/Plotting/UnitTesting/PlotUtilitiesTest.py
+++ b/src/sas/qtgui/Plotting/UnitTesting/PlotUtilitiesTest.py
@@ -1,4 +1,3 @@
-import sys
 from collections import OrderedDict
 
 from sas.qtgui.UnitTesting.TestUtils import WarningTestNotImplemented

--- a/src/sas/qtgui/Plotting/UnitTesting/Plotter2DTest.py
+++ b/src/sas/qtgui/Plotting/UnitTesting/Plotter2DTest.py
@@ -1,4 +1,3 @@
-import sys
 import numpy
 import platform
 import pytest
@@ -12,9 +11,7 @@ from PySide6 import QtCore
 from matplotlib.backends.backend_qt5agg import FigureCanvasQTAgg as FigureCanvas
 from mpl_toolkits.mplot3d import Axes3D
 
-from sas.qtgui.Plotting.PlotterData import Data1D
 from sas.qtgui.Plotting.PlotterData import Data2D
-from sas.qtgui.UnitTesting.TestUtils import WarningTestNotImplemented
 
 # Tested module
 import sas.qtgui.Plotting.Plotter2D as Plotter2D

--- a/src/sas/qtgui/Plotting/UnitTesting/PlotterBaseTest.py
+++ b/src/sas/qtgui/Plotting/UnitTesting/PlotterBaseTest.py
@@ -1,4 +1,3 @@
-import sys
 import platform
 
 import pytest
@@ -12,9 +11,7 @@ import matplotlib as mpl
 mpl.use("Qt5Agg")
 
 from PySide6 import QtGui, QtWidgets, QtPrintSupport
-import matplotlib.pyplot as plt
 from matplotlib.backends.backend_qt5agg import FigureCanvasQTAgg as FigureCanvas
-from matplotlib.backends.backend_qt5agg import NavigationToolbar2QT as NavigationToolbar
 
 from sas.qtgui.Plotting.ScaleProperties import ScaleProperties
 from sas.qtgui.Plotting.WindowTitle import WindowTitle

--- a/src/sas/qtgui/Plotting/UnitTesting/PlotterBaseTest.py
+++ b/src/sas/qtgui/Plotting/UnitTesting/PlotterBaseTest.py
@@ -5,7 +5,6 @@ import pytest
 import matplotlib as mpl
 mpl.use("Qt5Agg")
 
-import pytest
 
 import matplotlib as mpl
 mpl.use("Qt5Agg")

--- a/src/sas/qtgui/Plotting/UnitTesting/PlotterTest.py
+++ b/src/sas/qtgui/Plotting/UnitTesting/PlotterTest.py
@@ -1,4 +1,3 @@
-import sys
 import platform
 from unittest.mock import patch
 
@@ -12,10 +11,6 @@ from PySide6 import QtCore
 from matplotlib.backends.backend_qt5agg import FigureCanvasQTAgg as FigureCanvas
 
 from sas.qtgui.Plotting.PlotterData import Data1D
-from sas.qtgui.Plotting.PlotterData import Data2D
-from sas.qtgui.UnitTesting.TestUtils import WarningTestNotImplemented
-from sas.qtgui.Plotting.LinearFit import LinearFit
-from sas.qtgui.Plotting.PlotProperties import PlotProperties
 
 # Tested module
 import sas.qtgui.Plotting.Plotter as Plotter

--- a/src/sas/qtgui/Plotting/UnitTesting/QRangeSliderTests.py
+++ b/src/sas/qtgui/Plotting/UnitTesting/QRangeSliderTests.py
@@ -1,8 +1,6 @@
-import sys
 
 import pytest
 
-from PySide6 import QtCore, QtWidgets
 
 # Local
 from PySide6.QtWidgets import QMdiArea

--- a/src/sas/qtgui/Plotting/UnitTesting/ScalePropertiesTest.py
+++ b/src/sas/qtgui/Plotting/UnitTesting/ScalePropertiesTest.py
@@ -1,6 +1,5 @@
-import sys
 
-from PySide6 import QtGui, QtWidgets
+from PySide6 import QtWidgets
 import pytest
 
 # Local

--- a/src/sas/qtgui/Plotting/UnitTesting/SetGraphRangeTest.py
+++ b/src/sas/qtgui/Plotting/UnitTesting/SetGraphRangeTest.py
@@ -1,4 +1,3 @@
-import sys
 
 import pytest
 

--- a/src/sas/qtgui/Plotting/UnitTesting/SlicerModelTest.py
+++ b/src/sas/qtgui/Plotting/UnitTesting/SlicerModelTest.py
@@ -1,9 +1,7 @@
-import sys
 
 import pytest
 
-from PySide6 import QtGui, QtWidgets
-from PySide6 import QtCore
+from PySide6 import QtGui
 
 # Local
 from sas.qtgui.Plotting.SlicerModel import SlicerModel

--- a/src/sas/qtgui/Plotting/UnitTesting/SlicerParametersTest.py
+++ b/src/sas/qtgui/Plotting/UnitTesting/SlicerParametersTest.py
@@ -1,4 +1,3 @@
-import sys
 import webbrowser
 
 import pytest

--- a/src/sas/qtgui/Plotting/UnitTesting/WindowTitleTest.py
+++ b/src/sas/qtgui/Plotting/UnitTesting/WindowTitleTest.py
@@ -1,8 +1,7 @@
-import sys
 
 import pytest
 
-from PySide6 import QtGui, QtWidgets
+from PySide6 import QtWidgets
 
 # Local
 from sas.qtgui.Plotting.WindowTitle import WindowTitle

--- a/src/sas/qtgui/Plotting/WindowTitle.py
+++ b/src/sas/qtgui/Plotting/WindowTitle.py
@@ -2,7 +2,7 @@
 Allows users to change the title of the current graph
 from "Graph_n" to any ASCII text.
 """
-from PySide6 import QtWidgets, QtCore
+from PySide6 import QtWidgets
 
 from sas.qtgui.Plotting.UI.WindowTitleUI import Ui_WindowTitle
 

--- a/src/sas/qtgui/UnitTesting/TestUtilsTest.py
+++ b/src/sas/qtgui/UnitTesting/TestUtilsTest.py
@@ -1,8 +1,6 @@
-import sys
 
 from PySide6.QtGui import *
 from PySide6.QtWidgets import *
-from PySide6.QtTest import QTest
 from PySide6.QtCore import *
 
 # Local

--- a/src/sas/qtgui/Utilities/About/About.py
+++ b/src/sas/qtgui/Utilities/About/About.py
@@ -1,7 +1,7 @@
 import functools
 
 from PySide6.QtCore import QSize
-from PySide6.QtGui import QPixmap, QIcon, QCloseEvent
+from PySide6.QtGui import QPixmap, QIcon
 from PySide6.QtWidgets import QWidget, QVBoxLayout, QLabel, QHBoxLayout, QSizePolicy, QSpacerItem, QFrame, QPushButton, \
     QGridLayout, QDialog
 

--- a/src/sas/qtgui/Utilities/CategoryInstaller.py
+++ b/src/sas/qtgui/Utilities/CategoryInstaller.py
@@ -9,7 +9,6 @@ Copyright (c) Institut Laue-Langevin 2012
 """
 
 import os
-import sys
 import json
 import logging
 from collections import defaultdict, OrderedDict

--- a/src/sas/qtgui/Utilities/ConnectionProxy.py
+++ b/src/sas/qtgui/Utilities/ConnectionProxy.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-import urllib.request, urllib.error, urllib.parse
+import urllib.request
+import urllib.error
+import urllib.parse
 import sys
 import json
 import logging

--- a/src/sas/qtgui/Utilities/CustomGUI/ParameterTree.py
+++ b/src/sas/qtgui/Utilities/CustomGUI/ParameterTree.py
@@ -1,6 +1,6 @@
-from PySide6.QtWidgets import QApplication, QTreeWidget, QTreeWidgetItem, QVBoxLayout, QWidget
+from PySide6.QtWidgets import QTreeWidget
 from PySide6.QtGui import QPainter, QPen, QColor, QFont
-from PySide6.QtCore import Qt, QRect
+from PySide6.QtCore import Qt
 
 class QParameterTreeWidget(QTreeWidget):
     def __init__(self, *args, **kwargs):

--- a/src/sas/qtgui/Utilities/DocViewWidget.py
+++ b/src/sas/qtgui/Utilities/DocViewWidget.py
@@ -233,7 +233,7 @@ class DocViewWindow(QtWidgets.QDialog, Ui_DocViewerWindow):
             rst_time = os.path.getmtime(src)
             html_time = os.path.getmtime(html)
             return not html_exists or rst_time > html_time
-        except Exception as e:
+        except Exception:
             # Catch exception for debugging
             return True
 

--- a/src/sas/qtgui/Utilities/FileConverter.py
+++ b/src/sas/qtgui/Utilities/FileConverter.py
@@ -7,7 +7,7 @@ import logging
 
 import numpy as np
 
-from PySide6 import QtWidgets, QtCore, QtGui
+from PySide6 import QtWidgets
 from PySide6.QtCore import QSize
 from PySide6.QtGui import QIcon
 

--- a/src/sas/qtgui/Utilities/FileConverter.py
+++ b/src/sas/qtgui/Utilities/FileConverter.py
@@ -331,9 +331,9 @@ class FileConverterWidget(QtWidgets.QDialog, Ui_FileConverterUI):
         # Check/add extension
         filename_tuple = os.path.splitext(text)
         ext = filename_tuple[1]
-        if not ext.lower() in ('.xml', '.h5'):
+        if ext.lower() not in ('.xml', '.h5'):
             text += '.h5'
-        if not self.is1D and not '.h5' in ext.lower():
+        if not self.is1D and '.h5' not in ext.lower():
             # quietly add .h5 as extension
             text += '.h5'
 
@@ -356,7 +356,7 @@ class FileConverterWidget(QtWidgets.QDialog, Ui_FileConverterUI):
         Enable/disable UI items based on input format spec
         """
         # ASCII 2D allows for one file only
-        self.is1D = not '2D' in self.cbInputFormat.currentText()
+        self.is1D = '2D' not in self.cbInputFormat.currentText()
         self.label_7.setVisible(self.is1D)
         self.txtQFile.setVisible(self.is1D)
         self.btnQFile.setVisible(self.is1D)

--- a/src/sas/qtgui/Utilities/GridPanel.py
+++ b/src/sas/qtgui/Utilities/GridPanel.py
@@ -2,10 +2,9 @@ import os
 import sys
 import time
 import logging
-import webbrowser
 
 from PySide6 import QtCore, QtWidgets, QtGui
-from PySide6.QtCore import QMimeType, QMimeDatabase, QUrl
+from PySide6.QtCore import QMimeDatabase, QUrl
 from PySide6.QtGui import QDesktopServices
 
 import sas.qtgui.Utilities.GuiUtils as GuiUtils

--- a/src/sas/qtgui/Utilities/GuiUtils.py
+++ b/src/sas/qtgui/Utilities/GuiUtils.py
@@ -754,7 +754,7 @@ class FormulaValidator(QtGui.QValidator):
             self._setStyleSheet("")
             return QtGui.QValidator.Acceptable
 
-        except Exception as e:
+        except Exception:
             self._setStyleSheet("background-color:pink;")
             return QtGui.QValidator.Intermediate
 

--- a/src/sas/qtgui/Utilities/GuiUtils.py
+++ b/src/sas/qtgui/Utilities/GuiUtils.py
@@ -1330,7 +1330,6 @@ def readProjectFromSVS(filepath):
     """
     Read old SVS file and convert to the project dictionary
     """
-    from sasdata.dataloader.readers.cansas_reader import Reader as CansasReader
     from sas.sascalc.fit.pagestate import Reader
 
     loader = Loader()

--- a/src/sas/qtgui/Utilities/HidableDialog.py
+++ b/src/sas/qtgui/Utilities/HidableDialog.py
@@ -1,6 +1,5 @@
 from typing import NamedTuple
 
-from PySide6 import QtGui
 from PySide6 import QtWidgets
 
 

--- a/src/sas/qtgui/Utilities/IPythonWidget.py
+++ b/src/sas/qtgui/Utilities/IPythonWidget.py
@@ -1,8 +1,4 @@
-from PySide6 import QtCore
-from PySide6 import QtGui
-from PySide6 import QtWidgets
 
-from PySide6 import QtSvg
 
 from sas.qtgui.Utilities import GuiUtils
 

--- a/src/sas/qtgui/Utilities/ModelEditors/AddMultEditor/AddMultEditor.py
+++ b/src/sas/qtgui/Utilities/ModelEditors/AddMultEditor/AddMultEditor.py
@@ -4,12 +4,10 @@ Widget for simple add / multiply editor.
 # numpy methods required for the validator! Don't remove.
 # pylint: disable=unused-import,unused-wildcard-import,redefined-builtin
 from numpy import *
-import numpy as np
 
 from PySide6 import QtCore
 from PySide6 import QtGui
 from PySide6 import QtWidgets
-import webbrowser
 
 import os
 import logging

--- a/src/sas/qtgui/Utilities/MuMag/MuMag.py
+++ b/src/sas/qtgui/Utilities/MuMag/MuMag.py
@@ -153,7 +153,7 @@ class MuMag(QtWidgets.QMainWindow, Ui_MuMagTool):
         a_max = self.aMaxSpinBox.value()
 
         if a_max <= a_min:
-            raise ValueError(f"minimum A must be less than maximum A")
+            raise ValueError("minimum A must be less than maximum A")
 
         match self.ScatteringGeometrySelect.currentText().lower():
             case "parallel":

--- a/src/sas/qtgui/Utilities/MuMag/MuMag.py
+++ b/src/sas/qtgui/Utilities/MuMag/MuMag.py
@@ -1,4 +1,3 @@
-import webbrowser
 
 from sas.qtgui.Utilities.MuMag.UI.MuMagUI import Ui_MuMagTool
 from PySide6.QtWidgets import QVBoxLayout

--- a/src/sas/qtgui/Utilities/MuMag/MuMagLib.py
+++ b/src/sas/qtgui/Utilities/MuMag/MuMagLib.py
@@ -482,7 +482,7 @@ class MuMagLib:
             os.mkdir(path)
 
         with open(os.path.join(path, "fit_info.txt"), "w") as fid:
-            fid.write(f"FitMagneticSANS Toolbox - SimpleFit Results Info File \n\n")
+            fid.write("FitMagneticSANS Toolbox - SimpleFit Results Info File \n\n")
             fid.write(f"Timestamp: {timestamp}\n")
             fid.write(f"SANS geometry: {data.parameters.experiment_geometry.name}\n\n")
             fid.write(f"Maximal Scattering Vector:  q_max = {np.max(data.refined_fit_data.q)} /nm\n")

--- a/src/sas/qtgui/Utilities/MuMag/MuMagLib.py
+++ b/src/sas/qtgui/Utilities/MuMag/MuMagLib.py
@@ -1,12 +1,10 @@
 import numpy as np
-import matplotlib.pylab as pl
 import os
 import os.path
 from datetime import datetime
 
 import scipy.optimize
 
-from PySide6 import QtWidgets
 from PySide6.QtWidgets import QFileDialog
 
 from sas.qtgui.Utilities.MuMag.datastructures import ExperimentalData, LoadFailure, FitFailure, ExperimentGeometry, \

--- a/src/sas/qtgui/Utilities/NewVersion/NewVersionAvailable.py
+++ b/src/sas/qtgui/Utilities/NewVersion/NewVersionAvailable.py
@@ -3,7 +3,6 @@ from copy import copy
 from typing import Optional
 
 import json
-import re
 from packaging.version import Version, parse
 
 from PySide6.QtCore import QSize
@@ -13,7 +12,7 @@ from PySide6.QtWidgets import QDialog, QVBoxLayout, QHBoxLayout, QLabel, QWidget
 
 import logging
 
-from sas import config, system
+from sas import config
 from sas.qtgui.Utilities.ConnectionProxy import ConnectionProxy
 from sas.system import web
 

--- a/src/sas/qtgui/Utilities/NewVersion/NewVersionAvailable.py
+++ b/src/sas/qtgui/Utilities/NewVersion/NewVersionAvailable.py
@@ -41,9 +41,9 @@ class NewVersionAvailable(QDialog):
 
         self.setLayout(vertical_layout)
 
-        text = QLabel(f"<p>A new version of sasview is available.</p>"
-                       f""
-                       f"<p><center>Visit the download page?</centre></p><p/>")
+        text = QLabel("<p>A new version of sasview is available.</p>"
+                       ""
+                       "<p><center>Visit the download page?</centre></p><p/>")
 
         vertical_layout.addWidget(text)
 

--- a/src/sas/qtgui/Utilities/OrientationViewer/OrientationViewer.py
+++ b/src/sas/qtgui/Utilities/OrientationViewer/OrientationViewer.py
@@ -1,5 +1,4 @@
-import webbrowser
-from typing import Optional, List
+from typing import Optional
 
 import numpy as np
 from PySide6.QtGui import QIcon
@@ -9,7 +8,6 @@ from PySide6 import QtWidgets
 from PySide6.QtWidgets import QSizePolicy
 from PySide6.QtCore import Qt, QSize
 
-from sas.qtgui.Utilities.DocViewWidget import DocViewWindow
 from sasmodels.core import load_model_info, build_model
 from sasmodels.data import empty_data2D
 from sasmodels.direct_model import DirectModel

--- a/src/sas/qtgui/Utilities/PluginManager.py
+++ b/src/sas/qtgui/Utilities/PluginManager.py
@@ -3,7 +3,7 @@ import os
 from shutil import copyfile
 import logging
 
-from PySide6 import QtWidgets, QtCore
+from PySide6 import QtWidgets
 
 from sas.sascalc.fit import models
 from sas.qtgui.Utilities.ModelEditors.TabbedEditor.TabbedModelEditor import TabbedModelEditor

--- a/src/sas/qtgui/Utilities/PluginManager.py
+++ b/src/sas/qtgui/Utilities/PluginManager.py
@@ -122,7 +122,7 @@ class PluginManager(QtWidgets.QDialog, Ui_PluginManagerUI):
             logging.info(model_results)
         # We can't guarantee the type of the exception coming from
         # Sasmodels, so need the overreaching general Exception
-        except Exception as ex:
+        except Exception:
             msg = "Invalid plugin: %s " % file_name
             msgbox = QtWidgets.QMessageBox()
             msgbox.setIcon(QtWidgets.QMessageBox.Critical)

--- a/src/sas/qtgui/Utilities/Preferences/UnitTesting/PreferencesPanelTest.py
+++ b/src/sas/qtgui/Utilities/Preferences/UnitTesting/PreferencesPanelTest.py
@@ -1,6 +1,5 @@
 import pytest
-from PySide6.QtWidgets import QWidget, QLineEdit, QComboBox, QCheckBox
-from PySide6.QtGui import QIntValidator, QDoubleValidator
+from PySide6.QtWidgets import QWidget
 
 
 from sas.qtgui.Plotting.PlotterData import Data1D

--- a/src/sas/qtgui/Utilities/ReactorCore.py
+++ b/src/sas/qtgui/Utilities/ReactorCore.py
@@ -412,7 +412,7 @@ def win32install():
 
 
 if runtime.platform.getType() == 'win32':
-    from win32event import CreateEvent, MsgWaitForMultipleObjects
+    from win32event import MsgWaitForMultipleObjects
     from win32event import WAIT_OBJECT_0, WAIT_TIMEOUT, QS_ALLINPUT, QS_ALLEVENTS
     install = win32install
 else:

--- a/src/sas/qtgui/Utilities/Reports/ReportDialog.py
+++ b/src/sas/qtgui/Utilities/Reports/ReportDialog.py
@@ -145,7 +145,7 @@ class ReportDialog(QtWidgets.QDialog, Ui_ReportDialogUI):
                                             encoding='UTF-8')
                 return pisaStatus.err
 
-        except Exception as ex:
+        except Exception:
             # logging.error("Error creating pdf: " + str(ex))
             logging.error("Error creating pdf: " + traceback.format_exc())
         return False

--- a/src/sas/qtgui/Utilities/Reports/ReportDialog.py
+++ b/src/sas/qtgui/Utilities/Reports/ReportDialog.py
@@ -1,6 +1,4 @@
 import os
-import sys
-import re
 import logging
 import traceback
 from typing import Optional

--- a/src/sas/qtgui/Utilities/ResultPanel.py
+++ b/src/sas/qtgui/Utilities/ResultPanel.py
@@ -35,7 +35,6 @@ class ResultPanel(QtWidgets.QTabWidget):
 
     def onPlotResults(self, results, optimizer="Unknown"):
         # import moved here due to its cost
-        from bumps.dream.stats import var_stats, format_vars
         self.clearAnyData()
 
         result = results[0][0]

--- a/src/sas/qtgui/Utilities/SasviewLogger.py
+++ b/src/sas/qtgui/Utilities/SasviewLogger.py
@@ -1,5 +1,3 @@
-import os
-import sys
 import logging
 
 from PySide6.QtCore import QObject, Signal

--- a/src/sas/qtgui/Utilities/UnitTesting/AddMultEditorTest.py
+++ b/src/sas/qtgui/Utilities/UnitTesting/AddMultEditorTest.py
@@ -1,4 +1,3 @@
-import sys
 import os
 
 import pytest

--- a/src/sas/qtgui/Utilities/UnitTesting/FileConverterTest.py
+++ b/src/sas/qtgui/Utilities/UnitTesting/FileConverterTest.py
@@ -1,4 +1,3 @@
-import sys
 import os
 import numpy as np
 from lxml import etree

--- a/src/sas/qtgui/Utilities/UnitTesting/GridPanelTest.py
+++ b/src/sas/qtgui/Utilities/UnitTesting/GridPanelTest.py
@@ -1,12 +1,10 @@
-import sys
 import numpy as np
 from unittest.mock import mock_open, patch
-import webbrowser
 import logging
 
 import pytest
 
-from PySide6 import QtGui, QtWidgets
+from PySide6 import QtWidgets
 
 from sas.qtgui.UnitTesting.TestUtils import QtSignalSpy
 

--- a/src/sas/qtgui/Utilities/UnitTesting/GuiUtilsTest.py
+++ b/src/sas/qtgui/Utilities/UnitTesting/GuiUtilsTest.py
@@ -1,4 +1,3 @@
-import sys
 import webbrowser
 import pytest
 

--- a/src/sas/qtgui/Utilities/UnitTesting/ModelEditorTest.py
+++ b/src/sas/qtgui/Utilities/UnitTesting/ModelEditorTest.py
@@ -1,5 +1,3 @@
-import sys
-import logging
 import pytest
 
 from PySide6.QtGui import *

--- a/src/sas/qtgui/Utilities/UnitTesting/PluginDefinitionTest.py
+++ b/src/sas/qtgui/Utilities/UnitTesting/PluginDefinitionTest.py
@@ -1,5 +1,3 @@
-import sys
-import logging
 import pytest
 
 from PySide6.QtGui import *

--- a/src/sas/qtgui/Utilities/UnitTesting/SasviewLoggerTest.py
+++ b/src/sas/qtgui/Utilities/UnitTesting/SasviewLoggerTest.py
@@ -1,4 +1,3 @@
-import sys
 import logging
 import pytest
 

--- a/src/sas/qtgui/Utilities/UnitTesting/TabbedModelEditorTest.py
+++ b/src/sas/qtgui/Utilities/UnitTesting/TabbedModelEditorTest.py
@@ -1,6 +1,4 @@
 import os
-import sys
-import logging
 
 import pytest
 
@@ -8,7 +6,6 @@ from PySide6.QtGui import *
 from PySide6.QtCore import *
 from PySide6.QtWidgets import *
 
-from sas.qtgui.UnitTesting.TestUtils import QtSignalSpy
 
 # Local
 import sas.qtgui.Utilities.GuiUtils as GuiUtils

--- a/src/sas/qtgui/Utilities/WhatsNew/WhatsNew.py
+++ b/src/sas/qtgui/Utilities/WhatsNew/WhatsNew.py
@@ -1,7 +1,7 @@
 from collections import defaultdict
 
 from PySide6 import QtWidgets
-from PySide6.QtGui import QImage, QPixmap, QIcon
+from PySide6.QtGui import QPixmap, QIcon
 from PySide6.QtWidgets import QDialog, QWidget, QTextBrowser, QVBoxLayout, QHBoxLayout, QPushButton, QCheckBox
 from PySide6.QtCore import QUrl, QSize
 
@@ -226,7 +226,6 @@ class WhatsNew(QDialog):
 def main():
     """ Demo/testing window"""
 
-    from sas.qtgui.convertUI import main
 
     app = QtWidgets.QApplication([])
 

--- a/src/sas/qtgui/Utilities/WhatsNew/newer.py
+++ b/src/sas/qtgui/Utilities/WhatsNew/newer.py
@@ -1,5 +1,4 @@
 from typing import Tuple
-import re
 
 from packaging.version import parse, Version, InvalidVersion
 

--- a/src/sas/qtgui/Utilities/WhatsNew/newer.py
+++ b/src/sas/qtgui/Utilities/WhatsNew/newer.py
@@ -9,7 +9,7 @@ def reduced_version(version_string: str) -> Tuple[int, int, int]:
 
     try:
         version = parse(version_string)
-    except InvalidVersion as e:
+    except InvalidVersion:
         raise ValueError(f"{version_string} not a valid version string")
 
     return (version.major, version.minor, version.micro)

--- a/src/sas/sascalc/calculator/ausaxs/ausaxs_sans_debye.py
+++ b/src/sas/sascalc/calculator/ausaxs/ausaxs_sans_debye.py
@@ -77,7 +77,7 @@ def _invoke_independent(q, coords, w, queue):
     This will redo the import every time it is called, and is only intended for use in a subprocess.
     """
     ausaxs, ausaxs_state = _attach_hooks()
-    if not ausaxs_state is lib_state.READY:
+    if ausaxs_state is not lib_state.READY:
         queue.put(None)
         queue.put(-1)
         return

--- a/src/sas/sascalc/calculator/gsc_model.py
+++ b/src/sas/sascalc/calculator/gsc_model.py
@@ -1,7 +1,6 @@
 """
 create plugin model from the Generic Scattering Calculator
 """
-import logging
 import math
 from pathlib import Path
 

--- a/src/sas/sascalc/calculator/resolution_calculator.py
+++ b/src/sas/sascalc/calculator/resolution_calculator.py
@@ -3,7 +3,6 @@ This object is a small tool to allow user to quickly
 determine the variance in q  from the
 instrumental parameters.
 """
-import sys
 from math import pi, sqrt
 import math
 import logging

--- a/src/sas/sascalc/calculator/sas_gen.py
+++ b/src/sas/sascalc/calculator/sas_gen.py
@@ -1261,7 +1261,7 @@ class PDBReader(object):
                                 index = int(part) - 1
                                 bonded_indices.append(index)
 
-                            except ValueError as ve:
+                            except ValueError:
                                 pass
 
                         # Store pairs in canonical order

--- a/src/sas/sascalc/corfunc/corfunc_calculator.py
+++ b/src/sas/sascalc/corfunc/corfunc_calculator.py
@@ -4,8 +4,6 @@ This module implements corfunc
 
 
 from typing import Optional, Tuple, Callable
-from dataclasses import dataclass
-from enum import Enum
 
 import numpy as np
 import scipy.optimize
@@ -27,8 +25,6 @@ from sas.sascalc.corfunc.calculation_data import (TransformedData,
 
 
 from sasdata.dataloader.data_info import Data1D
-from sas.sascalc.corfunc.transform_thread import FourierThread
-from sas.sascalc.corfunc.transform_thread import HilbertThread
 from sas.sascalc.corfunc.smoothing import SmoothJoin
 
 

--- a/src/sas/sascalc/corfunc/smoothing.py
+++ b/src/sas/sascalc/corfunc/smoothing.py
@@ -1,7 +1,6 @@
 import numpy as np
-import warnings
 
-from typing import Optional, Callable, Union
+from typing import Optional, Callable
 from collections import namedtuple
 
 

--- a/src/sas/sascalc/corfunc/vectorisation.py
+++ b/src/sas/sascalc/corfunc/vectorisation.py
@@ -1,5 +1,5 @@
 import numpy as np
-from typing import Union, Callable, Any
+from typing import Union, Callable
 
 # TODO: Proper typing when newer numpy (>1.20) is supported
 ArrayLike = Union[np.ndarray, float, int]

--- a/src/sas/sascalc/data_util/calcthread.py
+++ b/src/sas/sascalc/data_util/calcthread.py
@@ -225,7 +225,7 @@ class CalcThread:
     def compute(self, *args, **kwargs):
         """Perform a work unit.  The subclass will provide details of
         the arguments."""
-        raise NotImplemented("Calculation thread needs compute method")
+        raise NotImplementedError("Calculation thread needs compute method")
 
     def exception(self):
         """

--- a/src/sas/sascalc/doc_regen/regenmodel.py
+++ b/src/sas/sascalc/doc_regen/regenmodel.py
@@ -40,13 +40,12 @@ have one.
 
 import sys
 import os
-from os.path import basename, dirname, realpath, join as joinpath, exists
+from os.path import basename, dirname, join as joinpath, exists
 from pathlib import Path
 import math
 import re
 import shutil
 import argparse
-import subprocess
 
 import matplotlib.axes
 from os import makedirs
@@ -59,7 +58,7 @@ from sasmodels.data import empty_data1D, empty_data2D
 
 from sas.sascalc.doc_regen.makedocumentation import MAIN_DOC_SRC, generate_html, PATH_LIKE
 
-from typing import Any, Dict, Union
+from typing import Any, Dict
 from sasmodels.kernel import KernelModel
 from sasmodels.modelinfo import ModelInfo
 

--- a/src/sas/sascalc/doc_regen/regentoc.py
+++ b/src/sas/sascalc/doc_regen/regentoc.py
@@ -2,14 +2,12 @@ import sys
 # make sure sasmodels is on the path
 sys.path.append('..')
 
-import os
 from os import mkdir
 from os.path import basename, exists, join as joinpath
-from pathlib import Path
 from sasmodels.core import load_model_info
 from sas.sascalc.doc_regen.makedocumentation import MAIN_DOC_SRC, PATH_LIKE
 
-from typing import Optional, IO, BinaryIO, Union
+from typing import Optional, IO, BinaryIO
 
 
 TEMPLATE = """\

--- a/src/sas/sascalc/fit/AbstractFitEngine.py
+++ b/src/sas/sascalc/fit/AbstractFitEngine.py
@@ -2,7 +2,6 @@ from __future__ import print_function
 
 import  copy
 #import logging
-import sys
 import math
 import numpy as np
 

--- a/src/sas/sascalc/fit/AbstractFitEngine.py
+++ b/src/sas/sascalc/fit/AbstractFitEngine.py
@@ -542,7 +542,7 @@ class FitArrange:
 
         :param data: Data to add in the list
         """
-        if not data in self.data_list:
+        if data not in self.data_list:
             self.data_list.append(data)
 
     def get_model(self):

--- a/src/sas/sascalc/fit/BumpsFitting.py
+++ b/src/sas/sascalc/fit/BumpsFitting.py
@@ -10,7 +10,6 @@ import uncertainties
 
 import numpy as np
 
-import bumps
 from bumps import fitters
 try:
     from bumps.options import FIT_CONFIG

--- a/src/sas/sascalc/fit/MultiplicationModel.py
+++ b/src/sas/sascalc/fit/MultiplicationModel.py
@@ -62,7 +62,7 @@ class MultiplicationModel(BaseComponent):
         for item in self.p_model.magnetic_params:
             self.magnetic_params.append(item)
         for item in self.s_model.orientation_params:
-            if not item in self.orientation_params:
+            if item not in self.orientation_params:
                 self.orientation_params.append(item)
         # get multiplicity if model provide it, else 1.
         try:
@@ -135,12 +135,12 @@ class MultiplicationModel(BaseComponent):
         """
 
         for name , value in self.p_model.params.items():
-            if not name in self.params.keys() and name not in self.excluded_params:
+            if name not in self.params.keys() and name not in self.excluded_params:
                 self.params[name] = value
 
         for name , value in self.s_model.params.items():
             #Remove the radius_effective from the (P*S) model parameters.
-            if not name in self.params.keys() and name not in self.excluded_params:
+            if name not in self.params.keys() and name not in self.excluded_params:
                 self.params[name] = value
 
         # Set "scale and effec_radius to P and S model as initializing
@@ -159,7 +159,7 @@ class MultiplicationModel(BaseComponent):
                 self.details[name] = detail
 
         for name , detail in self.s_model.details.items():
-            if not name in self.details.keys() or name not in self.exluded_params:
+            if name not in self.details.keys() or name not in self.exluded_params:
                 self.details[name] = detail
 
     def _set_backgrounds(self):
@@ -190,7 +190,7 @@ class MultiplicationModel(BaseComponent):
         """
         Set effective radius to S(Q) model
         """
-        if not 'radius_effective' in self.s_model.params.keys():
+        if 'radius_effective' not in self.s_model.params.keys():
             return
         effective_radius = self.p_model.calculate_ER()
         #Reset the effective_radius of s_model just before the run

--- a/src/sas/sascalc/fit/expression.py
+++ b/src/sas/sascalc/fit/expression.py
@@ -584,7 +584,7 @@ def test_expr():
             p6 = TestParameter('broken', expression=expr)
             fn = compile_constraints(*world(p6))
             fn()
-        except Exception as msg:
+        except Exception:
             #print(msg)
             pass
         else:

--- a/src/sas/sascalc/fit/models.py
+++ b/src/sas/sascalc/fit/models.py
@@ -166,7 +166,7 @@ def find_plugin_models():
                 #if not model.name.startswith(PLUGIN_NAME_BASE):
                 #    model.name = PLUGIN_NAME_BASE + model.name
                 plugins[model.name] = model
-            except Exception as exc:
+            except Exception:
                 msg = traceback.format_exc()
                 msg += "\nwhile accessing model in %r" % path
                 plugin_log(msg)

--- a/src/sas/sascalc/fit/pagestate.py
+++ b/src/sas/sascalc/fit/pagestate.py
@@ -20,7 +20,6 @@ import logging
 import numpy as np
 import traceback
 
-import xml.dom.minidom
 from xml.dom.minidom import parseString
 from xml.dom.minidom import getDOMImplementation
 from lxml import etree
@@ -30,11 +29,8 @@ import sasmodels.weights
 
 from sas.system.version import __version__ as SASVIEW_VERSION
 
-import sasdata.dataloader
 from sasdata.dataloader.readers.cansas_reader import Reader as CansasReader
-from sasdata.dataloader.readers.cansas_reader import get_content, write_node
-from sasdata.dataloader.data_info import Data2D, Collimation, Detector
-from sasdata.dataloader.data_info import Process, Aperture
+from sasdata.dataloader.readers.cansas_reader import get_content
 
 logger = logging.getLogger(__name__)
 

--- a/src/sas/sascalc/fit/pagestate.py
+++ b/src/sas/sascalc/fit/pagestate.py
@@ -611,7 +611,7 @@ class PageState(object):
         for line in lines:
             # Skip lines which are not key: value pairs, which includes
             # blank lines and freeform notes in SASNotes fields.
-            if not ':' in line:
+            if ':' not in line:
                 #msg = "Report string expected 'name: value' but got %r" % line
                 #logger.error(msg)
                 continue

--- a/src/sas/sascalc/fit/qsmearing.py
+++ b/src/sas/sascalc/fit/qsmearing.py
@@ -8,12 +8,8 @@
 #See the license text in license.txt
 #copyright 2008, University of Tennessee
 ######################################################################
-import math
-import logging
-import sys
 
 import numpy as np  # type: ignore
-from numpy import pi, exp # type:ignore
 
 from sasmodels.resolution import Slit1D, Pinhole1D
 from sasmodels.sesans import SesansTransform

--- a/src/sas/sascalc/pr/calc.py
+++ b/src/sas/sascalc/pr/calc.py
@@ -4,16 +4,7 @@ Implements low level inversion functionality, with conditional Numba njit compil
 """
 from __future__ import division
 
-import sys
-import math
-import time
-import copy
-import os
-import re
-import logging
-import time
 
-from functools import reduce
 import numpy as np
 from numpy import pi
 

--- a/src/sas/sascalc/pr/distance_explorer.py
+++ b/src/sas/sascalc/pr/distance_explorer.py
@@ -15,7 +15,6 @@ of D_max value. User picks a number of points and a range of
 distances, then get a series of outputs as a function of D_max
 over that range.
 """
-import sys
 
 
 class Results(object):

--- a/src/sas/sascalc/pr/num_term.py
+++ b/src/sas/sascalc/pr/num_term.py
@@ -3,7 +3,6 @@ from __future__ import print_function, division
 import math
 import numpy as np
 import copy
-import sys
 import logging
 from sas.sascalc.pr.Invertor import Invertor
 

--- a/src/sas/sascalc/realspace/VolumeCanvas.py
+++ b/src/sas/sascalc/realspace/VolumeCanvas.py
@@ -28,7 +28,8 @@ from sas.sascalc.simulation.pointsmodelpy import pointsmodelpy
 from sas.sascalc.simulation.geoshapespy import geoshapespy
 
 
-import os.path, math
+import os.path
+import math
 
 class ShapeDescriptor(object):
     """

--- a/src/sas/sascalc/realspace/VolumeCanvas.py
+++ b/src/sas/sascalc/realspace/VolumeCanvas.py
@@ -426,7 +426,7 @@ class VolumeCanvas(BaseComponent):
                 raise ValueError("VolumeCanvas.getParam: Could not find "
                                  "%s" % name)
 
-            if not toks[1] in shapeinstance.params:
+            if toks[1] not in shapeinstance.params:
                 raise ValueError("VolumeCanvas.getParam: Could not find "
                                  "%s" % name)
 
@@ -460,7 +460,7 @@ class VolumeCanvas(BaseComponent):
                     param_list.append(fullname)
 
         else:
-            if not shapeid in self.shapes:
+            if shapeid not in self.shapes:
                 raise ValueError("VolumeCanvas: getParamList: Could not find "
                                  "%s" % shapeid)
 

--- a/src/sas/sascalc/simulation/analmodelpy/analmodelpy/__init__.py
+++ b/src/sas/sascalc/simulation/analmodelpy/analmodelpy/__init__.py
@@ -12,7 +12,7 @@
 # 
 
 def copyright():
-    return "analmodelpy pyre module: Copyright (c) 1998-2005 Michael A.G. Aivazis";
+    return "analmodelpy pyre module: Copyright (c) 1998-2005 Michael A.G. Aivazis"
 
 
 # version

--- a/src/sas/sascalc/simulation/geoshapespy/geoshapespy/__init__.py
+++ b/src/sas/sascalc/simulation/geoshapespy/geoshapespy/__init__.py
@@ -12,7 +12,7 @@
 # 
 
 def copyright():
-    return "geoshapespy pyre module: Copyright (c) 1998-2005 Michael A.G. Aivazis";
+    return "geoshapespy pyre module: Copyright (c) 1998-2005 Michael A.G. Aivazis"
 
 
 # version

--- a/src/sas/sascalc/simulation/iqPy/iqPy/__init__.py
+++ b/src/sas/sascalc/simulation/iqPy/iqPy/__init__.py
@@ -12,7 +12,7 @@
 # 
 
 def copyright():
-    return "iqPy pyre module: Copyright (c) 1998-2005 Michael A.G. Aivazis";
+    return "iqPy pyre module: Copyright (c) 1998-2005 Michael A.G. Aivazis"
 
 
 # version

--- a/src/sas/sascalc/simulation/pointsmodelpy/pointsmodelpy/__init__.py
+++ b/src/sas/sascalc/simulation/pointsmodelpy/pointsmodelpy/__init__.py
@@ -12,7 +12,7 @@
 # 
 
 def copyright():
-    return "pointsmodelpy pyre module: Copyright (c) 1998-2005 Michael A.G. Aivazis";
+    return "pointsmodelpy pyre module: Copyright (c) 1998-2005 Michael A.G. Aivazis"
 
 
 # version

--- a/src/sas/sascalc/simulation/pointsmodelpy/tests/test2dui.py
+++ b/src/sas/sascalc/simulation/pointsmodelpy/tests/test2dui.py
@@ -8,24 +8,16 @@ Demonstration of drawing a 2D image plot using the "hot" colormap
 #--------------------------------------------------------------------------------
 from __future__ import print_function
 
-import wx
 
-from enthought.traits import Any, Instance
-from enthought.enable.wx     import Window
-from enthought.pyface        import ApplicationWindow, GUI
-from enthought.util.numerix  import pi, concatenate, array, zeros, ones, \
-                                    arange, resize, ravel
-from enthought.util.numerix import Float as NumericFloat
+from enthought.pyface        import GUI
+from enthought.util.numerix  import arange
 from math import sqrt, sin
 
-from enthought.chaco.plot_component import PlotComponent
 from enthought.chaco.plot_axis import PlotAxis
-from enthought.chaco.plot_canvas import PlotCanvas
 from enthought.chaco.plot_group import PlotGroup
 from enthought.chaco.image_plot_value import ImageData, CmapImagePlotValue
-from enthought.chaco.colormap import LinearColormap
 from enthought.chaco.colormap_legend import ColormapLegend
-from enthought.chaco.default_colormaps import hot, gray
+from enthought.chaco.default_colormaps import hot
 from enthought.chaco.demo.demo_base import PlotApplicationWindow
 
 

--- a/src/sas/sascalc/simulation/pointsmodelpy/tests/testcomplexmodel.py
+++ b/src/sas/sascalc/simulation/pointsmodelpy/tests/testcomplexmodel.py
@@ -13,7 +13,7 @@ def test_complex():
     pointsmodelpy.pdbmodel_add(p,"ff0.pdb")
 
     vp = pointsmodelpy.new_point3dvec()
-    pointsmodelpy.get_pdbpoints(p,vp);
+    pointsmodelpy.get_pdbpoints(p,vp)
 
     pointsmodelpy.get_pdb_pr(p,vp)
     pointsmodelpy.save_pdb_pr(p,"testcomplex.pr")
@@ -27,17 +27,17 @@ def test_complex():
     lm = pointsmodelpy.new_loresmodel(0.1)
     pointsmodelpy.lores_add(lm,a,1.0)
 
-    vpcomplex = pointsmodelpy.new_point3dvec();
+    vpcomplex = pointsmodelpy.new_point3dvec()
     complex = pointsmodelpy.new_complexmodel()
-    pointsmodelpy.complexmodel_add(complex,p,"PDB");
-    pointsmodelpy.complexmodel_add(complex,lm,"LORES");
+    pointsmodelpy.complexmodel_add(complex,p,"PDB")
+    pointsmodelpy.complexmodel_add(complex,lm,"LORES")
     
-    pointsmodelpy.get_complexpoints(complex,vpcomplex);
-    pointsmodelpy.get_complex_pr(complex,vpcomplex);
-    pointsmodelpy.save_complex_pr(complex,"testcomplex1.pr");
+    pointsmodelpy.get_complexpoints(complex,vpcomplex)
+    pointsmodelpy.get_complex_pr(complex,vpcomplex)
+    pointsmodelpy.save_complex_pr(complex,"testcomplex1.pr")
 
     iqcomplex = iqPy.new_iq(100,0.001, 0.3)
-    pointsmodelpy.get_complex_iq(complex,iqcomplex);
+    pointsmodelpy.get_complex_iq(complex,iqcomplex)
 
     iqPy.OutputIQ(iq,"testcomplex1.iq")
 
@@ -49,13 +49,13 @@ def test_complex2():
   lores = pointsmodelpy.new_loresmodel(0.1)
 
   complex = pointsmodelpy.new_complexmodel()	
-  pointsmodelpy.complexmodel_add(complex,pdb,"PDB");
+  pointsmodelpy.complexmodel_add(complex,pdb,"PDB")
   pointsmodelpy.complexmodel_add(complex,lores,"LORES")
 
   points = pointsmodelpy.new_point3dvec()
   pointsmodelpy.get_complexpoints(complex,points)
 
-  pointsmodelpy.get_complex_pr(complex,points);
+  pointsmodelpy.get_complex_pr(complex,points)
   pointsmodelpy.save_complex_pr(complex,"testcomplex2.pr")
 
   iqcomplex = iqPy.new_iq(100,0.001, 0.3)
@@ -76,13 +76,13 @@ def test_complex3():
   pointsmodelpy.lores_add(lores,sph,1.0)
 
   complex = pointsmodelpy.new_complexmodel()	
-  pointsmodelpy.complexmodel_add(complex,pdb,"PDB");
+  pointsmodelpy.complexmodel_add(complex,pdb,"PDB")
   pointsmodelpy.complexmodel_add(complex,lores,"LORES")
 
   points = pointsmodelpy.new_point3dvec()
   pointsmodelpy.get_complexpoints(complex,points)
 
-  pointsmodelpy.get_complex_pr(complex,points);
+  pointsmodelpy.get_complex_pr(complex,points)
   pointsmodelpy.save_complex_pr(complex,"testcomplex3.pr")
 
   iqcomplex = iqPy.new_iq(100,0.001, 0.3)
@@ -102,14 +102,14 @@ def test_complex4():
     lm = pointsmodelpy.new_loresmodel(0.1)
     pointsmodelpy.lores_add(lm,a,1.0)
 
-    vpcomplex = pointsmodelpy.new_point3dvec();
+    vpcomplex = pointsmodelpy.new_point3dvec()
     complex = pointsmodelpy.new_complexmodel()
-    pointsmodelpy.complexmodel_add(complex,lm,"LORES");
+    pointsmodelpy.complexmodel_add(complex,lm,"LORES")
     
-    pointsmodelpy.get_complexpoints(complex,vpcomplex);
+    pointsmodelpy.get_complexpoints(complex,vpcomplex)
  
-    print(pointsmodelpy.get_complex_iq_2D(complex,vpcomplex,0.1,0.1));
-    print(pointsmodelpy.get_complex_iq_2D(complex,vpcomplex,0.01,0.1));
+    print(pointsmodelpy.get_complex_iq_2D(complex,vpcomplex,0.1,0.1))
+    print(pointsmodelpy.get_complex_iq_2D(complex,vpcomplex,0.01,0.1))
 
 
 if __name__ == "__main__":

--- a/src/sas/sascalc/simulation/pointsmodelpy/tests/testlores2d.py
+++ b/src/sas/sascalc/simulation/pointsmodelpy/tests/testlores2d.py
@@ -29,10 +29,8 @@ def test_lores2d(phi):
   iqPy.OutputIQ(iq, "out_xy.iq")
 
 def get2d():
-  from math import pi
-  from Numeric import arange,zeros
+  from Numeric import zeros
   from enthought.util.numerix import Float,zeros
-  from sasModeling.file2array import readfile2array
   from sasModeling.pointsmodelpy import pointsmodelpy
   from sasModeling.geoshapespy import geoshapespy
 
@@ -69,10 +67,8 @@ def get2d():
   return value_grid
 
 def get2d_2():
-  from math import pi
-  from Numeric import arange,zeros
+  from Numeric import zeros
   from enthought.util.numerix import Float,zeros
-  from sasModeling.file2array import readfile2array
   from sasModeling.pointsmodelpy import pointsmodelpy
   from sasModeling.geoshapespy import geoshapespy
 

--- a/src/sas/sascalc/simulation/pointsmodelpy/tests/testnegativepr.py
+++ b/src/sas/sascalc/simulation/pointsmodelpy/tests/testnegativepr.py
@@ -1,6 +1,5 @@
 if __name__ == "__main__":
   from sasModeling.pointsmodelpy import pointsmodelpy
-  from sasModeling.iqPy import iqPy
   from sasModeling.geoshapespy import geoshapespy
 
   a = geoshapespy.new_sphere(10)

--- a/src/sas/sascalc/size_distribution/SizeDistribution.py
+++ b/src/sas/sascalc/size_distribution/SizeDistribution.py
@@ -523,7 +523,7 @@ class sizeDistribution():
                 convergence.append([converged, conv_iter])
                 if (not converged):
                     logger.warning("Maximum Entropy did not converge. Try increasing the weight factor to increase the weighting effect.")
-            except ZeroDivisionError as e:
+            except ZeroDivisionError:
                 logger.error("Divide by Zero Error occured in maximum entropy fitting. Try increasing the weight factor to increase the error weighting")
 
         # If all bin magnitudes are NaN, raise an error and let the caller handle it

--- a/src/sas/sascalc/size_distribution/maxEnt_method.py
+++ b/src/sas/sascalc/size_distribution/maxEnt_method.py
@@ -261,10 +261,10 @@ class maxEntMethod():
             xi[0] = f * cgrad / cnorm
             xi[1] = f * (a * sgrad - b * cgrad)
             
-            eta[0] = np.dot(xi[0], Gqr.transpose());          # solution --> data
-            eta[1] = np.dot(xi[1], Gqr.transpose());          # solution --> data
+            eta[0] = np.dot(xi[0], Gqr.transpose())          # solution --> data
+            eta[1] = np.dot(xi[1], Gqr.transpose())          # solution --> data
             ox = eta[1] / (sigma * sigma)
-            xi[2] = np.dot(ox, Gqr);          # data --> solution
+            xi[2] = np.dot(ox, Gqr)          # data --> solution
             a = 1.0 / math.sqrt(sum(f * xi[2]*xi[2]))
             xi[2] = f * xi[2] * a
             eta[2] = np.dot(xi[2], Gqr.transpose())           # solution --> data

--- a/src/sas/system/config/config_meta.py
+++ b/src/sas/system/config/config_meta.py
@@ -1,5 +1,4 @@
-import re
-from typing import Dict, Any, List, Set
+from typing import Dict, Any, List
 import os
 import logging
 import json

--- a/src/sas/system/config/config_meta.py
+++ b/src/sas/system/config/config_meta.py
@@ -142,7 +142,7 @@ class ConfigBase:
                 self.load_from_file_object(file)
 
         else:
-            logger.warning(f"No config file found - one will be created when sasview exits")
+            logger.warning("No config file found - one will be created when sasview exits")
 
     def load_from_file_object(self, file):
         """ Load config file """

--- a/src/sas/system/config/schema_elements.py
+++ b/src/sas/system/config/schema_elements.py
@@ -108,7 +108,7 @@ class SchemaNonSpecified(SchemaElement):
         return isinstance(other, SchemaNonSpecified)
 
     def __repr__(self):
-        return f"SchemaNonSpecified"
+        return "SchemaNonSpecified"
 
 
 class SchemaList(SchemaElement):

--- a/src/sas/system/console.py
+++ b/src/sas/system/console.py
@@ -159,9 +159,6 @@ def setup_console_simple(stderr_to_stdout=True):
 def demo():
     setup_console()
     if 0:
-        import win32
-        from win32 import win32console
-        from win32 import win32gui
         from win32 import win32process, win32api
         pid = win32process.GetWindowThreadProcessId(hwnd)
         handle = win32api.OpenProcess(win32con.PROCESS_QUERY_INFORMATION | win32con.PROCESS_VM_READ, False, pid[1])

--- a/src/sas/system/console.py
+++ b/src/sas/system/console.py
@@ -1,7 +1,8 @@
 """
 Windows console binding for SasView
 """
-import os, sys
+import os
+import sys
 import atexit
 
 def attach_windows_console():

--- a/src/sas/webfit/analyze/admin.py
+++ b/src/sas/webfit/analyze/admin.py
@@ -1,3 +1,2 @@
-from django.contrib import admin
 
 # Register your models here.

--- a/src/sas/webfit/analyze/fitting/admin.py
+++ b/src/sas/webfit/analyze/fitting/admin.py
@@ -1,4 +1,2 @@
-from django.contrib import admin
-from .models import Fit, FitParameter
 
 # Register your models here.

--- a/src/sas/webfit/analyze/fitting/tests.py
+++ b/src/sas/webfit/analyze/fitting/tests.py
@@ -6,20 +6,12 @@ from django.conf import settings
 from django.test import TestCase
 from django.contrib.auth.models import User
 from django.shortcuts import get_object_or_404
-from rest_framework import status
-from rest_framework.test import APIRequestFactory, APIClient, force_authenticate, APITestCase
+from rest_framework.test import APIRequestFactory, APIClient, APITestCase
 
-from sasmodels.data import empty_data1D
 from sasdata.dataloader.loader import Loader
-import numpy as np
 
 from data.models import Data
-from .models import (
-    Fit,
-    FitParameter
-)
 from .views import (
-    start,
     start_fit,
 )
 

--- a/src/sas/webfit/analyze/fitting/urls.py
+++ b/src/sas/webfit/analyze/fitting/urls.py
@@ -1,5 +1,5 @@
 import logging
-from django.urls import path, re_path, include
+from django.urls import path, include
 from . import views
 
 logger = logging.getLogger(__name__)

--- a/src/sas/webfit/analyze/fitting/views.py
+++ b/src/sas/webfit/analyze/fitting/views.py
@@ -1,17 +1,15 @@
 import json
 from logging import getLogger
 
-from django.http import HttpResponseBadRequest, HttpResponseForbidden
+from django.http import HttpResponseBadRequest
 from django.shortcuts import get_object_or_404
 from rest_framework.response import Response
 from rest_framework.decorators import api_view
 
 from bumps.names import *
 from bumps import fitters
-from bumps.formatnum import format_uncertainty
-from sasdata.dataloader.loader import Loader
 from sasmodels.core import load_model, load_model_info, list_models
-from sasmodels.data import load_data, empty_data1D, empty_data2D, empty_sesans
+from sasmodels.data import load_data, empty_data1D
 from sasmodels.bumps_model import Model, Experiment
 from sasmodels.direct_model import DirectModel
 from sas.sascalc.fit.models import ModelManager

--- a/src/sas/webfit/analyze/urls.py
+++ b/src/sas/webfit/analyze/urls.py
@@ -1,7 +1,5 @@
 import logging
-from django.urls import path, re_path, include
-from analyze.fitting import views as fit_views
-from . import views
+from django.urls import path, include
 
 logger = logging.getLogger(__name__)
 

--- a/src/sas/webfit/analyze/views.py
+++ b/src/sas/webfit/analyze/views.py
@@ -1,18 +1,8 @@
 from logging import getLogger
 
-from django.shortcuts import render
-from django.http import HttpResponse, HttpResponseBadRequest, HttpResponseForbidden
-from django.shortcuts import get_object_or_404
-from rest_framework.response import Response
 from rest_framework.decorators import api_view
 
-from sasdata.dataloader.loader import Loader
 
-from serializers import FitSerializer
-from .models import (
-    AnalysisBase,
-    AnalysisParameterBase,
-)
 
 analysis_logger = getLogger(__name__)
 

--- a/src/sas/webfit/data/admin.py
+++ b/src/sas/webfit/data/admin.py
@@ -1,3 +1,2 @@
-from django.contrib import admin
 
 # Register your models here.

--- a/src/sas/webfit/data/forms.py
+++ b/src/sas/webfit/data/forms.py
@@ -1,6 +1,5 @@
 from django import forms
 from .models import Data
-from django.contrib.auth.models import User
 
 # Create the form class.
 class DataForm(forms.ModelForm):

--- a/src/sas/webfit/data/models.py
+++ b/src/sas/webfit/data/models.py
@@ -3,7 +3,6 @@ from logging import getLogger
 from django.db import models
 from django.contrib.auth.models import User
 from django.core.files.storage import FileSystemStorage 
-from django.utils.deconstruct import deconstructible
 
 models_logger = getLogger(__name__)
 

--- a/src/sas/webfit/data/tests.py
+++ b/src/sas/webfit/data/tests.py
@@ -1,22 +1,13 @@
-import os
 import shutil
-from glob import glob
-from pathlib import Path, PurePath
+from pathlib import Path
 
 from django.conf import settings
 from django.test import TestCase
 from django.contrib.auth.models import User
-from django.shortcuts import get_object_or_404
 from rest_framework import status
-from rest_framework.test import APIClient, force_authenticate, APITestCase
+from rest_framework.test import APIClient, APITestCase
 
 from .models import Data
-from .views import (
-    list_data,
-    data_info,
-    upload,
-    download
-)
 
 def find(filename):
     return Path(__file__).resolve().parent.parent.parent/'example_data'/'1d_data'/filename

--- a/src/sas/webfit/data/urls.py
+++ b/src/sas/webfit/data/urls.py
@@ -1,5 +1,5 @@
 import logging
-from django.urls import path, re_path, include
+from django.urls import path
 from . import views
 
 logger = logging.getLogger(__name__)

--- a/src/sas/webfit/data/views.py
+++ b/src/sas/webfit/data/views.py
@@ -5,7 +5,6 @@ from django.http import HttpResponseBadRequest, HttpResponseForbidden, Http404
 from django.core.files.storage import FileSystemStorage
 
 #TODO go over to see if token is needed for is_authenticated
-from rest_framework.authtoken.models import Token
 from rest_framework.response import Response
 from rest_framework.decorators import api_view
 

--- a/src/sas/webfit/serializers.py
+++ b/src/sas/webfit/serializers.py
@@ -2,8 +2,7 @@ from copy import deepcopy
 
 #from django.contrib.auth.models import Group, Permission
 #from django.contrib.contenttypes.models import ContentType
-from rest_framework import serializers, validators
-from rest_framework.fields import CharField, ChoiceField, DateTimeField, DecimalField, IntegerField
+from rest_framework import serializers
 from rest_framework.utils import model_meta
 from django.contrib.auth.models import User
 from dj_rest_auth.serializers import UserDetailsSerializer

--- a/src/sas/webfit/settings.py
+++ b/src/sas/webfit/settings.py
@@ -17,7 +17,6 @@ from django.core.signals import setting_changed
 from django.conf import settings
 # Import from `django.core.signals` instead of the official location
 # `django.test.signals` to avoid importing the test module unnecessarily.
-from django.core.signals import setting_changed
 from django.utils.module_loading import import_string
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.

--- a/src/sas/webfit/settings.py
+++ b/src/sas/webfit/settings.py
@@ -12,7 +12,6 @@ https://docs.djangoproject.com/en/4.2/ref/settings/
 
 import os
 from pathlib import Path
-from rest_framework import permissions, versioning
 from django.core.signals import setting_changed
 
 from django.conf import settings
@@ -20,7 +19,6 @@ from django.conf import settings
 # `django.test.signals` to avoid importing the test module unnecessarily.
 from django.core.signals import setting_changed
 from django.utils.module_loading import import_string
-from rest_framework import ISO_8601
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent

--- a/src/sas/webfit/upload_example_data.py
+++ b/src/sas/webfit/upload_example_data.py
@@ -1,7 +1,4 @@
 import os
-import re
-import sys
-import json
 import logging
 import django
 from glob import glob
@@ -11,8 +8,6 @@ from sasdata import example_data
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "settings")
 django.setup()
 
-from django.contrib.auth.models import User
-from django.core.files.uploadedfile import SimpleUploadedFile
 from data.models import Data
 
 EXAMPLE_DATA_DIR = os.environ.get("EXAMPLE_DATA_DIR", os.path.dirname(example_data.__file__))

--- a/src/sas/webfit/urls.py
+++ b/src/sas/webfit/urls.py
@@ -18,7 +18,6 @@ import logging
 
 from django.contrib import admin
 from django.urls import path, re_path, include
-from rest_framework import routers, serializers
 
 logger = logging.getLogger(__name__)
 

--- a/src/sas/webfit/user_app/admin.py
+++ b/src/sas/webfit/user_app/admin.py
@@ -1,3 +1,2 @@
-from django.contrib import admin
 
 # Register your models here.

--- a/src/sas/webfit/user_app/models.py
+++ b/src/sas/webfit/user_app/models.py
@@ -1,6 +1,4 @@
-from django.db import models
 from logging import getLogger
-from django.contrib.auth.models import User
 
 models_logger = getLogger(__name__)
 

--- a/src/sas/webfit/user_app/tests.py
+++ b/src/sas/webfit/user_app/tests.py
@@ -1,3 +1,2 @@
-from django.test import TestCase
 
 # Create your tests here.

--- a/src/sas/webfit/user_app/urls.py
+++ b/src/sas/webfit/user_app/urls.py
@@ -1,5 +1,5 @@
 import logging
-from django.urls import path, re_path, include
+from django.urls import path, include
 from .views import KnoxLoginView, KnoxRegisterView
 
 logger = logging.getLogger(__name__)

--- a/src/sas/webfit/versioning.py
+++ b/src/sas/webfit/versioning.py
@@ -1,4 +1,3 @@
-import re
 
 from django.utils.translation import gettext_lazy as _
 

--- a/test/corfunc/utest_corfunc.py
+++ b/test/corfunc/utest_corfunc.py
@@ -2,11 +2,9 @@
 Unit Tests for CorfuncCalculator class
 """
 
-from typing import Optional
 
 import os.path
 import unittest
-import time
 
 import numpy as np
 

--- a/test/pr_inversion/utest_explorer.py
+++ b/test/pr_inversion/utest_explorer.py
@@ -2,9 +2,8 @@
     Unit tests for DistExplorer class
 """
 
-import sys
 import os.path
-import unittest, math, numpy
+import unittest
 # TODO: This import is broken. It needs to be rewritten if this test is to be renabled.
 # from sas.sascalc.pr.invertor import Invertor
 import pytest

--- a/test/pr_inversion/utest_invertor.py
+++ b/test/pr_inversion/utest_invertor.py
@@ -584,7 +584,6 @@ def pr_theory(r, R):
 def load(path = find("sphere_60_q0_2.txt")):
     import numpy as np
     import math
-    import sys
     # Read the data from the data file
     data_x   = np.zeros(0)
     data_y   = np.zeros(0)

--- a/test/sascalculator/utest_sld.py
+++ b/test/sascalculator/utest_sld.py
@@ -4,11 +4,9 @@ import unittest
 _SCALE = 1e-6
 
 # the calculator default value for wavelength is 6
-import periodictable
 from periodictable import formula
 from periodictable.xsf import xray_energy, xray_sld_from_atoms
-from periodictable.constants import avogadro_number
-from  periodictable.nsf import neutron_scattering, neutron_sld
+from  periodictable.nsf import neutron_scattering
 
 
 def calculate_xray_sld(element, density, molecule_formula):

--- a/test/sasinvariant/utest_data_handling.py
+++ b/test/sasinvariant/utest_data_handling.py
@@ -51,7 +51,8 @@ class TestLinearFit(unittest.TestCase):
         """ 
             Simple linear fit with noise
         """
-        import random, math
+        import random
+        import math
     
         for i in range(len(self.data.y)):
             self.data.y[i] = self.data.y[i]+.1*(random.random()-0.5)
@@ -80,7 +81,8 @@ class TestLinearFit(unittest.TestCase):
         """ 
             Simple linear fit with noise
         """
-        import random, math
+        import random
+        import math
 
         for i in range(len(self.data.y)):
             self.data.y[i] = self.data.y[i]+.1*(random.random()-0.5)

--- a/test/sasrealspace/sim_validation.py
+++ b/test/sasrealspace/sim_validation.py
@@ -6,7 +6,9 @@
 """
 from __future__ import print_function
 
-import math, time, pylab
+import math
+import time
+import pylab
 
 try:
     import VolumeCanvas

--- a/test/sasrealspace/utest_oriented.py
+++ b/test/sasrealspace/utest_oriented.py
@@ -4,7 +4,8 @@
 """
 from __future__ import print_function
 
-import unittest, math
+import unittest
+import math
 
 # Disable "missing docstring" complaint
 # pylint: disable-msg=C0111

--- a/test/sasrealspace/utest_oriented.py
+++ b/test/sasrealspace/utest_oriented.py
@@ -4,7 +4,7 @@
 """
 from __future__ import print_function
 
-import unittest, math, sys
+import unittest, math
 
 # Disable "missing docstring" complaint
 # pylint: disable-msg=C0111

--- a/test/sasrealspace/utest_realspace.py
+++ b/test/sasrealspace/utest_realspace.py
@@ -4,7 +4,9 @@
 """
 from __future__ import print_function
 
-import unittest, math, time
+import unittest
+import math
+import time
 
 # Disable "missing docstring" complaint
 # pylint: disable-msg=C0111

--- a/test/utest_sasview.py
+++ b/test/utest_sasview.py
@@ -12,7 +12,7 @@ logging.config.fileConfig(LOGGER_CONFIG_FILE)
 logger = logging.getLogger(__name__)
 
 try:
-    import xmlrunner
+    pass
 except:
     logger.error("xmlrunner needs to be installed to run these tests")
     logger.error("Try easy_install unittest-xml-reporting")


### PR DESCRIPTION
## Description

I have run `ruff check` on the codebase and applied the automatic fixes to the errors with such a fix available. These mainly concern unused imports (see #3498 for full details).

Begins work on issue #3498 

## How Has This Been Tested?

There are no changes to the functionality of the code. The CI should pass.

## Review Checklist:

[if using the editor, use `[x]` in place of `[ ]` to check a box]

**Documentation** (check at least one)
- [x] There is **nothing** that needs documenting
- [ ] Documentation changes are **in this PR**
- [ ] There is an **issue** open for the documentation (link?)

**Installers**
- [ ] There is a chance this will affect the **installers**, if so
  - [ ] **Windows** installer (GH artifact) has been tested (installed and worked) 
  - [ ] **MacOSX** installer (GH artifact) has been tested (installed and worked)
  - [ ] **Wheels** installer (GH artifact) has been tested (installed and worked)

**Licensing** (untick if necessary)
- [x] The introduced changes comply with SasView license (BSD 3-Clause)

