### PR TITLE
Specify a requirement of at least Python 3.11 in the pyproject.toml 

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ dynamic = [
 ]
 description = "SasView application"
 readme = "README.md"
-requires-python = ">=3.9"
+requires-python = ">=3.11"
 license = { text = "BSD-3-Clause" }
 authors = [
     {name = "SasView Team", email = "developers@sasview.org"},


### PR DESCRIPTION
## Description

This raises the minimum Python version to Python 3.11. This is what we have been testing on for the release, so it makes sense to specify this in the `pyproject.toml` as well.

As per discussion in #3498

## How Has This Been Tested?

I haven't had a chance to, but presumably it should fail to install on Python versions < 3.11.

## Review Checklist:

**Documentation**
- [x] There is **nothing** that needs documenting
- [ ] Documentation changes are **in this PR**
- [ ] There is an **issue** open for the documentation (link?)

**Installers**
- [ ] There is a chance this will affect the **installers**, if so
  - [ ] **Windows** installer (GH artifact) has been tested (installed and worked) 
  - [ ] **MacOSX** installer (GH artifact) has been tested (installed and worked)
  - [ ] **Wheels** installer (GH artifact) has been tested (installed and worked)

**Licensing**
- [x] The introduced changes comply with SasView license (BSD 3-Clause)

