### PR TITLE
Fix Invariant Test Warnings

### DIFF
--- a/src/sas/sascalc/invariant/invariant.py
+++ b/src/sas/sascalc/invariant/invariant.py
@@ -360,7 +360,7 @@ class Extrapolator(object):
             try:
                 inv_cov = np.dot(A.transpose(), A)
                 cov = np.linalg.pinv(inv_cov)
-                err_matrix = math.fabs(residuals) * cov
+                err_matrix = np.fabs(residuals) * cov
                 err = [math.sqrt(err_matrix[0][0]), math.sqrt(err_matrix[1][1])]
             except:
                 err = [-1.0, -1.0]

--- a/src/sas/sascalc/invariant/invariant.py
+++ b/src/sas/sascalc/invariant/invariant.py
@@ -346,8 +346,8 @@ class Extrapolator(object):
                      np.ones(len(linearized_data.x)) * b - linearized_data.y
             residuals = np.sum(deltas * deltas / sigma2)
 
-            err = math.fabs(residuals) / np.sum(1.0 / sigma2)
-            return [a, b], [0, math.sqrt(err)]
+            err = np.fabs(residuals) / np.sum(1.0 / sigma2)
+            return [a, b], [0, np.sqrt(err)]
         else:
             A = np.vstack([linearized_data.x / linearized_data.dy, 1.0 / linearized_data.dy]).T
             # CRUFT: numpy>=1.14.0 allows rcond=None for the following default
@@ -361,7 +361,7 @@ class Extrapolator(object):
                 inv_cov = np.dot(A.transpose(), A)
                 cov = np.linalg.pinv(inv_cov)
                 err_matrix = np.fabs(residuals) * cov
-                err = [math.sqrt(err_matrix[0][0]), math.sqrt(err_matrix[1][1])]
+                err = [np.sqrt(err_matrix[0][0]), np.sqrt(err_matrix[1][1])]
             except:
                 err = [-1.0, -1.0]
 


### PR DESCRIPTION
## Description

Running the calculation unit tests locally gave a set of warnings:

> =============================== warnings summary ===============================
test/sasinvariant/utest_data_handling.py: 26 warnings
test/sasinvariant/utest_use_cases.py: 13 warnings
  /home/runner/work/sasview/sasview/src/sas/sascalc/invariant/invariant.py:363: DeprecationWarning: Conversion of an array with ndim > 0 to a scalar is deprecated, and will error in future. Ensure you extract a single element from your array before performing this operation. (Deprecated NumPy 1.25.)
    err_matrix = math.fabs(residuals) * cov
-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html

One CI example that shows the warnings: https://github.com/SasView/sasview/actions/runs/16317859941/job/46088019662

## How Has This Been Tested?

These warnings are no longer shown when running the unit tests after this change. I also compared the calculations run in v6.1.0 (Windows release binary) to running from source. Using the same data file with the same Invariant parameter values, all calculated paramter values and errors matched between the two versions.

## Review Checklist:

**Documentation** (check at least one)
- [x] There is **nothing** that needs documenting
- [ ] Documentation changes are **in this PR**
- [ ] There is an **issue** open for the documentation (link?)

**Installers**
- [ ] There is a chance this will affect the **installers**, if so
  - [ ] **Windows** installer (GH artifact) has been tested (installed and worked) 
  - [ ] **MacOSX** installer (GH artifact) has been tested (installed and worked)
  - [ ] **Wheels** installer (GH artifact) has been tested (installed and worked)

**Licensing** (untick if necessary)
- [x] The introduced changes comply with SasView license (BSD 3-Clause)

