### PR TITLE
Adds ability to automatically apply ruff linting fixes to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,21 @@ env:
   INSTALLER_USE_DEBUG: false
 
 jobs:
+
+  ruff:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/ruff-action@v3
+        with:
+          args: "check --fix-only --exit-non-zero-on-fix"
+      - uses: pre-commit-ci/lite-action@v1.1.0
+        if: always()
+        with:
+          msg: '[pre-commit.ci lite] apply automatic fixes for ruff linting errors'
+
   matrix:
+    needs: [ruff]
     name: Generate test matrix
 
     #if: false    # uncomment to prevent the rest of the workflow running
@@ -47,6 +61,7 @@ jobs:
 
 
   builddeps:
+    needs: [ruff]
     runs-on: ubuntu-latest
 
     strategy:

--- a/.gitignore
+++ b/.gitignore
@@ -79,3 +79,6 @@ tests.log
 /installers/build
 /installers/dist
 *.exe
+
+# Local pre-commit hooks
+.pre-commit-config.yaml


### PR DESCRIPTION
## Description

The CI has been modified to run the ruff linter using the default ruleset. If the linter detects any changes which it is able to fix automatically, the CI is stopped for that commit, and a new commit from "pre-commit" is added which contains the ruff fixes, and the CI then run on that commit. If the ruff linter detects changes it cannot automatically fix, they are ignored.

These changes to the CI require the installation of "pre-commit lite" on this repository. I have already requested this.

Fixes #3498 

## How Has This Been Tested?

I have filed pull requests on my own fork of SasView. See: https://github.com/DrPaulSharp/sasview-test/pull/11

## Review Checklist:

[if using the editor, use `[x]` in place of `[ ]` to check a box]

**Documentation** (check at least one)
- [x] There is **nothing** that needs documenting
- [ ] Documentation changes are **in this PR**
- [ ] There is an **issue** open for the documentation (link?)

**Installers**
- [ ] There is a chance this will affect the **installers**, if so
  - [ ] **Windows** installer (GH artifact) has been tested (installed and worked) 
  - [ ] **MacOSX** installer (GH artifact) has been tested (installed and worked)
  - [ ] **Wheels** installer (GH artifact) has been tested (installed and worked)

**Licensing** (untick if necessary)
- [x] The introduced changes comply with SasView license (BSD 3-Clause)

