### PR TITLE
3537: End plugin model necromancy

### DIFF
--- a/src/sas/system/user.py
+++ b/src/sas/system/user.py
@@ -136,6 +136,9 @@ def copy_old_files_to_new_location():
     for old_path, new_path in location_map.items():
         if old_path.exists() and not new_path.exists():
             shutil.copy2(old_path, new_path)
+        # Once the file is moved, the old file should be removed from the system to ensure
+        if old_path.exists():
+            os.remove(old_path)
 
 
 def module_copytree(module: str, src: PATH_LIKE, dest: PATH_LIKE) -> None:

--- a/src/sas/system/user.py
+++ b/src/sas/system/user.py
@@ -136,7 +136,8 @@ def copy_old_files_to_new_location():
     for old_path, new_path in location_map.items():
         if old_path.exists() and not new_path.exists():
             shutil.copy2(old_path, new_path)
-        # Once the file is moved, the old file should be removed from the system to ensure
+        # Once the file is copied, the old file should be removed from the system to ensure.
+        # I did not change the shutil to a move, to ensure files that exist in both locations aren't overlooked.
         if old_path.exists():
             os.remove(old_path)
 


### PR DESCRIPTION
## Description

This ensures, once files are copied from ~/.sasview/ to the new locations, the original file is removed from the system. The most important aspect of this is to ensure plugin models deleted through the plugin model manager do not reappear later.

This branch was based off [3522-example-data-branch](https://github.com/SasView/sasview/tree/3522-example-data-branch), so I currently have this as a chained PR.

Fixes #3537

## How Has This Been Tested?

Locally, all plugin models were wiped away in my ~/.sasview/plugin_models/ directory.

## Review Checklist:

**Documentation** (check at least one)
- [x] There is **nothing** that needs documenting
- [ ] Documentation changes are **in this PR**
- [ ] There is an **issue** open for the documentation (link?)

**Installers**
- [x] There is a chance this will affect the **installers**, if so
  - [ ] **Windows** installer (GH artifact) has been tested (installed and worked) 
  - [ ] **MacOSX** installer (GH artifact) has been tested (installed and worked)
  - [ ] **Wheels** installer (GH artifact) has been tested (installed and worked)

**Licensing** (untick if necessary)
- [x] The introduced changes comply with SasView license (BSD 3-Clause)

