### PR TITLE
Applies fixes for Ruff linting errors

### DIFF
--- a/run.py
+++ b/run.py
@@ -83,8 +83,8 @@ def prepare():
     #    with cd(root):
     #        subprocess.call((sys.executable, "setup.py", "build"), shell=False)
 
-import multiprocessing
 if __name__ == "__main__":
+    import multiprocessing
     multiprocessing.freeze_support()
     multiprocessing.set_start_method('spawn')
     prepare()

--- a/src/sas/__init__.py
+++ b/src/sas/__init__.py
@@ -1,7 +1,7 @@
 from sas.system.version import __version__
 from sas.system import config
 
-__all__ = ['config']
+__all__ = ["config", "__version__"]
 
 # TODO: fix logger-config circular dependency
 # Load the config file

--- a/src/sas/qtgui/Calculators/DataOperationUtilityPanel.py
+++ b/src/sas/qtgui/Calculators/DataOperationUtilityPanel.py
@@ -128,8 +128,8 @@ class DataOperationUtilityPanel(QtWidgets.QDialog, Ui_DataOperationUtility):
         # calculate and send data to DataExplorer
         output = None
         try:
-            data1 = self.data1
-            data2 = self.data2
+            self.data1
+            self.data2
             output = eval("data1 %s data2" % operator)
         except Exception as ex:
             logging.error(ex)

--- a/src/sas/qtgui/Calculators/DensityPanel.py
+++ b/src/sas/qtgui/Calculators/DensityPanel.py
@@ -136,7 +136,7 @@ class DensityPanel(QtWidgets.QDialog):
 
     def formulaChanged(self, current_text):
         try:
-            molarMass = toMolarMass(current_text)
+            toMolarMass(current_text)
             # if this doesn't fail, update the model item for formula
             # so related values can get recomputed
             self.model.item(MODEL.MOLECULAR_FORMULA).setText(current_text)

--- a/src/sas/qtgui/Calculators/GenericScatteringCalculator.py
+++ b/src/sas/qtgui/Calculators/GenericScatteringCalculator.py
@@ -1752,7 +1752,7 @@ class Plotter3DWidget(PlotterBase):
         for key in list(color_dic.keys()):
             chosen_color = pix_symbol == key
             if numpy.any(chosen_color):
-                other_color = other_color & (chosen_color!=True)
+                other_color = other_color & (not chosen_color)
                 color = color_dic[key]
                 im = ax.plot(pos_x[chosen_color], pos_z[chosen_color],
                          pos_y[chosen_color], marker, c=color, alpha=0.5,
@@ -1770,17 +1770,17 @@ class Plotter3DWidget(PlotterBase):
                     if a_name.count(name) == 0:
                         a_name += new_name
             # plot in black
-            im = ax.plot(pos_x[other_color], pos_z[other_color],
-                         pos_y[other_color], marker, c="k", alpha=0.5,
-                         markeredgecolor="k", markersize=m_size, label=a_name)
+            ax.plot(pos_x[other_color], pos_z[other_color],
+                    pos_y[other_color], marker, c="k", alpha=0.5,
+                    markeredgecolor="k", markersize=m_size, label=a_name)
         if data.pix_type == 'atom':
             ax.legend(loc='upper left', prop={'size': 10})
         # IV. Draws atomic bond with grey lines if any
         if data.has_conect:
             for ind in range(len(data.line_x)):
-                im = ax.plot(data.line_x[ind], data.line_z[ind],
-                             data.line_y[ind], '-', lw=0.6, c="grey",
-                             alpha=0.3)
+                ax.plot(data.line_x[ind], data.line_z[ind],
+                        data.line_y[ind], '-', lw=0.6, c="grey",
+                        alpha=0.3)
         # V. Draws magnetic vectors
         if has_arrow and len(pos_x) > 0:
             def _draw_arrow(input=None, update=None):

--- a/src/sas/qtgui/Calculators/UnitTesting/DataOperationUtilityTest.py
+++ b/src/sas/qtgui/Calculators/UnitTesting/DataOperationUtilityTest.py
@@ -7,7 +7,7 @@ import pytest
 
 
 from sas.qtgui.Calculators.DataOperationUtilityPanel import DataOperationUtilityPanel
-from sas.qtgui.Utilities.GuiUtils import *
+from sas.qtgui.Utilities.GuiUtils import Communicate
 from sas.qtgui.Plotting.PlotterData import Data1D
 from sas.qtgui.Plotting.PlotterData import Data2D
 from sas.qtgui.MainWindow.DataState import DataState

--- a/src/sas/qtgui/Calculators/UnitTesting/GenericScatteringCalculatorTest.py
+++ b/src/sas/qtgui/Calculators/UnitTesting/GenericScatteringCalculatorTest.py
@@ -1,5 +1,6 @@
 import time
 import numpy
+import os
 
 import pytest
 from PySide6 import QtGui, QtWidgets
@@ -14,7 +15,7 @@ from sas.qtgui.Calculators.GenericScatteringCalculator import GenericScatteringC
 from sas.qtgui.Calculators.GenericScatteringCalculator import Plotter3D
 from sas.qtgui.Plotting.PlotterBase import PlotHelper
 
-from sas.qtgui.Utilities.GuiUtils import *
+from sas.qtgui.Utilities.GuiUtils import Communicate
 from sas.sascalc.calculator import sas_gen
 
 

--- a/src/sas/qtgui/GL/models.py
+++ b/src/sas/qtgui/GL/models.py
@@ -8,7 +8,7 @@ from typing import Sequence, Tuple, Union, Optional
 
 import numpy as np
 
-from OpenGL.GL import *
+from OpenGL import GL
 
 from sas.qtgui.GL.renderable import Renderable
 from sas.qtgui.GL.color import ColorSpecification, ColorSpecificationMethod
@@ -90,41 +90,41 @@ class SolidVertexModel(SolidModel):
 
             if self.colors.method == ColorSpecificationMethod.UNIFORM:
 
-                glEnableClientState(GL_VERTEX_ARRAY)
-                glColor4f(*self.colors.data)
+                GL.glEnableClientState(GL.GL_VERTEX_ARRAY)
+                GL.glColor4f(*self.colors.data)
 
-                glVertexPointerf(self._vertex_array)
+                GL.glVertexPointerf(self._vertex_array)
 
                 for triangle_mesh in self._triangle_mesh_arrays:
-                    glDrawElementsui(GL_TRIANGLES, triangle_mesh)
+                    GL.glDrawElementsui(GL.GL_TRIANGLES, triangle_mesh)
 
-                glDisableClientState(GL_VERTEX_ARRAY)
+                GL.glDisableClientState(GL.GL_VERTEX_ARRAY)
 
             elif self.colors.method == ColorSpecificationMethod.BY_COMPONENT:
 
-                glEnableClientState(GL_VERTEX_ARRAY)
+                GL.glEnableClientState(GL.GL_VERTEX_ARRAY)
 
-                glVertexPointerf(self._vertex_array)
+                GL.glVertexPointerf(self._vertex_array)
 
                 for triangle_mesh, color in zip(self._triangle_mesh_arrays, self.colors.data):
-                    glColor4f(*color)
-                    glDrawElementsui(GL_TRIANGLES, triangle_mesh)
+                    GL.glColor4f(*color)
+                    GL.glDrawElementsui(GL.GL_TRIANGLES, triangle_mesh)
 
-                glDisableClientState(GL_VERTEX_ARRAY)
+                GL.glDisableClientState(GL.GL_VERTEX_ARRAY)
 
             elif self.colors.method == ColorSpecificationMethod.BY_VERTEX:
 
-                glEnableClientState(GL_VERTEX_ARRAY)
-                glEnableClientState(GL_COLOR_ARRAY)
+                GL.glEnableClientState(GL.GL_VERTEX_ARRAY)
+                GL.glEnableClientState(GL.GL_COLOR_ARRAY)
 
-                glVertexPointerf(self._vertex_array)
-                glColorPointerf(self.colors.data)
+                GL.glVertexPointerf(self._vertex_array)
+                GL.glColorPointerf(self.colors.data)
 
                 for triangle_mesh in self._triangle_mesh_arrays:
-                    glDrawElementsui(GL_TRIANGLES, triangle_mesh)
+                    GL.glDrawElementsui(GL.GL_TRIANGLES, triangle_mesh)
 
-                glDisableClientState(GL_COLOR_ARRAY)
-                glDisableClientState(GL_VERTEX_ARRAY)
+                GL.glDisableClientState(GL.GL_COLOR_ARRAY)
+                GL.glDisableClientState(GL.GL_VERTEX_ARRAY)
 
 
 class WireModel(ModelBase):
@@ -155,26 +155,26 @@ class WireModel(ModelBase):
 
             if colors.method == ColorSpecificationMethod.UNIFORM:
 
-                glBegin(GL_LINES)
-                glColor4f(*colors.data)
+                GL.glBegin(GL.GL_LINES)
+                GL.glColor4f(*colors.data)
 
                 for edge in self.edges:
-                    glVertex3f(*vertices[edge[0]])
-                    glVertex3f(*vertices[edge[1]])
+                    GL.glVertex3f(*vertices[edge[0]])
+                    GL.glVertex3f(*vertices[edge[1]])
 
-                glEnd()
+                GL.glEnd()
 
             elif colors.method == ColorSpecificationMethod.BY_COMPONENT:
 
-                glBegin(GL_LINES)
+                GL.glBegin(GL.GL_LINES)
                 for edge, color in zip(self.edges, colors.data):
 
-                    glColor4f(*color)
+                    GL.glColor4f(*color)
 
-                    glVertex3f(*vertices[edge[0]])
-                    glVertex3f(*vertices[edge[1]])
+                    GL.glVertex3f(*vertices[edge[0]])
+                    GL.glVertex3f(*vertices[edge[1]])
 
-                glEnd()
+                GL.glEnd()
 
             elif colors.method == ColorSpecificationMethod.BY_VERTEX:
                 raise NotImplementedError("Vertex coloring of wireframe is currently not supported")

--- a/src/sas/qtgui/GL/scene.py
+++ b/src/sas/qtgui/GL/scene.py
@@ -5,8 +5,7 @@ import numpy as np
 from PySide6 import QtGui, QtCore
 from PySide6 import QtWidgets, QtOpenGLWidgets 
 
-from OpenGL.GL import *
-from OpenGL.GLU import *
+from OpenGL import GL, GLU
 
 from sas.qtgui.GL.renderable import Renderable
 from sas.qtgui.GL.surface import Surface
@@ -52,10 +51,10 @@ class Scene(QtOpenGLWidgets.QOpenGLWidget):
 
 
     def initializeGL(self):
-        glClearDepth(1.0)
-        glDepthFunc(GL_LESS)
-        glEnable(GL_DEPTH_TEST)
-        glShadeModel(GL_SMOOTH)
+        GL.glClearDepth(1.0)
+        GL.glDepthFunc(GL.GL_LESS)
+        GL.glEnable(GL.GL_DEPTH_TEST)
+        GL.glShadeModel(GL.GL_SMOOTH)
 
     def default_viewport(self):
         x = int(self.width() * self.devicePixelRatioF())
@@ -70,24 +69,24 @@ class Scene(QtOpenGLWidgets.QOpenGLWidget):
         Paint the GL viewport
         """
 
-        glViewport(*self.default_viewport())
+        GL.glViewport(*self.default_viewport())
         self.set_projection()
 
-        glClearColor(*self.background_color)
-        glClear( GL_DEPTH_BUFFER_BIT | GL_COLOR_BUFFER_BIT )
+        GL.glClearColor(*self.background_color)
+        GL.glClear( GL.GL_DEPTH_BUFFER_BIT | GL.GL_COLOR_BUFFER_BIT )
 
         self.set_model_view()
 
         # self.test_paint()
-        glEnable(GL_POLYGON_OFFSET_FILL)
+        GL.glEnable(GL.GL_POLYGON_OFFSET_FILL)
 
         for item in self._items:
-            glPolygonOffset(1.0, 10.0)
+            GL.glPolygonOffset(1.0, 10.0)
             item.render_solid()
-            glPolygonOffset(0.0, 0.0)
+            GL.glPolygonOffset(0.0, 0.0)
             item.render_wireframe()
 
-        glPolygonOffset(0.0, 0.0)
+        GL.glPolygonOffset(0.0, 0.0)
 
 
     def projection_matrix(self):
@@ -105,10 +104,10 @@ class Scene(QtOpenGLWidgets.QOpenGLWidget):
 
     def set_projection(self):
 
-        glMatrixMode(GL_PROJECTION)
-        glLoadIdentity()
-        # gluPerspective(45.0,1.33,0.1, 100.0)
-        glLoadMatrixf(np.array(self.projection_matrix().data(), dtype=np.float32))
+        GL.glMatrixMode(GL.GL_PROJECTION)
+        GL.glLoadIdentity()
+        # GLU.gluPerspective(45.0,1.33,0.1, 100.0)
+        GL.glLoadMatrixf(np.array(self.projection_matrix().data(), dtype=np.float32))
 
     def set_model_view(self):
 
@@ -125,13 +124,13 @@ class Scene(QtOpenGLWidgets.QOpenGLWidget):
         y = centre[1] - self.view_distance*np.sin(azimuth)*np.cos(elevation)
         z = centre[2] + self.view_distance*np.sin(elevation)
 
-        gluLookAt(
+        GLU.gluLookAt(
             x, y, z,
             centre[0], centre[1], centre[2],
             0.0, 0.0, 1.0)
 
 
-        glMatrixMode(GL_MODELVIEW)
+        GL.glMatrixMode(GL.GL_MODELVIEW)
 
 
     def mousePressEvent(self, ev):

--- a/src/sas/qtgui/GL/transforms.py
+++ b/src/sas/qtgui/GL/transforms.py
@@ -3,8 +3,7 @@ from typing import List
 
 import numpy as np
 
-from OpenGL.GL import *
-from OpenGL.GLU import *
+from OpenGL import GL
 
 from sas.qtgui.GL.renderable import Renderable
 
@@ -37,11 +36,11 @@ class SceneGraphNode(Renderable):
         if self.solid_render_enabled:
 
             # Apply transform
-            glPushMatrix()
+            GL.glPushMatrix()
             self.apply()
 
             # Check stack
-            if glGetIntegerv(GL_MODELVIEW_STACK_DEPTH) >= 16:
+            if GL.glGetIntegerv(GL.GL_MODELVIEW_STACK_DEPTH) >= 16:
                 logger.info("GL Stack size utilisation {glGetIntegerv(GL_MODELVIEW_STACK_DEPTH))}, the limit could be as low as is 16")
 
             # Render children
@@ -49,18 +48,18 @@ class SceneGraphNode(Renderable):
                 child.render_solid()
 
             # Unapply
-            glPopMatrix()
+            GL.glPopMatrix()
 
 
     def render_wireframe(self):
 
         if self.wireframe_render_enabled:
             # Apply transform
-            glPushMatrix()
+            GL.glPushMatrix()
             self.apply()
 
             # Check stack
-            if glGetIntegerv(GL_MODELVIEW_STACK_DEPTH) >= 16:
+            if GL.glGetIntegerv(GL.GL_MODELVIEW_STACK_DEPTH) >= 16:
                 logger.info("GL Stack size utilisation {glGetIntegerv(GL_MODELVIEW_STACK_DEPTH))}, the limit could be as low as is 16")
 
 
@@ -69,7 +68,7 @@ class SceneGraphNode(Renderable):
                 child.render_wireframe()
 
             # unapply transform
-            glPopMatrix()
+            GL.glPopMatrix()
 
 
 class Rotation(SceneGraphNode):
@@ -89,7 +88,7 @@ class Rotation(SceneGraphNode):
         self.z = z
 
     def apply(self):
-        glRotate(self.angle, self.x, self.y, self.z)
+        GL.glRotate(self.angle, self.x, self.y, self.z)
 
 
 class Translation(SceneGraphNode):
@@ -109,7 +108,7 @@ class Translation(SceneGraphNode):
         self.z = z
 
     def apply(self):
-        glTranslate(self.x, self.y, self.z)
+        GL.glTranslate(self.x, self.y, self.z)
 
 
 class Scaling(SceneGraphNode):
@@ -129,7 +128,7 @@ class Scaling(SceneGraphNode):
         self.z = z
 
     def apply(self):
-        glScale(self.x, self.y, self.z)
+        GL.glScale(self.x, self.y, self.z)
 
 class MatrixTransform(SceneGraphNode):
 
@@ -147,4 +146,4 @@ class MatrixTransform(SceneGraphNode):
         self.matrix = matrix
 
     def apply(self):
-        glMultMatrixd(self.matrix)
+        GL.glMultMatrixd(self.matrix)

--- a/src/sas/qtgui/MainWindow/DataExplorer.py
+++ b/src/sas/qtgui/MainWindow/DataExplorer.py
@@ -381,7 +381,8 @@ class DataExplorerWindow(DroppableDataLoadWidget):
         for i in range(model.rowCount()):
             item = model.item(i)
             data = GuiUtils.dataFromItem(item)
-            if data is None: continue
+            if data is None:
+                continue
             # Now, all plots under this item
             name = data.name
             all_data[name] = data
@@ -408,7 +409,8 @@ class DataExplorerWindow(DroppableDataLoadWidget):
             properties = {}
             item = model.item(i)
             data = GuiUtils.dataFromItem(item)
-            if data is None: continue
+            if data is None:
+                continue
             # Now, all plots under this item
             name = data.name
             is_checked_bool = item.checkState() == QtCore.Qt.Checked
@@ -428,8 +430,8 @@ class DataExplorerWindow(DroppableDataLoadWidget):
                 properties = {}
                 item = model.item(i)
                 data = GuiUtils.dataFromItem(item)
-                if data is None: continue
-                if data.id != id: continue
+                if data is None or data.id != id:
+                    continue
                 # We found the dataset - save it.
                 name = data.name
                 is_checked_bool = item.checkState() == QtCore.Qt.Checked
@@ -447,8 +449,8 @@ class DataExplorerWindow(DroppableDataLoadWidget):
         for model in (self.model, self.theory_model):
             for i in range(model.rowCount()):
                 data = GuiUtils.dataFromItem(model.item(i))
-                if data is None: continue
-                if data.id != id: continue
+                if data is None or data.id != id:
+                    continue
                 # We found the item - return it
                 item = model.item(i)
                 break
@@ -658,7 +660,8 @@ class DataExplorerWindow(DroppableDataLoadWidget):
             # key - cardinal number of dataset
             # value - main dataset, [dependant filesets]
             # add the main index
-            if not value: continue
+            if not value:
+                continue
             new_data = value[0]
             from sasdata.dataloader.data_info import Data1D as old_data1d
             from sasdata.dataloader.data_info import Data2D as old_data2d
@@ -1311,7 +1314,7 @@ class DataExplorerWindow(DroppableDataLoadWidget):
         plot_id = str(graph.currentText())
         try:
             assert plot_id in PlotHelper.currentPlotIds(), "No such plot: %s" % (plot_id)
-        except:
+        except AssertionError:
             return
 
         old_plot = PlotHelper.plotById(plot_id)

--- a/src/sas/qtgui/MainWindow/GuiManager.py
+++ b/src/sas/qtgui/MainWindow/GuiManager.py
@@ -475,19 +475,19 @@ class GuiManager:
         #
         # checking `isinstance`` fails in PySide6 with
         # AttributeError: type object 'FittingWindow' has no attribute '_abc_impl'
-        if type(new_perspective) == FittingWindow:
+        if type(new_perspective) == FittingWindow: # noqa: E721
             self.checkAnalysisOption(self._workspace.actionFitting)
 
-        elif type(new_perspective) == InvariantWindow:
+        elif type(new_perspective) == InvariantWindow: # noqa: E721
             self.checkAnalysisOption(self._workspace.actionInvariant)
 
-        elif type(new_perspective) == InversionWindow:
+        elif type(new_perspective) == InversionWindow: # noqa: E721
             self.checkAnalysisOption(self._workspace.actionInversion)
 
-        elif type(new_perspective) == CorfuncWindow:
+        elif type(new_perspective) == CorfuncWindow: # noqa: E721
             self.checkAnalysisOption(self._workspace.actionCorfunc)
 
-        elif type(new_perspective) == SizeDistributionWindow:
+        elif type(new_perspective) == SizeDistributionWindow: # noqa: E721
             self.checkAnalysisOption(self._workspace.actionSizeDistribution)
 
 

--- a/src/sas/qtgui/MainWindow/GuiManager.py
+++ b/src/sas/qtgui/MainWindow/GuiManager.py
@@ -8,8 +8,8 @@ import traceback
 from typing import Optional, Dict
 from pathlib import Path
 
-from PySide6.QtWidgets import *
-from PySide6.QtGui import *
+from PySide6.QtWidgets import QDockWidget, QTextBrowser, QProgressBar, QLabel
+from PySide6.QtGui import QStandardItem
 from PySide6.QtCore import Qt, QLocale
 
 

--- a/src/sas/qtgui/MainWindow/UnitTesting/DataExplorerTest.py
+++ b/src/sas/qtgui/MainWindow/UnitTesting/DataExplorerTest.py
@@ -6,7 +6,7 @@ import pytest
 from PySide6.QtGui import QIcon, QStandardItemModel, QStandardItem
 from PySide6.QtWidgets import QTabWidget, QTreeView, QFileDialog, QMessageBox, QApplication
 from PySide6.QtTest import QTest
-from PySide6.QtCore import QSize, QSortFilterProxyModel
+from PySide6.QtCore import QItemSelectionModel, QPoint, QSize, QSortFilterProxyModel, Qt
 
 
 # Local
@@ -15,7 +15,7 @@ from sasdata.dataloader.loader import Loader
 from sas.qtgui.MainWindow.DataManager import DataManager
 
 from sas.qtgui.MainWindow.DataExplorer import DataExplorerWindow
-from sas.qtgui.Utilities.GuiUtils import Communicate
+from sas.qtgui.Utilities.GuiUtils import Communicate, HashableStandardItem
 from sas.qtgui.UnitTesting.TestUtils import QtSignalSpy
 from sas.qtgui.Plotting.Plotter import Plotter
 from sas.qtgui.Plotting.Plotter2D import Plotter2D
@@ -566,7 +566,7 @@ class DataExplorerTest:
         assert form.manager.add_data.called
 
     @pytest.mark.xfail(reason="2022-09 already broken - input file issue")
-    def testNewPlot1D(self, mocker):
+    def testNewPlot1D(self, form, mocker):
         """
         Creating new plots from Data1D/2D
         """
@@ -606,7 +606,7 @@ class DataExplorerTest:
         assert form.cmdAppend.isEnabled()
 
     @pytest.mark.xfail(reason="2022-09 already broken - input file issue")
-    def testNewPlot2D(self, mocker):
+    def testNewPlot2D(self, form, mocker):
         """
         Creating new plots from Data1D/2D
         """
@@ -641,7 +641,7 @@ class DataExplorerTest:
         #assert form.cmdAppend.isEnabled()
 
     @pytest.mark.xfail(reason="2022-09 already broken - input file issue")
-    def testAppendPlot(self, mocker):
+    def testAppendPlot(self, form, mocker):
         """
         Creating new plots from Data1D/2D
         """
@@ -977,7 +977,7 @@ class DataExplorerTest:
         QFileDialog.getSaveFileName.assert_called_once()
 
     @pytest.mark.xfail(reason="2022-09 already broken - input file issue")
-    def testQuickDataPlot(self, form):
+    def testQuickDataPlot(self, form, mocker):
         """
         Quick data plot generation.
         """
@@ -995,7 +995,7 @@ class DataExplorerTest:
         form.quickDataPlot()
         assert Plotter.show.called
 
-    def notestQuickData3DPlot(self, form):
+    def notestQuickData3DPlot(self, form, mocker):
         """
         Slow(er) 3D data plot generation.
         """
@@ -1023,7 +1023,7 @@ class DataExplorerTest:
         pass
 
     @pytest.mark.xfail(reason="2022-09 already broken - input file issue")
-    def testDeleteItem(self, form):
+    def testDeleteItem(self, form, mocker):
         """
         Delete selected item from data explorer
         """
@@ -1042,7 +1042,7 @@ class DataExplorerTest:
         assert form.model.rowCount() == 3
 
         # Add an item to first file item
-        item1 = QtGui.QStandardItem("test")
+        item1 = QStandardItem("test")
         item1.setCheckable(True)
         form.model.item(0).appendRow(item1)
 
@@ -1058,7 +1058,7 @@ class DataExplorerTest:
         form.current_view.expandAll()
 
         # Select the newly created item
-        form.current_view.selectionModel().select(select_index, QtCore.QItemSelectionModel.Rows)
+        form.current_view.selectionModel().select(select_index, QItemSelectionModel.Rows)
 
         # Attempt at deleting
         form.deleteFile()
@@ -1073,7 +1073,7 @@ class DataExplorerTest:
         mocker.patch.object(QMessageBox, 'question', return_value=QMessageBox.Yes)
 
         # Select the newly created item
-        form.current_view.selectionModel().select(select_index, QtCore.QItemSelectionModel.Rows)
+        form.current_view.selectionModel().select(select_index, QItemSelectionModel.Rows)
         # delete it. now for good
         form.deleteFile()
 
@@ -1084,7 +1084,7 @@ class DataExplorerTest:
         assert form.model.rowCount() == 3
 
     @pytest.mark.xfail(reason="2022-09 already broken - input file issue")
-    def testClosePlotsForItem(self, form):
+    def testClosePlotsForItem(self, form, mocker):
         """
         Delete selected item from data explorer should also delete corresponding plots
         """

--- a/src/sas/qtgui/MainWindow/UnitTesting/DataExplorerTest.py
+++ b/src/sas/qtgui/MainWindow/UnitTesting/DataExplorerTest.py
@@ -3,10 +3,10 @@ import random
 import pytest
 
 
-from PySide6.QtGui import *
-from PySide6.QtWidgets import *
+from PySide6.QtGui import QIcon, QStandardItemModel, QStandardItem
+from PySide6.QtWidgets import QTabWidget, QTreeView, QFileDialog, QMessageBox, QApplication
 from PySide6.QtTest import QTest
-from PySide6.QtCore import *
+from PySide6.QtCore import QSize, QSortFilterProxyModel
 
 
 # Local
@@ -15,7 +15,7 @@ from sasdata.dataloader.loader import Loader
 from sas.qtgui.MainWindow.DataManager import DataManager
 
 from sas.qtgui.MainWindow.DataExplorer import DataExplorerWindow
-from sas.qtgui.Utilities.GuiUtils import *
+from sas.qtgui.Utilities.GuiUtils import Communicate
 from sas.qtgui.UnitTesting.TestUtils import QtSignalSpy
 from sas.qtgui.Plotting.Plotter import Plotter
 from sas.qtgui.Plotting.Plotter2D import Plotter2D

--- a/src/sas/qtgui/MainWindow/UnitTesting/DroppableDataLoadWidgetTest.py
+++ b/src/sas/qtgui/MainWindow/UnitTesting/DroppableDataLoadWidgetTest.py
@@ -1,10 +1,10 @@
 import pytest
 
 from PySide6.QtWidgets import QApplication
-from PySide6 import QtCore
+from PySide6 import QtCore, QtGui
 
 from sas.qtgui.MainWindow.DroppableDataLoadWidget import DroppableDataLoadWidget
-from sas.qtgui.Utilities.GuiUtils import *
+from sas.qtgui.Utilities.GuiUtils import Communicate
 from sas.qtgui.UnitTesting.TestUtils import QtSignalSpy
 
 

--- a/src/sas/qtgui/MainWindow/UnitTesting/DroppableDataLoadWidgetTest.py
+++ b/src/sas/qtgui/MainWindow/UnitTesting/DroppableDataLoadWidgetTest.py
@@ -6,6 +6,7 @@ from PySide6 import QtCore, QtGui
 from sas.qtgui.MainWindow.DroppableDataLoadWidget import DroppableDataLoadWidget
 from sas.qtgui.Utilities.GuiUtils import Communicate
 from sas.qtgui.UnitTesting.TestUtils import QtSignalSpy
+from sas.qtgui.MainWindow.UnitTesting.DataExplorerTest import MyPerspective
 
 
 class DroppableDataLoadWidgetTest:

--- a/src/sas/qtgui/MainWindow/UnitTesting/GuiManagerTest.py
+++ b/src/sas/qtgui/MainWindow/UnitTesting/GuiManagerTest.py
@@ -4,8 +4,7 @@ import webbrowser
 import logging
 import pytest
 
-from PySide6.QtGui import *
-from PySide6.QtWidgets import *
+from PySide6.QtWidgets import QMdiArea, QDockWidget, QTextBrowser, QMessageBox, QFileDialog
 from PySide6 import QtCore
 
 # Local

--- a/src/sas/qtgui/MainWindow/UnitTesting/MainWindowTest.py
+++ b/src/sas/qtgui/MainWindow/UnitTesting/MainWindowTest.py
@@ -3,7 +3,6 @@ import sys
 import pytest
 
 from PySide6 import QtWidgets
-from PySide6.QtGui import *
 from PySide6.QtTest import QTest
 from PySide6 import QtCore
 

--- a/src/sas/qtgui/Perspectives/Corfunc/UnitTesting/CorfuncTest.py
+++ b/src/sas/qtgui/Perspectives/Corfunc/UnitTesting/CorfuncTest.py
@@ -76,7 +76,7 @@ class CorfuncTest:
         assert widget.calculate_background.called_once()
 
     @pytest.mark.xfail(reason="2022-09 already broken - input file issue")
-    def testProcess(self, widget):
+    def testProcess(self, widget, mocker):
         """Test the full analysis path"""
 
         filename = os.path.join("UnitTesting", "ISIS_98929.txt")

--- a/src/sas/qtgui/Perspectives/Corfunc/util.py
+++ b/src/sas/qtgui/Perspectives/Corfunc/util.py
@@ -26,6 +26,5 @@ def safe_float(x: str):
 
     try:
         return float(x)
-
     except:
         return 0.0

--- a/src/sas/qtgui/Perspectives/Fitting/ComplexConstraint.py
+++ b/src/sas/qtgui/Perspectives/Fitting/ComplexConstraint.py
@@ -12,11 +12,11 @@ from PySide6 import QtWidgets
 from sas.qtgui.Perspectives.Fitting import FittingUtilities
 from sas.qtgui.Perspectives.Fitting.Constraint import Constraint
 
-#ALLOWED_OPERATORS = ['=','<','>','>=','<=']
-ALLOWED_OPERATORS = ['=']
-
 # Local UI
 from sas.qtgui.Perspectives.Fitting.UI.ComplexConstraintUI import Ui_ComplexConstraintUI
+
+#ALLOWED_OPERATORS = ['=','<','>','>=','<=']
+ALLOWED_OPERATORS = ['=']
 
 class ComplexConstraint(QtWidgets.QDialog, Ui_ComplexConstraintUI):
     constraintReadySignal = QtCore.Signal(tuple)
@@ -358,7 +358,8 @@ class ComplexConstraint(QtWidgets.QDialog, Ui_ComplexConstraintUI):
         # create an empty list to store redefined constraints
         redefined_constraints = []
         for item in items1:
-            if item not in items2: continue
+            if item not in items2:
+                continue
             param = item
             value = item
             func = self.cbModel2.currentText() + "." + param

--- a/src/sas/qtgui/Perspectives/Fitting/ConsoleUpdate.py
+++ b/src/sas/qtgui/Perspectives/Fitting/ConsoleUpdate.py
@@ -39,7 +39,8 @@ class ConsoleUpdate(FitHandler):
         """
         Report on progress.
         """
-        if self.quiet: return
+        if self.quiet:
+            return
 
         t = time.time()
         p = int((100 * k) // n)
@@ -54,7 +55,8 @@ class ConsoleUpdate(FitHandler):
 
         # Update percent complete
         dp = p - self.progress_percent
-        if dp < 1: return
+        if dp < 1:
+            return
         dt = t - self.progress_time
         if dt > self.progress_delta:
             if 1 <= dp <= 2:

--- a/src/sas/qtgui/Perspectives/Fitting/ConstraintWidget.py
+++ b/src/sas/qtgui/Perspectives/Fitting/ConstraintWidget.py
@@ -346,7 +346,8 @@ class ConstraintWidget(QtWidgets.QWidget, Ui_ConstraintWidgetUI):
         # Prepare the fitter object
         try:
             for tab in tabs_to_fit:
-                if not self.isTabImportable(tab): continue
+                if not self.isTabImportable(tab):
+                    continue
                 tab_object = ObjectLibrary.getObject(tab)
                 if tab_object is None:
                     # No such tab!
@@ -772,11 +773,15 @@ class ConstraintWidget(QtWidgets.QWidget, Ui_ConstraintWidgetUI):
         """
         Determines if the tab can be imported and included in the widget
         """
-        if not isinstance(tab, str): return False
-        if self.currentType not in tab: return False
+        if not isinstance(tab, str):
+            return False
+        if self.currentType not in tab:
+            return False
         object = ObjectLibrary.getObject(tab)
-        if not isinstance(object, FittingWidget): return False
-        if not object.data_is_loaded : return False
+        if not isinstance(object, FittingWidget):
+            return False
+        if not object.data_is_loaded:
+            return False
         return True
 
     def showModelContextMenu(self, position):

--- a/src/sas/qtgui/Perspectives/Fitting/FitThread.py
+++ b/src/sas/qtgui/Perspectives/Fitting/FitThread.py
@@ -71,7 +71,6 @@ class FitThread(CalcThread):
         """
         Perform a fit
         """
-        msg = ""
         try:
             fitter_size = len(self.fitter)
             list_handler = [self.handler]*fitter_size

--- a/src/sas/qtgui/Perspectives/Fitting/FittingOptions.py
+++ b/src/sas/qtgui/Perspectives/Fitting/FittingOptions.py
@@ -100,10 +100,10 @@ class FittingOptions(PreferencesWidget, Ui_FittingOptions):
         for option in bumps.options.FIT_FIELDS.keys():
             (f_name, f_type) = bumps.options.FIT_FIELDS[option]
             validator = None
-            if type(f_type) == types.FunctionType:
+            if isinstance(f_type, types.FunctionType):
                 validator = QtGui.QIntValidator()
                 validator.setBottom(0)
-            elif f_type == float:
+            elif isinstance(f_type, float):
                 validator = GuiUtils.DoubleValidator()
                 validator.setBottom(0)
             else:
@@ -245,9 +245,11 @@ class FittingOptions(PreferencesWidget, Ui_FittingOptions):
         """
         if current_fitter is None:
             current_fitter = self.current_fitter_id
-        if option_id not in list(bumps.options.FIT_FIELDS.keys()): return None
+        if option_id not in list(bumps.options.FIT_FIELDS.keys()):
+            return None
         option = option_id + '_' + current_fitter
-        if not hasattr(self, option): return None
+        if not hasattr(self, option):
+            return None
         return eval('self.' + option)
 
     def getResults(self):

--- a/src/sas/qtgui/Perspectives/Fitting/FittingPerspective.py
+++ b/src/sas/qtgui/Perspectives/Fitting/FittingPerspective.py
@@ -178,7 +178,8 @@ class FittingWindow(QtWidgets.QTabWidget, Perspective):
             if len(line) > 1:
                 line_dict[line[0]] = line[1:]
 
-        if 'data_id' not in line_dict: return state
+        if 'data_id' not in line_dict:
+            return state
         id = line_dict['data_id'][0]
         if not isinstance(id, list):
             id = [id]

--- a/src/sas/qtgui/Perspectives/Fitting/FittingUtilities.py
+++ b/src/sas/qtgui/Perspectives/Fitting/FittingUtilities.py
@@ -514,7 +514,6 @@ def residualsData1D(reference_data, current_data, weights):
     """
     # temporary default values for index and weight
     index = None
-    weight = None
 
     # 1d theory from model_thread is only in the range of index
     if current_data.dy is None or not len(current_data.dy):

--- a/src/sas/qtgui/Perspectives/Fitting/MultiConstraint.py
+++ b/src/sas/qtgui/Perspectives/Fitting/MultiConstraint.py
@@ -105,7 +105,8 @@ class MultiConstraint(QtWidgets.QDialog, Ui_MultiConstraintUI):
         return
 
         # Don't validate if requested
-        if not self.validate: return
+        if not self.validate:
+            return
 
         formula_is_valid = False
         formula_is_valid = self.validateConstraint(self.txtConstraint.text())

--- a/src/sas/qtgui/Perspectives/Fitting/OrderWidget.py
+++ b/src/sas/qtgui/Perspectives/Fitting/OrderWidget.py
@@ -30,11 +30,14 @@ class OrderWidget(QtWidgets.QWidget, Ui_OrderWidgetUI):
         """
         Populate the widget with dataset names in original order
         """
-        if self.all_data is None: return
+        if self.all_data is None:
+            return
         for item in self.all_data:
-            if not hasattr(item, 'data'): continue
+            if not hasattr(item, 'data'):
+                continue
             dataset = GuiUtils.dataFromItem(item)
-            if dataset is None: continue
+            if dataset is None:
+                continue
             dataset_name = dataset.name
             self.order[dataset_name] = item
             self.lstOrder.addItem(dataset_name)

--- a/src/sas/qtgui/Perspectives/Fitting/SmearingWidget.py
+++ b/src/sas/qtgui/Perspectives/Fitting/SmearingWidget.py
@@ -7,7 +7,6 @@ from PySide6 import QtCore
 from PySide6 import QtGui
 from PySide6 import QtWidgets
 import logging
-logger = logging.getLogger(__name__)
 
 from sas.sascalc.fit.qsmearing import smear_selection, PySmear, PySmear2D
 from sas.qtgui.Plotting.PlotterData import Data1D
@@ -19,6 +18,9 @@ from sasmodels.sesans import SesansTransform
 
 # Local UI
 from sas.qtgui.Perspectives.Fitting.UI.SmearingWidgetUI import Ui_SmearingWidgetUI
+
+logger = logging.getLogger(__name__)
+
 
 class DataWidgetMapper(QtWidgets.QDataWidgetMapper):
     """

--- a/src/sas/qtgui/Perspectives/Fitting/UnitTesting/ConstraintWidgetTest.py
+++ b/src/sas/qtgui/Perspectives/Fitting/UnitTesting/ConstraintWidgetTest.py
@@ -148,11 +148,11 @@ class ConstraintWidgetTest:
 
         # disable the tab
         widget.tblTabList.item(0, 0).setCheckState(0)
-        assert widget.tabs_for_fitting["test_tab"] == False
+        assert not widget.tabs_for_fitting["test_tab"]
         assert not widget.cmdFit.isEnabled()
         # enable the tab
         widget.tblTabList.item(0, 0).setCheckState(2)
-        assert widget.tabs_for_fitting["test_tab"] == True
+        assert widget.tabs_for_fitting["test_tab"]
         assert widget.cmdFit.isEnabled()
 
     def testUpdateFitLine(self, widget, mocker):
@@ -348,7 +348,7 @@ class ConstraintWidgetTest:
         # Should be unchecked in tblConstraint
         assert widget.tblConstraints.item(0, 0).checkState() == 0
         # Constraint should be deactivated
-        assert self.constraint1.active == False
+        assert not self.constraint1.active
 
     def testOnConstraintChange(self, widget, mocker):
         ''' test edition of the constraint list '''
@@ -446,6 +446,6 @@ class ConstraintWidgetTest:
         widget.tblConstraints.item(0, 0).setCheckState(0)
         assert test_tab.modifyViewOnRow.call_args[0][0] == 0
         assert not test_tab.modifyViewOnRow.call_args[1]
-        assert self.constraint1.active == False
+        assert not self.constraint1.active
         # Check the reloading of the view
         widget.initializeFitList.assert_called_once()

--- a/src/sas/qtgui/Perspectives/Fitting/UnitTesting/FittingLogicTest.py
+++ b/src/sas/qtgui/Perspectives/Fitting/UnitTesting/FittingLogicTest.py
@@ -15,8 +15,8 @@ class FittingLogicTest:
     def logic(self, qapp):
         '''Create/Destroy the component'''
         data = Data1D(x=[1,2,3],y=[3,4,5])
-        l = FittingLogic(data=data)
-        yield l
+        logic = FittingLogic(data=data)
+        yield logic
 
     def testDefaults(self, logic):
         """Test the component in its default state"""

--- a/src/sas/qtgui/Perspectives/Fitting/UnitTesting/FittingPerspectiveTest.py
+++ b/src/sas/qtgui/Perspectives/Fitting/UnitTesting/FittingPerspectiveTest.py
@@ -266,7 +266,7 @@ class FittingPerspectiveTest:
         '''test the constraint tab getter'''
         # no constraint tab is present, should return None
         constraint_tab = widget.getConstraintTab()
-        assert constraint_tab == None
+        assert constraint_tab is None
 
         # add a constraint tab
         widget.addConstraintTab()
@@ -303,7 +303,7 @@ class FittingPerspectiveTest:
         # getPage should include an extra param 'data_id' removed by serialize
         assert len(params) != len(page)
         assert len(params) == 28
-        assert page.get('data_id', None) == None
+        assert page.get('data_id', None) is None
 
     def testUpdateFromConstraints(self, widget, mocker):
         '''tests the method that parses the loaded project dict and retuens a dict with constrains across all fit pages'''

--- a/src/sas/qtgui/Perspectives/Fitting/UnitTesting/FittingWidgetTest.py
+++ b/src/sas/qtgui/Perspectives/Fitting/UnitTesting/FittingWidgetTest.py
@@ -3,6 +3,7 @@ import logging
 import os
 import glob
 import pytest
+import webbrowser
 
 from PySide6 import QtGui
 from PySide6 import QtWidgets
@@ -13,8 +14,10 @@ from unittest.mock import MagicMock
 from twisted.internet import threads
 
 # Local
-from sas.qtgui.Utilities.GuiUtils import *
-from sas.qtgui.Perspectives.Fitting.FittingWidget import *
+from sas import config
+from sas.qtgui.Utilities import GuiUtils
+from sas.qtgui.Perspectives.Fitting import FittingWidget
+from sas.qtgui.Perspectives.Fitting import FittingUtilities
 from sas.qtgui.Perspectives.Fitting.Constraint import Constraint
 from sas.qtgui.UnitTesting.TestUtils import QtSignalSpy
 from sas.qtgui.Perspectives.Fitting.ModelThread import Calc2D
@@ -28,7 +31,7 @@ from sas.sascalc.fit.models import ModelManagerBase, ModelManager
 
 class dummy_manager(object):
     HELP_DIRECTORY_LOCATION = "html"
-    communicate = Communicate()
+    communicate = GuiUtils.Communicate()
 
     def __init__(self):
         self._perspective = dummy_perspective()
@@ -108,7 +111,7 @@ class ModelManagerMod(ModelManager):
         if ModelManagerMod.base is None:
             ModelManagerMod.base = ModelManagerBaseMod()
 
-class FittingWidgetMod(FittingWidget):
+class FittingWidgetMod(FittingWidget.FittingWidget):
     """
     Inherits from FittingWidget class which is the main widget for selecting form and structure factor models.
     Modified to test handling of plugin models.
@@ -161,7 +164,7 @@ class FittingWidgetTest:
             assert fittingWindow.cbCategory.findText(category) != -1
 
         #Test what is current text in the combobox
-        assert fittingWindow.cbCategory.currentText() == CATEGORY_DEFAULT
+        assert fittingWindow.cbCategory.currentText() == FittingWidget.CATEGORY_DEFAULT
 
     def testWidgetWithData(self, widget, mocker):
         """
@@ -284,7 +287,7 @@ class FittingWidgetTest:
         assert widget.cbModel.count() == 30
 
         # Set the structure factor
-        structure_index=widget.cbCategory.findText(CATEGORY_STRUCTURE)
+        structure_index=widget.cbCategory.findText(FittingWidget.CATEGORY_STRUCTURE)
         widget.cbCategory.setCurrentIndex(structure_index)
         # check the enablement of controls
         assert not widget.cbModel.isEnabled()
@@ -347,7 +350,7 @@ class FittingWidgetTest:
 
         # Check that the factor combo is active and the default is chosen
         assert widget.cbStructureFactor.isEnabled()
-        assert widget.cbStructureFactor.currentText() == STRUCTURE_DEFAULT
+        assert widget.cbStructureFactor.currentText() == FittingWidget.STRUCTURE_DEFAULT
 
         # We have this many rows in the model
         rowcount = widget._model_model.rowCount()
@@ -367,7 +370,7 @@ class FittingWidgetTest:
         assert widget.cbStructureFactor.currentText() == 'squarewell'
 
         # Switch category to structure factor
-        structure_index=widget.cbCategory.findText(CATEGORY_STRUCTURE)
+        structure_index=widget.cbCategory.findText(FittingWidget.CATEGORY_STRUCTURE)
         widget.cbCategory.setCurrentIndex(structure_index)
         # Observe the correct enablement
         assert widget.cbStructureFactor.isEnabled()
@@ -800,7 +803,7 @@ class FittingWidgetTest:
         # Set data
         test_data = Data1D(x=[1,2], y=[1,2])
         item = QtGui.QStandardItem()
-        updateModelItem(item, test_data, "test")
+        GuiUtils.updateModelItem(item, test_data, "test")
         # Force same data into logic
         widget.data = item
 
@@ -831,7 +834,7 @@ class FittingWidgetTest:
         # Set data
         test_data = Data1D(x=[1,2], y=[1,2])
         item = QtGui.QStandardItem()
-        updateModelItem(item, test_data, "test")
+        GuiUtils.updateModelItem(item, test_data, "test")
         # Force same data into logic
         widget.data = item
 
@@ -858,7 +861,7 @@ class FittingWidgetTest:
 
         # Force same data into logic
         item = QtGui.QStandardItem()
-        updateModelItem(item, test_data, "test")
+        GuiUtils.updateModelItem(item, test_data, "test")
 
         # Force same data into logic
         widget.data = item
@@ -884,7 +887,7 @@ class FittingWidgetTest:
         # Set data
         test_data = Data1D(x=[1,2], y=[1,2])
         item = QtGui.QStandardItem()
-        updateModelItem(item, test_data, "test")
+        GuiUtils.updateModelItem(item, test_data, "test")
         # Force same data into logic
         widget.data = item
         category_index = widget.cbCategory.findText("Sphere")
@@ -929,7 +932,7 @@ class FittingWidgetTest:
 
         # Force same data into logic
         item = QtGui.QStandardItem()
-        updateModelItem(item, test_data, "test")
+        GuiUtils.updateModelItem(item, test_data, "test")
         # Force same data into logic
         widget.data = item
         category_index = widget.cbCategory.findText("Sphere")
@@ -1011,7 +1014,7 @@ class FittingWidgetTest:
         # Set data
         test_data = Data1D(x=[1,2], y=[1,2])
         item = QtGui.QStandardItem()
-        updateModelItem(item, test_data, "test")
+        GuiUtils.updateModelItem(item, test_data, "test")
         # Force same data into logic
         widget.data = item
 
@@ -1059,7 +1062,7 @@ class FittingWidgetTest:
         widget.data_is_loaded = True
 
         #item = QtGui.QStandardItem()
-        #updateModelItem(item, [test_data], "test")
+        #GuiUtils.updateModelItem(item, [test_data], "test")
         # Force same data into logic
         #widget.logic.data = item
         #widget.data_is_loaded = True
@@ -1101,7 +1104,7 @@ class FittingWidgetTest:
         # Set data
         test_data = Data1D(x=[1,2], y=[1,2])
         item = QtGui.QStandardItem()
-        updateModelItem(item, test_data, "test")
+        GuiUtils.updateModelItem(item, test_data, "test")
         # Force same data into logic
         widget.data = item
         category_index = widget.cbCategory.findText("Sphere")
@@ -1128,7 +1131,7 @@ class FittingWidgetTest:
         # Set data
         test_data = Data1D(x=[1,2], y=[1,2])
         item = QtGui.QStandardItem()
-        updateModelItem(item, test_data, "test")
+        GuiUtils.updateModelItem(item, test_data, "test")
         # Force same data into logic
         widget.data = item
         category_index = widget.cbCategory.findText("Sphere")
@@ -1800,7 +1803,7 @@ class FittingWidgetTest:
         data = Data1D(x=[1,2], y=[1,2])
         mocker.patch.object(GuiUtils, 'dataFromItem', return_value=data)
         item = QtGui.QStandardItem("test")
-        widget_with_data = FittingWidget(dummy_manager(), data=item, tab_id=3)
+        widget_with_data = FittingWidget.FittingWidget(dummy_manager(), data=item, tab_id=3)
         assert widget_with_data.options_widget.qmin == min(data.x)
         assert widget_with_data.options_widget.qmax == max(data.x)
         assert widget_with_data.options_widget.npts == len(data.x)

--- a/src/sas/qtgui/Perspectives/Fitting/UnitTesting/FittingWidgetTest.py
+++ b/src/sas/qtgui/Perspectives/Fitting/UnitTesting/FittingWidgetTest.py
@@ -880,7 +880,7 @@ class FittingWidgetTest:
         assert logging.error.called_with('no fitting parameters')
         widget.close()
 
-    def notestOnFit1D(self, widget):
+    def notestOnFit1D(self, widget, mocker):
         """
         Test the threaded fitting call
         """
@@ -1772,7 +1772,7 @@ class FittingWidgetTest:
         # Check that QMessagebox was called
         QtWidgets.QMessageBox.exec_.assert_called_once()
         # Constraint should be inactive
-        assert constraint.active == False
+        assert not constraint.active
         # Check that the uncheckConstraint method was called
         constraint_tab.uncheckConstraint.assert_called_with("M1:scale")
 

--- a/src/sas/qtgui/Perspectives/Fitting/ViewDelegate.py
+++ b/src/sas/qtgui/Perspectives/Fitting/ViewDelegate.py
@@ -107,7 +107,7 @@ class ModelViewDelegate(QtWidgets.QStyledItemDelegate):
         """
         if index.column() in (self.param_min, self.param_max):
             try:
-                value_float = float(editor.text())
+                float(editor.text())
             except ValueError:
                 # TODO: present the failure to the user
                 # balloon popup? tooltip? cell background colour flash?

--- a/src/sas/qtgui/Perspectives/Invariant/InvariantPerspective.py
+++ b/src/sas/qtgui/Perspectives/Invariant/InvariantPerspective.py
@@ -837,7 +837,7 @@ class InvariantWindow(QtWidgets.QDialog, Ui_tabbedInvariantUI, Perspective):
         item = QtGui.QStandardItem(str(self._scale))
         self.model.setItem(WIDGETS.W_SCALE, item)
         # leave line edit empty if Porod constant not defined
-        if self._porod != None:
+        if self._porod is not None:
             item = QtGui.QStandardItem(str(self._porod))
         else:
             item = QtGui.QStandardItem(str(''))

--- a/src/sas/qtgui/Perspectives/Invariant/UnitTesting/InvariantDetailsTest.py
+++ b/src/sas/qtgui/Perspectives/Invariant/UnitTesting/InvariantDetailsTest.py
@@ -2,11 +2,10 @@ import pytest
 
 from PySide6.QtTest import QTest
 from PySide6.QtCore import Qt
+from pyside6 import QtGui, QtWidgets
 
 from sas.qtgui.Perspectives.Invariant.InvariantDetails import DetailsDialog
 from sas.qtgui.Perspectives.Invariant.InvariantUtils import WIDGETS
-
-from sas.qtgui.Utilities.GuiUtils import *
 
 
 BG_COLOR_ERR = 'background-color: rgb(244, 170, 164);'

--- a/src/sas/qtgui/Perspectives/Inversion/UnitTesting/InversionPerspectiveTest.py
+++ b/src/sas/qtgui/Perspectives/Inversion/UnitTesting/InversionPerspectiveTest.py
@@ -1,6 +1,10 @@
 import numpy as np
 import pytest
 
+
+from PySide6 import QtGui, QtWidgets
+import logging
+
 import matplotlib as mpl
 mpl.use("Qt5Agg")
 
@@ -325,8 +329,8 @@ class InversionTest:
         # getPage should include an extra param 'data_id' removed by serialize
         assert len(params) != len(page)
         assert len(params) == 26
-        assert params.get('data_id', None) == None
-        assert page.get('data_id', None) != None
-        assert params.get('alpha', None) != None
+        assert params.get('data_id', None) is None
+        assert page.get('data_id', None) is not None
+        assert params.get('alpha', None) is not None
         assert params.get('alpha', None) == page.get('alpha', None)
         assert np.isnan(params.get('rg'))

--- a/src/sas/qtgui/Perspectives/Inversion/UnitTesting/InversionPerspectiveTest.py
+++ b/src/sas/qtgui/Perspectives/Inversion/UnitTesting/InversionPerspectiveTest.py
@@ -1,9 +1,10 @@
+import numpy as np
 import pytest
 
 import matplotlib as mpl
 mpl.use("Qt5Agg")
 
-from sas.qtgui.Utilities.GuiUtils import *
+from sas.qtgui.Utilities.GuiUtils import Communicate
 from sas.qtgui.Perspectives.Inversion.InversionPerspective import InversionWindow
 from sas.qtgui.Perspectives.Inversion.InversionUtils import WIDGETS
 from sas.qtgui.Plotting.PlotterData import Data1D

--- a/src/sas/qtgui/Perspectives/ParticleEditor/AngularSamplingMethodSelector.py
+++ b/src/sas/qtgui/Perspectives/ParticleEditor/AngularSamplingMethodSelector.py
@@ -17,13 +17,13 @@ class ParametersForm(QWidget):
         self.parameter_callbacks = []
 
         for parameter_name, text, cls in sampling_class.parameters():
-            if cls == GeodesicDivisions:
+            if isinstance(cls, GeodesicDivisions):
                 widget = GeodesicSamplingSpinBox()
 
                 def callback():
                     return widget.getNDivisions()
 
-            elif cls == float:
+            elif isinstance(cls, float):
                 widget = QDoubleSpinBox()
 
                 def callback():

--- a/src/sas/qtgui/Perspectives/ParticleEditor/ParameterFunctionality/ParameterTableModel.py
+++ b/src/sas/qtgui/Perspectives/ParticleEditor/ParameterFunctionality/ParameterTableModel.py
@@ -9,7 +9,8 @@ from sas.qtgui.Perspectives.ParticleEditor.datamodel.types import SLDFunction, M
 from sas.qtgui.Perspectives.ParticleEditor.datamodel.parameters import (
     SolventSLD, Background, Scale, FunctionParameter, MagnetismParameterContainer, ValueSource, CalculationParameters)
 
-class LinkingImpossible(Exception): pass
+class LinkingImpossible(Exception):
+    pass
 
 class ParameterTableModel:
     """

--- a/src/sas/qtgui/Perspectives/ParticleEditor/tests/test_point_generator.py
+++ b/src/sas/qtgui/Perspectives/ParticleEditor/tests/test_point_generator.py
@@ -20,7 +20,7 @@ def test_with_grid(npoints, splits):
 
 @mark.parametrize("splits", [42, 100, 381, 999])
 @mark.parametrize("npoints", [100, 1000, 8001])
-def test_with_grid(npoints, splits):
+def test_with_random_cube(npoints, splits):
     point_generator = RandomCube(100, npoints)
     n_measured = 0
     for x, y, z in PointGeneratorStepper(point_generator, splits):

--- a/src/sas/qtgui/Perspectives/SizeDistribution/UnitTesting/SizeDistributionPerspectiveTest.py
+++ b/src/sas/qtgui/Perspectives/SizeDistribution/UnitTesting/SizeDistributionPerspectiveTest.py
@@ -4,7 +4,9 @@ import matplotlib as mpl
 
 mpl.use("Qt5Agg")
 
-from sas.qtgui.Utilities.GuiUtils import *
+from PySide6 import QtWidgets
+
+from sas.qtgui.Utilities.GuiUtils import Communicate
 from sas.qtgui.Perspectives.SizeDistribution.SizeDistributionPerspective import (
     SizeDistributionWindow,
 )

--- a/src/sas/qtgui/Plotting/Binder.py
+++ b/src/sas/qtgui/Plotting/Binder.py
@@ -118,7 +118,8 @@ class BindArtist(object):
         In case we need to disconnect from the canvas...
         """
         try:
-            for cid in self._connections: self.canvas.mpl_disconnect(cid)
+            for cid in self._connections:
+                self.canvas.mpl_disconnect(cid)
         except:
             logging.error("Error disconnection canvas: %s" % sys.exc_info()[1])
         self._connections = []

--- a/src/sas/qtgui/Plotting/ColorMap.py
+++ b/src/sas/qtgui/Plotting/ColorMap.py
@@ -14,10 +14,10 @@ from sas.qtgui.Plotting.PlotterData import Data2D
 from sas.qtgui.Utilities.GuiUtils import formatNumber, DoubleValidator
 from superqt import QDoubleRangeSlider
 
-DEFAULT_MAP = 'jet'
-
 # Local UI
 from sas.qtgui.Plotting.UI.ColorMapUI import Ui_ColorMapUI
+
+DEFAULT_MAP = 'jet'
 
 class ColorMap(QtWidgets.QDialog, Ui_ColorMapUI):
     apply_signal = QtCore.Signal(tuple, str)

--- a/src/sas/qtgui/Plotting/ConvertUnits.py
+++ b/src/sas/qtgui/Plotting/ConvertUnits.py
@@ -66,14 +66,14 @@ if __name__ == "__main__":
     unit7 = "m/s^{2}"  #         1/x                 (m/s^{2})^{-1}
     unit8 = "m/s^{4}"  #         x^2               (m/s^{4})^{2}
 
-    print("this unit1 %s ,its powerer %s , and value %s" % (unit1, 1, convert_unit(1, unit1)))
-    print("this unit2 %s ,its powerer %s , and value %s" % (unit2, 1, convert_unit(1, unit2)))
-    print("this unit3 %s ,its powerer %s , and value %s" % (unit3, 2, convert_unit(2, unit3)))
-    print("this unit4 %s ,its powerer %s , and value %s" % (unit4, -1, convert_unit(-1, unit4)))
-    print("this unit5 %s ,its powerer %s , and value %s" % (unit5, 2, convert_unit(2, unit5)))
-    print("this unit6 %s ,its powerer %s , and value %s" % (unit6, 2, convert_unit(2, unit6)))
-    print("this unit7 %s ,its powerer %s , and value %s" % (unit7, -1, convert_unit(-1, unit7)))
-    print("this unit8 %s ,its powerer %s , and value %s" % (unit8, 2, convert_unit(2, unit8)))
-    print("this unit9 %s ,its powerer %s , and value %s" % (unit9, 2, convert_unit(2, unit9)))
+    print("this unit1 %s ,its powerer %s , and value %s" % (unit1, 1, convertUnit(1, unit1)))
+    print("this unit2 %s ,its powerer %s , and value %s" % (unit2, 1, convertUnit(1, unit2)))
+    print("this unit3 %s ,its powerer %s , and value %s" % (unit3, 2, convertUnit(2, unit3)))
+    print("this unit4 %s ,its powerer %s , and value %s" % (unit4, -1, convertUnit(-1, unit4)))
+    print("this unit5 %s ,its powerer %s , and value %s" % (unit5, 2, convertUnit(2, unit5)))
+    print("this unit6 %s ,its powerer %s , and value %s" % (unit6, 2, convertUnit(2, unit6)))
+    print("this unit7 %s ,its powerer %s , and value %s" % (unit7, -1, convertUnit(-1, unit7)))
+    print("this unit8 %s ,its powerer %s , and value %s" % (unit8, 2, convertUnit(2, unit8)))
+    print("this unit9 %s ,its powerer %s , and value %s" % (unit9, 2, convertUnit(2, unit9)))
 
 

--- a/src/sas/qtgui/Plotting/MaskEditor.py
+++ b/src/sas/qtgui/Plotting/MaskEditor.py
@@ -218,7 +218,7 @@ class MaskEditor(QtWidgets.QDialog, Ui_MaskEditorUI):
         temp_mask = temp_mask / temp_mask
         temp_mask[mask] = temp_data.data[mask]
 
-        temp_data.data[mask == False] = temp_mask[mask == False]
+        temp_data.data[not mask] = temp_mask[not mask]
 
         if self.current_slicer is not None:
             self.current_slicer.clear()

--- a/src/sas/qtgui/Plotting/Masks/BoxMask.py
+++ b/src/sas/qtgui/Plotting/Masks/BoxMask.py
@@ -150,7 +150,7 @@ class BoxMask(BaseInteractor):
         mask = Boxcut(x_min=x_min, x_max=x_max, y_min=y_min, y_max=y_max)
 
         if self.is_inside:
-            out = (mask(data) == False)
+            out = (not mask(data))
         else:
             out = (mask(data))
         # self.base.data.mask=out

--- a/src/sas/qtgui/Plotting/Masks/CircularMask.py
+++ b/src/sas/qtgui/Plotting/Masks/CircularMask.py
@@ -95,7 +95,7 @@ class CircularMask(BaseInteractor):
         mask = Ringcut(r_min=rmin, r_max=rmax)
 
         if self.is_inside:
-            out = (mask(data) == False)
+            out = (not mask(data))
         else:
             out = (mask(data))
         return out

--- a/src/sas/qtgui/Plotting/Masks/SectorMask.py
+++ b/src/sas/qtgui/Plotting/Masks/SectorMask.py
@@ -120,7 +120,7 @@ class SectorMask(BaseInteractor):
 
         mask = Sectorcut(phi_min=phimin, phi_max=phimax)
         if self.is_inside:
-            out = (mask(self.data) == False)
+            out = (not mask(self.data))
         else:
             out = (mask(self.data))
         return out

--- a/src/sas/qtgui/Plotting/Plottables.py
+++ b/src/sas/qtgui/Plotting/Plottables.py
@@ -224,7 +224,7 @@ class Graph(object):
         min_value = None
         max_value = None
         for p in self.plottables:
-            if p.hidden == True:
+            if p.hidden:
                 continue
             if p.x is not None:
                 for x_i in p.x:
@@ -1056,7 +1056,7 @@ class PlottableData1D(Plottable):
         """
         Renders the plottable on the graph
         """
-        if self.interactive == True:
+        if self.interactive:
             kw['symbol'] = self.symbol
             kw['id'] = self.id
             kw['hide_error'] = self.hide_error

--- a/src/sas/qtgui/Plotting/Plotter.py
+++ b/src/sas/qtgui/Plotting/Plotter.py
@@ -207,7 +207,7 @@ class PlotterWidget(PlotterBase):
             else:
                 dy = data.view.dy
                 # Convert tuple (lo,hi) to array [(x-lo),(hi-x)]
-                if dy is not None and type(dy) == type(()):
+                if dy is not None and isinstance(dy, tuple):
                     dy = np.vstack((y - dy[0], dy[1] - y)).transpose()
 
                 line = ax.errorbar(x, y,
@@ -603,7 +603,6 @@ class PlotterWidget(PlotterBase):
         if num_text < 1:
             return
         txt = self.textList[num_text - 1]
-        text_remove = txt.get_text()
         try:
             txt.remove()
         except ValueError:

--- a/src/sas/qtgui/Plotting/Plotter2D.py
+++ b/src/sas/qtgui/Plotting/Plotter2D.py
@@ -363,22 +363,27 @@ class Plotter2DWidget(PlotterBase):
         """
         Update circular averaging plot on Data2D change
         """
-        if not hasattr(self, '_item'): return
+        if not hasattr(self, '_item'):
+            return
         item = self._item
         if self._item.parent() is not None:
             item = self._item.parent()
 
         # Get all plots for current item
         plots = GuiUtils.plotsFromModel("", item)
-        if plots is None: return
+        if plots is None:
+            return
         ca_caption = '2daverage' + self.data0.name
         # See if current item plots contain 2D average plot
         has_plot = False
         for plot in plots:
-            if plot.id is None: continue
-            if ca_caption in plot.id: has_plot = True
+            if plot.id is None:
+                continue
+            if ca_caption in plot.id:
+                has_plot = True
         # return prematurely if no circular average plot found
-        if not has_plot: return
+        if not has_plot:
+            return
 
         # Create a new plot
         new_plot = self.circularAverage()
@@ -392,22 +397,27 @@ class Plotter2DWidget(PlotterBase):
         """
         Update slicer plot on Data2D change
         """
-        if not hasattr(self, '_item'): return
+        if not hasattr(self, '_item'):
+            return
         item = self._item
         if self._item.parent() is not None:
             item = self._item.parent()
 
         # Get all plots for current item
         plots = GuiUtils.plotsFromModel("", item)
-        if plots is None: return
+        if plots is None:
+            return
         slicer_caption = 'Slicer' + self.data0.name
         # See if current item plots contain slicer plot
         has_plot = False
         for plot in plots:
-            if not hasattr(plot, 'type_id') or plot.type_id is None: continue
-            if slicer_caption in plot.type_id: has_plot = True
+            if not hasattr(plot, 'type_id') or plot.type_id is None:
+                continue
+            if slicer_caption in plot.type_id:
+                has_plot = True
         # return prematurely if no slicer plot found
-        if not has_plot: return
+        if not has_plot:
+            return
 
         # Now that we've identified the right plot, update the 2D data the slicer uses
         self.slicer.data = self.data0
@@ -644,8 +654,6 @@ class Plotter2DWidget(PlotterBase):
                 output[output > 0] = numpy.log10(output[output > 0])
                 pass
 
-        vmin, vmax = None, None
-
         self.cmap = cmap
         if self.dimension != 3:
             #Re-adjust colorbar
@@ -728,9 +736,9 @@ class Plotter2DWidget(PlotterBase):
         :Param img: [imread(path) from matplotlib.pyplot]
         """
         if origin is not None:
-            im = self.ax.imshow(img, origin=origin)
+            self.ax.imshow(img, origin=origin)
         else:
-            im = self.ax.imshow(img)
+            self.ax.imshow(img)
 
     def replacePlot(self, id, new_plot):
         """

--- a/src/sas/qtgui/Plotting/PlotterBase.py
+++ b/src/sas/qtgui/Plotting/PlotterBase.py
@@ -12,7 +12,6 @@ from matplotlib import rcParams
 
 from packaging import version
 
-DEFAULT_CMAP = mpl.cm.jet
 from sas.qtgui.Plotting.PlotterData import Data1D
 
 from sas.qtgui.Plotting.ScaleProperties import ScaleProperties
@@ -23,6 +22,7 @@ import sas.qtgui.Plotting.PlotHelper as PlotHelper
 
 from sas import config
 
+DEFAULT_CMAP = mpl.cm.jet
 
 class PlotterBase(QtWidgets.QWidget):
     #TODO: Describe what this class is
@@ -117,7 +117,7 @@ class PlotterBase(QtWidgets.QWidget):
 
         self.contextMenu = QtWidgets.QMenu(self)
         self.toolbar = NavigationToolbar(self.canvas, self)
-        cid = self.canvas.mpl_connect('resize_event', self.onResize)
+        self.canvas.mpl_connect('resize_event', self.onResize)
         self.canvas.setContextMenuPolicy(QtCore.Qt.CustomContextMenu)
         self.canvas.customContextMenuRequested.connect(self.showContextMenu)
 

--- a/src/sas/qtgui/Plotting/Slicers/BaseInteractor.py
+++ b/src/sas/qtgui/Plotting/Slicers/BaseInteractor.py
@@ -59,7 +59,8 @@ class BaseInteractor(object):
         """
         Clear old markers and interfaces.
         """
-        for h in self.markers: h.remove()
+        for h in self.markers:
+            h.remove()
         if self.markers:
             self.base.connect.clear(*self.markers)
         self.markers = []
@@ -158,7 +159,8 @@ class BaseInteractor(object):
                 self.clicky -= dy
             elif ev.key == 'right':
                 self.clickx += dx
-            else: self.clickx -= dx
+            else:
+                self.clickx -= dx
             self.move(self.clickx, self.clicky, ev)
         else:
             return False

--- a/src/sas/qtgui/Plotting/Slicers/BoxSlicer.py
+++ b/src/sas/qtgui/Plotting/Slicers/BoxSlicer.py
@@ -309,9 +309,12 @@ class BoxInteractor(BaseInteractor, SlicerModel):
         restoring the vertical lines and then doing an updated will take care
         of the related values in horizontal lines.
         """
-        if self.horizontal_lines.has_move: self.horizontal_lines.restore(ev)
-        if self.vertical_lines.has_move: self.vertical_lines.restore(ev)
-        if self.center.has_move: self.center.restore(ev)
+        if self.horizontal_lines.has_move:
+            self.horizontal_lines.restore(ev)
+        if self.vertical_lines.has_move:
+            self.vertical_lines.restore(ev)
+        if self.center.has_move:
+            self.center.restore(ev)
 
     def move(self, x, y, ev):
         """
@@ -723,7 +726,7 @@ class VerticalDoubleLine(BaseInteractor):
             self.base.update()
             self.base.draw()
         else:
-            if self.valid_move == True:
+            if self.valid_move:
                 self.valid_move = False
                 logging.warning("the ROI cannot be negative")
 
@@ -905,7 +908,7 @@ class HorizontalDoubleLine(BaseInteractor):
             self.base.update()
             self.base.draw()
         else:
-            if self.valid_move == True:
+            if self.valid_move:
                 self.valid_move = False
                 logging.warning("the ROI cannot be negative")
 

--- a/src/sas/qtgui/Plotting/UnitTesting/ColorMapTest.py
+++ b/src/sas/qtgui/Plotting/UnitTesting/ColorMapTest.py
@@ -151,7 +151,7 @@ class ColorMapTest:
         assert widget.txtMaxAmplitude.text() == "45"
 
     @pytest.mark.skip(reason="2022-09 already broken - causes segfault")
-    def testOnMapIndexChange(self, widget):
+    def testOnMapIndexChange(self, widget, mocker):
         '''Test the response to the combo box index change'''
 
         mocker.patch.object(widget.canvas, 'draw')
@@ -165,7 +165,7 @@ class ColorMapTest:
         assert mpl.colorbar.ColorbarBase.called
 
     @pytest.mark.skip(reason="2022-09 already broken - causes segfault")
-    def testOnColorMapReversed(self, widget):
+    def testOnColorMapReversed(self, widget, mocker):
         '''Test reversing the color map functionality'''
         # Check the defaults
         assert widget._cmap == "jet"
@@ -179,7 +179,7 @@ class ColorMapTest:
         assert widget.cbColorMap.addItems.called
 
     @pytest.mark.skip(reason="2022-09 already broken - causes segfault")
-    def testOnAmplitudeChange(self, widget):
+    def testOnAmplitudeChange(self, widget, mocker):
         '''Check the callback method for responding to changes in textboxes'''
         mocker.patch.object(widget.canvas, 'draw')
         mocker.patch.object(mpl.colors, 'Normalize')

--- a/src/sas/qtgui/Plotting/UnitTesting/PlotHelperTest.py
+++ b/src/sas/qtgui/Plotting/UnitTesting/PlotHelperTest.py
@@ -7,7 +7,7 @@ class PlotProxy:
         self.name = name
 
     def __str__(self):
-        return name
+        return self.name
 
 
 class PlotHelperTest:

--- a/src/sas/qtgui/Plotting/UnitTesting/Plotter2DTest.py
+++ b/src/sas/qtgui/Plotting/UnitTesting/Plotter2DTest.py
@@ -12,6 +12,8 @@ from matplotlib.backends.backend_qt5agg import FigureCanvasQTAgg as FigureCanvas
 from mpl_toolkits.mplot3d import Axes3D
 
 from sas.qtgui.Plotting.PlotterData import Data2D
+from sas.qtgui.Utilities.GuiUtils import Communicate
+from sas.qtgui.MainWindow.UnitTesting.DataExplorerTest import MyPerspective
 
 # Tested module
 import sas.qtgui.Plotting.Plotter2D as Plotter2D

--- a/src/sas/qtgui/Plotting/UnitTesting/PlotterBaseTest.py
+++ b/src/sas/qtgui/Plotting/UnitTesting/PlotterBaseTest.py
@@ -12,6 +12,7 @@ from sas.qtgui.Plotting.ScaleProperties import ScaleProperties
 from sas.qtgui.Plotting.WindowTitle import WindowTitle
 from sas.qtgui.Utilities.GuiUtils import Communicate
 import sas.qtgui.Plotting.PlotHelper as PlotHelper
+from sas.qtgui.MainWindow.UnitTesting.DataExplorerTest import MyPerspective
 
 # Tested module
 import sas.qtgui.Plotting.PlotterBase as PlotterBase

--- a/src/sas/qtgui/Plotting/UnitTesting/PlotterBaseTest.py
+++ b/src/sas/qtgui/Plotting/UnitTesting/PlotterBaseTest.py
@@ -5,16 +5,12 @@ import pytest
 import matplotlib as mpl
 mpl.use("Qt5Agg")
 
-
-import matplotlib as mpl
-mpl.use("Qt5Agg")
-
-from PySide6 import QtGui, QtWidgets, QtPrintSupport
+from PySide6 import QtCore, QtGui, QtWidgets, QtPrintSupport
 from matplotlib.backends.backend_qt5agg import FigureCanvasQTAgg as FigureCanvas
 
 from sas.qtgui.Plotting.ScaleProperties import ScaleProperties
 from sas.qtgui.Plotting.WindowTitle import WindowTitle
-from sas.qtgui.Utilities.GuiUtils import *
+from sas.qtgui.Utilities.GuiUtils import Communicate
 import sas.qtgui.Plotting.PlotHelper as PlotHelper
 
 # Tested module

--- a/src/sas/qtgui/Plotting/UnitTesting/SlicerParametersTest.py
+++ b/src/sas/qtgui/Plotting/UnitTesting/SlicerParametersTest.py
@@ -191,7 +191,7 @@ class SlicerParametersTest:
         mocker.patch.object(widget, 'onApply')
         assert widget.lstParams.model().rowCount() == 0
         assert widget.lstParams.model().columnCount() == 0
-        assert widget.lstParams.model().index(0, 0).data() == None
+        assert widget.lstParams.model().index(0, 0).data() is None
 
     @pytest.mark.skip(reason="2022-09 already broken - causes segfault")
     def testOnApply(self, widget, mocker):

--- a/src/sas/qtgui/UnitTesting/TestUtils.py
+++ b/src/sas/qtgui/UnitTesting/TestUtils.py
@@ -1,7 +1,4 @@
-from PySide6.QtCore import *
-from PySide6.QtGui import *
-from PySide6.QtWidgets import *
-from PySide6.QtTest import *
+from PySide6.QtCore import QObject, slot
 import inspect
 
 def WarningTestNotImplemented(method_name=None):

--- a/src/sas/qtgui/UnitTesting/TestUtils.py
+++ b/src/sas/qtgui/UnitTesting/TestUtils.py
@@ -1,4 +1,4 @@
-from PySide6.QtCore import QObject, slot
+from PySide6.QtCore import QObject, slot, pyqtBoundSignal
 import inspect
 
 def WarningTestNotImplemented(method_name=None):

--- a/src/sas/qtgui/UnitTesting/TestUtilsTest.py
+++ b/src/sas/qtgui/UnitTesting/TestUtilsTest.py
@@ -1,11 +1,8 @@
-
-from PySide6.QtGui import *
-from PySide6.QtWidgets import *
-from PySide6.QtCore import *
+from PySide6.QtWidgets import QWidget
 
 # Local
 from sas.qtgui.Utilities.GuiUtils import Communicate
-from sas.qtgui.UnitTesting.TestUtils import *
+from sas.qtgui.UnitTesting.TestUtils import QtSignalSpy
 
 class TestUtilsTest:
     '''Test TestUtils'''

--- a/src/sas/qtgui/Utilities/ConnectionProxy.py
+++ b/src/sas/qtgui/Utilities/ConnectionProxy.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 import urllib.request
-import urllib.error
-import urllib.parse
 import sys
 import json
 import logging

--- a/src/sas/qtgui/Utilities/FileConverter.py
+++ b/src/sas/qtgui/Utilities/FileConverter.py
@@ -476,7 +476,6 @@ class FileConverterWidget(QtWidgets.QDialog, Ui_FileConverterUI):
         :param n_frames: How many frames the loaded data file has
         :return: A dictionary containing the parameters input by the user
         """
-        valid_input = False
         output_path = self.txtOutputFile.text()
         if not output_path:
             return

--- a/src/sas/qtgui/Utilities/GuiUtils.py
+++ b/src/sas/qtgui/Utilities/GuiUtils.py
@@ -17,7 +17,6 @@ from pathlib import Path
 
 import numpy as np
 
-warnings.simplefilter("ignore")
 import logging
 
 from PySide6 import QtCore
@@ -49,6 +48,8 @@ import sas
 from sas import config
 
 from sasdata.dataloader.loader import Loader
+
+warnings.simplefilter("ignore")
 
 # This matches the ID of a plot created using FittingLogic._create1DPlot, e.g.
 # "5 [P(Q)] modelname"
@@ -1342,7 +1343,7 @@ def readProjectFromSVS(filepath):
         if state is not None:
             state_svs.append(state)
     state_reader = Reader(call_back=collector)
-    data_svs = state_reader.read(filepath)
+    state_reader.read(filepath)
 
     if isinstance(temp, list) and isinstance(state_svs, list):
         output = list(zip(temp, state_svs))
@@ -1430,7 +1431,6 @@ def convertFromSVS(datasets):
             for p in params.fittable_param:
                 p_name = p[1]
                 p_opt = str(p[0])
-                p_err = "0"
                 p_width = str(p[2])
                 p_min = str(0)
                 p_max = "inf"

--- a/src/sas/qtgui/Utilities/MuMag/MuMag.py
+++ b/src/sas/qtgui/Utilities/MuMag/MuMag.py
@@ -2,7 +2,6 @@
 from sas.qtgui.Utilities.MuMag.UI.MuMagUI import Ui_MuMagTool
 from PySide6.QtWidgets import QVBoxLayout
 from PySide6 import QtWidgets
-from sas.qtgui.Utilities.MuMag import MuMagLib
 
 from matplotlib.backends.backend_qt5agg import FigureCanvasQTAgg as FigureCanvas
 import matplotlib.pyplot as plt

--- a/src/sas/qtgui/Utilities/Preferences/PreferencesPanel.py
+++ b/src/sas/qtgui/Utilities/Preferences/PreferencesPanel.py
@@ -84,7 +84,6 @@ class PreferencesPanel(QDialog, Ui_preferencesUI):
 
     def prefMenuChanged(self):
         """When the preferences menu selection changes, change to the appropriate preferences widget """
-        row = self.listWidget.currentRow()
         self.setWidgetIndex(self.listWidget.currentRow())
 
     def setMenuByName(self, name: str):

--- a/src/sas/qtgui/Utilities/Reports/reports.py
+++ b/src/sas/qtgui/Utilities/Reports/reports.py
@@ -10,7 +10,7 @@ import base64
 from io import BytesIO
 
 import dominate
-from dominate.tags import *
+from dominate import tags
 from dominate.util import raw
 
 import html2text
@@ -28,7 +28,7 @@ from sas.qtgui.Utilities.Reports.reportdata import ReportData
 # Utility classes
 #
 
-class pretty_units(span):
+class pretty_units(tags.span):
     """ HTML tag for units, prettifies angstroms, inverse angstroms and inverse cm
     TODO: Should be replaced when there is a better way of handling units"""
     tagname = "span"
@@ -58,7 +58,7 @@ class pretty_units(span):
 
         if do_superscript_power:
             with self:
-                span("-1", style="vertical-align:super;")
+                tags.span("-1", style="vertical-align:super;")
 
 
 
@@ -93,42 +93,42 @@ class ReportBase:
         self.plots = []
 
         with self._html_doc.head:
-            meta(http_equiv="Content-Type", content="text/html; charset=utf-8")
-            meta(name="Generator", content=f"SasView {sas.system.version.__version__}")
+            tags.meta(http_equiv="Content-Type", content="text/html; charset=utf-8")
+            tags.meta(name="Generator", content=f"SasView {sas.system.version.__version__}")
 
             if style_link is not None:
-                link(rel="stylesheet", href=style_link)
+                tags.link(rel="stylesheet", href=style_link)
 
             else:
                 style_data = pkg_resources.read_text("sas.qtgui.Utilities.Reports", "report_style.css")
-                style(style_data)
+                tags.style(style_data)
 
         with self._html_doc.body:
-            with div(id="main"):
+            with tags.div(id="main"):
 
-                with div(id="sasview"):
-                    h1(title)
-                    p(datetime.datetime.now().strftime("%I:%M%p, %B %d, %Y"))
-                    with div(id="version-info"):
-                        p(f"sasview {sas.system.version.__version__}, sasmodels {sasmodels.__version__}", cls="sasview-details")
+                with tags.div(id="sasview"):
+                    tags.h1(title)
+                    tags.p(datetime.datetime.now().strftime("%I:%M%p, %B %d, %Y"))
+                    with tags.div(id="version-info"):
+                        tags.p(f"sasview {sas.system.version.__version__}, sasmodels {sasmodels.__version__}", cls="sasview-details")
 
-                div(id="perspective")
-                with div(id="data"):
-                    h2("Data")
+                tags.div(id="perspective")
+                with tags.div(id="data"):
+                    tags.h2("Data")
 
-                with div(id="model"):
+                with tags.div(id="model"):
 
                     if show_param_section_title:
-                        h2("Details")
+                        tags.h2("Details")
 
-                    div(id="model-details")
-                    div(id="model-parameters")
+                    tags.div(id="model-details")
+                    tags.div(id="model-parameters")
 
-                with div(id='figures-outer'):
+                with tags.div(id='figures-outer'):
                     if show_figure_section_title:
-                        h2("Figures")
+                        tags.h2("Figures")
 
-                    div(id="figures")
+                    tags.div(id="figures")
 
     def add_data_details(self, data: Data1D):
         """ Add details of input data to the report"""
@@ -141,8 +141,8 @@ class ReportBase:
         table_data = [
             ["File", os.path.basename(data.filename)],
             ["n Samples", n_points],
-            ["Q min", span(low_q, pretty_units(data.x_unit))],
-            ["Q max", span(high_q, pretty_units(data.x_unit))]
+            ["Q min", tags.span(low_q, pretty_units(data.x_unit))],
+            ["Q max", tags.span(high_q, pretty_units(data.x_unit))]
         ]
 
         self.add_table(table_data, target_tag="data", column_prefix="data-column")
@@ -160,7 +160,7 @@ class ReportBase:
         """
 
         if figure_title is not None:
-            h2(figure_title)
+            tags.h2(figure_title)
 
         if image_type == "svg":
             logging.warning("xhtml2pdf does not currently support svg export to pdf.")
@@ -209,9 +209,9 @@ class ReportBase:
 
         data64 = base64.b64encode(bytes.getvalue())
         with self._html_doc.getElementById("figures"):
-            with p():
-                img(src=f"data:image/{file_type};base64," + data64.decode("utf-8"),
-                    style="width:100%")
+            with tags.p():
+                tags.img(src=f"data:image/{file_type};base64," + data64.decode("utf-8"),
+                         style="width:100%")
 
     def add_table_dict(self, d: Dict[str, Any], titles: Optional[Tuple[str, str]]=None):
 
@@ -226,17 +226,17 @@ class ReportBase:
         """ Add a table of parameters to the report"""
         with self._html_doc.getElementById(target_tag):
 
-            with table():
+            with tags.table():
 
                 if titles is not None:
-                    with tr():
+                    with tags.tr():
                         for title in titles:
-                            th(title)
+                            tags.th(title)
 
                 for row in sorted(data, key=lambda x: x[0]):
-                    with tr():
+                    with tags.tr():
                         for i, value in enumerate(row):
-                            td(value, cls=f"{column_prefix}-{i}")
+                            tags.td(value, cls=f"{column_prefix}-{i}")
 
     @property
     def text(self) -> str:
@@ -284,7 +284,6 @@ def main():
     it will generate a report with some arbitrary data"""
 
     from sasdata.dataloader.loader import Loader
-    import os
     import matplotlib.pyplot as plt
     import numpy as np
     loader = Loader()

--- a/src/sas/qtgui/Utilities/UnitTesting/GuiUtilsTest.py
+++ b/src/sas/qtgui/Utilities/UnitTesting/GuiUtilsTest.py
@@ -1,5 +1,7 @@
 import webbrowser
 import pytest
+import os
+import logging
 
 from PySide6 import QtCore
 from PySide6 import QtGui, QtWidgets
@@ -11,7 +13,7 @@ from sas.qtgui.Plotting.PlotterData import Data1D
 from sas.qtgui.Plotting.PlotterData import Data2D
 
 # Tested module
-from sas.qtgui.Utilities.GuiUtils import *
+from sas.qtgui.Utilities import GuiUtils
 
 
 class GuiUtilsTest:
@@ -36,7 +38,7 @@ class GuiUtilsTest:
         """
         Test the container class with signal definitions
         """
-        com = Communicate()
+        com = GuiUtils.Communicate()
 
         # All defined signals
         list_of_signals = [
@@ -65,7 +67,7 @@ class GuiUtilsTest:
         name = "Black Sabbath"
 
         # update the item
-        updateModelItem(test_item, test_list, name)
+        GuiUtils.updateModelItem(test_item, test_list, name)
 
         # Make sure test_item got all data added
         assert test_item.child(0).text() == name
@@ -94,7 +96,7 @@ class GuiUtilsTest:
         update_data.id = '[0]data0'
         update_data.name = 'data0'
         # update the item
-        updateModelItemWithPlot(test_item, update_data, name)
+        GuiUtils.updateModelItemWithPlot(test_item, update_data, name)
 
         # Make sure test_item got all data added
         assert test_item.child(0).text() == name
@@ -111,7 +113,7 @@ class GuiUtilsTest:
         update_data1.name = 'data1'
         name1 = "Black Sabbath1"
         # update the item and check number of rows
-        updateModelItemWithPlot(test_item, update_data1, name1)
+        GuiUtils.updateModelItemWithPlot(test_item, update_data1, name1)
 
         assert test_item.rowCount() == 2
 
@@ -121,7 +123,7 @@ class GuiUtilsTest:
         update_data2.id = '[1]data0'
         update_data2.name = 'data0'
         name2 = "Black Sabbath2"
-        updateModelItemWithPlot(test_item, update_data2, name2)
+        GuiUtils.updateModelItemWithPlot(test_item, update_data2, name2)
         assert test_item.rowCount() == 2
 
         data_from_item = test_item.child(0).child(0).data()
@@ -170,7 +172,7 @@ class GuiUtilsTest:
         checkbox_model.appendRow(checkbox_item)
 
         # Pull out the "plottable" documents
-        plot_list = plotsFromCheckedItems(checkbox_model)
+        plot_list = GuiUtils.plotsFromCheckedItems(checkbox_model)
 
         # Make sure only the checked data is present
         # FRIDAY IN
@@ -195,7 +197,7 @@ class GuiUtilsTest:
         new_data = manager.create_gui_data(output_object[0], p_file)
 
         # Extract Info elements into a model item
-        item = infoFromData(new_data)
+        item = GuiUtils.infoFromData(new_data)
 
         # Test the item and its children
         assert isinstance(item, QtGui.QStandardItem)
@@ -220,31 +222,31 @@ class GuiUtilsTest:
         bad_url3 = r"poop;//**I.am.a.!bad@url"
 
         mocker.patch.object(webbrowser, 'open')
-        openLink(good_url1)
-        openLink(good_url2)
-        openLink(good_url3)
+        GuiUtils.openLink(good_url1)
+        GuiUtils.openLink(good_url2)
+        GuiUtils.openLink(good_url3)
         assert webbrowser.open.call_count == 3
 
         with pytest.raises(AttributeError):
-            openLink(bad_url1)
+            GuiUtils.openLink(bad_url1)
         with pytest.raises(AttributeError):
-            openLink(bad_url2)
+            GuiUtils.openLink(bad_url2)
         with pytest.raises(AttributeError):
-            openLink(bad_url3)
+            GuiUtils.openLink(bad_url3)
 
     def testRetrieveData1d(self):
         """
         """
         with pytest.raises(AttributeError):
-            retrieveData1d("BOOP")
+            GuiUtils.retrieveData1d("BOOP")
 
         #data = Data1D()
         #with pytest.raises(ValueError):
-        #    retrieveData1d(data)
+        #    GuiUtils.retrieveData1d(data)
 
         data = Data1D(x=[1.0, 2.0, 3.0], y=[10.0, 11.0, 12.0])
 
-        text = retrieveData1d(data)
+        text = GuiUtils.retrieveData1d(data)
 
         assert "Temperature:" in text
         assert "Beam_size:" in text
@@ -255,13 +257,13 @@ class GuiUtilsTest:
         """
         """
         with pytest.raises(AttributeError):
-            retrieveData2d("BOOP")
+            GuiUtils.retrieveData2d("BOOP")
         data = Data2D(image=[1.0, 2.0, 3.0],
                       err_image=[0.01, 0.02, 0.03],
                       qx_data=[0.1, 0.2, 0.3],
                       qy_data=[0.1, 0.2, 0.3])
 
-        text = retrieveData2d(data)
+        text = GuiUtils.retrieveData2d(data)
 
         assert "Type:         Data2D" in text
         assert "I_min = 1.0" in text
@@ -283,11 +285,11 @@ class GuiUtilsTest:
         data = Data1D(x=[1.0, 2.0, 3.0], y=[])
         # Expect a raise
         with pytest.raises(IndexError):
-            onTXTSave(data, path)
+            GuiUtils.onTXTSave(data, path)
 
         # Good data - no dX/dY
         data = Data1D(x=[1.0, 2.0, 3.0], y=[10.0, 11.0, 12.0])
-        onTXTSave(data, path)
+        GuiUtils.onTXTSave(data, path)
 
         assert os.path.isfile(save_path)
         with open(save_path,'r') as out:
@@ -307,7 +309,7 @@ class GuiUtilsTest:
         data = Data1D(x=[1.0, 2.0, 3.0], y=[10.0, 11.0, 12.0],
                       dx=[0.1, 0.2, 0.3], dy=[0.1, 0.2, 0.3])
 
-        onTXTSave(data, path)
+        GuiUtils.onTXTSave(data, path)
         with open(save_path,'r') as out:
             data_read = out.read()
             assert "<X> <Y> <dY> <dX>\n" in data_read
@@ -392,11 +394,11 @@ class GuiUtilsTest:
 
     def genericFileSaveTest(self, data, name, name_full="", file_format="ASCII", level=None, caplog=False):
         if level == '1D':
-            saveMethod = saveData1D
+            saveMethod = GuiUtils.saveData1D
         elif level == "2D":
-            saveMethod = saveData2D
+            saveMethod = GuiUtils.saveData2D
         else:
-            saveMethod = saveAnyData
+            saveMethod = GuiUtils.saveAnyData
 
         name_full = name if name_full == "" else name_full
 
@@ -417,62 +419,62 @@ class GuiUtilsTest:
         data = Data1D(x=[1.0, 2.0, 3.0], y=[10.0, 11.0, 12.0],
                       dx=[0.1, 0.2, 0.3], dy=[0.1, 0.2, 0.3])
 
-        xLabel, yLabel, xscale, yscale = xyTransform(data, xLabel="x", yLabel="y")
+        xLabel, yLabel, xscale, yscale = GuiUtils.xyTransform(data, xLabel="x", yLabel="y")
         assert xLabel == "()"
         assert xscale == "linear"
         assert yscale == "linear"
 
-        xLabel, yLabel, xscale, yscale = xyTransform(data, xLabel="x^(2)", yLabel="1/y")
+        xLabel, yLabel, xscale, yscale = GuiUtils.xyTransform(data, xLabel="x^(2)", yLabel="1/y")
         assert xLabel == "^{2}(()^{2})"
         assert yLabel == "1/(()^{-1})"
         assert xscale == "linear"
         assert yscale == "linear"
 
-        xLabel, yLabel, xscale, yscale = xyTransform(data, xLabel="x^(4)", yLabel="ln(y)")
+        xLabel, yLabel, xscale, yscale = GuiUtils.xyTransform(data, xLabel="x^(4)", yLabel="ln(y)")
         assert xLabel == "^{4}(()^{4})"
         assert yLabel == "\\ln{()}()"
         assert xscale == "linear"
         assert yscale == "linear"
 
-        xLabel, yLabel, xscale, yscale = xyTransform(data, xLabel="ln(x)", yLabel="y^(2)")
+        xLabel, yLabel, xscale, yscale = GuiUtils.xyTransform(data, xLabel="ln(x)", yLabel="y^(2)")
         assert xLabel == "\\ln{()}()"
         assert yLabel == "^{2}(()^{2})"
         assert xscale == "linear"
         assert yscale == "linear"
 
-        xLabel, yLabel, xscale, yscale = xyTransform(data, xLabel="log10(x)", yLabel="y*x^(2)")
+        xLabel, yLabel, xscale, yscale = GuiUtils.xyTransform(data, xLabel="log10(x)", yLabel="y*x^(2)")
         assert xLabel == "()"
         assert yLabel == " \\ \\ ^{2}(()^{2})"
         assert xscale == "log"
         assert yscale == "linear"
 
-        xLabel, yLabel, xscale, yscale = xyTransform(data, xLabel="log10(x^(4))", yLabel="y*x^(4)")
+        xLabel, yLabel, xscale, yscale = GuiUtils.xyTransform(data, xLabel="log10(x^(4))", yLabel="y*x^(4)")
         assert xLabel == "^{4}(()^{4})"
         assert yLabel == " \\ \\ ^{4}(()^{16})"
         assert xscale == "log"
         assert yscale == "linear"
 
-        xLabel, yLabel, xscale, yscale = xyTransform(data, xLabel="x", yLabel="1/sqrt(y)")
+        xLabel, yLabel, xscale, yscale = GuiUtils.xyTransform(data, xLabel="x", yLabel="1/sqrt(y)")
         assert yLabel == "1/\\sqrt{}(()^{-0.5})"
         assert yscale == "linear"
 
-        xLabel, yLabel, xscale, yscale = xyTransform(data, xLabel="x", yLabel="log10(y)")
+        xLabel, yLabel, xscale, yscale = GuiUtils.xyTransform(data, xLabel="x", yLabel="log10(y)")
         assert yLabel == "()"
         assert yscale == "log"
 
-        xLabel, yLabel, xscale, yscale = xyTransform(data, xLabel="x", yLabel="ln(y*x)")
+        xLabel, yLabel, xscale, yscale = GuiUtils.xyTransform(data, xLabel="x", yLabel="ln(y*x)")
         assert yLabel == "\\ln{( \\ \\ )}()"
         assert yscale == "linear"
 
-        xLabel, yLabel, xscale, yscale = xyTransform(data, xLabel="x", yLabel="ln(y*x^(2))")
+        xLabel, yLabel, xscale, yscale = GuiUtils.xyTransform(data, xLabel="x", yLabel="ln(y*x^(2))")
         assert yLabel == "\\ln ( \\ \\ ^{2})(()^{2})"
         assert yscale == "linear"
 
-        xLabel, yLabel, xscale, yscale = xyTransform(data, xLabel="x", yLabel="ln(y*x^(4))")
+        xLabel, yLabel, xscale, yscale = GuiUtils.xyTransform(data, xLabel="x", yLabel="ln(y*x^(4))")
         assert yLabel == "\\ln ( \\ \\ ^{4})(()^{4})"
         assert yscale == "linear"
 
-        xLabel, yLabel, xscale, yscale = xyTransform(data, xLabel="x", yLabel="log10(y*x^(4))")
+        xLabel, yLabel, xscale, yscale = GuiUtils.xyTransform(data, xLabel="x", yLabel="log10(y*x^(4))")
         assert yLabel == " \\ \\ ^{4}(()^{4})"
         assert yscale == "log"
 
@@ -480,132 +482,132 @@ class GuiUtilsTest:
         ''' test single character replacement '''
         s = None
         with pytest.raises(AttributeError):
-            result = replaceHTMLwithUTF8(s)
+            result = GuiUtils.replaceHTMLwithUTF8(s)
 
         s = ""
-        assert replaceHTMLwithUTF8(s) == s
+        assert GuiUtils.replaceHTMLwithUTF8(s) == s
 
         s = "aaaa"
-        assert replaceHTMLwithUTF8(s) == s
+        assert GuiUtils.replaceHTMLwithUTF8(s) == s
 
         s = "&#x212B; &#x221e;      &#177;"
-        assert replaceHTMLwithUTF8(s) == "Å ∞      ±"
+        assert GuiUtils.replaceHTMLwithUTF8(s) == "Å ∞      ±"
 
     def testReplaceHTMLwithASCII(self):
         ''' test single character replacement'''
         s = None
         with pytest.raises(AttributeError):
-            result = replaceHTMLwithASCII(s)
+            result = GuiUtils.replaceHTMLwithASCII(s)
 
         s = ""
-        assert replaceHTMLwithASCII(s) == s
+        assert GuiUtils.replaceHTMLwithASCII(s) == s
 
         s = "aaaa"
-        assert replaceHTMLwithASCII(s) == s
+        assert GuiUtils.replaceHTMLwithASCII(s) == s
 
         s = "&#x212B; &#x221e;      &#177;"
-        assert replaceHTMLwithASCII(s) == "Ang inf      +/-"
+        assert GuiUtils.replaceHTMLwithASCII(s) == "Ang inf      +/-"
 
     def testrstToHtml(self):
         ''' test rst to html conversion'''
         s = None
         with pytest.raises(TypeError):
-            result = rstToHtml(s)
+            result = GuiUtils.rstToHtml(s)
 
         s = ".. |Ang| unicode:: U+212B"
-        assert rstToHtml(s) == ('Ang', 'Å')
+        assert GuiUtils.rstToHtml(s) == ('Ang', 'Å')
         s = r".. |Ang^-1| replace:: |Ang|\ :sup:`-1`"
-        assert rstToHtml(s) == ('Ang^-1', 'Å<sup>-1</sup>')
+        assert GuiUtils.rstToHtml(s) == ('Ang^-1', 'Å<sup>-1</sup>')
         s = r".. |1e-6Ang^-2| replace:: 10\ :sup:`-6`\ |Ang|\ :sup:`-2`"
-        assert rstToHtml(s) == ('1e-6Ang^-2', '10<sup>-6</sup> Å<sup>-2</sup>')
+        assert GuiUtils.rstToHtml(s) == ('1e-6Ang^-2', '10<sup>-6</sup> Å<sup>-2</sup>')
         s = r".. |cm^-1| replace:: cm\ :sup:`-1`"
-        assert rstToHtml(s) == ('cm^-1', 'cm<sup>-1</sup>')
+        assert GuiUtils.rstToHtml(s) == ('cm^-1', 'cm<sup>-1</sup>')
         s = ".. |deg| unicode:: U+00B0"
-        assert rstToHtml(s) == ('deg', '°')
+        assert GuiUtils.rstToHtml(s) == ('deg', '°')
         s = ".. |cdot| unicode:: U+00B7"
-        assert rstToHtml(s) == ('cdot', '·')
+        assert GuiUtils.rstToHtml(s) == ('cdot', '·')
         s = "bad string"
-        assert rstToHtml(s) == (None, None)
+        assert GuiUtils.rstToHtml(s) == (None, None)
 
 
     def testConvertUnitToHTML(self):
         ''' test unit string replacement'''
         s = None
-        assert convertUnitToHTML(s) == ""
+        assert GuiUtils.convertUnitToHTML(s) == ""
 
         s = ""
-        assert convertUnitToHTML(s) == s
+        assert GuiUtils.convertUnitToHTML(s) == s
 
         s = "aaaa"
-        assert convertUnitToHTML(s) == s
+        assert GuiUtils.convertUnitToHTML(s) == s
 
         s = "1/A"
-        assert convertUnitToHTML(s) == "Å<sup>-1</sup>"
+        assert GuiUtils.convertUnitToHTML(s) == "Å<sup>-1</sup>"
 
         s = "Ang"
-        assert convertUnitToHTML(s) == "Å"
+        assert GuiUtils.convertUnitToHTML(s) == "Å"
 
         s = "1e-6/Ang^2"
-        assert convertUnitToHTML(s) == "10<sup>-6</sup>/Å<sup>2</sup>"
+        assert GuiUtils.convertUnitToHTML(s) == "10<sup>-6</sup>/Å<sup>2</sup>"
 
         s = "inf"
-        assert convertUnitToHTML(s) == "∞"
+        assert GuiUtils.convertUnitToHTML(s) == "∞"
         s = "-inf"
 
-        assert convertUnitToHTML(s) == "-∞"
+        assert GuiUtils.convertUnitToHTML(s) == "-∞"
 
         s = "1/cm"
-        assert convertUnitToHTML(s) == "cm<sup>-1</sup>"
+        assert GuiUtils.convertUnitToHTML(s) == "cm<sup>-1</sup>"
 
         s = "degrees"
-        assert convertUnitToHTML(s) == "°"
+        assert GuiUtils.convertUnitToHTML(s) == "°"
 
     def testParseName(self):
         '''test parse out a string from the beinning of a string'''
         # good input
         value = "_test"
-        assert parseName(value, '_') == 'test'
+        assert GuiUtils.parseName(value, '_') == 'test'
         value = "____test____"
-        assert parseName(value, '_') == '___test____'
-        assert parseName(value, '___') == '_test____'
-        assert parseName(value, 'test') == '____test____'
+        assert GuiUtils.parseName(value, '_') == '___test____'
+        assert GuiUtils.parseName(value, '___') == '_test____'
+        assert GuiUtils.parseName(value, 'test') == '____test____'
         # bad input
         with pytest.raises(TypeError):
-            parseName(value, None)
+            GuiUtils.parseName(value, None)
         with pytest.raises(TypeError):
-            parseName(None, '_')
+            GuiUtils.parseName(None, '_')
         value = []
         with pytest.raises(TypeError):
-            parseName(value, '_')
+            GuiUtils.parseName(value, '_')
         value = 1.44
         with pytest.raises(TypeError):
-            parseName(value, 'p')
+            GuiUtils.parseName(value, 'p')
         value = 100
         with pytest.raises(TypeError):
-            parseName(value, 'p')
+            GuiUtils.parseName(value, 'p')
 
     @pytest.mark.xfail(reason="2022-09 already broken")
     def testToDouble(self):
         '''test homemade string-> double converter'''
         #good values
         value = "1"
-        assert toDouble(value) == 1.0
+        assert GuiUtils.toDouble(value) == 1.0
         value = "1.2"
         # has to be AlmostEqual due to numerical rounding
-        assert toDouble(value) == pytest.approx(1.2, abs=1e-6)
+        assert GuiUtils.toDouble(value) == pytest.approx(1.2, abs=1e-6)
         value = "2,1"
-        assert toDouble(value) == pytest.approx(2.1, abs=1e-6)
+        assert GuiUtils.toDouble(value) == pytest.approx(2.1, abs=1e-6)
 
         # bad values
         value = None
         with pytest.raises(TypeError):
-            toDouble(value)
+            GuiUtils.toDouble(value)
         value = "MyDouble"
         with pytest.raises(TypeError):
-            toDouble(value)
+            GuiUtils.toDouble(value)
         value = [1,2.2]
         with pytest.raises(TypeError):
-            toDouble(value)
+            GuiUtils.toDouble(value)
 
 
 class DoubleValidatorTest:
@@ -613,7 +615,7 @@ class DoubleValidatorTest:
     @pytest.fixture(autouse=True)
     def validator(self, qapp):
         '''Create/Destroy the validator'''
-        v = DoubleValidator()
+        v = GuiUtils.DoubleValidator()
         yield v
 
     def testValidateGood(self, validator):
@@ -649,7 +651,7 @@ class FormulaValidatorTest:
     @pytest.fixture(autouse=True)
     def validator(self, qapp):
         '''Create/Destroy the validator'''
-        v = FormulaValidator()
+        v = GuiUtils.FormulaValidator()
         yield v
 
     def testValidateGood(self, validator):
@@ -675,7 +677,7 @@ class HashableStandardItemTest:
     @pytest.fixture(autouse=True)
     def item(self, qapp):
         '''Create/Destroy the HashableStandardItem'''
-        i = HashableStandardItem()
+        i = GuiUtils.HashableStandardItem()
         yield i
 
     def testHash(self, item):
@@ -709,7 +711,7 @@ class HashableStandardItemTest:
         fit_page2 = {'fit_data': None, 'fit_params': [fit_params2]}
         fit_project = {'dataset1': fit_page1, 'dataset2': fit_page2}
         # get the constraint_dict
-        constraint_dict = getConstraints(fit_project)
+        constraint_dict = GuiUtils.getConstraints(fit_project)
         # we have two constraints on different fit pages
         assert len(constraint_dict) == 2
         # we have one constraint per fit page

--- a/src/sas/qtgui/Utilities/UnitTesting/GuiUtilsTest.py
+++ b/src/sas/qtgui/Utilities/UnitTesting/GuiUtilsTest.py
@@ -482,7 +482,7 @@ class GuiUtilsTest:
         ''' test single character replacement '''
         s = None
         with pytest.raises(AttributeError):
-            result = GuiUtils.replaceHTMLwithUTF8(s)
+            GuiUtils.replaceHTMLwithUTF8(s)
 
         s = ""
         assert GuiUtils.replaceHTMLwithUTF8(s) == s
@@ -497,7 +497,7 @@ class GuiUtilsTest:
         ''' test single character replacement'''
         s = None
         with pytest.raises(AttributeError):
-            result = GuiUtils.replaceHTMLwithASCII(s)
+            GuiUtils.replaceHTMLwithASCII(s)
 
         s = ""
         assert GuiUtils.replaceHTMLwithASCII(s) == s
@@ -512,7 +512,7 @@ class GuiUtilsTest:
         ''' test rst to html conversion'''
         s = None
         with pytest.raises(TypeError):
-            result = GuiUtils.rstToHtml(s)
+            GuiUtils.rstToHtml(s)
 
         s = ".. |Ang| unicode:: U+212B"
         assert GuiUtils.rstToHtml(s) == ('Ang', 'Å')

--- a/src/sas/qtgui/Utilities/UnitTesting/ModelEditorTest.py
+++ b/src/sas/qtgui/Utilities/UnitTesting/ModelEditorTest.py
@@ -1,9 +1,5 @@
 import pytest
 
-from PySide6.QtGui import *
-from PySide6.QtCore import *
-from PySide6.QtWidgets import *
-
 from sas.qtgui.UnitTesting.TestUtils import QtSignalSpy
 
 # Local

--- a/src/sas/qtgui/Utilities/UnitTesting/PluginDefinitionTest.py
+++ b/src/sas/qtgui/Utilities/UnitTesting/PluginDefinitionTest.py
@@ -1,8 +1,6 @@
 import pytest
 
-from PySide6.QtGui import *
-from PySide6.QtCore import *
-from PySide6.QtWidgets import *
+from PySide6.QtWidgets import QTableWidgetItem
 
 from sas.qtgui.UnitTesting.TestUtils import QtSignalSpy
 

--- a/src/sas/qtgui/Utilities/UnitTesting/SasviewLoggerTest.py
+++ b/src/sas/qtgui/Utilities/UnitTesting/SasviewLoggerTest.py
@@ -12,15 +12,15 @@ class SasviewLoggerTest:
     @pytest.fixture(autouse=True)
     def logger(self, qapp):
         '''Create/Destroy the logger'''
-        l = logging.getLogger(__name__)
+        logger = logging.getLogger(__name__)
         self.handler = QtHandler()
         self.handler.setFormatter(logging.Formatter("%(levelname)s: %(message)s"))
-        l.addHandler(self.handler)
-        l.setLevel(logging.DEBUG)
+        logger.addHandler(self.handler)
+        logger.setLevel(logging.DEBUG)
 
         self.outHandlerGui=QTextBrowser()
 
-        yield l
+        yield logger
 
 
     def testQtHandler(self, logger):

--- a/src/sas/qtgui/Utilities/UnitTesting/SasviewLoggerTest.py
+++ b/src/sas/qtgui/Utilities/UnitTesting/SasviewLoggerTest.py
@@ -1,9 +1,7 @@
 import logging
 import pytest
 
-from PySide6.QtGui import *
-from PySide6.QtCore import *
-from PySide6.QtWidgets import *
+from PySide6.QtWidgets import QTextBrowser
 
 # Local
 from sas.qtgui.Utilities.SasviewLogger import QtHandler

--- a/src/sas/qtgui/Utilities/UnitTesting/TabbedModelEditorTest.py
+++ b/src/sas/qtgui/Utilities/UnitTesting/TabbedModelEditorTest.py
@@ -2,9 +2,8 @@ import os
 
 import pytest
 
-from PySide6.QtGui import *
-from PySide6.QtCore import *
-from PySide6.QtWidgets import *
+from PySide6.QtCore import QObject
+from PySide6.QtWidgets import QMessageBox, QDialogButtonBox, QWidget
 
 
 # Local

--- a/src/sas/sascalc/calculator/ausaxs/sasview_sans_debye.py
+++ b/src/sas/sascalc/calculator/ausaxs/sasview_sans_debye.py
@@ -26,7 +26,8 @@ def _calc_Iq_batch(Iq, q_pi, coords, weight):
     *weight* is the weight associated with each point.
     """
     for j in range(len(weight)):
-        if j % 100 == 0: logging.info(f"\tprogress: {j/len(weight)*100:.0f}%")
+        if j % 100 == 0:
+            logging.info(f"\tprogress: {j/len(weight)*100:.0f}%")
         # Compute dx for one row of the upper triangle matrix.
         dx = coords[:, j:] - coords[:, j:j+1]
         # Find the length of each dx vector.

--- a/src/sas/sascalc/calculator/sas_gen.py
+++ b/src/sas/sascalc/calculator/sas_gen.py
@@ -673,7 +673,6 @@ class VTKReader:
                 sld_mz = np.zeros_like(sld_n)
             elif element_data[0][2] == 3:
                 sld_mx, sld_my, sld_mz = np.hsplit(element_data[0][0], 3)
-                nuc_data = np.zeros_like(sld_mx)
             else:
                 logging.error("Data attributes did not have 1 or 3 components - cannot interpret as nuclear or magnetic SLD")
                 return None
@@ -1062,7 +1061,8 @@ class OMFReader(object):
                 # Reading Header; Segment count ignored
                     s_line = line.split(":", 1)
                     if s_line[0].lower().count("oommf") > 0:
-                        if len(s_line) < 2: s_line = line.split(" ",1)
+                        if len(s_line) < 2:
+                            s_line = line.split(" ",1)
                         oommf = s_line[1].strip()                               
 
                     if s_line[0].lower().count("title") > 0:
@@ -1198,7 +1198,6 @@ class PDBReader(object):
             buff = decode(input_f.read())
             lines = buff.split('\n')
             input_f.close()
-            num = 0
             for line in lines:
                 try:
                     # check if line starts with "ATOM"

--- a/src/sas/sascalc/corfunc/transform_thread.py
+++ b/src/sas/sascalc/corfunc/transform_thread.py
@@ -31,14 +31,16 @@ class FourierThread(CalcThread):
         self.update(msg="Fourier transform in progress.")
         self.ready(delay=0.0)
 
-        if self.check_if_cancelled(): return
+        if self.check_if_cancelled():
+            return
         try:
             # ----- 1D Correlation Function -----
             gamma1 = dct((iqs-background)*(qs**2))
             Q = gamma1.max()
             gamma1 /= Q
 
-            if self.check_if_cancelled(): return
+            if self.check_if_cancelled():
+                return
 
             # ----- 3D Correlation Function -----
             # gamma3(R) = 1/R int_{0}^{R} gamma1(x) dx
@@ -47,12 +49,14 @@ class FourierThread(CalcThread):
             gamma3 = cumulative_trapezoid(gamma1, xs)/xs[1:]
             gamma3 = np.hstack((1.0, gamma3)) # gamma3(0) is defined as 1
 
-            if self.check_if_cancelled(): return
+            if self.check_if_cancelled():
+                return
 
             # ----- Interface Distribution function -----
             idf = dct(-qs**4 * (iqs-background))
 
-            if self.check_if_cancelled(): return
+            if self.check_if_cancelled():
+                return
 
             # Manually calculate IDF(0.0), since scipy DCT tends to give us a
             # very large negative value.

--- a/src/sas/sascalc/data_util/pathutils.py
+++ b/src/sas/sascalc/data_util/pathutils.py
@@ -18,16 +18,21 @@ def relpath(p1, p2):
     """Compute the relative path of p1 with respect to p2."""
 
     def commonpath(L1, L2, common=[]):
-        if len(L1) < 1: return (common, L1, L2)
-        if len(L2) < 1: return (common, L1, L2)
-        if L1[0] != L2[0]: return (common, L1, L2)
+        if len(L1) < 1:
+            return (common, L1, L2)
+        if len(L2) < 1:
+            return (common, L1, L2)
+        if L1[0] != L2[0]:
+            return (common, L1, L2)
         return commonpath(L1[1:], L2[1:], common=common+[L1[0]])
 
     # if the strings are equal, then return "."
-    if p1 == p2: return "."
+    if p1 == p2:
+        return "."
     (common,L1,L2) = commonpath(p2.split(sep), p1.split(sep))
     # if there is nothing in common, then return an empty string
-    if not common: return ""
+    if not common:
+        return ""
     # otherwise, replace the common pieces with "../" (or "..\")
     p = [(".."+sep) * len(L1)] + L2
     return join(*p)

--- a/src/sas/sascalc/fit/BumpsFitting.py
+++ b/src/sas/sascalc/fit/BumpsFitting.py
@@ -72,7 +72,8 @@ class BumpsMonitor(object):
         history.requires(time=1, value=2, point=1, step=1)
 
     def __call__(self, history):
-        if self.handler is None: return
+        if self.handler is None:
+            return
         self.handler.set_result(Progress(history, self.max_step, self.pars, self.dof))
         self.handler.progress(history.step[0], self.max_step)
         if len(history.step) > 1 and history.step[1] > history.step[0]:
@@ -378,8 +379,10 @@ class BumpsFit(FitEngine):
 
 def run_bumps(problem, handler, curr_thread):
     def abort_test():
-        if curr_thread is None: return False
-        try: curr_thread.isquit()
+        if curr_thread is None:
+            return False
+        try:
+            curr_thread.isquit()
         except KeyboardInterrupt:
             if handler is not None:
                 handler.stop("Fitting: Terminated!!!")

--- a/src/sas/sascalc/fit/qsmearing.py
+++ b/src/sas/sascalc/fit/qsmearing.py
@@ -108,7 +108,8 @@ class PySmear(object):
         The returned value is of the same length as iq_in, with the range
         first_bin:last_bin set to the resolution smeared values.
         """
-        if last_bin is None: last_bin = len(iq_in)
+        if last_bin is None:
+            last_bin = len(iq_in)
         start, end = first_bin + self.offset, last_bin + self.offset
         q_calc = self.resolution.q_calc
         iq_calc = np.empty_like(q_calc)

--- a/src/sas/sascalc/invariant/invariant.py
+++ b/src/sas/sascalc/invariant/invariant.py
@@ -313,7 +313,7 @@ class Extrapolator(object):
         fx = np.zeros(len(self.data.x))
 
         # Uncertainty
-        if type(self.data.dy) == np.ndarray and \
+        if isinstance(self.data.dy, np.ndarray) and \
             len(self.data.dy) == len(self.data.x) and \
                 np.all(self.data.dy > 0):
             sigma = self.data.dy

--- a/src/sas/sascalc/pr/Invertor.py
+++ b/src/sas/sascalc/pr/Invertor.py
@@ -203,8 +203,8 @@ class Invertor():
         # CRUFT: numpy>=1.14.0 allows rcond=None for the following default
 
         rcond = np.finfo(float).eps * max(a.shape)
-        if rcond ==None:
-            rcond =-1
+        if rcond is None:
+            rcond = -1
         c, chi2, _, _ = lstsq(a, b, rcond=rcond)
         # Sanity check
         try:

--- a/src/sas/sascalc/simulation/pointsmodelpy/tests/testlores2d.py
+++ b/src/sas/sascalc/simulation/pointsmodelpy/tests/testlores2d.py
@@ -29,7 +29,6 @@ def test_lores2d(phi):
   iqPy.OutputIQ(iq, "out_xy.iq")
 
 def get2d():
-  from Numeric import zeros
   from enthought.util.numerix import Float,zeros
   from sasModeling.pointsmodelpy import pointsmodelpy
   from sasModeling.geoshapespy import geoshapespy
@@ -67,7 +66,6 @@ def get2d():
   return value_grid
 
 def get2d_2():
-  from Numeric import zeros
   from enthought.util.numerix import Float,zeros
   from sasModeling.pointsmodelpy import pointsmodelpy
   from sasModeling.geoshapespy import geoshapespy

--- a/src/sas/system/console.py
+++ b/src/sas/system/console.py
@@ -160,7 +160,8 @@ def setup_console_simple(stderr_to_stdout=True):
 def demo():
     setup_console()
     print("demo ready")
-    import code; code.interact(local={'exit': sys.exit})
+    import code
+    code.interact(local={'exit': sys.exit})
     print('demo done')
     #import time; time.sleep(2)
 

--- a/src/sas/webfit/analyze/fitting/views.py
+++ b/src/sas/webfit/analyze/fitting/views.py
@@ -6,13 +6,14 @@ from django.shortcuts import get_object_or_404
 from rest_framework.response import Response
 from rest_framework.decorators import api_view
 
-from bumps.names import *
+from bumps.fitProblem import FitProblem
 from bumps import fitters
 from sasmodels.core import load_model, load_model_info, list_models
 from sasmodels.data import load_data, empty_data1D
 from sasmodels.bumps_model import Model, Experiment
 from sasmodels.direct_model import DirectModel
 from sas.sascalc.fit.models import ModelManager
+import numpy as np
 
 #TODO categoryinstallers should belong in SasView.System rather than in QTGUI
 from sas.qtgui.Utilities.CategoryInstaller import CategoryInstaller
@@ -141,9 +142,9 @@ def start_fit(fit_db):
         #TODO be able to do multiple experiments
         problem = FitProblem(M)
         if fit_db.optimizer:
-            fitted = fit(problem, method=fit_db.optimizer)
+            fitted = fitters.fit(problem, method=fit_db.optimizer)
         else:
-            fitted = fit(problem)
+            fitted = fitters.fit(problem)
         #TODO results to be formatted differently later
         result = M.__getstate__()
         result['_data'] = test_data.__str__()

--- a/src/sas/webfit/data/views.py
+++ b/src/sas/webfit/data/views.py
@@ -74,7 +74,7 @@ def upload(request, data_id = None, version = None):
     #saves or updates file
     elif request.method == 'PUT':
         #require data_id
-        if data_id != None and request.user:
+        if data_id is not None and request.user:
             if request.user.is_authenticated:
                 db = get_object_or_404(Data, current_user = request.user.id, id = data_id)
                 form = DataForm(request.data, request.FILES, instance=db)

--- a/src/sas/webfit/settings.py
+++ b/src/sas/webfit/settings.py
@@ -19,13 +19,13 @@ from django.conf import settings
 # `django.test.signals` to avoid importing the test module unnecessarily.
 from django.utils.module_loading import import_string
 
-# Build paths inside the project like this: BASE_DIR / 'subdir'.
-BASE_DIR = Path(__file__).resolve().parent
 
 #imports for knox
 from datetime import timedelta
 from rest_framework.settings import api_settings
 
+# Build paths inside the project like this: BASE_DIR / 'subdir'.
+BASE_DIR = Path(__file__).resolve().parent
 
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/4.2/howto/deployment/checklist/

--- a/src/sas/webfit/upload_example_data.py
+++ b/src/sas/webfit/upload_example_data.py
@@ -4,11 +4,12 @@ import django
 from glob import glob
 from sasdata import example_data
 
+from data.models import Data
+
 # Initialise the Django environment. This must be done before importing anything
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "settings")
 django.setup()
 
-from data.models import Data
 
 EXAMPLE_DATA_DIR = os.environ.get("EXAMPLE_DATA_DIR", os.path.dirname(example_data.__file__))
 

--- a/test/pr_inversion/utest_explorer.py
+++ b/test/pr_inversion/utest_explorer.py
@@ -4,10 +4,9 @@
 
 import os.path
 import unittest
-# TODO: This import is broken. It needs to be rewritten if this test is to be renabled.
-# from sas.sascalc.pr.invertor import Invertor
 import pytest
 from sas.sascalc.pr.distance_explorer import DistExplorer
+from sas.sascalc.pr.Invertor import Invertor
 
 pytest.skip(reason="Refactored invertor doesn't support this test", allow_module_level=True)
 

--- a/test/pr_inversion/utest_invertor.py
+++ b/test/pr_inversion/utest_invertor.py
@@ -12,8 +12,7 @@ import unittest
 import math
 import numpy
 import pytest
-# TODO: This import is broken. It needs to be rewritten if this test is to be renabled.
-# from sas.sascalc.pr.invertor import Invertor
+from sas.sascalc.pr.Invertor import Invertor
 
 
 pytest.skip(reason="Refactored invertor doesn't support this test", allow_module_level=True)
@@ -601,7 +600,7 @@ def load(path = find("sphere_60_q0_2.txt")):
                     if len(toks)>2:
                         err = float(toks[2])
                     else:
-                        if scale==None:
+                        if scale is None:
                             scale = 0.15*math.sqrt(y)
                         err = scale*math.sqrt(y)
                     data_x = np.append(data_x, x)

--- a/test/sascalculator/utest_sas_gen.py
+++ b/test/sascalculator/utest_sas_gen.py
@@ -4,7 +4,6 @@ Unit tests for the sas_gen
 
 import os.path
 import warnings
-warnings.simplefilter("ignore")
 
 import unittest
 import numpy as np
@@ -13,6 +12,8 @@ from scipy.spatial.transform import Rotation
 
 
 from sas.sascalc.calculator import sas_gen
+
+warnings.simplefilter("ignore")
 
 MFACTOR_AM = 2.90636E-12
 

--- a/test/sascalculator/utest_sld.py
+++ b/test/sascalculator/utest_sld.py
@@ -1,13 +1,13 @@
 
 import unittest
 
-_SCALE = 1e-6
 
 # the calculator default value for wavelength is 6
 from periodictable import formula
 from periodictable.xsf import xray_energy, xray_sld_from_atoms
 from  periodictable.nsf import neutron_scattering
 
+_SCALE = 1e-6
 
 def calculate_xray_sld(element, density, molecule_formula):
     """

--- a/test/sasrealspace/sim_validation.py
+++ b/test/sasrealspace/sim_validation.py
@@ -13,7 +13,7 @@ import pylab
 try:
     import VolumeCanvas
     print("Testing local version")
-except:
+except ImportError:
     print("Testing installed version")
     import sas.sascalc.realspace.VolumeCanvas as VolumeCanvas
      

--- a/test/sasrealspace/utest_oriented.py
+++ b/test/sasrealspace/utest_oriented.py
@@ -16,12 +16,13 @@ import math
 # pylint: disable-msg=W0702
 
 from sasmodels.sasview_model import _make_standard_model
+
+import sas.sascalc.realspace.VolumeCanvas as VolumeCanvas
+
 EllipsoidModel = _make_standard_model('ellipsoid')
 SphereModel = _make_standard_model('sphere')
 CylinderModel = _make_standard_model('cylinder')
 CoreShellModel = _make_standard_model('core_shell_sphere')
-
-import sas.sascalc.realspace.VolumeCanvas as VolumeCanvas
 
 
 

--- a/test/sasrealspace/utest_realspace.py
+++ b/test/sasrealspace/utest_realspace.py
@@ -16,12 +16,13 @@ import time
 # pylint: disable-msg=R0201
 
 from sasmodels.sasview_model import _make_standard_model
+import sas.sascalc.realspace.VolumeCanvas as VolumeCanvas
+
 EllipsoidModel = _make_standard_model('ellipsoid')
 SphereModel = _make_standard_model('sphere')
 CylinderModel = _make_standard_model('cylinder')
 CoreShellModel = _make_standard_model('core_shell_sphere')
 
-import sas.sascalc.realspace.VolumeCanvas as VolumeCanvas
 
 class TestRealSpaceModel(unittest.TestCase):
     """ Unit tests for sphere model """

--- a/test/size_distribution/MaxEntTest.py
+++ b/test/size_distribution/MaxEntTest.py
@@ -64,7 +64,7 @@ def test_noRes(data1):
     # TODO: Need to understand how IRENA is reporting bins. It seems to be using bin 1 and last as the
     #       values input from the user while we are starting from the midpoint of what should be the
     #       the first bin if the min diameter is the bottom edge of the bin.
-    assert convergence[0][0] == True
+    assert convergence[0][0]
     assert data1.MaxEnt_statistics['volume'] == pytest.approx(4.84, abs=0.02)
     assert data1.BinMagnitude_maxEnt == pytest.approx(answerMags, abs=1e-3)
 


### PR DESCRIPTION
## Description

Applies fixes for most (~75%) of the linting errors in the sasview codebase. This mostly concerns correcting import statements, either by adding those that are missing, or specifying routines instead of relying on star imports (i.e., `from numpy import *`)

Fixes #3498

## How Has This Been Tested?

The code passes its own tests. There should be no change in functionality.

## Review Checklist:

[if using the editor, use `[x]` in place of `[ ]` to check a box]

**Documentation** (check at least one)
- [x] There is **nothing** that needs documenting
- [ ] Documentation changes are **in this PR**
- [ ] There is an **issue** open for the documentation (link?)

**Installers**
- [ ] There is a chance this will affect the **installers**, if so
  - [ ] **Windows** installer (GH artifact) has been tested (installed and worked) 
  - [ ] **MacOSX** installer (GH artifact) has been tested (installed and worked)
  - [ ] **Wheels** installer (GH artifact) has been tested (installed and worked)

**Licensing** (untick if necessary)
- [x] The introduced changes comply with SasView license (BSD 3-Clause)

