### PR TITLE
Replace usage of connection proxy with the requests library.

### DIFF
--- a/build_tools/requirements.txt
+++ b/build_tools/requirements.txt
@@ -37,6 +37,7 @@ twisted
 uncertainties
 xhtml2pdf
 zope
+requests
 
 # Alphabetized list of OS-specific packages
 pywin32; platform_system == "Windows"

--- a/src/sas/qtgui/MainWindow/GuiManager.py
+++ b/src/sas/qtgui/MainWindow/GuiManager.py
@@ -629,7 +629,8 @@ class GuiManager:
         version number has been obtained. If the check is being done in the
         background, the user will not be notified unless there's an update.
 
-        :param version_str: version string
+        :param version_info: tuple of version string, download url, and the
+        version object.
         """
         version_str, download_url, _ = version_info
         try:

--- a/src/sas/qtgui/MainWindow/GuiManager.py
+++ b/src/sas/qtgui/MainWindow/GuiManager.py
@@ -6,6 +6,7 @@ import traceback
 import webbrowser
 from pathlib import Path
 from typing import Dict, Optional
+from packaging.version import Version
 
 from PySide6.QtCore import QLocale, Qt
 from PySide6.QtGui import QStandardItem
@@ -621,7 +622,7 @@ class GuiManager:
         """
         PackageGatherer().log_imported_packages()
 
-    def processVersion(self, version_str):
+    def processVersion(self, version_info: tuple[str, str, Version]):
         """
         Call-back method for the process of checking for updates.
         This methods is called by a VersionThread object once the current
@@ -630,11 +631,12 @@ class GuiManager:
 
         :param version_str: version string
         """
+        version_str, download_url, _ = version_info
         try:
             if version_str.__gt__(sas.system.version.__version__):
-                msg = "Version %s is available! " % str(version_str)
-                if "download_url" in version_str:
-                    webbrowser.open(version_str["download_url"])
+                msg = "Version %s is available! " % str(version_info)
+                if download_url is not None:
+                    webbrowser.open(version_info["download_url"])
                 else:
                     webbrowser.open(web.download_url)
                 self.communicate.statusBarUpdateSignal.emit(msg)

--- a/src/sas/qtgui/Utilities/NewVersion/NewVersionAvailable.py
+++ b/src/sas/qtgui/Utilities/NewVersion/NewVersionAvailable.py
@@ -4,10 +4,7 @@ import webbrowser
 from copy import copy
 from typing import Optional
 
-<<<<<<< HEAD
-=======
 import requests
->>>>>>> ab18ce7d8 ([pre-commit.ci lite] apply automatic fixes for ruff linting errors)
 from packaging.version import Version, parse
 from PySide6.QtCore import QSize
 from PySide6.QtGui import QIcon

--- a/src/sas/qtgui/Utilities/NewVersion/NewVersionAvailable.py
+++ b/src/sas/qtgui/Utilities/NewVersion/NewVersionAvailable.py
@@ -1,4 +1,3 @@
-import json
 import logging
 import webbrowser
 from copy import copy

--- a/src/sas/qtgui/Utilities/NewVersion/NewVersionAvailable.py
+++ b/src/sas/qtgui/Utilities/NewVersion/NewVersionAvailable.py
@@ -87,10 +87,6 @@ class NewVersionAvailable(QDialog):
 
 def get_current_release_version() -> Optional[tuple[str, str, Version]]:
     """ Get the current version from the server """
-
-    c = ConnectionProxy(web.update_url, config.UPDATE_TIMEOUT)
-    response = c.connect()
-
     try:
         response = requests.get(web.update_url)
         # Will throw Exception if the HTTP status code returned isn't success

--- a/src/sas/qtgui/Utilities/NewVersion/NewVersionAvailable.py
+++ b/src/sas/qtgui/Utilities/NewVersion/NewVersionAvailable.py
@@ -105,6 +105,7 @@ def get_current_release_version() -> Optional[tuple[str, str, Version]]:
         return None
     except Exception as ex:
         logging.info("Failed to get version number %s", ex)
+        return None
 
 
 

--- a/src/sas/qtgui/Utilities/NewVersion/NewVersionAvailable.py
+++ b/src/sas/qtgui/Utilities/NewVersion/NewVersionAvailable.py
@@ -103,9 +103,6 @@ def get_current_release_version() -> Optional[tuple[str, str, Version]]:
 
         return version_string, url, parse(version_string)
 
-    except ConnectionError:
-        # Return None if we can't reach the server.
-        return None
     except Exception as ex:
         logging.info("Failed to get version number %s", ex)
         return None

--- a/src/sas/qtgui/Utilities/NewVersion/NewVersionAvailable.py
+++ b/src/sas/qtgui/Utilities/NewVersion/NewVersionAvailable.py
@@ -91,7 +91,7 @@ class NewVersionAvailable(QDialog):
 def get_current_release_version() -> Optional[tuple[str, str, Version]]:
     """ Get the current version from the server """
     try:
-        response = requests.get(web.update_url)
+        response = requests.get(web.update_url, timeout=config.UPDATE_TIMEOUT)
         # Will throw Exception if the HTTP status code returned isn't success
         # (2xx)
         response.raise_for_status()

--- a/src/sas/qtgui/Utilities/NewVersion/NewVersionAvailable.py
+++ b/src/sas/qtgui/Utilities/NewVersion/NewVersionAvailable.py
@@ -4,6 +4,10 @@ import webbrowser
 from copy import copy
 from typing import Optional
 
+<<<<<<< HEAD
+=======
+import requests
+>>>>>>> ab18ce7d8 ([pre-commit.ci lite] apply automatic fixes for ruff linting errors)
 from packaging.version import Version, parse
 from PySide6.QtCore import QSize
 from PySide6.QtGui import QIcon
@@ -20,7 +24,6 @@ from PySide6.QtWidgets import (
 )
 
 from sas import config
-from sas.qtgui.Utilities.ConnectionProxy import ConnectionProxy
 from sas.system import web
 from sas.system.version import __version__ as current_version_string
 


### PR DESCRIPTION
## Description

This PR aims to fix #3420 by removing our reliance on the `ConnectionProxy` class, and instead use the `get` request function from the `requests` library.

## How Has This Been Tested?

Tested on `run.py`, and the wheel. Unfortunately, I haven't been able to test on the installer as I'm not sure if there is a way to fake the version to an older one to test the popup menu. Does anyone know how to do this? It might be useful if we add a debug version override flag for this purpose.

## Review Checklist:

**Documentation** (check at least one)
- [x] There is **nothing** that needs documenting
- [ ] Documentation changes are **in this PR**
- [ ] There is an **issue** open for the documentation (link?)

**Installers**
- [x] There is a chance this will affect the **installers**, if so
  - [ ] **Windows** installer (GH artifact) has been tested (installed and worked) 
  - [ ] **MacOSX** installer (GH artifact) has been tested (installed and worked)
  - [x] **Wheels** installer (GH artifact) has been tested (installed and worked)

**Licensing** (untick if necessary)
- [x] The introduced changes comply with SasView license (BSD 3-Clause)

