### PR TITLE
Restores UI import statements

### DIFF
--- a/src/sas/qtgui/Calculators/DensityPanel.py
+++ b/src/sas/qtgui/Calculators/DensityPanel.py
@@ -7,6 +7,7 @@ from periodictable import formula as Formula
 
 
 # Local UI
+from sas.qtgui.UI import main_resources_rc # noqa: F401
 from sas.qtgui.Calculators.UI.DensityPanel import Ui_DensityPanel
 
 from sas.qtgui.Utilities.GuiUtils import enum

--- a/src/sas/qtgui/Calculators/GenericScatteringCalculator.py
+++ b/src/sas/qtgui/Calculators/GenericScatteringCalculator.py
@@ -16,7 +16,7 @@ from PySide6 import QtCore
 from PySide6 import QtGui
 from PySide6 import QtWidgets
 
-from matplotlib.backends.backend_qt5agg import (FigureCanvas)
+from matplotlib.backends.backend_qt5agg import FigureCanvas
 from mpl_toolkits.mplot3d.axes3d import Axes3D
 
 from twisted.internet import threads

--- a/src/sas/qtgui/Calculators/KiessigPanel.py
+++ b/src/sas/qtgui/Calculators/KiessigPanel.py
@@ -2,6 +2,7 @@ from PySide6 import QtCore
 from PySide6 import QtGui
 from PySide6 import QtWidgets
 
+from sas.qtgui.UI import main_resources_rc # noqa: F401
 from .UI.KiessigPanel import Ui_KiessigPanel
 
 # sas-global

--- a/src/sas/qtgui/Calculators/SldPanel.py
+++ b/src/sas/qtgui/Calculators/SldPanel.py
@@ -10,6 +10,7 @@ from periodictable.nsf import neutron_scattering
 
 import sas.qtgui.Utilities.GuiUtils as GuiUtils
 
+from sas.qtgui.UI import main_resources_rc # noqa: F401
 
 # Local UI
 from sas.qtgui.Calculators.UI.SldPanel import Ui_SldPanel

--- a/src/sas/qtgui/Calculators/SlitSizeCalculator.py
+++ b/src/sas/qtgui/Calculators/SlitSizeCalculator.py
@@ -7,6 +7,7 @@ import logging
 
 from PySide6 import QtWidgets
 
+from sas.qtgui.UI import main_resources_rc # noqa: F401
 
 from .UI.SlitSizeCalculator import Ui_SlitSizeCalculator
 from sasdata.dataloader.loader import Loader

--- a/src/sas/qtgui/MainWindow/DroppableDataLoadWidget.py
+++ b/src/sas/qtgui/MainWindow/DroppableDataLoadWidget.py
@@ -4,6 +4,7 @@ from PySide6 import QtCore
 from PySide6 import QtWidgets
 
 # UI
+from sas.qtgui.UI import main_resources_rc # noqa: F401
 from sas.qtgui.MainWindow.UI.DataExplorerUI import Ui_DataLoadWidget
 
 class DroppableDataLoadWidget(QtWidgets.QTabWidget, Ui_DataLoadWidget):

--- a/src/sas/qtgui/MainWindow/MainWindow.py
+++ b/src/sas/qtgui/MainWindow/MainWindow.py
@@ -14,6 +14,7 @@ from PySide6.QtCore import Qt, QTimer
 from importlib import resources
 
 # Local UI
+from sas.qtgui.UI import main_resources_rc # noqa: F401
 from .UI.MainWindowUI import Ui_SasView
 from ..Utilities.NewVersion.NewVersionAvailable import maybe_prompt_new_version_download
 

--- a/src/sas/qtgui/Perspectives/ParticleEditor/CodeToolBar.py
+++ b/src/sas/qtgui/Perspectives/ParticleEditor/CodeToolBar.py
@@ -1,6 +1,7 @@
 from PySide6 import QtWidgets, QtGui
 
 from sas.qtgui.Perspectives.ParticleEditor.UI.CodeToolBarUI import Ui_CodeToolBar
+import sas.qtgui.Perspectives.ParticleEditor.UI.icons_rc # noqa: F401
 
 class CodeToolBar(QtWidgets.QWidget, Ui_CodeToolBar):
     def __init__(self, parent=None):

--- a/src/sas/qtgui/Plotting/BoxSum.py
+++ b/src/sas/qtgui/Plotting/BoxSum.py
@@ -8,6 +8,7 @@ from PySide6 import QtWidgets
 import sas.qtgui.Utilities.GuiUtils as GuiUtils
 
 # Local UI
+from sas.qtgui.UI import main_resources_rc # noqa: F401
 from sas.qtgui.Plotting.UI.BoxSumUI import Ui_BoxSumUI
 
 class BoxSum(QtWidgets.QDialog, Ui_BoxSumUI):

--- a/src/sas/qtgui/Plotting/ColorMap.py
+++ b/src/sas/qtgui/Plotting/ColorMap.py
@@ -15,6 +15,7 @@ from sas.qtgui.Utilities.GuiUtils import formatNumber, DoubleValidator
 from superqt import QDoubleRangeSlider
 
 # Local UI
+from sas.qtgui.UI import main_resources_rc # noqa: F401
 from sas.qtgui.Plotting.UI.ColorMapUI import Ui_ColorMapUI
 
 DEFAULT_MAP = 'jet'

--- a/src/sas/qtgui/Plotting/MaskEditor.py
+++ b/src/sas/qtgui/Plotting/MaskEditor.py
@@ -7,6 +7,7 @@ from PySide6 import QtWidgets
 from sas.qtgui.Plotting.PlotterData import Data2D
 
 # Local UI
+from sas.qtgui.UI import main_resources_rc # noqa: F401
 from sas.qtgui.Plotting.UI.MaskEditorUI import Ui_MaskEditorUI
 from sas.qtgui.Plotting.Plotter2D import Plotter2DWidget
 

--- a/src/sas/qtgui/Plotting/ScaleProperties.py
+++ b/src/sas/qtgui/Plotting/ScaleProperties.py
@@ -1,5 +1,6 @@
 from PySide6 import QtWidgets
 
+from sas.qtgui.UI import main_resources_rc # noqa: F401
 from sas.qtgui.Plotting.UI.ScalePropertiesUI import Ui_scalePropertiesUI
 
 x_values = ["x", "x^(2)", "x^(4)", "ln(x)", "log10(x)", "log10(x^(4))"]

--- a/src/sas/qtgui/Plotting/SetGraphRange.py
+++ b/src/sas/qtgui/Plotting/SetGraphRange.py
@@ -6,6 +6,7 @@ from PySide6 import QtWidgets
 import sas.qtgui.Utilities.GuiUtils as GuiUtils
 
 # Local UI
+from sas.qtgui.UI import main_resources_rc # noqa: F401
 from sas.qtgui.Plotting.UI.SetGraphRangeUI import Ui_setGraphRangeUI
 
 class SetGraphRange(QtWidgets.QDialog, Ui_setGraphRangeUI):


### PR DESCRIPTION
## Description

In #3507, a number of import statements referring to UI components were automatically removed as they are not explicitly referred to in the code. However, they are required for the GUI to function properly, as shown in #3551. I have restored all of the import statements that were removed. Note that the accompanying comment `# noqa: F401`  prevents ruff from applying the unused import fix to this line.

Fixes #3551

## How Has This Been Tested?

I have followed the reproduction steps in #3551 and seen that the icons are restored.

## Review Checklist:

[if using the editor, use `[x]` in place of `[ ]` to check a box]

**Documentation** (check at least one)
- [x] There is **nothing** that needs documenting
- [ ] Documentation changes are **in this PR**
- [ ] There is an **issue** open for the documentation (link?)

**Installers**
- [ ] There is a chance this will affect the **installers**, if so
  - [ ] **Windows** installer (GH artifact) has been tested (installed and worked) 
  - [ ] **MacOSX** installer (GH artifact) has been tested (installed and worked)
  - [ ] **Wheels** installer (GH artifact) has been tested (installed and worked)

**Licensing** (untick if necessary)
- [x] The introduced changes comply with SasView license (BSD 3-Clause)

