### PR TITLE
Ensure libausaxs is downloaded when building installers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,10 +160,6 @@ jobs:
         run: |
           uv pip install dist/*whl
 
-      - name: Fetch external AUSAXS C library
-        run: |
-          python build_tools/get_external_dependencies.py
-
       - name: Install Python dependencies
         if: ${{ ! env.RELEASE_BRANCH_BUILD }}
         run: |
@@ -176,6 +172,10 @@ jobs:
         if: ${{ env.RELEASE_BRANCH_BUILD }}
         run: |
           python -m pip install --no-deps -r build_tools/requirements-release-${{ matrix.os }}.txt
+
+      - name: Fetch external AUSAXS C library
+        run: |
+          python build_tools/get_external_dependencies.py
 
       ### Actual building of sasview
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -165,6 +165,7 @@ jobs:
         run: |
           uv pip install -r build_tools/requirements.txt
           uv pip install -r build_tools/requirements-dev.txt
+          python build_tools/get_external_dependencies.py
 
       ### For pull_requests with the release branch as the base -or- branches with the name *release*
 
@@ -172,6 +173,7 @@ jobs:
         if: ${{ env.RELEASE_BRANCH_BUILD }}
         run: |
           python -m pip install --no-deps -r build_tools/requirements-release-${{ matrix.os }}.txt
+          python build_tools/get_external_dependencies.py
 
       ### Actual building of sasview
 
@@ -199,7 +201,6 @@ jobs:
         if: ${{ matrix.tests }}
         run: |
           uv pip install -r build_tools/requirements-test.txt
-          python build_tools/get_external_dependencies.py
 
       - name: Test with pytest
         if: ${{ matrix.tests }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,12 +160,15 @@ jobs:
         run: |
           uv pip install dist/*whl
 
+      - name: Fetch external AUSAXS C library
+        run: |
+          python build_tools/get_external_dependencies.py
+
       - name: Install Python dependencies
         if: ${{ ! env.RELEASE_BRANCH_BUILD }}
         run: |
           uv pip install -r build_tools/requirements.txt
           uv pip install -r build_tools/requirements-dev.txt
-          python build_tools/get_external_dependencies.py
 
       ### For pull_requests with the release branch as the base -or- branches with the name *release*
 
@@ -173,7 +176,6 @@ jobs:
         if: ${{ env.RELEASE_BRANCH_BUILD }}
         run: |
           python -m pip install --no-deps -r build_tools/requirements-release-${{ matrix.os }}.txt
-          python build_tools/get_external_dependencies.py
 
       ### Actual building of sasview
 


### PR DESCRIPTION
## Description

`libausaxs` should now be present and included in the installers. 

Fixes #3545, needed for #3544

## How Has This Been Tested?

The Linux installer has been tested and verified to now include `libausaxs`. The issue was that `libausaxs` was previously only being downloaded for test builds, but not for the installers, which were therefore created without it. As functionality was already verified in #2882 and tests are still passing (including the `libausaxs` test), I don't think we have to do anything further here. 

## Review Checklist:

**Documentation** (check at least one)
- [x] There is **nothing** that needs documenting
- [ ] Documentation changes are **in this PR**
- [ ] There is an **issue** open for the documentation (link?)

**Installers**
- [x] This will affect the **installers**, so
  - [x] **Linux** installer (GH artifact) has been tested (worked) 
  - [ ] **Windows** installer (GH artifact) has been tested (installed and worked) 
  - [ ] **MacOSX** installer (GH artifact) has been tested (installed and worked)
  - [ ] **Wheels** installer (GH artifact) has been tested (installed and worked)

**Licensing** (untick if necessary)
- [x] The introduced changes comply with SasView license (BSD 3-Clause)