### PR TITLE
3543: Fix batch fit results display and plotting

### DIFF
--- a/src/sas/qtgui/Utilities/GridPanel.py
+++ b/src/sas/qtgui/Utilities/GridPanel.py
@@ -158,7 +158,6 @@ class BatchOutputPanel(QtWidgets.QMainWindow, Ui_GridPanelUI):
         """
         # pull out page name from results
         page_name = None
-        results = results.get(DICT_KEYS[0])
         if len(results)>=2:
             if isinstance(results[-1], str):
                 page_name = results[-1]
@@ -200,11 +199,9 @@ class BatchOutputPanel(QtWidgets.QMainWindow, Ui_GridPanelUI):
         # look for the 'Data' column and extract the filename
         for row in rows:
             try:
-                name = data['Filename'][row]
-                self.prPlot = self.batch_results[name].get(DICT_KEYS[1])
-                self.dataPlot = self.batch_results[name].get(DICT_KEYS[2])
+                name = data['Data'][row]
                 # emit a signal so the plots are being shown
-                self.parent.showPlots(self.batch_results[name]['Result'])
+                self.communicate.plotFromNameSignal.emit(name)
                 # This is an important processEvent.
                 # This allows charts to be properly updated in order
                 # of plots being applied.
@@ -222,14 +219,8 @@ class BatchOutputPanel(QtWidgets.QMainWindow, Ui_GridPanelUI):
         assert(isinstance(table, QtWidgets.QTableWidget))
         params = {}
         for column in range(table.columnCount()):
-            value = []
+            value = [table.item(row, column).data(0) for row in range(table.rowCount())]
             key = table.horizontalHeaderItem(column).data(0)
-            for row in range(table.rowCount()):
-                item = table.item(row, column)
-                if item is not None:
-                    value.append(item.data(0))
-                else:
-                    value.append(" ")
             params[key] = value
         return params
 
@@ -326,7 +317,6 @@ class BatchOutputPanel(QtWidgets.QMainWindow, Ui_GridPanelUI):
 
         if data is None or widget is None:
             return
-        data = data.get(DICT_KEYS[0])
         # Figure out the headers
         model = data[0][0]
 


### PR DESCRIPTION
## Description

This fixes an issue introduced in v6.1.0 in PR #3137. The batch fitting window would no longer open due to different data structure between the batch P(r) results and batch Fitting results. The P(r) functionality was moved to the `BatchInversionOutputPanel` class and the original functionality was restored for the batch fitting.

Despite the code freeze, I think this fix should be implemented for v6.1.1 due to the importance of the batch results window.

Fixes #3543

## How Has This Been Tested?

Loaded AOT core and AOT shell files. Sent both to batch fitting and batch P(r). Tested fits and plotting from the results panel and everything worked for both batch fitting methods.

## Review Checklist:

**Documentation** (check at least one)
- [x] There is **nothing** that needs documenting
- [ ] Documentation changes are **in this PR**
- [ ] There is an **issue** open for the documentation (link?)

**Installers**
- [x] There is a chance this will affect the **installers**, if so
  - [ ] **Windows** installer (GH artifact) has been tested (installed and worked) 
  - [ ] **MacOSX** installer (GH artifact) has been tested (installed and worked)
  - [ ] **Wheels** installer (GH artifact) has been tested (installed and worked)

**Licensing** (untick if necessary)
- [x] The introduced changes comply with SasView license (BSD 3-Clause)

