### PR TITLE
Converts type comments to type hints

### DIFF
--- a/src/sas/qtgui/Perspectives/Fitting/AssociatedComboBox.py
+++ b/src/sas/qtgui/Perspectives/Fitting/AssociatedComboBox.py
@@ -1,4 +1,4 @@
-from PySide6 import QtWidgets
+from PySide6 import QtGui, QtWidgets
 
 
 class AssociatedComboBox(QtWidgets.QComboBox):
@@ -7,10 +7,9 @@ class AssociatedComboBox(QtWidgets.QComboBox):
 
     When the combo box's current text is changed, the change is immediately reflected in the associated item; either
     the text itself is set as the item's data, or the current index is used; see constructor."""
-    item = None  # type: QtGui.QStandardItem
+    item: QtGui.QStandardItem = None
 
-    def __init__(self, item, idx_as_value=False, parent=None):
-        # type: (QtGui.QStandardItem, bool, QtWidgets.QWidget) -> None
+    def __init__(self, item: QtGui.QStandardItem, idx_as_value: bool = False, parent: QtWidgets.QWidget = None) -> None:
         """
         Initialize widget. idx_as_value indicates whether to use the combo box's current index (otherwise, current text)
         as the associated item's new data.
@@ -23,15 +22,13 @@ class AssociatedComboBox(QtWidgets.QComboBox):
         else:
             self.currentTextChanged.connect(self._onTextChanged)
 
-    def _onTextChanged(self, text):
-        # type: (str) -> None
+    def _onTextChanged(self, text: str) -> None:
         """
         Callback for combo box's currentTextChanged. Set associated item's data to the new text.
         """
         self.item.setText(text)
 
-    def _onIndexChanged(self, idx):
-        # type: (int) -> None
+    def _onIndexChanged(self, idx: int) -> None:
         """
         Callback for combo box's currentIndexChanged. Set associated item's data to the new index.
         """

--- a/src/sas/qtgui/Perspectives/Fitting/FittingUtilities.py
+++ b/src/sas/qtgui/Perspectives/Fitting/FittingUtilities.py
@@ -1,4 +1,5 @@
 import copy
+from collections.abc import Sequence
 
 import numpy
 from PySide6 import QtCore, QtGui, QtWidgets
@@ -998,8 +999,7 @@ def isParamPolydisperse(param_name, kernel_params, is2D=False):
             break
     return has_poly
 
-def checkConstraints(symtab, constraints):
-    # type: (Dict[str, float], Sequence[Tuple[str, str]]) -> str
+def checkConstraints(symtab: dict[str, float], constraints: Sequence[tuple[str, str]]) -> str:
     """
     Compile and evaluate the constraints in the context of the initial values
     and return the list of errors.

--- a/src/sas/qtgui/Plotting/QRangeSlider.py
+++ b/src/sas/qtgui/Plotting/QRangeSlider.py
@@ -1,5 +1,6 @@
 """Double slider interactor for setting the Q range for a fit or function"""
 
+from collections.abc import Callable
 from typing import TYPE_CHECKING
 
 import numpy as np
@@ -163,22 +164,22 @@ class LineInteractor(BaseInteractor):
             self._input.editingFinished.connect(self.inputChanged)
 
     @property
-    def setter(self) -> callable | None:
+    def setter(self) -> Callable | None:
         """ Get the x-value setter method associated with this slider """
         return self._setter
 
     @setter.setter
-    def setter(self, setter: callable | None) -> None:
+    def setter(self, setter: Callable | None) -> None:
         """ Set the x-value setter method associated with this slider """
         self._setter = setter if callable(setter) else None
 
     @property
-    def getter(self) -> callable | None:
+    def getter(self) -> Callable | None:
         """ Get the x-value getter method associated with this slider """
         return self._getter
 
     @getter.setter
-    def getter(self, getter: callable | None) -> None:
+    def getter(self, getter: Callable | None) -> None:
         """ Set the x-value getter associated with this slider """
         self._getter = getter if callable(getter) else None
 

--- a/src/sas/qtgui/Plotting/QRangeSlider.py
+++ b/src/sas/qtgui/Plotting/QRangeSlider.py
@@ -1,5 +1,7 @@
 """Double slider interactor for setting the Q range for a fit or function"""
 
+from typing import TYPE_CHECKING
+
 import numpy as np
 from PySide6.QtCore import QEvent
 from PySide6.QtWidgets import QLineEdit, QTextEdit
@@ -9,6 +11,8 @@ from sas.qtgui.Plotting.Plotter import Plotter
 from sas.qtgui.Plotting.PlotterData import Data1D
 from sas.qtgui.Plotting.Slicers.BaseInteractor import BaseInteractor
 
+if TYPE_CHECKING:
+    from sas.qtgui.Plotting.Plotter import Plotter
 
 class QRangeSlider(BaseInteractor):
     """  Draw a pair of draggable vertical lines. Each line can be linked to a GUI input.

--- a/src/sas/qtgui/Plotting/QRangeSlider.py
+++ b/src/sas/qtgui/Plotting/QRangeSlider.py
@@ -7,7 +7,6 @@ from PySide6.QtCore import QEvent
 from PySide6.QtWidgets import QLineEdit, QTextEdit
 
 import sas.qtgui.Utilities.ObjectLibrary as ol
-from sas.qtgui.Plotting.Plotter import Plotter
 from sas.qtgui.Plotting.PlotterData import Data1D
 from sas.qtgui.Plotting.Slicers.BaseInteractor import BaseInteractor
 
@@ -18,7 +17,7 @@ class QRangeSlider(BaseInteractor):
     """  Draw a pair of draggable vertical lines. Each line can be linked to a GUI input.
     The GUI input should update the lines and vice-versa.
     """
-    def __init__(self, base: Plotter, axes: Plotter.ax, color: str = 'black', zorder: int = 5, data: Data1D = None) -> None:
+    def __init__(self, base: "Plotter", axes: "Plotter.ax", color: str = 'black', zorder: int = 5, data: Data1D = None) -> None:
         """ Initialize the slideable lines and associated markers """
         # Assert the data object is a plottable
         assert isinstance(data, Data1D)
@@ -109,7 +108,7 @@ class LineInteractor(BaseInteractor):
     """
     Draw a single vertical line that can be dragged on a plot
     """
-    def __init__(self, base: Plotter, axes: Plotter.ax, color: str = 'black', zorder: int = 5, x: float = 0.5, y: float = 0.5,
+    def __init__(self, base: "Plotter", axes: "Plotter.ax", color: str = 'black', zorder: int = 5, x: float = 0.5, y: float = 0.5,
                  input: list[str] = None, setter: list[str] = None, getter: list[str] = None, perspective: str = None, tab: str = None) -> None:
         """ Initialize the line interactor object"""
         BaseInteractor.__init__(self, base, axes, color=color)

--- a/src/sas/qtgui/Plotting/QRangeSlider.py
+++ b/src/sas/qtgui/Plotting/QRangeSlider.py
@@ -1,7 +1,11 @@
 """Double slider interactor for setting the Q range for a fit or function"""
+
 import numpy as np
+from PySide6.QtCore import QEvent
+from PySide6.QtWidgets import QLineEdit, QTextEdit
 
 import sas.qtgui.Utilities.ObjectLibrary as ol
+from sas.qtgui.Plotting.Plotter import Plotter
 from sas.qtgui.Plotting.PlotterData import Data1D
 from sas.qtgui.Plotting.Slicers.BaseInteractor import BaseInteractor
 
@@ -10,8 +14,7 @@ class QRangeSlider(BaseInteractor):
     """  Draw a pair of draggable vertical lines. Each line can be linked to a GUI input.
     The GUI input should update the lines and vice-versa.
     """
-    def __init__(self, base, axes, color='black', zorder=5, data=None):
-        # type: (Plotter, Plotter.ax, str, int, Data1D) -> None
+    def __init__(self, base: Plotter, axes: Plotter.ax, color: str = 'black', zorder: int = 5, data: Data1D = None) -> None:
         """ Initialize the slideable lines and associated markers """
         # Assert the data object is a plottable
         assert isinstance(data, Data1D)
@@ -43,67 +46,57 @@ class QRangeSlider(BaseInteractor):
         self.has_move = True
         self.update()
 
-    def clear(self):
-        # type: () -> None
+    def clear(self) -> None:
         """ Clear this slicer and its markers """
         self.clear_markers()
 
-    def show(self):
-        # type: () -> None
+    def show(self) -> None:
         """ Show this slicer and its markers """
         self.line_max.draw()
         self.line_min.draw()
         self.update()
 
-    def remove(self):
-        # type: () -> None
+    def remove(self) -> None:
         """ Remove this slicer and its markers """
         self.line_max.remove()
         self.line_min.remove()
         self.draw()
         self.is_visible = False
 
-    def update(self, x=None, y=None):
-        # type: (float, float) -> None
+    def update(self, x: float = None, y: float = None) -> None:
         """Draw the new lines on the graph."""
         self.line_min.update(x, y, draw=self.updateOnMove)
         self.line_max.update(x, y, draw=self.updateOnMove)
         self.base.update()
         self.is_visible = True
 
-    def save(self, ev):
-        # type: (QEvent) -> None
+    def save(self, ev: QEvent) -> None:
         """ Remember the position of the lines so that we can restore on Esc. """
         self.line_min.save(ev)
         self.line_max.save(ev)
 
-    def restore(self, ev):
-        # type: (QEvent) -> None
+    def restore(self, ev: QEvent) -> None:
         """ Restore the lines. """
         self.line_max.restore(ev)
         self.line_min.restore(ev)
 
-    def toggle(self):
-        # type: () -> None
+    def toggle(self) -> None:
         """ Toggle the slider visibility. """
         if self.is_visible:
             self.remove()
         else:
             self.show()
 
-    def move(self, x, y, ev):
-        # type: (float, float, QEvent) -> None
+    def move(self, x: float, y: float, ev: QEvent) -> None:
         """ Process move to a new position, making sure that the move is allowed. """
         pass
 
-    def clear_markers(self):
-        # type: () -> None
+    def clear_markers(self) -> None:
         """ Clear each of the lines individually """
         self.line_min.clear()
         self.line_max.clear()
 
-    def draw(self):
-        # type: () -> None
+    def draw(self) -> None:
         """ Update the plot """
         self.base.draw()
 
@@ -112,9 +105,8 @@ class LineInteractor(BaseInteractor):
     """
     Draw a single vertical line that can be dragged on a plot
     """
-    def __init__(self, base, axes, color='black', zorder=5, x=0.5, y=0.5,
-                 input=None, setter=None, getter=None, perspective=None, tab=None):
-        # type: (Plotter, Plotter.ax, str, int, float, float, [str], [str], [str], str, str) -> None
+    def __init__(self, base: Plotter, axes: Plotter.ax, color: str = 'black', zorder: int = 5, x: float = 0.5, y: float = 0.5,
+                 input: list[str] = None, setter: list[str] = None, getter: list[str] = None, perspective: str = None, tab: str = None) -> None:
         """ Initialize the line interactor object"""
         BaseInteractor.__init__(self, base, axes, color=color)
         # Plotter object
@@ -156,59 +148,50 @@ class LineInteractor(BaseInteractor):
         self.inputChanged()
 
     @property
-    def input(self):
-        # type: () -> Union[QLineEdit, QTextEdit, None]
+    def input(self) -> QLineEdit | QTextEdit | None:
         """ Get the text input that should be linked to the position of this slider """
         return self._input
 
     @input.setter
-    def input(self, input):
-        # type: (Union[QLineEdit, QTextEdit, None]) -> None
+    def input(self, input: QLineEdit | QTextEdit | None) -> None:
         """ Set the text input that should be linked to the position of this slider """
         self._input = input
         if self._input:
             self._input.editingFinished.connect(self.inputChanged)
 
     @property
-    def setter(self):
-        # type: () -> Union[callable, None]
+    def setter(self) -> callable | None:
         """ Get the x-value setter method associated with this slider """
         return self._setter
 
     @setter.setter
-    def setter(self, setter):
-        # type: (Union[callable, None]) -> None
+    def setter(self, setter: callable | None) -> None:
         """ Set the x-value setter method associated with this slider """
         self._setter = setter if callable(setter) else None
 
     @property
-    def getter(self):
-        # type: () -> Union[callable, None]
+    def getter(self) -> callable | None:
         """ Get the x-value getter method associated with this slider """
         return self._getter
 
     @getter.setter
-    def getter(self, getter):
-        # type: (Union[callable, None]) -> None
+    def getter(self, getter: callable | None) -> None:
         """ Set the x-value getter associated with this slider """
         self._getter = getter if callable(getter) else None
 
-    def clear(self):
-        # type: () -> None
+    def clear(self) -> None:
         """ Disconnect any inputs and callbacks and the clear the line and marker """
         self.clear_markers()
         self.remove()
 
-    def remove(self):
-        # type: () -> None
+    def remove(self) -> None:
         """ Clear this slicer and its markers """
         if self.inner_marker:
             self.inner_marker.remove()
         if self.line:
             self.line.remove()
 
-    def draw(self, zorder=5):
-        # type: (int) -> None
+    def draw(self, zorder: int = 5) -> None:
         """ Draw the line and marker on the linked plot using the latest x and y values """
         # Inner circle marker
         self.inner_marker = self.axes.plot([self.x], [self.y_marker], linestyle='', marker='o', markersize=4,
@@ -217,8 +200,7 @@ class LineInteractor(BaseInteractor):
         self.line = self.axes.axvline(self.x, linestyle='-', color=self.color, marker='', pickradius=5,
                                       label=None, zorder=zorder, visible=True)
 
-    def _get_input_or_callback(self, connection_list=None):
-        # type: ([str]) -> Union[QLineEdit, QTextEdit, None]
+    def _get_input_or_callback(self, connection_list: list[str] = None) -> QLineEdit | QTextEdit | None:
         """ Returns an input or callback method based on a list of inputs/commands """
         connection = None
         if isinstance(connection_list, list):
@@ -230,8 +212,7 @@ class LineInteractor(BaseInteractor):
                     return None
         return connection
 
-    def _set_q(self, value):
-        # type: (float) -> None
+    def _set_q(self, value: float) -> None:
         """ Call the q setter callback method if it exists """
         self.x = value
         if self.setter and callable(self.setter):
@@ -239,8 +220,7 @@ class LineInteractor(BaseInteractor):
         elif hasattr(self.input, 'setText'):
             self.input.setText(f"{value:.3}")
 
-    def _get_q(self):
-        # type: () -> None
+    def _get_q(self) -> None:
         """ Get the q value, inferring the method to get the value """
         if self.getter:
             # Separate callback method to get Q value
@@ -252,15 +232,13 @@ class LineInteractor(BaseInteractor):
             # Text box
             self.x = float(self.input.getText())
 
-    def inputChanged(self):
-        # type: () -> None
+    def inputChanged(self) -> None:
         """ Track the input linked to the x value for this slider and update as needed """
         self._get_q()
         self.y_marker = self.base.data.y[(np.abs(self.base.data.x - self.x)).argmin()]
         self.update(draw=True)
 
-    def update(self, x=None, y=None, draw=False):
-        # type: (float, float, bool) -> None
+    def update(self, x: float = None, y: float = None, draw: bool = False) -> None:
         """ Update the line position on the graph. """
         # Reset x, y -coordinates if given as parameters
         if x is not None:
@@ -274,20 +252,17 @@ class LineInteractor(BaseInteractor):
         if draw:
             self.base.draw()
 
-    def save(self, ev):
-        # type: (QEvent) -> None
+    def save(self, ev: QEvent) -> None:
         """ Remember the position for this line so that we can restore on Esc. """
         self.save_x = self.x
         self.save_y = self.y_marker
 
-    def restore(self, ev):
-        # type: (QEvent) -> None
+    def restore(self, ev: QEvent) -> None:
         """ Restore the position for this line """
         self.x = self.save_x
         self.y_marker = self.save_y
 
-    def move(self, x, y, ev):
-        # type: (float, float, QEvent) -> None
+    def move(self, x: float, y: float, ev: QEvent) -> None:
         """ Process move to a new position, making sure that the move is allowed. """
         self.has_move = True
         self.x = x
@@ -296,8 +271,7 @@ class LineInteractor(BaseInteractor):
         self.y_marker = self.base.data.y[(np.abs(self.base.data.x - self.x)).argmin()]
         self.update(draw=self.base.updateOnMove)
 
-    def onRelease(self, ev):
-        # type: (QEvent) -> bool
+    def onRelease(self, ev: QEvent) -> bool:
         """ Update the line position when the mouse button is released """
         # Set the Q value if a callable setter exists otherwise update the attached input
         self._set_q(self.x)
@@ -305,8 +279,7 @@ class LineInteractor(BaseInteractor):
         self.moveend(ev)
         return True
 
-    def clear_markers(self):
-        # type: () -> None
+    def clear_markers(self) -> None:
         """ Disconnect the input and clear the callbacks """
         if self.input:
             self.input.editingFinished.disconnect(self.inputChanged)

--- a/src/sas/sascalc/doc_regen/regenmodel.py
+++ b/src/sas/sascalc/doc_regen/regenmodel.py
@@ -86,7 +86,7 @@ def plot_1d(model: KernelModel, opts: dict[str, Any], ax: matplotlib.axes.Axes):
 def plot_2d(model: KernelModel, opts: dict[str, Any], ax: matplotlib.axes.Axes):
     """Create a 2-D image based on the model."""
     qx_max, nq2d = opts['qx_max'], opts['nq2d']
-    q = np.linspace(-qx_max, qx_max, nq2d) # type: np.ndarray
+    q: np.ndarray = np.linspace(-qx_max, qx_max, nq2d)
     data2d = empty_data2D(q, resolution=0.0)
     calculator = DirectModel(data2d, model)
     Iq2D = calculator() #background=0)

--- a/src/sas/sascalc/fit/models.py
+++ b/src/sas/sascalc/fit/models.py
@@ -10,7 +10,7 @@ import sys
 import time
 import traceback
 
-from sasmodels.sasview_model import load_custom_model, load_standard_models
+from sasmodels.sasview_model import SasviewModelType, load_custom_model, load_standard_models
 
 from sas.system.user import get_plugin_dir
 
@@ -175,13 +175,13 @@ class ModelManagerBase:
     """
     #: mutable dictionary of models, continually updated to reflect the
     #: current set of plugins
-    model_dictionary = None  # type: Dict[str, Model]
+    model_dictionary: dict[str, SasviewModelType] = None
     #: constant list of standard models
-    standard_models = None  # type: Dict[str, Model]
+    standard_models: dict[str, SasviewModelType] = None
     #: list of plugin models reset each time the plugin directory is queried
-    plugin_models = None  # type: Dict[str, Model]
+    plugin_models: dict[str, SasviewModelType] = None
     #: timestamp on the plugin directory at the last plugin update
-    last_time_dir_modified = 0  # type: int
+    last_time_dir_modified: int = 0
 
     def __init__(self):
         # the model dictionary is allocated at the start and updated to
@@ -286,7 +286,7 @@ class ModelManager:
     """
     manage the list of available models
     """
-    base = None  # type: ModelManagerBase()
+    base: ModelManagerBase = None
 
     def __init__(self):
         if ModelManager.base is None:


### PR DESCRIPTION
## Description

I have converted type comments in the codebase to type hints, as discussed in #3170. I used the tool [com2ann](https://github.com/ilevkivskyi/com2ann) for the initial conversion before a bit of tidying up.

## How Has This Been Tested?

The code builds correctly and the tests pass.

## Review Checklist:

[if using the editor, use `[x]` in place of `[ ]` to check a box]

**Documentation** (check at least one)
- [x] There is **nothing** that needs documenting
- [ ] Documentation changes are **in this PR**
- [ ] There is an **issue** open for the documentation (link?)

**Installers**
- [ ] There is a chance this will affect the **installers**, if so
  - [ ] **Windows** installer (GH artifact) has been tested (installed and worked) 
  - [ ] **MacOSX** installer (GH artifact) has been tested (installed and worked)
  - [ ] **Wheels** installer (GH artifact) has been tested (installed and worked)

**Licensing** (untick if necessary)
- [x] The introduced changes comply with SasView license (BSD 3-Clause)

