### PR TITLE
3576: Fix polydispersity values shown in fit params tab

### DIFF
--- a/src/sas/qtgui/Perspectives/Fitting/FittingWidget.py
+++ b/src/sas/qtgui/Perspectives/Fitting/FittingWidget.py
@@ -1996,6 +1996,28 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         for row_i in range(self._model_model.rowCount()):
             func(row_i)
 
+    def updateFunctionCaption(self, row):
+        # Utility function for update of polydispersity function name in the main model
+        param_name = self._model_model.item(row, 0).text()
+        dispersion_value = self.polydispersity_widget.poly_params.get(param_name + ".width", None)
+        # This is an explicit check against None which means the param is not in the polydispersity list
+        if dispersion_value is None:
+            return
+        combo_string = DEFAULT_POLYDISP_FUNCTION
+        # TODO: Get dispersity function
+        for child in self.polydispersity_widget.lstPoly.children():
+            print(child)
+        # Modify the param value
+        param_row = self._model_model.item(row, 0).child(0)
+        self._model_model.blockSignals(True)
+        param_row.child(0, 1).setText(str(dispersion_value))
+        if self.has_error_column:
+            # err column changes the indexing
+            param_row.child(0, 5).setText(combo_string)
+        else:
+            param_row.child(0, 4).setText(combo_string)
+        self._model_model.blockSignals(False)
+
     def updateModelFromList(self, param_dict: dict[str, tuple[float, float]]) -> None:
         """
         Update the model with new parameters, create the errors column

--- a/src/sas/qtgui/Perspectives/Fitting/FittingWidget.py
+++ b/src/sas/qtgui/Perspectives/Fitting/FittingWidget.py
@@ -2010,7 +2010,7 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         # Modify the param value
         param_row = self._model_model.item(row, 0).child(0)
         self._model_model.blockSignals(True)
-        param_row.child(0, 1).setText(str(dispersion_value))
+        param_row.child(0, 1).setText(f"{dispersion_value:.3f}")
         if self.has_error_column:
             # err column changes the indexing
             param_row.child(0, 5).setText(combo_string)

--- a/src/sas/qtgui/Perspectives/Fitting/FittingWidget.py
+++ b/src/sas/qtgui/Perspectives/Fitting/FittingWidget.py
@@ -2003,10 +2003,11 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         # This is an explicit check against None which means the param is not in the polydispersity list
         if dispersion_value is None:
             return
-        combo_string = DEFAULT_POLYDISP_FUNCTION
-        # TODO: Get dispersity function
-        for child in self.polydispersity_widget.lstPoly.children():
-            print(child)
+        try:
+            dispersion_model = self.logic.kernel_module.dispersion.get(param_name, None)
+            combo_string = dispersion_model.get('type')
+        except AttributeError:
+            combo_string = DEFAULT_POLYDISP_FUNCTION
         # Modify the param value
         param_row = self._model_model.item(row, 0).child(0)
         self._model_model.blockSignals(True)

--- a/src/sas/qtgui/Perspectives/Fitting/PolydispersityWidget.py
+++ b/src/sas/qtgui/Perspectives/Fitting/PolydispersityWidget.py
@@ -132,7 +132,7 @@ class PolydispersityWidget(QtWidgets.QWidget, Ui_PolydispersityWidgetUI):
                 value = GuiUtils.toDouble(item.text())
             except TypeError:
                 # Can't be converted properly, bring back the old value and exit
-                pass
+                return
 
             current_details = self.logic.kernel_module.details[parameter_name_w]
             if self.has_poly_error_column:
@@ -150,7 +150,7 @@ class PolydispersityWidget(QtWidgets.QWidget, Ui_PolydispersityWidgetUI):
                 value = GuiUtils.toDouble(item.text())
             except TypeError:
                 # Can't be converted properly, bring back the old value and exit
-                pass
+                return
 
             # Update the sasmodel
             # PD[ratio] -> width, npts -> npts, nsigs -> nsigmas

--- a/src/sas/qtgui/Perspectives/Fitting/PolydispersityWidget.py
+++ b/src/sas/qtgui/Perspectives/Fitting/PolydispersityWidget.py
@@ -132,7 +132,7 @@ class PolydispersityWidget(QtWidgets.QWidget, Ui_PolydispersityWidgetUI):
                 value = GuiUtils.toDouble(item.text())
             except TypeError:
                 # Can't be converted properly, bring back the old value and exit
-                return
+                pass
 
             current_details = self.logic.kernel_module.details[parameter_name_w]
             if self.has_poly_error_column:
@@ -150,20 +150,22 @@ class PolydispersityWidget(QtWidgets.QWidget, Ui_PolydispersityWidgetUI):
                 value = GuiUtils.toDouble(item.text())
             except TypeError:
                 # Can't be converted properly, bring back the old value and exit
-                return
+                pass
 
             # Update the sasmodel
             # PD[ratio] -> width, npts -> npts, nsigs -> nsigmas
-            if model_column not in delegate.columnDict():
-                return
-            # Map the column to the poly param that was changed
-            associations = {1: "width", delegate.poly_npts: "npts", delegate.poly_nsigs: "nsigmas"}
-            p_name = f"{parameter_name}.{associations.get(model_column, 'width')}"
-            self.poly_params[p_name] = value
-            self.logic.kernel_module.setParam(p_name, value)
+            if model_column in delegate.columnDict():
+                # Map the column to the poly param that was changed
+                associations = {1: "width", delegate.poly_npts: "npts", delegate.poly_nsigs: "nsigmas"}
+                p_name = f"{parameter_name}.{associations.get(model_column, 'width')}"
+                self.poly_params[p_name] = value
+                self.logic.kernel_module.setParam(p_name, value)
 
-            # Update plot
-            self.updateDataSignal.emit()
+                # Update plot
+                self.updateDataSignal.emit()
+
+        # Update main model for display
+        self.iterateOverModelSignal.emit()
 
     def checkedListFromModel(self) -> list[str]:
         """
@@ -290,8 +292,6 @@ class PolydispersityWidget(QtWidgets.QWidget, Ui_PolydispersityWidgetUI):
                 combo_box.blockSignals(False)
                 # Load the file
                 self.loadPolydispArray(row_index)
-                # Update main model for display
-                self.iterateOverModelSignal.emit()
                 self.logic.kernel_module.set_dispersion(param.name, self.disp_model)
                 # uncheck the parameter
                 self.poly_model.item(row_index, 0).setCheckState(QtCore.Qt.Unchecked)
@@ -325,7 +325,6 @@ class PolydispersityWidget(QtWidgets.QWidget, Ui_PolydispersityWidgetUI):
         self.poly_model.setData(npts_index, npts)
         self.poly_model.setData(nsigs_index, nsigs)
 
-        # self.iterateOverModel(updateFunctionCaption)
         if combo_box is not None:
             self.orig_poly_index = combo_box.currentIndex()
 


### PR DESCRIPTION
## Description

This fixes an issue introduced in v6.1.0 with the polydispersity params not updating in the fit tab after they are updated on the PD tab. The method to do this was inadvertently removed during the fitting refactor.

Fixes #3576

## How Has This Been Tested?

From source, I tested both the sphere and cylinder models, and saw, as the PD width and PD function change, the child values for the fit page also change to match.

## Review Checklist:

**Documentation** (check at least one)
- [x] There is **nothing** that needs documenting
- [ ] Documentation changes are **in this PR**
- [ ] There is an **issue** open for the documentation (link?)

**Installers**
- [x] There is a chance this will affect the **installers**, if so
  - [ ] **Windows** installer (GH artifact) has been tested (installed and worked) 
  - [ ] **MacOSX** installer (GH artifact) has been tested (installed and worked)
  - [ ] **Wheels** installer (GH artifact) has been tested (installed and worked)

**Licensing** (untick if necessary)
- [x] The introduced changes comply with SasView license (BSD 3-Clause)

