### PR TITLE
3577: Example data directory at base installation directory

### DIFF
--- a/installers/sasview.spec
+++ b/installers/sasview.spec
@@ -15,6 +15,7 @@ datas = []
 datas.append((os.path.join(PYTHON_PACKAGES, 'debugpy'), 'debugpy'))
 datas.append((os.path.join(PYTHON_PACKAGES, 'jedi'), 'jedi'))
 datas.append((os.path.join(PYTHON_PACKAGES, 'zmq'), 'zmq'))
+datas.append(('../src/sas/example_data', './example_data'))
 
 def add_data(data):
     for component in data:


### PR DESCRIPTION
## Description

This ensures the `example_data` directory is in the base installation directory to match the tutorials

Fixes #3577

## How Has This Been Tested?

Downloaded the installer and tested locally on Windows.

## Review Checklist:

[**Documentation** (check at least one)
- [x] There is **nothing** that needs documenting
- [ ] Documentation changes are **in this PR**
- [ ] There is an **issue** open for the documentation (link?)

**Installers**
- [x] There is a chance this will affect the **installers**, if so
  - [ ] **Windows** installer (GH artifact) has been tested (installed and worked) 
  - [ ] **MacOSX** installer (GH artifact) has been tested (installed and worked)
  - [ ] **Wheels** installer (GH artifact) has been tested (installed and worked)

**Licensing** (untick if necessary)
- [x] The introduced changes comply with SasView license (BSD 3-Clause)

