### PR TITLE
Corfunc range update

### DIFF
--- a/src/sas/qtgui/Perspectives/Corfunc/CorfuncPerspective.py
+++ b/src/sas/qtgui/Perspectives/Corfunc/CorfuncPerspective.py
@@ -616,6 +616,7 @@ class CorfuncWindow(QtWidgets.QDialog, Ui_CorfuncDialog, Perspective):
             msg = "The slider values are out of range."
             msg += f"\n The minimum value is {qmin:.8g} and the maximum value is {qmax:.8g}"
             dialog = QtWidgets.QMessageBox(self, text=msg)
+            dialog.setWindowTitle("Value out of range")
             dialog.setStandardButtons(QtWidgets.QMessageBox.Ok)
             dialog.exec_()
             return

--- a/src/sas/qtgui/Perspectives/Corfunc/CorfuncPerspective.py
+++ b/src/sas/qtgui/Perspectives/Corfunc/CorfuncPerspective.py
@@ -593,13 +593,20 @@ class CorfuncWindow(QtWidgets.QDialog, Ui_CorfuncDialog, Perspective):
         """ Set the colour of the text boxes to red if they have bad parameter definitions"""
         normal = "QLineEdit { background-color: rgb(0,0,0); color: rgb(255,255,255) }"
         red    = "QLineEdit { background-color: rgb(255,0,0); color: rgb(255,255,255) }"
+        
+        # Round values to 8 significant figures to avoid floating point precision issues
+        p1 = float(f"{params.point_1:.8g}")
+        p2 = float(f"{params.point_2:.8g}")
+        p3 = float(f"{params.point_3:.8g}")
+        qmin = float(f"{params.data_q_min:.8g}")
+        qmax = float(f"{params.data_q_max:.8g}")
 
-        # Determine validity flags first
-        invalid_1 = params.point_1 < params.data_q_min or params.point_1 >= params.point_2
-        invalid_2 = params.point_2 <= params.point_1 or params.point_2 >= params.point_3
-        invalid_3 = params.point_3 <= params.point_2 or params.point_3 > params.data_q_max
+        # Determine validity flags such that data_q_min <= point_1 < point_2 < point_3 <= data_q_max
+        invalid_1 = p1 < qmin or p1 >= p2
+        invalid_2 = p2 <= p1 or p2 >= p3
+        invalid_3 = p3 <= p2 or p3 > qmax
 
-        # Apply styles based on flags
+        # Make the background red if the text box is invalid
         self.txtLowerQMax.setStyleSheet(red if invalid_1 else normal)
         self.txtUpperQMin.setStyleSheet(red if invalid_2 else normal)
         self.txtUpperQMax.setStyleSheet(red if invalid_3 else normal)

--- a/src/sas/qtgui/Perspectives/Corfunc/CorfuncPerspective.py
+++ b/src/sas/qtgui/Perspectives/Corfunc/CorfuncPerspective.py
@@ -610,6 +610,15 @@ class CorfuncWindow(QtWidgets.QDialog, Ui_CorfuncDialog, Perspective):
         self.txtLowerQMax.setStyleSheet(red if invalid_1 else normal)
         self.txtUpperQMin.setStyleSheet(red if invalid_2 else normal)
         self.txtUpperQMax.setStyleSheet(red if invalid_3 else normal)
+        
+        # Pops a message box if the slider values are out of range
+        if p1 < qmin or p3 > qmax:
+            msg = "The slider values are out of range."
+            msg += f"\n The minimum value is {qmin:.8g} and the maximum value is {qmax:.8g}"
+            dialog = QtWidgets.QMessageBox(self, text=msg)
+            dialog.setStandardButtons(QtWidgets.QMessageBox.Ok)
+            dialog.exec_()
+            return
 
     def on_extrapolation_slider_changed(self, state: ExtrapolationParameters):
         """ Slider state changed"""

--- a/src/sas/qtgui/Perspectives/Corfunc/CorfuncPerspective.py
+++ b/src/sas/qtgui/Perspectives/Corfunc/CorfuncPerspective.py
@@ -591,33 +591,18 @@ class CorfuncWindow(QtWidgets.QDialog, Ui_CorfuncDialog, Perspective):
 
     def notify_extrapolation_text_box_validity(self, params):
         """ Set the colour of the text boxes to red if they have bad parameter definitions"""
-        box_1_style = ""
-        box_2_style = ""
-        box_3_style = ""
-        red = "QLineEdit { background-color: rgb(255,0,0); color: rgb(255,255,255) }"
+        normal = "QLineEdit { background-color: rgb(0,0,0); color: rgb(255,255,255) }"
+        red    = "QLineEdit { background-color: rgb(255,0,0); color: rgb(255,255,255) }"
 
-        if params.point_1 <= params.data_q_min:
-            box_1_style = red
+        # Determine validity flags first
+        invalid_1 = params.point_1 < params.data_q_min or params.point_1 >= params.point_2
+        invalid_2 = params.point_2 <= params.point_1 or params.point_2 >= params.point_3
+        invalid_3 = params.point_3 <= params.point_2 or params.point_3 > params.data_q_max
 
-        if params.point_2 <= params.point_1:
-            box_1_style = red
-            box_2_style = red
-
-        if params.point_3 <= params.point_2:
-            box_2_style = red
-            box_3_style = red
-
-        if params.data_q_max <= params.point_3:
-            box_3_style = red
-
-        # if v3 < v1 and v2, all three will go red (because of transitivity of <=), but this is good
-        if params.point_3 <= params.point_1:
-            box_1_style = red
-            box_3_style = red
-
-        self.txtLowerQMax.setStyleSheet(box_1_style)
-        self.txtUpperQMin.setStyleSheet(box_2_style)
-        self.txtUpperQMax.setStyleSheet(box_3_style)
+        # Apply styles based on flags
+        self.txtLowerQMax.setStyleSheet(red if invalid_1 else normal)
+        self.txtUpperQMin.setStyleSheet(red if invalid_2 else normal)
+        self.txtUpperQMax.setStyleSheet(red if invalid_3 else normal)
 
     def on_extrapolation_slider_changed(self, state: ExtrapolationParameters):
         """ Slider state changed"""
@@ -628,6 +613,9 @@ class CorfuncWindow(QtWidgets.QDialog, Ui_CorfuncDialog, Perspective):
                            QtGui.QStandardItem(format_string%state.point_2))
         self.model.setItem(WIDGETS.W_QCUTOFF,
                            QtGui.QStandardItem(format_string%state.point_3))
+
+        # Check validity of the text boxes
+        self.notify_extrapolation_text_box_validity(state)
 
     def on_extrapolation_slider_changing(self, state: ExtrapolationInteractionState):
         """ Slider is being moved about"""

--- a/src/sas/qtgui/Perspectives/Corfunc/CorfuncSlider.py
+++ b/src/sas/qtgui/Perspectives/Corfunc/CorfuncSlider.py
@@ -80,17 +80,17 @@ class CorfuncSlider(QtWidgets.QWidget):
         :param params: An extrapolation parameters object describing a desired state
         :returns: A description of the problem if it exists, otherwise None
         """
-        if params.data_q_min >= params.point_1:
-            return "min_q should be smaller than q_point_1"
+        if params.data_q_min > params.point_1:
+            return "min_q should be smaller than or equal to q_point_1"
 
-        if params.point_1 > params.point_2:
-            return "q_point_1 should be smaller or equal to q_point_2"
+        if params.point_1 >= params.point_2:
+            return "q_point_1 should be smaller than q_point_2"
 
-        if params.point_2 > params.point_3:
-            return "q_point_2 should be smaller or equal to q_point_3"
+        if params.point_2 >= params.point_3:
+            return "q_point_2 should be smaller than q_point_3"
 
         if params.point_3 > params.data_q_max:
-            return "q_point_3 should be smaller or equal to max_q"
+            return "q_point_3 should be smaller than or equal to max_q"
 
         return None
 

--- a/src/sas/qtgui/Perspectives/Corfunc/CorfuncSlider.py
+++ b/src/sas/qtgui/Perspectives/Corfunc/CorfuncSlider.py
@@ -134,7 +134,8 @@ class CorfuncSlider(QtWidgets.QWidget):
     def mouseReleaseEvent(self, event: QtGui.QMouseEvent):
         if self.isEnabled():
             if self._drag_id is not None and self._movement_line_position is not None:
-                self.set_boundary(self._drag_id, self.inverse_transform(self._movement_line_position))
+                safe_pos = self._sanitise_new_position(self._drag_id, self._movement_line_position)
+                self.set_boundary(self._drag_id, self.inverse_transform(safe_pos))
 
             self._drag_id = None
             self._movement_line_position = None

--- a/src/sas/qtgui/Perspectives/Corfunc/CorfuncSlider.py
+++ b/src/sas/qtgui/Perspectives/Corfunc/CorfuncSlider.py
@@ -273,7 +273,7 @@ class CorfuncSlider(QtWidgets.QWidget):
     @property
     def guinier_label_position(self) -> float:
         """ Position to put the text for the guinier region"""
-        return 0.5*self.left_pad
+        return 0.5 * self.transform(self._point_1)
 
     @property
     def data_label_centre(self) -> float:


### PR DESCRIPTION
## Description

Fixed issues with the Corfunc perspective range:
- Users could go out of range by clicking outside
- The textbox would remain red at times, even after the value is within range
- Inconsistencies between the two code files regarding the appropriate values
- Guinier label remaining static

Added features:
- Pops a dialogue box when the entered values are out of range, showing the users the max and min value
- Rounds the value checked to 8sf to omit floating point precision errors

Fixes #3580 #3579 
## How Has This Been Tested?

Tested the range check logic by loading a few different data files into Corfunc view and trying out values in and out of range, and trying to reproduce previously present issues.

## Review Checklist:

[if using the editor, use `[x]` in place of `[ ]` to check a box]

**Documentation** (check at least one)
- [x] There is **nothing** that needs documenting
- [ ] Documentation changes are **in this PR**
- [ ] There is an **issue** open for the documentation (link?)

**Installers**
- [ ] There is a chance this will affect the **installers**, if so
  - [ ] **Windows** installer (GH artifact) has been tested (installed and worked) 
  - [ ] **MacOSX** installer (GH artifact) has been tested (installed and worked)
  - [ ] **Wheels** installer (GH artifact) has been tested (installed and worked)

**Licensing** (untick if necessary)
- [x] The introduced changes comply with SasView license (BSD 3-Clause)

