### PR TITLE
Replaces 'magic numbers' with enum

### DIFF
--- a/src/sas/qtgui/Plotting/SlicerParameters.py
+++ b/src/sas/qtgui/Plotting/SlicerParameters.py
@@ -372,7 +372,6 @@ class SlicerParameters(QtWidgets.QDialog, Ui_SlicerParametersUI):
         # We can get away with directly querying the UI, since this is the only
         # place we need that state.
         fitting_requested = FittingType(self.cbFitOptions.currentIndex())
-        print('fitting_requested', fitting_requested)
         self.sendToFit(items_for_fit, fitting_requested)
 
     def setModel(self, model):


### PR DESCRIPTION
## Description

Replaced 'magic numbers' in SlicerParameters.py with enums representing the fitting types

Fixes #3568 

## How Has This Been Tested?

Running the program to check behaviour is identical to before.

## Review Checklist:

**Documentation** (check at least one)
- [x] There is **nothing** that needs documenting
- [ ] Documentation changes are **in this PR**
- [ ] There is an **issue** open for the documentation (link?)

**Installers**
- [ ] There is a chance this will affect the **installers**, if so
  - [ ] **Windows** installer (GH artifact) has been tested (installed and worked) 
  - [ ] **MacOSX** installer (GH artifact) has been tested (installed and worked)
  - [ ] **Wheels** installer (GH artifact) has been tested (installed and worked)

**Licensing** (untick if necessary)
- [x] The introduced changes comply with SasView license (BSD 3-Clause)

