### PR TITLE
Adds plotUpdateSignal to BoxSlicer

### DIFF
--- a/src/sas/qtgui/Plotting/Slicers/BoxSlicer.py
+++ b/src/sas/qtgui/Plotting/Slicers/BoxSlicer.py
@@ -285,6 +285,7 @@ class BoxInteractor(BaseInteractor, SlicerModel):
         if self._item.parent() is not None:
             item = self._item.parent()
         GuiUtils.updateModelItemWithPlot(item, new_plot, new_plot.id)
+        self.base.manager.communicator.plotUpdateSignal.emit([new_plot])
         self.base.manager.communicator.forcePlotDisplaySignal.emit([item, new_plot])
 
         if self.update_model:


### PR DESCRIPTION
## Description

I have added the `plotUpdateSignal` to the `_post_data` method of the `BoxSlicer` This brings it in line with the same metyhod of the `AnnulusSlicer`, `SectorSlicer`, and `WedgeSlicer`. I noticed this difference when reviewing #3597

## How Has This Been Tested?

I have fitted data and used the Box Slicer both without and with the signal. The plot functions and updates in both cases.

## Review Checklist:

[if using the editor, use `[x]` in place of `[ ]` to check a box]

**Documentation** (check at least one)
- [x] There is **nothing** that needs documenting
- [ ] Documentation changes are **in this PR**
- [ ] There is an **issue** open for the documentation (link?)

**Installers**
- [ ] There is a chance this will affect the **installers**, if so
  - [ ] **Windows** installer (GH artifact) has been tested (installed and worked) 
  - [ ] **MacOSX** installer (GH artifact) has been tested (installed and worked)
  - [ ] **Wheels** installer (GH artifact) has been tested (installed and worked)

**Licensing** (untick if necessary)
- [x] The introduced changes comply with SasView license (BSD 3-Clause)

