### PR TITLE
Qwedge

### DIFF
--- a/src/sas/qtgui/Plotting/Slicers/WedgeSlicer.py
+++ b/src/sas/qtgui/Plotting/Slicers/WedgeSlicer.py
@@ -40,7 +40,6 @@ class WedgeInteractor(BaseInteractor, SlicerModel):
         self.qmax = max(self.data.xmax, np.fabs(self.data.xmin), self.data.ymax, np.fabs(self.data.ymin))
         self.dqmin = min(np.fabs(self.data.qx_data))
         self.connect = self.base.connect
-        
 
         # Number of points on the plot
         self.nbins = 100


### PR DESCRIPTION
## Description

Sets the fold for Wedge Slicer to True, so the Wedge Averaging in Q does not create data in the negative Q space. 

Fixes #3221 

## How Has This Been Tested?

Tried out a few data sets to see if the expected behaviour is produced.

## Review Checklist:

[if using the editor, use `[x]` in place of `[ ]` to check a box]

**Documentation** (check at least one)
- [x] There is **nothing** that needs documenting
- [ ] Documentation changes are **in this PR**
- [ ] There is an **issue** open for the documentation (link?)

**Installers**
- [ ] There is a chance this will affect the **installers**, if so
  - [ ] **Windows** installer (GH artifact) has been tested (installed and worked) 
  - [ ] **MacOSX** installer (GH artifact) has been tested (installed and worked)
  - [ ] **Wheels** installer (GH artifact) has been tested (installed and worked)

**Licensing** (untick if necessary)
- [x] The introduced changes comply with SasView license (BSD 3-Clause)

