### PR TITLE
Dependabot: Include all action updates in one PR

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -7,3 +7,7 @@ updates:
     schedule:
       # Check for updates to GitHub Actions every week
       interval: "weekly"
+    groups:
+      all-dependencies:
+        patterns:
+          - "*"  # include all actions in a single PR to ensure tied updates are able to work together.


### PR DESCRIPTION
## Description

This bundles all github action updates, made by Dependabot, into a single PR. This will ensure we aren't in a situation where a series of major updates that depend on one another aren't pushed into different PRs, each of which is failing, without knowing if they will work together well (see #3588, #3589, #3590, #3591, and #3592 as an example).

## Review Checklist:

**Licensing** (untick if necessary)
- [x] The introduced changes comply with SasView license (BSD 3-Clause)

