### PR TITLE
Install innosetup in windows installer CI runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -259,6 +259,11 @@ jobs:
             installers/dist/sasview-pyinstaller-dist.tar.gz
           if-no-files-found: ignore
 
+      - name: Install OS-specific installer tools (Windows)
+        if: ${{ matrix.installer && startsWith(matrix.os, 'windows') }}
+        run: |
+          choco install innosetup
+
       - name: Build sasview installer with INNO (Windows)
         if: ${{ matrix.installer && startsWith(matrix.os, 'windows') }}
         run: |


### PR DESCRIPTION
## Description

The windows-2025 images do not include innosetup to build the windows installer, so this PR adds a step to install the tool; this unfortunately adds an additional 2min to the CI run time. 

According to https://github.com/actions/runner-images/issues/12677, `D:` should no longer exist in these images but it is used by the digicert action for signing and currently works; there's a chance that will break in the future.

These changes should be kept and *not* the changes in #3604 when the `release-6.1.1` branch is merged back into `main`.


Fixes #3603

## How Has This Been Tested?

CI on this PR

Note that someone with windows needs to check that the installer is correctly signed.

## Review Checklist:

[if using the editor, use `[x]` in place of `[ ]` to check a box]

**Documentation** (check at least one)
- [X] There is **nothing** that needs documenting
- [ ] Documentation changes are **in this PR**
- [ ] There is an **issue** open for the documentation (link?)

**Installers**
- [x] There is a chance this will affect the **installers**, if so
  - [ ] **Windows** installer (GH artifact) has been tested (installed and worked) 
  - [ ] **MacOSX** installer (GH artifact) has been tested (installed and worked)
  - [ ] **Wheels** installer (GH artifact) has been tested (installed and worked)

**Licensing** (untick if necessary)
- [x] The introduced changes comply with SasView license (BSD 3-Clause)

