### PR TITLE
Limit windows signing action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,9 +110,11 @@ jobs:
             (github.event_name == 'push' && contains(github.ref, 'release')) ||
             (github.event_name == 'push' && contains(github.ref, 'tags/v6.1')) ||
             (github.event_name == 'pull_request' && contains(github.base_ref, 'release-6.1'))
-          ) && 'true' || ''
-        }}
-      SIGN_INSTALLER: ${{ (! github.event.repository.fork && ! github.event.pull_request.head.repo.fork && RELEASE_BRANCH_BUILD == 'true') && 'true' || '' }}
+          ) && 'true' || '' }}
+
+      # Only sign the installer if non-forked repo
+      SIGN_INSTALLER: ${{ (! github.event.repository.fork && ! github.event.pull_request.head.repo.fork ) && 'true' || '' }}
+
       UV_SYSTEM_PYTHON: 1
 
     name: "${{ matrix.job_name }}"
@@ -352,7 +354,7 @@ jobs:
         shell: bash
 
       - name: Sign the binary using keypair alias
-        if: ${{ matrix.installer && startsWith(matrix.os, 'windows') && env.SIGN_INSTALLER }}
+        if: ${{ matrix.installer && startsWith(matrix.os, 'windows') && env.SIGN_INSTALLER && env.RELEASE_BRANCH_BUILD }}
         run: |
            smctl sign --keypair-alias key_911959544 --input installers/dist/setupSasView.exe
         shell: cmd


### PR DESCRIPTION
## Description

We need to monitor how often the installer is getting signed, given we have a limited number of signatures per year.
We also share those signatures with other windows applications built at ESS.

Let's not target 6.1.1 here, as it is nearing the release. However, `main` should have this ASAP, as well as branches created from the main branch.

## How Has This Been Tested?

Branch checks.

## Review Checklist:

[if using the editor, use `[x]` in place of `[ ]` to check a box]

**Documentation** (check at least one)
- [X] There is **nothing** that needs documenting
- [ ] Documentation changes are **in this PR**
- [ ] There is an **issue** open for the documentation (link?)

**Installers**
- [X] There is a chance this will affect the **installers**, if so
  - [X] **Windows** installer (GH artifact) has been tested (installed and worked) 
  - [ ] **MacOSX** installer (GH artifact) has been tested (installed and worked)
  - [ ] **Wheels** installer (GH artifact) has been tested (installed and worked)

**Licensing** (untick if necessary)
- [x] The introduced changes comply with SasView license (BSD 3-Clause)

