### PR TITLE
Removes macos-13 from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -318,28 +318,11 @@ jobs:
           appstore-connect-team-id: 8CX8K63BQM
           verbose: True
 
-      - name: Notarize Release Build (OSX)
-        if: ${{ matrix.installer && matrix.os == 'macos-13' && env.SIGN_INSTALLER }}
-        uses: lando/notarize-action@v2
-        with:
-          product-path: installers/dist/SasView6-macos-13.dmg
-          primary-bundle-id: "org.sasview.SasView6"
-          appstore-connect-username: ${{ secrets.NOTARIZATION_USERNAME }}
-          appstore-connect-password: ${{ secrets.NOTARIZATION_PASSWORD }}
-          appstore-connect-team-id: 8CX8K63BQM
-          verbose: True
-
       - name: Staple Release Build (OSX)
         if: ${{ matrix.installer && matrix.os == 'macos-latest' && env.SIGN_INSTALLER }}
         uses: BoundfoxStudios/action-xcode-staple@v1
         with:
           product-path: installers/dist/SasView6-macos-latest.dmg
-
-      - name: Staple Release Build (OSX)
-        if: ${{ matrix.installer && matrix.os == 'macos-13' && env.SIGN_INSTALLER }}
-        uses: BoundfoxStudios/action-xcode-staple@v1
-        with:
-          product-path: installers/dist/SasView6-macos-13.dmg
 
       - name: Install DigiCert Client tools from Github Custom Actions marketplace
         if: ${{ matrix.installer && startsWith(matrix.os, 'windows') && env.SIGN_INSTALLER }}
@@ -375,7 +358,6 @@ jobs:
           name: SasView-Installer-${{ matrix.os }}-${{ matrix.python-version }}
           path: |
             installers/dist/setupSasView.exe
-            installers/dist/SasView6-macos-13.dmg
             installers/dist/SasView6-macos-latest.dmg
             installers/dist/SasView6.tar.gz
           if-no-files-found: ignore

--- a/.github/workflows/matrix.py
+++ b/.github/workflows/matrix.py
@@ -29,7 +29,6 @@ os_release_list = [
     'ubuntu-22.04',
     'windows-latest',
     'macos-latest',
-    'macos-13',
 ]
 
 # List of OS images to use for release tests


### PR DESCRIPTION
## Description

I have removed the `macos-13` runner from our CI. This is because the runner will be closed down in the very near future (4th December). See: https://github.blog/changelog/2025-07-11-upcoming-changes-to-macos-hosted-runners-macos-latest-migration-and-xcode-support-policy-updates/#macos-13-is-closing-down

Fixes #3628

## How Has This Been Tested?

Running the CI, which still passes. Note we also use the `macos-latest` runner.

## Review Checklist:

[if using the editor, use `[x]` in place of `[ ]` to check a box]

**Documentation** (check at least one)
- [x] There is **nothing** that needs documenting
- [ ] Documentation changes are **in this PR**
- [ ] There is an **issue** open for the documentation (link?)

**Installers**
- [ ] There is a chance this will affect the **installers**, if so
  - [ ] **Windows** installer (GH artifact) has been tested (installed and worked) 
  - [ ] **MacOSX** installer (GH artifact) has been tested (installed and worked)
  - [ ] **Wheels** installer (GH artifact) has been tested (installed and worked)

**Licensing** (untick if necessary)
- [x] The introduced changes comply with SasView license (BSD 3-Clause)

