### PR TITLE
Removes redundant param

### DIFF
--- a/src/sas/qtgui/Perspectives/Invariant/InvariantPerspective.py
+++ b/src/sas/qtgui/Perspectives/Invariant/InvariantPerspective.py
@@ -293,7 +293,7 @@ class InvariantWindow(QtWidgets.QDialog, Ui_tabbedInvariantUI, Perspective):
             self.communicate.plotRequestedSignal.emit(plots, None)
 
         # Update the details dialog in case it is open
-        self.update_details_widget(model)
+        self.update_details_widget()
 
     def update_details_widget(self) -> None:
         """


### PR DESCRIPTION
## Description

Previous PR #3627 changing the Invariant perspective files removed the param `model` from the definition for `update_details_widget`, but it was left behind in a call. This PR fixes that.

## How Has This Been Tested?

Ran the Invariant perspective.

## Review Checklist:

**Documentation** (check at least one)
- [x] There is **nothing** that needs documenting
- [ ] Documentation changes are **in this PR**
- [ ] There is an **issue** open for the documentation (link?)

**Installers**
- [ ] There is a chance this will affect the **installers**, if so
  - [ ] **Windows** installer (GH artifact) has been tested (installed and worked) 
  - [ ] **MacOSX** installer (GH artifact) has been tested (installed and worked)
  - [ ] **Wheels** installer (GH artifact) has been tested (installed and worked)

**Licensing** (untick if necessary)
- [x] The introduced changes comply with SasView license (BSD 3-Clause)

