### PR TITLE
Adds function for close

### DIFF
--- a/src/sas/qtgui/Perspectives/Invariant/InvariantDetails.py
+++ b/src/sas/qtgui/Perspectives/Invariant/InvariantDetails.py
@@ -35,6 +35,7 @@ class DetailsDialog(QtWidgets.QDialog, Ui_Dialog):
             margin: 1px;
         }
         """
+        self.setWindowTitle('Status')
         self.progressBarLowQ.setStyleSheet(DEFAULT_STYLE)
         self.progressBarData.setStyleSheet(DEFAULT_STYLE)
         self.progressBarHighQ.setStyleSheet(DEFAULT_STYLE)
@@ -68,6 +69,12 @@ class DetailsDialog(QtWidgets.QDialog, Ui_Dialog):
         self.progress_low_qstar = 0.0
         self.progress_high_qstar = 0.0
         self.progress_data_qstar = 100.0
+
+    def closeEvent(self, event):
+        """Re-enables the status button when closed"""
+        parent = self.parent()
+        parent.cmdStatus.setEnabled(True)
+        super().closeEvent(event)
 
     def setModel(self, model):
         """ """


### PR DESCRIPTION
## Description

When the 'Status' window is closed using 'x', it re-enables the Status button on the main window for the Invariant perspective so that the window can be reopened.

Also renames the window to 'Status'.

Fixes #3632

## How Has This Been Tested?

Tried the functionality.

## Review Checklist:

**Documentation** (check at least one)
- [x] There is **nothing** that needs documenting
- [ ] Documentation changes are **in this PR**
- [ ] There is an **issue** open for the documentation (link?)

**Installers**
- [ ] There is a chance this will affect the **installers**, if so
  - [ ] **Windows** installer (GH artifact) has been tested (installed and worked) 
  - [ ] **MacOSX** installer (GH artifact) has been tested (installed and worked)
  - [ ] **Wheels** installer (GH artifact) has been tested (installed and worked)

**Licensing** (untick if necessary)
- [x] The introduced changes comply with SasView license (BSD 3-Clause)

