### PR TITLE
Change remaining mentions of appdirs to platformdirs

### DIFF
--- a/build_tools/requirements-release-macos-13.txt
+++ b/build_tools/requirements-release-macos-13.txt
@@ -2,7 +2,6 @@ AccessControl==7.2
 Acquisition==6.1
 alabaster==1.0.0
 altgraph==0.17.4
-appdirs==1.4.4
 appnope==0.1.4
 arabic-reshaper==3.0.0
 asn1crypto==1.5.1

--- a/build_tools/requirements-release-macos-latest.txt
+++ b/build_tools/requirements-release-macos-latest.txt
@@ -2,7 +2,6 @@ AccessControl==7.2
 Acquisition==6.1
 alabaster==1.0.0
 altgraph==0.17.4
-appdirs==1.4.4
 appnope==0.1.4
 arabic-reshaper==3.0.0
 asn1crypto==1.5.1

--- a/build_tools/requirements-release-ubuntu-22.04.txt
+++ b/build_tools/requirements-release-ubuntu-22.04.txt
@@ -2,7 +2,6 @@ AccessControl==7.2
 Acquisition==6.1
 alabaster==1.0.0
 altgraph==0.17.4
-appdirs==1.4.4
 arabic-reshaper==3.0.0
 asn1crypto==1.5.1
 astroid==3.3.9

--- a/build_tools/requirements-release-ubuntu-latest.txt
+++ b/build_tools/requirements-release-ubuntu-latest.txt
@@ -1,7 +1,6 @@
 AccessControl==7.2
 Acquisition==6.1
 alabaster==1.0.0
-appdirs==1.4.4
 arabic-reshaper==3.0.0
 asn1crypto==1.5.1
 astroid==3.3.9

--- a/build_tools/requirements-release-windows-latest.txt
+++ b/build_tools/requirements-release-windows-latest.txt
@@ -2,7 +2,6 @@ AccessControl==7.2
 Acquisition==6.1
 alabaster==1.0.0
 altgraph==0.17.4
-appdirs==1.4.4
 arabic-reshaper==3.0.0
 asn1crypto==1.5.1
 astroid==3.3.9

--- a/build_tools/requirements.txt
+++ b/build_tools/requirements.txt
@@ -1,5 +1,4 @@
 # Alphabetized list of OS and version agnostic dependencies
-appdirs
 bumps
 cffi
 docutils

--- a/docs/sphinx-docs/source/user/environment.rst
+++ b/docs/sphinx-docs/source/user/environment.rst
@@ -14,9 +14,12 @@ SasView creates and uses a number of environment variables:
 - **SAS_WEIGHTS_PATH=~/.sasview/weights**
    - sets the path to custom distribution files (see :ref:`polydispersityhelp`)
 
-- **XDG_CACHE_HOME=~/.cache**
-   - sets the pyopencl cache root (linux only)
-   - defined in the appdirs package
+- **XDG_CACHE_HOME=~/.cache/**
+   - sets the pyopencl cache root (on Linux)
+
+- **XDG_CONFIG_HOME=~/.config**
+   - sets configuration file location (on Linux)
+   - used via the `platformdirs <https://github.com/tox-dev/platformdirs?tab=readme-ov-file#example-output>` package
 
 - **SAS_COMPILER=tinycc|msvc|mingw|unix**
    - sets the DLL compiler


### PR DESCRIPTION

## Description

`appdirs` is already unused in the codebase, expunge it from the build requirements and update the docs to match.

Fixes #3616

## How Has This Been Tested?

Documentation only.

## Review Checklist:

[if using the editor, use `[x]` in place of `[ ]` to check a box]

**Documentation** (check at least one)
- [ ] There is **nothing** that needs documenting
- [x] Documentation changes are **in this PR**
- [ ] There is an **issue** open for the documentation (link?)

**Installers**
- [ ] There is a chance this will affect the **installers**, if so
  - [ ] **Windows** installer (GH artifact) has been tested (installed and worked) 
  - [ ] **MacOSX** installer (GH artifact) has been tested (installed and worked)
  - [ ] **Wheels** installer (GH artifact) has been tested (installed and worked)

**Licensing** (untick if necessary)
- [x] The introduced changes comply with SasView license (BSD 3-Clause)

