### PR TITLE
Upgrades python to version 3.12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: 3.11
+          python-version: 3.12
 
       - uses: actions/checkout@v5
 
@@ -84,7 +84,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: 3.11
+          python-version: 3.12
 
       ### Check if this wheel is already cached
 
@@ -154,7 +154,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: 3.11
+          python-version: 3.12
 
       - name: Install uv utilities to speed up python module installation
         uses: astral-sh/setup-uv@v6

--- a/.github/workflows/matrix.py
+++ b/.github/workflows/matrix.py
@@ -39,7 +39,7 @@ os_test_list = os_release_list + [
 
 # List of python versions to use for release builds
 python_release_list = [
-    '3.11',
+    '3.12',
 ]
 
 # List of python versions to use for tests

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,6 +1,6 @@
 # Quick Intro for Building SasView
 
-Note - at the current time SasView will only run in gui form under Python 3.11
+Note - at the current time SasView will only run in gui form under Python 3.12
 and later.
 
 Whether you're installing SasView to use as a tool for your research or

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ dynamic = [
 ]
 description = "SasView application"
 readme = "README.md"
-requires-python = ">=3.11"
+requires-python = ">=3.12"
 license = { text = "BSD-3-Clause" }
 authors = [
     {name = "SasView Team", email = "developers@sasview.org"},


### PR DESCRIPTION
## Description

Upgrades the minimum version of SasView to 3.12, following the upgrade to SasData in SasView/sasdata#166. This should fix the broken CI which was broken due to the clash in python versions.

## How Has This Been Tested?

Ran the CI.

## Review Checklist:

[if using the editor, use `[x]` in place of `[ ]` to check a box]

**Documentation** (check at least one)
- [ ] There is **nothing** that needs documenting
- [x] Documentation changes are **in this PR**
- [ ] There is an **issue** open for the documentation (link?)

**Installers**
- [ ] There is a chance this will affect the **installers**, if so
  - [ ] **Windows** installer (GH artifact) has been tested (installed and worked) 
  - [ ] **MacOSX** installer (GH artifact) has been tested (installed and worked)
  - [ ] **Wheels** installer (GH artifact) has been tested (installed and worked)

**Licensing** (untick if necessary)
- [x] The introduced changes comply with SasView license (BSD 3-Clause)

