### PR TITLE
Fixes bug in nightly build

### DIFF
--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -35,7 +35,7 @@ jobs:
 
       - name: Bundle up wheels
         run: |
-          cp sasview-wheel-*/* sasview-wheel/
+          cp build-dependency-*-wheel sasview-wheel/
           cd sasview-wheel
           zip ../SasView-nightly-wheels.zip *
 


### PR DESCRIPTION
## Description

The wheels for SasData and SasModels were renamed in #3642, but this was not changed in the nightly build. This PR fixes that.

## How Has This Been Tested?

Run CI, will check nightly on merge.

## Review Checklist:

[if using the editor, use `[x]` in place of `[ ]` to check a box]

**Documentation** (check at least one)
- [x] There is **nothing** that needs documenting
- [ ] Documentation changes are **in this PR**
- [ ] There is an **issue** open for the documentation (link?)

**Installers**
- [ ] There is a chance this will affect the **installers**, if so
  - [ ] **Windows** installer (GH artifact) has been tested (installed and worked) 
  - [ ] **MacOSX** installer (GH artifact) has been tested (installed and worked)
  - [ ] **Wheels** installer (GH artifact) has been tested (installed and worked)

**Licensing** (untick if necessary)
- [x] The introduced changes comply with SasView license (BSD 3-Clause)

