### PR TITLE
Use Python 3.13 for next release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: 3.12
+          python-version: 3.13
 
       - uses: actions/checkout@v5
 
@@ -84,7 +84,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: 3.12
+          python-version: 3.13
 
       ### Check if this wheel is already cached
 
@@ -154,7 +154,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: 3.12
+          python-version: 3.13
 
       - name: Install uv utilities to speed up python module installation
         uses: astral-sh/setup-uv@v6

--- a/.github/workflows/matrix.py
+++ b/.github/workflows/matrix.py
@@ -39,12 +39,13 @@ os_test_list = os_release_list + [
 
 # List of python versions to use for release builds
 python_release_list = [
-    "3.12",
+    "3.13",
 ]
 
 # List of python versions to use for tests
 python_test_list = python_release_list + [
     # No additional test versions - add more to this list as needed
+    "3.12",
 ]
 
 


### PR DESCRIPTION
## Description

For discussion at a development meeting soon - release using Python 3.13. This PR leaves tests running against Python 3.12 (and leaves that as the minimum Python version supported for the time being); this is about the version of Python that goes into the installer distributables.

## How Has This Been Tested?

Debian, Ubuntu and Flatpak releases from 6.0 onwards all used Python 6.13.

## Review Checklist:

[if using the editor, use `[x]` in place of `[ ]` to check a box]

**Documentation** (check at least one)
- [x] There is **nothing** that needs documenting
- [ ] Documentation changes are **in this PR**
- [ ] There is an **issue** open for the documentation (link?)

**Installers**
- [x] There is a chance this will affect the **installers**, if so
  - [ ] **Windows** installer (GH artifact) has been tested (installed and worked) 
  - [ ] **MacOSX** installer (GH artifact) has been tested (installed and worked)
  - [x] **Wheels** installer (GH artifact) has been tested (installed and worked)

**Licensing** (untick if necessary)
- [x] The introduced changes comply with SasView license (BSD 3-Clause)

