### PR TITLE
Rework CI variables

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,14 @@ defaults:
     shell: bash
 
 env:
-  RELEASE: ${{ github.event_name == 'push' && contains(github.ref, 'refs/tags/test-v') }}
+  # Determine if this CI is being done during the release polishing steps
+  RELEASE_BRANCH_BUILD: ${{
+      (
+        (github.event_name == 'push' && startsWith(github.ref, 'refs/heads/release')) ||
+        (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')) ||
+        (github.event_name == 'pull_request' && startsWith(github.base_ref, 'refs/heads/release'))
+      ) && 'true' || '' }}
+
   # The test-installer job can use an old existing image rather than the most
   # recently built image; the 'needs' can be commented out to allow the
   # test-installer job to run independently (and therefore faster)
@@ -18,7 +25,6 @@ env:
   INSTALLER_OLD_RUNID: 3204825457
   # The test-installer job can run with the pyinstaller debug bundle
   INSTALLER_USE_DEBUG: false
-  BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
 
 jobs:
 
@@ -218,12 +224,6 @@ jobs:
       matrix:
         include: ${{ fromJson(needs.matrix.outputs.test-matrix-json) }}
     env:
-      RELEASE_BRANCH_BUILD: ${{
-          (
-            (github.event_name == 'push' && contains(github.ref, 'release')) ||
-            (github.event_name == 'push' && contains(github.ref, 'tags/v6.1')) ||
-            (github.event_name == 'pull_request' && contains(github.base_ref, 'release-6.1'))
-          ) && 'true' || '' }}
       UV_SYSTEM_PYTHON: 1
 
     name: "${{ matrix.job_name }}"
@@ -276,16 +276,15 @@ jobs:
         include: ${{ fromJson(needs.matrix.outputs.installer-matrix-json) }}
     env:
       MACOS_DMG_NAME: SasView6-${{ matrix.os }}.dmg
-      # Be strict about version pinning during the release freeze
-      RELEASE_BRANCH_BUILD: ${{
-          (
-            (github.event_name == 'push' && contains(github.ref, 'release')) ||
-            (github.event_name == 'push' && contains(github.ref, 'tags/v6.1')) ||
-            (github.event_name == 'pull_request' && contains(github.base_ref, 'release-6.1'))
-          ) && 'true' || '' }}
 
-      # Only sign the installer if non-forked repo
-      SIGN_INSTALLER: ${{ (! github.event.repository.fork && ! github.event.pull_request.head.repo.fork ) && 'true' || '' }}
+      # Only sign the installer if non-forked repo and the build is important enough to sign
+      SIGN_INSTALLER: ${{
+        (
+          (! github.event.repository.fork) &&
+          (! github.event.pull_request.head.repo.fork) &&
+          (startsWith(github.ref, 'refs/tags/v') ||
+          startsWith(github.ref, 'refs/heads/release'))
+        ) && 'true' || '' }}
 
       UV_SYSTEM_PYTHON: 1
 
@@ -416,7 +415,7 @@ jobs:
         shell: bash
 
       - name: Sign the binary using keypair alias
-        if: ${{ startsWith(matrix.os, 'windows') && env.SIGN_INSTALLER && env.RELEASE_BRANCH_BUILD }}
+        if: ${{ startsWith(matrix.os, 'windows') && env.SIGN_INSTALLER }}
         run: |
            smctl sign --keypair-alias key_911959544 --input installers/dist/setupSasView.exe
         shell: cmd


### PR DESCRIPTION
## Description

Clean up variables in CI workflow, separating the tests for whether to build using pinned dependencies and whether to sign the installers more cleanly, being able to tweak those policies as needed.

It's not clear whether the reduction in signing to "only builds on the release branch" is enough to save the signing requests quota.

This is ready for discussion as to whether this is the intended signing policy, and what testing is desired prior to merging.

Fixes #3621

## How Has This Been Tested?

There are 4 cases that need testing (and it's not that easy to actually test them all):
- [x] CI runs without trying to sign in a fork
- [ ] CI runs in SasView/sasview:main without trying to sign and without pinning packages (we won't know until we merge it)
- [ ] CI runs in a release branch with pinned packages 
- [ ] CI running in SasView/sasview successfully signs when desired

The last 3 are somewhat hard to test... I could make some extra branches with `release` in the name within the SasView/sasview repo to do so if that's desirable.

## Review Checklist:

[if using the editor, use `[x]` in place of `[ ]` to check a box]

**Documentation** (check at least one)
- [x] There is **nothing** that needs documenting
- [ ] Documentation changes are **in this PR**
- [ ] There is an **issue** open for the documentation (link?)

**Installers**
- [ ] There is a chance this will affect the **installers**, if so
  - [ ] **Windows** installer (GH artifact) has been tested (installed and worked) 
  - [ ] **MacOSX** installer (GH artifact) has been tested (installed and worked)
  - [ ] **Wheels** installer (GH artifact) has been tested (installed and worked)

**Licensing** (untick if necessary)
- [x] The introduced changes comply with SasView license (BSD 3-Clause)

