### PR TITLE
Removes relative import in __main__.py

### DIFF
--- a/src/sas/__main__.py
+++ b/src/sas/__main__.py
@@ -5,7 +5,7 @@
 
 import sys
 
-from . import cli
+from sas import cli
 
 __doc__ = cli.__doc__
 


### PR DESCRIPTION
## Description

Changes the relative import in `__main__.py`. This allows users running IDEs such as VSCode or Pycharm, which we recommend in `INSTALL.md`, to run the GUI by clicking on the "run current file" button in `__main__.py`. Trying this on the `main` branch currently gives the error below.

Please advise if there may be any unexpected consequences from doing this.

<img width="1920" height="1020" alt="image" src="https://github.com/user-attachments/assets/cf789a6e-0054-4299-a570-fde69eb4605c" />

## How Has This Been Tested?

Checked that the "run current" file button in `__main__.py` launches the SasView GUI correctly. Also ran `python -m sas` and `sasview` in the terminal on this branch and verified they still work correctly.

## Review Checklist:

[if using the editor, use `[x]` in place of `[ ]` to check a box]

**Documentation** (check at least one)
- [ ] There is **nothing** that needs documenting
- [ ] Documentation changes are **in this PR**
- [x] There is an **issue** open for the documentation (link?) - I will file a PR shortly. EDIT: the PR is #3657 

**Installers**
- [ ] There is a chance this will affect the **installers**, if so
  - [ ] **Windows** installer (GH artifact) has been tested (installed and worked) 
  - [ ] **MacOSX** installer (GH artifact) has been tested (installed and worked)
  - [ ] **Wheels** installer (GH artifact) has been tested (installed and worked)

**Licensing** (untick if necessary)
- [x] The introduced changes comply with SasView license (BSD 3-Clause)

