### PR TITLE
Updates import statements for routine "find_plugins_dir"

### DIFF
--- a/src/sas/qtgui/Calculators/GenericScatteringCalculator.py
+++ b/src/sas/qtgui/Calculators/GenericScatteringCalculator.py
@@ -26,7 +26,7 @@ from sas.qtgui.Utilities.GenericReader import GenReader
 from sas.qtgui.Utilities.ModelEditors.TabbedEditor.TabbedModelEditor import TabbedModelEditor
 from sas.sascalc.calculator import sas_gen
 from sas.sascalc.calculator.geni import create_beta_plot, f_of_q, radius_of_gyration
-from sas.sascalc.fit import models
+from sas.system.user import find_plugins_dir
 
 # Local UI
 from .UI.GenericScatteringCalculator import Ui_GenericScatteringCalculator
@@ -1535,7 +1535,7 @@ class GenericScatteringCalculator(QtWidgets.QDialog, Ui_GenericScatteringCalcula
             self.txtFileName.setEnabled(False)
 
     def getFileName(self):
-        plugin_location = models.find_plugins_dir()
+        plugin_location = find_plugins_dir()
         i = 0
         while True:
             full_path = os.path.join(plugin_location, "custom_gsc" + str(i))

--- a/src/sas/qtgui/Calculators/Shape2SAS/genPlugin.py
+++ b/src/sas/qtgui/Calculators/Shape2SAS/genPlugin.py
@@ -3,17 +3,16 @@ import textwrap
 from pathlib import Path
 
 #Global SasView
-from sas.sascalc.fit import models
-
 #Local Perspectives
 from sas.sascalc.shape2sas.Shape2SAS import ModelProfile
+from sas.system.user import find_plugins_dir
 
 
 def generatePlugin(prof: ModelProfile, constrainParameters: (str), fitPar: [str],
                    Npoints: int, pr_points: int, file_name: str) -> (str, Path):
     """Generates a theoretical scattering plugin model"""
 
-    plugin_location = Path(models.find_plugins_dir())
+    plugin_location = Path(find_plugins_dir())
     full_path = plugin_location / file_name
     full_path = full_path.with_suffix('.py')
 

--- a/src/sas/qtgui/Perspectives/Fitting/FittingWidget.py
+++ b/src/sas/qtgui/Perspectives/Fitting/FittingWidget.py
@@ -38,7 +38,7 @@ from sas.qtgui.Plotting.PlotterData import Data1D, Data2D, DataRole
 from sas.qtgui.Utilities.CategoryInstaller import CategoryInstaller
 from sas.sascalc.fit import models
 from sas.sascalc.fit.BumpsFitting import BumpsFit as Fit
-from sas.system.user import HELP_DIRECTORY_LOCATION
+from sas.system.user import HELP_DIRECTORY_LOCATION, find_plugins_dir
 
 TAB_MAGNETISM = 4
 TAB_POLY = 3
@@ -2397,7 +2397,7 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         kernel_module = None
         if self.cbCategory.currentText() == CATEGORY_CUSTOM:
             # custom kernel load requires full path
-            name = os.path.join(models.find_plugins_dir(), model_name+".py")
+            name = os.path.join(find_plugins_dir(), model_name+".py")
         try:
             kernel_module = generate.load_kernel_module(name)
         except ModuleNotFoundError:

--- a/src/sas/qtgui/Utilities/ModelEditors/AddMultEditor/AddMultEditor.py
+++ b/src/sas/qtgui/Utilities/ModelEditors/AddMultEditor/AddMultEditor.py
@@ -17,7 +17,7 @@ from sas.qtgui.Perspectives.Fitting.FittingWidget import SUPPRESSED_MODELS
 
 # Local UI
 from sas.qtgui.Utilities.ModelEditors.AddMultEditor.UI.AddMultEditorUI import Ui_AddMultEditorUI
-from sas.sascalc.fit import models
+from sas.system.user import find_plugins_dir
 
 # Template for the output plugin file
 SUM_TEMPLATE = """
@@ -83,7 +83,7 @@ class AddMultEditor(QtWidgets.QDialog, Ui_AddMultEditorUI):
 
         # Name and directory for saving new plugin model
         self.plugin_filename = None
-        self.plugin_dir = models.find_plugins_dir()
+        self.plugin_dir = find_plugins_dir()
 
         # Validators
         rx = QtCore.QRegularExpression("^[A-Za-z0-9_]*$")

--- a/src/sas/qtgui/Utilities/ModelEditors/Dialogs/ModelSelector.py
+++ b/src/sas/qtgui/Utilities/ModelEditors/Dialogs/ModelSelector.py
@@ -12,6 +12,7 @@ from sasmodels.sasview_model import load_standard_models
 from sas.qtgui.Utilities.CategoryInstaller import CategoryInstaller
 from sas.qtgui.Utilities.ModelEditors.Dialogs.UI.ModelSelectorUI import Ui_ModelSelector
 from sas.sascalc.fit import models
+from sas.system.user import find_plugins_dir
 
 logger = logging.getLogger(__name__)
 
@@ -143,7 +144,7 @@ class ModelSelector(QtWidgets.QDialog, Ui_ModelSelector):
 
         if self.modelTree.selectedItems()[0].parent() == CATEGORY_CUSTOM:
             # custom kernel load requires full path
-            name = os.path.join(models.find_plugins_dir(), name+".py")
+            name = os.path.join(find_plugins_dir(), name+".py")
         try:
             kernel_module = generate.load_kernel_module(name)
         except (ModuleNotFoundError, FileNotFoundError):

--- a/src/sas/qtgui/Utilities/ModelEditors/TabbedEditor/TabbedModelEditor.py
+++ b/src/sas/qtgui/Utilities/ModelEditors/TabbedEditor/TabbedModelEditor.py
@@ -15,7 +15,6 @@ from sas.qtgui.Utilities.CustomGUI.CodeEditor import QCodeEditor
 from sas.qtgui.Utilities.ModelEditors.TabbedEditor.ModelEditor import ModelEditor
 from sas.qtgui.Utilities.ModelEditors.TabbedEditor.PluginDefinition import PluginDefinition
 from sas.qtgui.Utilities.ModelEditors.TabbedEditor.UI.TabbedModelEditor import Ui_TabbedModelEditor
-from sas.sascalc.fit import models
 from sas.system.user import MAIN_DOC_SRC, find_plugins_dir
 
 logger = logging.getLogger(__name__)
@@ -352,7 +351,7 @@ class TabbedModelEditor(QtWidgets.QDialog, Ui_TabbedModelEditor):
             return
 
         # check if file exists
-        plugin_location = models.find_plugins_dir()
+        plugin_location = find_plugins_dir()
 
         # Generate the full path of the python path for the model and ensure the extension is .py
         full_path = Path(plugin_location) / filename
@@ -512,7 +511,7 @@ class TabbedModelEditor(QtWidgets.QDialog, Ui_TabbedModelEditor):
         self.writeFile(filename, model_str)
 
         # Get model filepath
-        plugin_location = models.find_plugins_dir()
+        plugin_location = find_plugins_dir()
         full_path = Path(plugin_location) / filename
 
         error_line = self.findFirstError(full_path.with_suffix(".py"))

--- a/src/sas/qtgui/Utilities/PluginManager.py
+++ b/src/sas/qtgui/Utilities/PluginManager.py
@@ -9,6 +9,7 @@ import sas.qtgui.Utilities.GuiUtils as GuiUtils
 from sas.qtgui.Utilities.ModelEditors.TabbedEditor.TabbedModelEditor import TabbedModelEditor
 from sas.qtgui.Utilities.UI.PluginManagerUI import Ui_PluginManagerUI
 from sas.sascalc.fit import models
+from sas.system.user import find_plugins_dir
 
 logger = logging.getLogger(__name__)
 
@@ -92,7 +93,7 @@ class PluginManager(QtWidgets.QDialog, Ui_PluginManagerUI):
             name = self.plugins[plugin].filename
             # if no filename defined, attempt plugin name as filename
             if not name:
-                name = os.path.join(models.find_plugins_dir(), plugin + ".py")
+                name = os.path.join(find_plugins_dir(), plugin + ".py")
             os.remove(name)
 
         self.parent.communicate.customModelDirectoryChanged.emit()
@@ -114,7 +115,7 @@ class PluginManager(QtWidgets.QDialog, Ui_PluginManagerUI):
         if not plugin_file:
             return
 
-        plugin_dir = models.find_plugins_dir()
+        plugin_dir = find_plugins_dir()
         file_name = os.path.basename(str(plugin_file))
 
         # check if valid model
@@ -171,7 +172,7 @@ class PluginManager(QtWidgets.QDialog, Ui_PluginManagerUI):
         """
 
         plugins_to_copy = [s.data() for s in self.lstModels.selectionModel().selectedRows()]
-        plugin_dir = models.find_plugins_dir()
+        plugin_dir = find_plugins_dir()
         for plugin in plugins_to_copy:
             src_filename = plugin + ".py"
 
@@ -195,7 +196,7 @@ class PluginManager(QtWidgets.QDialog, Ui_PluginManagerUI):
         """
         Show the edit existing model dialog
         """
-        plugin_location = models.find_plugins_dir()
+        plugin_location = find_plugins_dir()
         # GUI assured only one row selected. Pick up the only element in list.
         try:
             model_to_edit = self.lstModels.selectionModel().selectedRows()[0].data()

--- a/src/sas/sascalc/calculator/gsc_model.py
+++ b/src/sas/sascalc/calculator/gsc_model.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 import numpy as np
 
-from sas.sascalc.fit import models
+from sas.system.user import find_plugins_dir
 
 
 def generate_plugin(f_name: str, data_to_plot: np.ndarray, x_values: np.ndarray, f_q: list,
@@ -20,7 +20,7 @@ def generate_plugin(f_name: str, data_to_plot: np.ndarray, x_values: np.ndarray,
     :param mass: The mass associated with the Rg calculation
     """
     # check if file exists & assign filename
-    plugin_location = Path(models.find_plugins_dir())
+    plugin_location = Path(find_plugins_dir())
     if not f_name.endswith('.py'):
         f_name += '.py'
     full_path = plugin_location / f_name


### PR DESCRIPTION
## Description

Makes sure that the routine `find_plugins_dir` is imported from `sas.system.user` *throughout* the code.

Fixes #3648, #3623

## How Has This Been Tested?

Manually checked all invocations. I also saw the errors associated with the tests given in #3648 had gone, although someone else more familiar with those may wish to check them as well.

## Review Checklist:

[if using the editor, use `[x]` in place of `[ ]` to check a box]

**Documentation** (check at least one)
- [x] There is **nothing** that needs documenting
- [ ] Documentation changes are **in this PR**
- [ ] There is an **issue** open for the documentation (link?)

**Installers**
- [ ] There is a chance this will affect the **installers**, if so
  - [ ] **Windows** installer (GH artifact) has been tested (installed and worked) 
  - [ ] **MacOSX** installer (GH artifact) has been tested (installed and worked)
  - [ ] **Wheels** installer (GH artifact) has been tested (installed and worked)

**Licensing** (untick if necessary)
- [x] The introduced changes comply with SasView license (BSD 3-Clause)

