### PR TITLE
Include API docs from sasmodels in sasview sphinx output

### DIFF
--- a/docs/sphinx-docs/collect_sphinx_sources.py
+++ b/docs/sphinx-docs/collect_sphinx_sources.py
@@ -23,6 +23,8 @@ SASVIEW_MEDIA_SOURCE = SASVIEW_SRC / "sas"
 SASMODELS_DOCS = BASE / "tmp" / "sasmodels" / "docs"
 SASMODELS_MODEL_SOURCE = SASMODELS_DOCS / "model"
 SASMODELS_MODEL_TARGET = SPHINX_SOURCE / "user" / "models"
+SASMODELS_API_SOURCE = SASMODELS_DOCS / "api"
+SASMODELS_API_TARGET = SPHINX_SOURCE / "dev" / "sasmodels-api"
 SASMODELS_DEV_SOURCE = SASMODELS_DOCS / "developer"
 SASMODELS_DEV_TARGET = SPHINX_SOURCE / "dev" / "sasmodels-dev"
 SASMODELS_GUIDE_SOURCE = SASMODELS_DOCS / "guide"
@@ -112,6 +114,7 @@ def retrieve_user_docs():
     print("=== Sasmodels Docs ===")
     shutil.copy(SASMODELS_DOCS / "rst_prolog", SPHINX_SOURCE)
     shutil.copytree(SASMODELS_MODEL_SOURCE, SASMODELS_MODEL_TARGET, dirs_exist_ok=True)
+    shutil.copytree(SASMODELS_API_SOURCE, SASMODELS_API_TARGET, dirs_exist_ok=True)
     shutil.copytree(SASMODELS_DEV_SOURCE, SASMODELS_DEV_TARGET, dirs_exist_ok=True)
     shutil.copytree(SASMODELS_GUIDE_SOURCE, SASMODELS_GUIDE_TARGET, dirs_exist_ok=True)
     for filename in SASMODELS_GUIDE_EXCLUDE:

--- a/docs/sphinx-docs/source/dev/dev.rst
+++ b/docs/sphinx-docs/source/dev/dev.rst
@@ -11,6 +11,7 @@ Contents
 
    SasView API <sasview-api/modules>
    sasmodels overview <sasmodels-dev/index>
+   sasmodels API <sasmodels-api/index>
    sasdata overview <sasdata-dev/dev>
    OpenGL subsystem <gl/opengl.rst>
 


### PR DESCRIPTION
## Description

Adds the API docs shipped by sasmodels to the sasview sphinx tree.


Fixes #3658

## How Has This Been Tested?

Local build, check built sphinx docs

## Review Checklist:

[if using the editor, use `[x]` in place of `[ ]` to check a box]

**Documentation** (check at least one)
- [ ] There is **nothing** that needs documenting
- [x] Documentation changes are **in this PR**
- [ ] There is an **issue** open for the documentation (link?)

**Installers**
- [ ] There is a chance this will affect the **installers**, if so
  - [ ] **Windows** installer (GH artifact) has been tested (installed and worked) 
  - [ ] **MacOSX** installer (GH artifact) has been tested (installed and worked)
  - [ ] **Wheels** installer (GH artifact) has been tested (installed and worked)

**Licensing** (untick if necessary)
- [x] The introduced changes comply with SasView license (BSD 3-Clause)

