### PR TITLE
Make ruff more verbose about what it doesn't like

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,9 @@ jobs:
       - uses: astral-sh/ruff-action@v3
         with:
           version: "latest"
-          args: "check --fix-only --exit-non-zero-on-fix"
+          args: "--version"
+      - run: ruff check --diff --exit-zero
+      - run: ruff check --fix-only --exit-non-zero-on-fix
       - uses: pre-commit-ci/lite-action@v1.1.0
         if: always()
         with:


### PR DESCRIPTION
## Description

Tweak the ruff options to make it show what it doesn't like in the files rather than just exiting with failure.

Fixes #3641

## How Has This Been Tested?

CI failures in another PR turning to verbose diffs ([logs](https://github.com/llimeht/sasview/actions/runs/18934250033/job/54057203634)).

```
--- src/sas/qtgui/MainWindow/GuiManager.py
+++ src/sas/qtgui/MainWindow/GuiManager.py
@@ -60,8 +60,7 @@
 # General SAS imports
 from sas.qtgui.Utilities.SasviewLogger import setup_qt_logging
 from sas.qtgui.Utilities.WhatsNew.WhatsNew import WhatsNew
-from sas.system import web
-from sas.system import HELP_SYSTEM
+from sas.system import HELP_SYSTEM, web
 from sas.system.user import create_user_files_if_needed
 from sas.system.version import __release_date__ as SASVIEW_RELEASE_DATE
 from sas.system.version import __version__ as SASVIEW_VERSION

--- src/sas/system/__init__.py
+++ src/sas/system/__init__.py
[... snipped ...]

Would fix 4 errors (132 additional fixes available with `--unsafe-fixes`).
```

## Review Checklist:

[if using the editor, use `[x]` in place of `[ ]` to check a box]

**Documentation** (check at least one)
- [x] There is **nothing** that needs documenting
- [ ] Documentation changes are **in this PR**
- [ ] There is an **issue** open for the documentation (link?)

**Installers**
- [ ] There is a chance this will affect the **installers**, if so
  - [ ] **Windows** installer (GH artifact) has been tested (installed and worked) 
  - [ ] **MacOSX** installer (GH artifact) has been tested (installed and worked)
  - [ ] **Wheels** installer (GH artifact) has been tested (installed and worked)

**Licensing** (untick if necessary)
- [x] The introduced changes comply with SasView license (BSD 3-Clause)

