### PR TITLE
Fixes bug on startup

### DIFF
--- a/src/sas/qtgui/Utilities/CategoryInstaller.py
+++ b/src/sas/qtgui/Utilities/CategoryInstaller.py
@@ -12,6 +12,7 @@ import json
 import logging
 import os
 from collections import OrderedDict, defaultdict
+from contextlib import suppress
 
 from sas.system.user import get_config_dir
 
@@ -109,7 +110,8 @@ class CategoryInstaller:
         for cat in list(master_category_dict.keys()):
             for ind in range(len(master_category_dict[cat])):
                 model_name, enabled = master_category_dict[cat][ind]
-                add_list.remove(model_name)
+                with suppress(ValueError):
+                    add_list.remove(model_name)
                 if not enabled:
                     model_enabled_dict.pop(model_name)
         if del_name or (len(add_list) > 0):


### PR DESCRIPTION
## Description

This PR fixes a bug on starting SasView. When starting the current main branch with `python sasview`, an error message appears in the terminal (although SasView starts correctly):

```
  File "C:\Users\gnn85523\projects\sasview\src\sas\qtgui\MainWindow\GuiManager.py", line 253, in addCategories
    CategoryInstaller.check_install(model_list=model_list)
  File "C:\Users\gnn85523\projects\sasview\src\sas\qtgui\Utilities\CategoryInstaller.py", line 112, in check_install
    add_list.remove(model_name)
ValueError: list.remove(x): x not in list
```

This PR fixes this error message, so it should not appear on startup.

## How Has This Been Tested?

Start up SasView with `python sasview` and see the error message has disappeared.

## Review Checklist:

[if using the editor, use `[x]` in place of `[ ]` to check a box]

**Documentation** (check at least one)
- [x] There is **nothing** that needs documenting
- [ ] Documentation changes are **in this PR**
- [ ] There is an **issue** open for the documentation (link?)

**Installers**
- [ ] There is a chance this will affect the **installers**, if so
  - [ ] **Windows** installer (GH artifact) has been tested (installed and worked) 
  - [ ] **MacOSX** installer (GH artifact) has been tested (installed and worked)
  - [ ] **Wheels** installer (GH artifact) has been tested (installed and worked)

**Licensing** (untick if necessary)
- [x] The introduced changes comply with SasView license (BSD 3-Clause)

