### PR TITLE
Fixes stray references to run.py

### DIFF
--- a/test/run_one.py
+++ b/test/run_one.py
@@ -21,7 +21,7 @@ if len(sys.argv) < 2:
     logger.error("Use %s <filename to test>",sys.argv[0])
     sys.exit(-1)
 
-run_py = joinpath(dirname(dirname(abspath(__file__))), 'run.py')
+run_py = joinpath(dirname(dirname(abspath(__file__))), 'src', 'sas', '__main__.py')
 run = SourceFileLoader('sasview_run', run_py).load_module()
 run.prepare()
 


### PR DESCRIPTION
## Description

The test file `run_one.py` contains a reference to the now-removed file `run.py`. This PR updates it to `__main__.py`.

## How Has This Been Tested?

Tested that the file correctly runs a single test file.

## Review Checklist:

[if using the editor, use `[x]` in place of `[ ]` to check a box]

**Documentation** (check at least one)
- [x] There is **nothing** that needs documenting
- [ ] Documentation changes are **in this PR**
- [ ] There is an **issue** open for the documentation (link?)

**Installers**
- [ ] There is a chance this will affect the **installers**, if so
  - [ ] **Windows** installer (GH artifact) has been tested (installed and worked) 
  - [ ] **MacOSX** installer (GH artifact) has been tested (installed and worked)
  - [ ] **Wheels** installer (GH artifact) has been tested (installed and worked)

**Licensing** (untick if necessary)
- [x] The introduced changes comply with SasView license (BSD 3-Clause)

