### PR TITLE
Speed up apt runs by ignoring man pages

### DIFF
--- a/.github/actions/install-wheel/action.yml
+++ b/.github/actions/install-wheel/action.yml
@@ -38,6 +38,8 @@ runs:
         DEBIAN_FRONTEND: noninteractive
       shell: bash
       run: |
+        echo "set man-db/auto-update false" | sudo debconf-communicate
+        sudo dpkg-reconfigure man-db
         sudo eatmydata apt-get update
         # libcairo2-dev is for building a wheel for pycairo if not cached
         # rest are for loading Qt widgets

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -170,6 +170,8 @@ jobs:
         env:
           DEBIAN_FRONTEND: noninteractive
         run: |
+          echo "set man-db/auto-update false" | sudo debconf-communicate
+          sudo dpkg-reconfigure man-db
           sudo eatmydata apt-get update
           # libcairo2-dev is for building a wheel for pycairo if not cached
           # rest are for loading Qt widgets
@@ -560,6 +562,8 @@ jobs:
         env:
           DEBIAN_FRONTEND: noninteractive
         run: |
+          echo "set man-db/auto-update false" | sudo debconf-communicate
+          sudo dpkg-reconfigure man-db
           sudo eatmydata apt-get update
           sudo eatmydata apt-get -y install --no-install-recommends libegl1 libopengl0 libxkbcommon-x11-0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 libxcb-xinerama0 libxcb-xfixes0 x11-utils xvfb libxcb-cursor0
 


### PR DESCRIPTION
## Description

If apt has to do a lot of work (because the base image is out of date, which happens periodically), then it can end up spending a lot of time generating the database of manual pages (trigger for pacakge man-db). If you're unlucky, it takes 30ish seconds on this. We don't need the man pages, so we can ensure this time is not wasted.


## How Has This Been Tested?

CI runs

## Review Checklist:

[if using the editor, use `[x]` in place of `[ ]` to check a box]

**Documentation** (check at least one)
- [x] There is **nothing** that needs documenting
- [ ] Documentation changes are **in this PR**
- [ ] There is an **issue** open for the documentation (link?)

**Installers**
- [ ] There is a chance this will affect the **installers**, if so
  - [ ] **Windows** installer (GH artifact) has been tested (installed and worked) 
  - [ ] **MacOSX** installer (GH artifact) has been tested (installed and worked)
  - [ ] **Wheels** installer (GH artifact) has been tested (installed and worked)

**Licensing** (untick if necessary)
- [x] The introduced changes comply with SasView license (BSD 3-Clause)

