### PR TITLE
Warn user before starting scattering calcs on large structures

### DIFF
--- a/src/sas/qtgui/Calculators/GenericScatteringCalculator.py
+++ b/src/sas/qtgui/Calculators/GenericScatteringCalculator.py
@@ -1402,7 +1402,7 @@ class GenericScatteringCalculator(QtWidgets.QDialog, Ui_GenericScatteringCalcula
         popup.setText(msg)
         popup.setWindowTitle("Large input structure")
         popup.setDefaultButton(QMessageBox.Cancel)
-        result = popup.exec_()
+        result = popup.exec()
         flag_continue = (result == QMessageBox.Ok)
         self.warned_user_large_calc = flag_continue
         return flag_continue
@@ -1415,7 +1415,7 @@ class GenericScatteringCalculator(QtWidgets.QDialog, Ui_GenericScatteringCalcula
         try:
             # create the combined sld data and update from gui
             sld_data = self.create_full_sld_data()
-            if not self.check_large_calculation(sld_data.data_length): return
+            if hasattr(sld_data, 'data_length') and not self.check_large_calculation(sld_data.data_length): return
 
             # TODO: implement fourier transform for meshes with multiple element or face types
             # The easy option is to simply convert all elements to tetrahedra - but this could rapidly


### PR DESCRIPTION
## Description

The user will now receive a popup if a GSC calculation is requested with large input structures. This will continue to appear on every such request until the user accepts it, after which it will no longer be shown.

Fixes #2915

## How Has This Been Tested?

Manually verified functionality by running with various different input structures, ranging from 50k to 500k atoms. 

**Documentation** (check at least one)
- [x] There is **nothing** that needs documenting
- [ ] Documentation changes are **in this PR**
- [ ] There is an **issue** open for the documentation (link?)

**Installers**
- [ ] There is a chance this will affect the **installers**, if so
  - [ ] **Windows** installer (GH artifact) has been tested (installed and worked) 
  - [ ] **MacOSX** installer (GH artifact) has been tested (installed and worked)
  - [ ] **Wheels** installer (GH artifact) has been tested (installed and worked)

**Licensing** (untick if necessary)
- [x] The introduced changes comply with SasView license (BSD 3-Clause)