### PR TITLE
Limits python version to <3.14

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ dynamic = [
 ]
 description = "SasView application"
 readme = "README.md"
-requires-python = ">=3.12"
+requires-python = ">=3.12,<3.14"
 license = { text = "BSD-3-Clause" }
 authors = [
     {name = "SasView Team", email = "developers@sasview.org"},


### PR DESCRIPTION
## Description

Fixes #3738. The change is ultimately academic, as the build system fails on the requirements for PySide6 before we get to the `requires-python` section, but I think it will be helpful for users/developers to see in SasView itself that we cannot support python 3.14 until PySide6 starts supporting it.

## How Has This Been Tested?

Attempted to install SasView with python 3.14. When commenting out pyopengl and pyside6 in the build system requirements, I get the desired error `ERROR: Package 'sasview' requires a different Python: 3.14.0 not in '<3.14,>=3.12'`

## Review Checklist:

[if using the editor, use `[x]` in place of `[ ]` to check a box]

**Documentation** (check at least one)
- [x] There is **nothing** that needs documenting
- [ ] Documentation changes are **in this PR**
- [ ] There is an **issue** open for the documentation (link?)

**Installers**
- [ ] There is a chance this will affect the **installers**, if so
  - [ ] **Windows** installer (GH artifact) has been tested (installed and worked) 
  - [ ] **MacOSX** installer (GH artifact) has been tested (installed and worked)
  - [ ] **Wheels** installer (GH artifact) has been tested (installed and worked)

**Licensing** (untick if necessary)
- [x] The introduced changes comply with SasView license (BSD 3-Clause)

