### PR TITLE
Screen out C&S fitting tabs for next tab_id calculation

### DIFF
--- a/src/sas/qtgui/Perspectives/Fitting/FittingPerspective.py
+++ b/src/sas/qtgui/Perspectives/Fitting/FittingPerspective.py
@@ -281,7 +281,10 @@ class FittingWindow(QtWidgets.QTabWidget, Perspective):
         """
         Returns the index of the next available tab
         """
-        return max((tab.tab_id for tab in self.tabs), default=0) + 1
+        # account for ConstraintWidget ids which are >300
+        max_tab = max((tab.tab_id for tab in self.tabs
+                       if not isinstance(tab, ConstraintWidget)), default=0) + 1
+        return max_tab
 
     def addClosedTab(self):
         """


### PR DESCRIPTION
## Description

If a simultaneous/constrained fit tab is opened before sending data to any fit tabs, if you send more than 3 data sets to new fit tabs, the 3rd, and all subsequent tabs, were numbered starting at 302. This PR fixes the counting to disregard the C&S tab_id values.

Fixes #3365 

## How Has This Been Tested?

Local win10

## Review Checklist:

[if using the editor, use `[x]` in place of `[ ]` to check a box]

**Documentation** (check at least one)
- [X ] There is **nothing** that needs documenting
- [ ] Documentation changes are **in this PR**
- [ ] There is an **issue** open for the documentation (link?)

**Installers**
- [ ] There is a chance this will affect the **installers**, if so
  - [ ] **Windows** installer (GH artifact) has been tested (installed and worked) 
  - [ ] **MacOSX** installer (GH artifact) has been tested (installed and worked)
  - [ ] **Wheels** installer (GH artifact) has been tested (installed and worked)

**Licensing** (untick if necessary)
- [x] The introduced changes comply with SasView license (BSD 3-Clause)

