### PR TITLE
Return should act as tab in parameter table

### DIFF
--- a/src/sas/qtgui/Utilities/ModelEditors/TabbedEditor/PluginDefinition.py
+++ b/src/sas/qtgui/Utilities/ModelEditors/TabbedEditor/PluginDefinition.py
@@ -410,18 +410,13 @@ class PluginDefinition(QtWidgets.QDialog, Ui_PluginDefinition):
             table.editItem(item)
 
     def eventFilter(self, obj: QtCore.QObject, event: QtCore.QEvent) -> bool:
-        """Intercept Enter/Return and Escape key presses while editing table cells.
+        """Intercept Enter/Return key presses while editing table cells.
         Enter/Return moves focus to the next cell (like Tab).
-        Escape is captured to prevent closing the dialog.
         This is installed at the application level so it catches editor
         widgets created while editing table cells.
         """
         if event.type() != QtCore.QEvent.KeyPress:
             return super(PluginDefinition, self).eventFilter(obj, event)
-
-        # Intercept Escape key to prevent dialog from closing
-        if event.key() == QtCore.Qt.Key_Escape:
-            return True
 
         # Handle Enter/Return key press
         if event.key() not in (QtCore.Qt.Key_Return, QtCore.Qt.Key_Enter):


### PR DESCRIPTION
## Description

Added custom event filter for Return key in the parameter tables.

Fixes #3300 

## How Has This Been Tested?

Local win10

## Review Checklist:

[if using the editor, use `[x]` in place of `[ ]` to check a box]

**Documentation** (check at least one)
- [X ] There is **nothing** that needs documenting
- [ ] Documentation changes are **in this PR**
- [ ] There is an **issue** open for the documentation (link?)

**Installers**
- [ ] There is a chance this will affect the **installers**, if so
  - [ ] **Windows** installer (GH artifact) has been tested (installed and worked) 
  - [ ] **MacOSX** installer (GH artifact) has been tested (installed and worked)
  - [ ] **Wheels** installer (GH artifact) has been tested (installed and worked)

**Licensing** (untick if necessary)
- [x] The introduced changes comply with SasView license (BSD 3-Clause)

