### PR TITLE
Keep the tabbed plot widget inside the main window

### DIFF
--- a/src/sas/qtgui/MainWindow/GuiManager.py
+++ b/src/sas/qtgui/MainWindow/GuiManager.py
@@ -196,7 +196,8 @@ class GuiManager:
         self.FileConverter = FileConverterWidget(self)
         self.WhatsNew = WhatsNew(self._parent)
 
-        self.tabbedPlotWidget = TabbedPlotWidget(self)
+        self.tabbedPlotWidget = TabbedPlotWidget(self._parent)
+        self.tabbedPlotWidgetSubWindow = self._workspace.workspace.addSubWindow(self.tabbedPlotWidget)
 
     def loadAllPerspectives(self):
         """ Load all the perspectives"""

--- a/src/sas/qtgui/Plotting/TabbedPlotWidget.py
+++ b/src/sas/qtgui/Plotting/TabbedPlotWidget.py
@@ -1,4 +1,5 @@
 from PySide6 import QtCore, QtGui, QtWidgets
+from PySide6.QtGui import QCloseEvent
 
 from sas.qtgui.Plotting.SubTabs import SubTabs
 from sas.qtgui.Utilities import GuiUtils
@@ -9,7 +10,7 @@ class TabbedPlotWidget(QtWidgets.QTabWidget):
     Central plot widget that holds tabs and subtabs for all existing plots
     """
     def __init__(self, parent=None):
-        super(TabbedPlotWidget, self).__init__()
+        super(TabbedPlotWidget, self).__init__(parent)
 
         # the manager/parent of this class is the GuiManager
         self.manager = parent
@@ -25,7 +26,7 @@ class TabbedPlotWidget(QtWidgets.QTabWidget):
         self.inv_tab_fitpage_dict = {}
 
         self._set_icon()
-        self.setWindowTitle('TabbedPlotWidget')
+        self.setWindowTitle('PlotViewer')
 
         self.setMinimumSize(500, 500)
         self.hide()
@@ -50,7 +51,7 @@ class TabbedPlotWidget(QtWidgets.QTabWidget):
 
     def add_tab_to_dict(self, tab_id: int) -> int:
         """
-        This method handles the bookkeeping for the existing tabs and there respective fitpages.
+        This method handles the bookkeeping for the existing tabs and their respective fitpages.
         Only adds the tab_id to the dict, if it does not already exist in there.
         Returns the tab index of the existing or newly added tab.
         """
@@ -102,4 +103,9 @@ class TabbedPlotWidget(QtWidgets.QTabWidget):
         else:
             return None
 
-
+    def closeEvent(self, event: QCloseEvent):
+        """
+        Overwrite the close event and minimize the window instead of closing it
+        """
+        self.setWindowState(QtCore.Qt.WindowMinimized)
+        event.ignore()


### PR DESCRIPTION
## Description

Small changes:
- keep the tabbed plot widget inside the main window (was floating independently)
- minimize the tabbed plot widget if the user closes the window

Minimizing rather than closing is a workaround for the tabbed plot widget getting into a weird state and not showing any plots after having been closed once. I think it is still something to discuss what the correct behavior should be. There is currently not a way to completely delete a plot from the tabbed plot widget, like how you can close and delete the existing floating plot windows. We may also want to keep the plot widget around permanently, like e.g. the data explorer.

Fixes # (issue/issues)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

## Review Checklist:

[if using the editor, use `[x]` in place of `[ ]` to check a box]

**Documentation** (check at least one)
- [ ] There is **nothing** that needs documenting
- [ ] Documentation changes are **in this PR**
- [ ] There is an **issue** open for the documentation (link?)

**Installers**
- [ ] There is a chance this will affect the **installers**, if so
  - [ ] **Windows** installer (GH artifact) has been tested (installed and worked) 
  - [ ] **MacOSX** installer (GH artifact) has been tested (installed and worked)
  - [ ] **Wheels** installer (GH artifact) has been tested (installed and worked)

**Licensing** (untick if necessary)
- [x] The introduced changes comply with SasView license (BSD 3-Clause)

