### PR TITLE
3762 error in data operation null outputs

### DIFF
--- a/src/sas/qtgui/Calculators/DataOperationUtilityPanel.py
+++ b/src/sas/qtgui/Calculators/DataOperationUtilityPanel.py
@@ -135,7 +135,7 @@ class DataOperationUtilityPanel(QtWidgets.QDialog, Ui_DataOperationUtility):
             # set operator to be applied
             operator = self.cbOperator.currentText()
             # calculate and send data to DataExplorer
-            output = None   
+            output = None
             try:
                 data1 = self.data1
                 data2 = self.data2
@@ -329,7 +329,7 @@ class DataOperationUtilityPanel(QtWidgets.QDialog, Ui_DataOperationUtility):
                 self.cbData2.setStyleSheet(BG_RED)
                 logger.error('Cannot compute 2D data of different lengths')
                 return False
-                
+
             else:
                 self.cbData1.setStyleSheet(BG_WHITE)
                 self.cbData2.setStyleSheet(BG_WHITE)


### PR DESCRIPTION
## Description

A condition was added to make sure the user cannot select the same dataset in both Data1 and Data2 comboboxes in the Data Opeartion tool. In the main version, if the user performs the subtraction of the same 1D data, an error raise. Now, the user cannot perform this action, and when the same 1D data is chosen in combobox2 a message appears in the log explorer.

Fixes #3762 

## How Has This Been Tested?

Tested on windows, version 6.1.2.dev

## Review Checklist:

[if using the editor, use `[x]` in place of `[ ]` to check a box]

**Documentation** (check at least one)
- [x] There is **nothing** that needs documenting
- [ ] Documentation changes are **in this PR**
- [ ] There is an **issue** open for the documentation (link?)

**Installers**
- [ ] There is a chance this will affect the **installers**, if so
  - [ ] **Windows** installer (GH artifact) has been tested (installed and worked) 
  - [ ] **MacOSX** installer (GH artifact) has been tested (installed and worked)
  - [ ] **Wheels** installer (GH artifact) has been tested (installed and worked)

**Licensing** (untick if necessary)
- [x] The introduced changes comply with SasView license (BSD 3-Clause)

