### PR TITLE
Revert the polydisp table to the original state on model change

### DIFF
--- a/src/sas/qtgui/Perspectives/Fitting/FittingWidget.py
+++ b/src/sas/qtgui/Perspectives/Fitting/FittingWidget.py
@@ -1411,6 +1411,8 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         # Reset parameters to fit
         self.resetParametersToFit()
         self.has_error_column = False
+        self.polydispersity_widget.has_poly_error_column = False
+        self.magnetism_widget.has_magnet_error_column = False
 
         structure = None
         if self.cbStructureFactor.isEnabled():
@@ -1454,6 +1456,8 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         # Reset parameters to fit
         self.resetParametersToFit()
         self.has_error_column = False
+        self.polydispersity_widget.has_poly_error_column = False
+        self.magnetism_widget.has_magnet_error_column = False
 
         self.respondToModelStructure(model=model, structure_factor=structure)
         # recast the original parameters into the model

--- a/src/sas/qtgui/Perspectives/Fitting/MagnetismWidget.py
+++ b/src/sas/qtgui/Perspectives/Fitting/MagnetismWidget.py
@@ -88,6 +88,15 @@ class MagnetismWidget(QtWidgets.QWidget, Ui_MagnetismWidgetUI):
 
         FittingUtilities.addHeadersToModel(self._magnet_model)
 
+        # Reset delegate column indices to standard (no error column)
+        delegate = self.lstMagnetic.itemDelegate()
+        delegate.mag_parameter = 0
+        delegate.mag_value = 1
+        delegate.mag_min = 2
+        delegate.mag_max = 3
+        delegate.mag_unit = 4
+        delegate.mag_error = -1
+
     def getParamNamesMagnet(self) -> list[str]:
         """
         Return list of magnetic parameters for the current model

--- a/src/sas/qtgui/Perspectives/Fitting/PolydispersityWidget.py
+++ b/src/sas/qtgui/Perspectives/Fitting/PolydispersityWidget.py
@@ -72,6 +72,19 @@ class PolydispersityWidget(QtWidgets.QWidget, Ui_PolydispersityWidgetUI):
         if self.is2D:
             parameters += self.logic.model_parameters.orientation_parameters
 
+        # Reset delegate column indices to standard (no error column) BEFORE creating parameters
+        # This ensures comboboxes are created at the correct column positions
+        delegate = self.lstPoly.itemDelegate()
+        delegate.poly_parameter = 0
+        delegate.poly_pd = 1
+        delegate.poly_error = None
+        delegate.poly_min = 2
+        delegate.poly_max = 3
+        delegate.poly_npts = 4
+        delegate.poly_nsigs = 5
+        delegate.poly_function = 6
+        delegate.poly_filename = 7
+
         [self.setPolyModelParameters(i, param) for i, param in \
             enumerate(parameters) if param.polydisperse]
 


### PR DESCRIPTION
## Description

Running a fit with polydisperse parameters checked adds an error column to the polydisp table.
This is OK when just running the fit - the min/max/npts/nsigs/function combobox columns get shifted and display ok.
But when a model is changed AFTER the fitting, the table is not properly reindexed.
THis PR fixes the issue.

Fixes # 3536

## How Has This Been Tested?

Local win 10 testing

## Review Checklist:

[if using the editor, use `[x]` in place of `[ ]` to check a box]

**Documentation** (check at least one)
- [ X] There is **nothing** that needs documenting
- [ ] Documentation changes are **in this PR**
- [ ] There is an **issue** open for the documentation (link?)

**Installers**
- [ ] There is a chance this will affect the **installers**, if so
  - [ ] **Windows** installer (GH artifact) has been tested (installed and worked) 
  - [ ] **MacOSX** installer (GH artifact) has been tested (installed and worked)
  - [ ] **Wheels** installer (GH artifact) has been tested (installed and worked)

**Licensing** (untick if necessary)
- [x] The introduced changes comply with SasView license (BSD 3-Clause)

