### PR TITLE
fixed disconnect logic with the proper PySide6 signal checking method.

### DIFF
--- a/src/sas/qtgui/Perspectives/Fitting/ConstraintWidget.py
+++ b/src/sas/qtgui/Perspectives/Fitting/ConstraintWidget.py
@@ -234,27 +234,14 @@ class ConstraintWidget(QtWidgets.QWidget, Ui_ConstraintWidgetUI):
         tab_object = ObjectLibrary.getObject(tab)
 
         # Disconnect all local slots, if connected
-        # None of the methods below seem to work with Qt6.2.4
-        # 1.
-        # if tab_object.receivers(tab_object.newModelSignal) > 0:
-        # 2.
-        # newModelSignal =QtCore.QMetaMethod.fromSignal(tab_object.newModelSignal)
-        # if tab_object.isSignalConnected(newModelSignal):
-        # 3.
-        # m_obj = tab_object.metaObject()
-        # is_connected = m_obj.isSignalConnected(m_obj.method(m_obj.indexOfSignal("newModelSignal()")))
-
-        try:
+        # Using isSignalConnected() with QMetaMethod (works with PySide6 6.9.1+)
+        newModelSignal = QtCore.QMetaMethod.fromSignal(tab_object.newModelSignal)
+        if tab_object.isSignalConnected(newModelSignal):
             tab_object.newModelSignal.disconnect()
-        except RuntimeError:
-            # need to pass here since no known PySide6 method of checking if signal is connected
-            # seems to work here. Need to upgrade to more recent version of PySide6 but this
-            # currently causes other issues.
-            pass
-        try:
+
+        constraintAddedSignal = QtCore.QMetaMethod.fromSignal(tab_object.constraintAddedSignal)
+        if tab_object.isSignalConnected(constraintAddedSignal):
             tab_object.constraintAddedSignal.disconnect()
-        except RuntimeError:
-            pass
 
         # Reconnect tab signals to local slots
         tab_object.constraintAddedSignal.connect(self.initializeFitList)


### PR DESCRIPTION
## Description

Before: The code used a try/except approach to blindly attempt disconnecting signals, catching RuntimeError exceptions when signals weren't connected.  We tried three ways to check signal connection status, which didn't work with Qt 6.2.4.

After: The code now uses the proper isSignalConnected() method with QMetaMethod.fromSignal(), which is the official and clean way to check if a signal is connected before attempting to disconnect it.

The proper usage pattern is
```python
signal_method = QtCore.QMetaMethod.fromSignal(obj.someSignal)
if obj.isSignalConnected(signal_method):
    obj.someSignal.disconnect()
```

as per https://doc.qt.io/qtforpython-6/PySide6/QtCore/QObject.html#PySide6.QtCore.QObject.isSignalConnected

Fixes #3205 

## How Has This Been Tested?

Local testing

## Review Checklist:

**Documentation** (check at least one)
- [X ] There is **nothing** that needs documenting
- [ ] Documentation changes are **in this PR**
- [ ] There is an **issue** open for the documentation (link?)

**Installers**
- [ ] There is a chance this will affect the **installers**, if so
  - [ ] **Windows** installer (GH artifact) has been tested (installed and worked) 
  - [ ] **MacOSX** installer (GH artifact) has been tested (installed and worked)
  - [ ] **Wheels** installer (GH artifact) has been tested (installed and worked)

**Licensing** (untick if necessary)
- [x] The introduced changes comply with SasView license (BSD 3-Clause)

