### PR TITLE
Adds logger error for unsuitably scaled axes

### DIFF
--- a/src/sas/qtgui/Plotting/Plotter.py
+++ b/src/sas/qtgui/Plotting/Plotter.py
@@ -1,5 +1,6 @@
 import copy
 import functools
+import logging
 import math
 import textwrap
 
@@ -21,6 +22,8 @@ from sas.qtgui.Plotting.PlotterData import Data1D, DataRole
 from sas.qtgui.Plotting.QRangeSlider import QRangeSlider
 from sas.qtgui.Plotting.ScaleProperties import ScaleProperties
 from sas.qtgui.Plotting.SetGraphRange import SetGraphRange
+
+logger = logging.getLogger(__name__)
 
 
 class PlotterWidget(PlotterBase):
@@ -302,8 +305,14 @@ class PlotterWidget(PlotterBase):
         self.setRange.defaultXRange = default_x_range
         self.setRange.defaultYRange = default_y_range
         # Go to expected range
-        self.ax.set_xbound(x_range[0], x_range[1])
-        self.ax.set_ybound(y_range[0], y_range[1])
+        try:
+            self.ax.set_xbound(x_range[0], x_range[1])
+            self.ax.set_ybound(y_range[0], y_range[1])
+        except ValueError:
+            logger.error(
+                "The axis ranges cannot be set for this plot. "
+                "It may be possible to plot the data on differently scaled axes."
+            )
 
         # Add q-range sliders
         if data.show_q_range_sliders:


### PR DESCRIPTION
## Description

When data is supplied that cannot be plotted on a set of axes with a particular scale (e.g., zero/negative data on log axes), we raise an error in the logger and suggest to the user to change the scale of the axes. This applies to general 1D plots, going beyond where the issue was originally discovered in the Data Operation tool.

Fixes #3762, #3767 

## How Has This Been Tested?

The test in #3762 now returns a logger error rather than a ValueError. The default log scale is retained for plots of data.

## Review Checklist:

[if using the editor, use `[x]` in place of `[ ]` to check a box]

**Documentation** (check at least one)
- [x] There is **nothing** that needs documenting
- [ ] Documentation changes are **in this PR**
- [ ] There is an **issue** open for the documentation (link?)

**Installers**
- [ ] There is a chance this will affect the **installers**, if so
  - [ ] **Windows** installer (GH artifact) has been tested (installed and worked) 
  - [ ] **MacOSX** installer (GH artifact) has been tested (installed and worked)
  - [ ] **Wheels** installer (GH artifact) has been tested (installed and worked)

**Licensing** (untick if necessary)
- [x] The introduced changes comply with SasView license (BSD 3-Clause)

