### PR TITLE
Specify the release python version in only place

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,8 @@ defaults:
     shell: bash
 
 env:
+  # Version of Python that will be used in the release builds
+  RELEASE_PYVER: "3.13"
   # Determine if this CI is being done during the release polishing steps
   RELEASE_BRANCH_BUILD: ${{
       (
@@ -72,7 +74,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: 3.12
+          python-version: ${{ env.RELEASE_PYVER }}
 
       - name: Set dependency refs and generate matrix
         id: set-refs
@@ -124,7 +126,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: 3.13
+          python-version: ${{ env.RELEASE_PYVER }}
 
       - uses: actions/checkout@v5
 
@@ -148,7 +150,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: 3.13
+          python-version: ${{ env.RELEASE_PYVER }}
 
       ### Check if this wheel is already cached
 
@@ -218,7 +220,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: 3.13
+          python-version: ${{ env.RELEASE_PYVER }}
 
       - name: Install uv utilities to speed up python module installation
         uses: astral-sh/setup-uv@v7

--- a/.github/workflows/matrix.py
+++ b/.github/workflows/matrix.py
@@ -39,12 +39,13 @@ os_test_list = os_release_list + [
 
 # List of python versions to use for release builds
 python_release_list = [
-    "3.13",
+    # The current interpreter, set from ci.yml, is the release version
+    f"{sys.version_info.major}.{sys.version_info.minor}"
 ]
 
 # List of python versions to use for tests
 python_test_list = python_release_list + [
-    # No additional test versions - add more to this list as needed
+    # Additional test versions - add more to this list as needed
     "3.12",
 ]
 


### PR DESCRIPTION
## Description

In reviewing #3652, @krzywon wondered if we could abstract to just one place where we specified the default python version for flows and for embedding in the installer.

This PR does so, by putting the version into a variable within `ci.yml`, and then when generating the test/build matrix in `matrix.py`, using the current interpreter as the release interpreter, thus bringing that config with it.

(This PR also fixes a stray 3.12 that crept in via a different parallel PR to the one moving to 3.13.)

## How Has This Been Tested?

CI to check that the right versions are used where intended. It's 3.13 everywhere except in the places where we want 3.12 for testing, just as desired.

## Review Checklist:

[if using the editor, use `[x]` in place of `[ ]` to check a box]

**Documentation** (check at least one)
- [x] There is **nothing** that needs documenting
- [ ] Documentation changes are **in this PR**
- [ ] There is an **issue** open for the documentation (link?)

**Installers**
- [ ] There is a chance this will affect the **installers**, if so
  - [ ] **Windows** installer (GH artifact) has been tested (installed and worked) 
  - [ ] **MacOSX** installer (GH artifact) has been tested (installed and worked)
  - [ ] **Wheels** installer (GH artifact) has been tested (installed and worked)

**Licensing** (untick if necessary)
- [x] The introduced changes comply with SasView license (BSD 3-Clause)

