### PR TITLE
Not handling cancel action on single fit with multi constraint

### DIFF
--- a/src/sas/qtgui/Perspectives/Fitting/FittingWidget.py
+++ b/src/sas/qtgui/Perspectives/Fitting/FittingWidget.py
@@ -1329,8 +1329,8 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
             msgbox.addButton(button_remove, QtWidgets.QMessageBox.YesRole)
             button_cancel = QtWidgets.QPushButton("Cancel")
             msgbox.addButton(button_cancel, QtWidgets.QMessageBox.RejectRole)
-            retval = msgbox.exec_()
-            if retval == QtWidgets.QMessageBox.RejectRole:
+            msgbox.exec_()
+            if msgbox.clickedButton() == button_cancel:
                 # cancel fit
                 raise ValueError("Fitting cancelled")
             else:


### PR DESCRIPTION


## Description

When a user presses "Fit" from on a model, when constraints have been added which tie this model to other models, a dialog box opens which notifies the user that if they continue, the constraint will be disabled so that the single fit can continue.

Currently, if you press "Cancel", the action is not cancelled, and the fit proceeds (and the constraint is disabled).

<img width="1251" height="1086" alt="image" src="https://github.com/user-attachments/assets/6c16feaf-2d80-4646-ad46-ebb392eb84b5" />


## How Has This Been Tested?

Loaded a model, then selected "FitPage1", then clicked "Fit" - and then clicked "Cancel".  Fit was cancelled, and constraint was not disabled.  See attached project for an example of a multi-model constrained fit project.
[6-1-2-constrained-fit.json](https://github.com/user-attachments/files/24037647/6-1-2-constrained-fit.json)

## Review Checklist:

[if using the editor, use `[x]` in place of `[ ]` to check a box]

**Documentation** (check at least one)
- [x] There is **nothing** that needs documenting
- [ ] Documentation changes are **in this PR**
- [ ] There is an **issue** open for the documentation (link?)

**Installers**
- [ ] There is a chance this will affect the **installers**, if so
  - [ ] **Windows** installer (GH artifact) has been tested (installed and worked) 
  - [ ] **MacOSX** installer (GH artifact) has been tested (installed and worked)
  - [ ] **Wheels** installer (GH artifact) has been tested (installed and worked)

**Licensing** (untick if necessary)
- [x] The introduced changes comply with SasView license (BSD 3-Clause)

