### PR TITLE
Fix uncheck constraint

### DIFF
--- a/src/sas/qtgui/Perspectives/Fitting/ConstraintWidget.py
+++ b/src/sas/qtgui/Perspectives/Fitting/ConstraintWidget.py
@@ -1242,7 +1242,6 @@ class ConstraintWidget(QtWidgets.QWidget, Ui_ConstraintWidgetUI):
             # slave parameter has model name and parameter separated
             # by colon e.g `M1:scale` so no need to parse the constraint
             # string.
-            print("Checking constraint:", constraint, "for", name, row, name in constraint)
             if name in constraint:
                 self.tblConstraints.item(row, 0).setCheckState(QtCore.Qt.Unchecked)
                 # deactivate the constraint


### PR DESCRIPTION
## Description

In the `ConstraintWidget.uncheckConstraint(name: str)` method, the constraint to be unchecked is always a string (it is the data of an `item = QtWidgets.QTableWidgetItem(label)`)

In that method, a call was made to `FittingWidget.getModelKey(self, constraint: Constraint)` which is expecting a `Constraint` object.  The call should be made to `FittingWidget.getModelKeyFromName(self, name: str)` instead.

This fixes an issue where the `uncheckConstraint` doesn't work, e.g. when called after initiating a single model fit when a multi-model constraint exists, and the constraint is to be disabled. (see #3808)

## How Has This Been Tested?

Start a fit with the first model in the project attached to #3808, then verify that the constraint has been disabled (and the fit starts)

## Review Checklist:

[if using the editor, use `[x]` in place of `[ ]` to check a box]

**Documentation** (check at least one)
- [x] There is **nothing** that needs documenting
- [ ] Documentation changes are **in this PR**
- [ ] There is an **issue** open for the documentation (link?)

**Installers**
- [ ] There is a chance this will affect the **installers**, if so
  - [ ] **Windows** installer (GH artifact) has been tested (installed and worked) 
  - [ ] **MacOSX** installer (GH artifact) has been tested (installed and worked)
  - [ ] **Wheels** installer (GH artifact) has been tested (installed and worked)

**Licensing** (untick if necessary)
- [x] The introduced changes comply with SasView license (BSD 3-Clause)

