### PR TITLE
3796: Fix name selection issue in Data Operations Panel

### DIFF
--- a/src/sas/qtgui/Calculators/DataOperationUtilityPanel.py
+++ b/src/sas/qtgui/Calculators/DataOperationUtilityPanel.py
@@ -76,7 +76,6 @@ class DataOperationUtilityPanel(QtWidgets.QDialog, Ui_DataOperationUtility):
          DataExplorer. For Data2, there is the additional option of choosing
          a number to apply to data1 """
         self.filenames = filenames
-        print(filenames)
 
         if list(filenames.keys()):
             # clear contents of comboboxes


### PR DESCRIPTION
## Description

This ensures the Data Operations Panel matches the entire data name when fetching data to ensure the data name isn't matched with a fit, that also might include the entire data name within it.

Fixes #3796

## How Has This Been Tested?

Locally from source - ensure the data file is loaded rather than the fit when selecting a data set in the data operations panel.

## Review Checklist:

**Documentation** (check at least one)
- [x] There is **nothing** that needs documenting
- [ ] Documentation changes are **in this PR**
- [ ] There is an **issue** open for the documentation (link?)

**Installers**
- [x] There is a chance this will affect the **installers**, if so
  - [ ] **Windows** installer (GH artifact) has been tested (installed and worked) 
  - [ ] **MacOSX** installer (GH artifact) has been tested (installed and worked)
  - [ ] **Wheels** installer (GH artifact) has been tested (installed and worked)

**Licensing** (untick if necessary)
- [x] The introduced changes comply with SasView license (BSD 3-Clause)

