### PR TITLE
Fix complex compiled constraints

### DIFF
--- a/src/sas/sascalc/fit/expression.py
+++ b/src/sas/sascalc/fit/expression.py
@@ -326,7 +326,7 @@ def _compile_constraints(symtab, exprs, context={}, html=False):
     # of the parameter in the expression.
     names = list(sorted(symtab.keys()))
     parameters = dict(('P%d'%i, symtab[k]) for i, k in enumerate(names))
-    mapping = dict((k, 'P%d.slot'%i) for i, k in enumerate(names))
+    mapping = dict((k, 'P%d.value'%i) for i, k in enumerate(names))
 
     # Add the parameters to the global context
     global_context = standard_symbols(context)


### PR DESCRIPTION
## Description

The compiled constraints are supposed to be a function that takes the parameters as input, and updates the values of the parameters based on the constraint expressions supplied, _after_ each call to `problem.setp(pvec)`, through the `setp_hook()` function.

The existing code (introduced in #3375) was incorrectly replacing the parameter names with `f"{name}.slot"`, which is wrong for 2 reasons:

1.  In the case of simple equality constraints, e.g. `P1 = P2`, it was instead executing `P1.slot = P2.slot`, which replaces the `Variable` in the slot of `P1` with the actual `Variable` instance in `P2`, so that the `P1` is essentially an alias for `P2` after that.  This will "work" and the fit will complete, but the parameter structure of the model is changed in an unintended way.
2. In the case of (even slightly) more complex constraints, the constraint expressions fail to execute properly, e.g. for this constraint expression:
   `M1.scale = M2.scale * 1.2` you end up with this expression to evaluate: `M1.scale.slot = M2.scale.slot * 1.2`, which doesn't work because `M2.scale.slot` is an instance of `Variable`, on which we can't directly do arithmetic.  

To achieve the goal of the compiled constraint functions, we should instead use the `.value` attribute; on the LHS of the equality, it will trigger the `.value` setter which pushes the new value down into the slot, and on the RHS it will use the getter to pull the value back out of the slot for (as a float) for doing expression math on it.

This fixes a sub-issue in https://github.com/SasView/sasview/issues/3793#issuecomment-3625907461

## How Has This Been Tested?

Ran the constrained fit in this project: 
[6-1-2-constrained-fit-expr.json](https://github.com/user-attachments/files/24040246/6-1-2-constrained-fit-expr.json)

## Review Checklist:

[if using the editor, use `[x]` in place of `[ ]` to check a box]

**Documentation** (check at least one)
- [x] There is **nothing** that needs documenting (fixes a bug)
- [ ] Documentation changes are **in this PR**
- [ ] There is an **issue** open for the documentation (link?)

**Installers**
- [ ] There is a chance this will affect the **installers**, if so
  - [ ] **Windows** installer (GH artifact) has been tested (installed and worked) 
  - [ ] **MacOSX** installer (GH artifact) has been tested (installed and worked)
  - [ ] **Wheels** installer (GH artifact) has been tested (installed and worked)

**Licensing** (untick if necessary)
- [x] The introduced changes comply with SasView license (BSD 3-Clause)

