### PR TITLE
3815: Fix for project load breaking the replace fit button

### DIFF
--- a/src/sas/qtgui/MainWindow/DataExplorer.py
+++ b/src/sas/qtgui/MainWindow/DataExplorer.py
@@ -166,6 +166,7 @@ class DataExplorerWindow(DroppableDataLoadWidget):
         self.actionReplace.setText("... replacing data in the current page")
         self.send_menu = QtWidgets.QMenu(self)
         self.send_menu.addAction(self.actionReplace)
+        self.actionReplace.triggered.connect(self.onDataReplaced)
 
     def closeEvent(self, event):
         """
@@ -1070,12 +1071,12 @@ class DataExplorerWindow(DroppableDataLoadWidget):
 
     def sendToMenu(self, hasSubmenu=False):
         # add menu to cmdSendTO
+        self.cmdSendTo.setMenu(None)
         if hasSubmenu:
             self.createSendToMenu()
             self.cmdSendTo.setMenu(self.send_menu)
             self.cmdSendTo.setPopupMode(QtWidgets.QToolButton.MenuButtonPopup)
         else:
-            self.cmdSendTo.setMenu(None)
             self.cmdSendTo.setPopupMode(QtWidgets.QToolButton.InstantPopup)
 
     def updatePerspectiveCombo(self, index):
@@ -1637,7 +1638,6 @@ class DataExplorerWindow(DroppableDataLoadWidget):
         self.actionEditMask.triggered.connect(self.showEditDataMask)
         self.actionDelete.triggered.connect(self.deleteFile)
         self.actionFreezeResults.triggered.connect(self.freezeSelectedItems)
-        self.actionReplace.triggered.connect(self.onDataReplaced)
 
     def onCustomContextMenu(self, position):
         """


### PR DESCRIPTION
## Description

On line 303 of `sas.qtgui.MainWindow.DataExplorer`, `initPerspectives()` is called as part of the project load process. Init perspectives destroys existing perspectives and creates fresh ones. This initialization also creates a new sub-menu for the send to button. While the menu is replaced, the trigger action is not renewed on the new menu item, so no connection is made. I've moved the connection into the method that creates the action to ensure any new actions created are linked properly.

Fixes #3815

## How Has This Been Tested?

Locally, tested loading a project and made sure the replace option replaces data in a fit tab.

## Review Checklist:

[if using the editor, use `[x]` in place of `[ ]` to check a box]

**Documentation** (check at least one)
- [x] There is **nothing** that needs documenting
- [ ] Documentation changes are **in this PR**
- [ ] There is an **issue** open for the documentation (link?)

**Installers**
- [x] There is a chance this will affect the **installers**, if so
  - [ ] **Windows** installer (GH artifact) has been tested (installed and worked) 
  - [ ] **MacOSX** installer (GH artifact) has been tested (installed and worked)
  - [ ] **Wheels** installer (GH artifact) has been tested (installed and worked)

**Licensing** (untick if necessary)
- [x] The introduced changes comply with SasView license (BSD 3-Clause)

