### PR TITLE
fixed keypair alias after certificate update

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -485,7 +485,7 @@ jobs:
       - name: Sign the binary using keypair alias
         if: ${{ startsWith(matrix.os, 'windows') && env.SIGN_INSTALLER }}
         run: |
-           smctl sign --keypair-alias key_911959544 --input installers/dist/setupSasView.exe
+           smctl sign --keypair-alias key_1369544803 --input installers/dist/setupSasView.exe
         shell: cmd
 
       - name: Publish installer package


### PR DESCRIPTION
## Description

Updated certificate info was not added to the current `main`. 
The changes include the API keypair alias name and the related repository secrets.

Fixes #3542

## How Has This Been Tested?

Windows-only run on a test branch `binary_sign_test`
Signed installer in the build artifacts:
https://github.com/SasView/sasview/actions/runs/20161241979


## Review Checklist:


**Documentation** (check at least one)
- [X] There is **nothing** that needs documenting
- [ ] Documentation changes are **in this PR**
- [ ] There is an **issue** open for the documentation (link?)

**Installers**
- [ ] There is a chance this will affect the **installers**, if so
  - [X] **Windows** installer (GH artifact) has been tested (installed and worked) 
  - [ ] **MacOSX** installer (GH artifact) has been tested (installed and worked)
  - [ ] **Wheels** installer (GH artifact) has been tested (installed and worked)

**Licensing** (untick if necessary)
- [x] The introduced changes comply with SasView license (BSD 3-Clause)

