### PR TITLE
Add Python 3.14 as a supported interpreter

### DIFF
--- a/.github/workflows/matrix.py
+++ b/.github/workflows/matrix.py
@@ -47,6 +47,7 @@ python_release_list = [
 python_test_list = python_release_list + [
     # Additional test versions - add more to this list as needed
     "3.12",
+    "3.14",
 ]
 
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,6 +1,6 @@
 # Quick Intro for Building SasView
 
-:warning: Note - at the current time SasView requires Python 3.12 or Python 3.13.
+:warning: Note - at the current time SasView requires Python 3.12, 3.13, or 3.14.
 
 Whether you're installing SasView to use as a tool for your research or
 because you're wanting to work on the code, it is recommended that you


### PR DESCRIPTION
## Description

numba has released version 0.63 and llvmlite 0.46 that are compatible with Python 3.14. We can now add Python 3.14 to the list of supported interpreters and continue to test against it, noting that the release version remains at 3.13 at this time.

Fixes #3738

## How Has This Been Tested?

- CI shows all tests pass
- wheel installed in python3.14 venv in linux and manual testing (including of GSC)

```
$ uv venv --python 3.14 venv-3.14
$ source venv-3.14/bin/activate
$ uv pip install ./sasview-6.1.0rc2.dev423+g0e0f29f85-py3-none-any.whl
$ sasview
```

## Review Checklist:

[if using the editor, use `[x]` in place of `[ ]` to check a box]

**Documentation** (check at least one)
- [ ] There is **nothing** that needs documenting
- [x] Documentation changes are **in this PR**
- [ ] There is an **issue** open for the documentation (link?)

**Installers**
- [ ] There is a chance this will affect the **installers**, if so
  - [ ] **Windows** installer (GH artifact) has been tested (installed and worked) 
  - [ ] **MacOSX** installer (GH artifact) has been tested (installed and worked)
  - [x] **Wheels** installer (GH artifact) has been tested (installed and worked)

**Licensing** (untick if necessary)
- [x] The introduced changes comply with SasView license (BSD 3-Clause)

