### PR TITLE
Restricts custom plot button to send to data explorer

### DIFF
--- a/src/sas/qtgui/MainWindow/DataExplorer.py
+++ b/src/sas/qtgui/MainWindow/DataExplorer.py
@@ -863,24 +863,16 @@ class DataExplorerWindow(DroppableDataLoadWidget):
         if row_index_child != -1:
             data = new_item.child(row_index_child)
             new_item = self.cloneTheory(data)
-            #new_item.setText(search_name)
-            #new_item.child(0).data().id = search_name
             model.beginResetModel()
             model.appendRow(new_item)
             model.endResetModel()
-        self.sendData([new_item])
 
     def sendData(self, event=None):
         """
         Send selected item data to the current perspective and set the relevant notifiers
         """
-
-        if type(event) == bool:
-            selected_items = self.selectedItems()
-        else:
-            selected_items = event
-
-        if len(selected_items) <1:
+        selected_items = self.selectedItems()
+        if len(selected_items) < 1:
             return
 
         # Check that only one item is selected when sending to perspectives that don't support batch mode

--- a/src/sas/qtgui/Plotting/Plotter.py
+++ b/src/sas/qtgui/Plotting/Plotter.py
@@ -60,12 +60,12 @@ class PlotterWidget(PlotterBase):
 
         # Connections used to prevent conflict between built in mpl toolbar actions and SasView context menu actions.
         # Toolbar actions only needed in 1D plots. 2D plots have no such conflicts.
-        self.toolbar._actions['home'].triggered.connect(self._home)
-        self.toolbar._actions['back'].triggered.connect(self._back)
-        self.toolbar._actions['forward'].triggered.connect(self._forward)
-        self.toolbar._actions['pan'].triggered.connect(self._pan)
-        self.toolbar._actions['zoom'].triggered.connect(self._zoom)
-        self.toolbar._actions['fitting'].setVisible(True)
+        self.toolbar._actions["home"].triggered.connect(self._home)
+        self.toolbar._actions["back"].triggered.connect(self._back)
+        self.toolbar._actions["forward"].triggered.connect(self._forward)
+        self.toolbar._actions["pan"].triggered.connect(self._pan)
+        self.toolbar._actions["zoom"].triggered.connect(self._zoom)
+        self.toolbar._actions["data_explorer"].setVisible(True)
 
         self.legendVisible = True
 

--- a/src/sas/qtgui/Plotting/Plotter.py
+++ b/src/sas/qtgui/Plotting/Plotter.py
@@ -65,7 +65,6 @@ class PlotterWidget(PlotterBase):
         self.toolbar._actions["forward"].triggered.connect(self._forward)
         self.toolbar._actions["pan"].triggered.connect(self._pan)
         self.toolbar._actions["zoom"].triggered.connect(self._zoom)
-        self.toolbar._actions["data_explorer"].setVisible(True)
 
         self.legendVisible = True
 

--- a/src/sas/qtgui/Plotting/PlotterBase.py
+++ b/src/sas/qtgui/Plotting/PlotterBase.py
@@ -33,17 +33,10 @@ class CustomToolbar(NavigationToolbar):
         custom_action.setToolTip("Send all data to the Data Explorer")
         custom_action.triggered.connect(self.sendToDataExplorer)
         self.insertAction(self.actions()[-1], custom_action)
-        self._actions["data_explorer"] = custom_action
-        self._actions["data_explorer"].setVisible(False)
 
     def sendToDataExplorer(self):
-        search_name = self.parent.data
-        for item in search_name:
+        for item in self.parent.data:
             self.parent.manager.communicator.freezeDataNameSignal.emit(item.name)
-        self._actions["data_explorer"].setEnabled(False)
-
-        # Re-enable after 3 seconds
-        QtCore.QTimer.singleShot(3000, lambda: self._actions["data_explorer"].setEnabled(True))
 
 class PlotterBase(QtWidgets.QWidget):
     #TODO: Describe what this class is

--- a/src/sas/qtgui/Plotting/PlotterBase.py
+++ b/src/sas/qtgui/Plotting/PlotterBase.py
@@ -25,26 +25,25 @@ class CustomToolbar(NavigationToolbar):
 
     def add_custom_button(self):
         # I have been told that a Button is better
-        # But all NavitaionToolbar interactions are Actions
+        # But all NavigationToolbar interactions are Actions
         # This way all can be called with:
         #   self._actions['xxx']
         custom_icon = QtGui.QIcon()  # You can load an icon here if you want e.g., QtGui.QIcon("path/to/icon.png")
-        custom_action = QtGui.QAction(custom_icon, "Send to Fitting", self)
-        custom_action.setToolTip("Send all data to Fitting in seperate tabs")
-        custom_action.triggered.connect(self.sendToFitting)
+        custom_action = QtGui.QAction(custom_icon, "Send to Data Explorer", self)
+        custom_action.setToolTip("Send all data to the Data Explorer")
+        custom_action.triggered.connect(self.sendToDataExplorer)
         self.insertAction(self.actions()[-1], custom_action)
-        #self.addAction(custom_action)
-        self._actions['fitting'] = custom_action
-        self._actions['fitting'].setVisible(False)
+        self._actions["data_explorer"] = custom_action
+        self._actions["data_explorer"].setVisible(False)
 
-    def sendToFitting(self):
+    def sendToDataExplorer(self):
         search_name = self.parent.data
         for item in search_name:
             self.parent.manager.communicator.freezeDataNameSignal.emit(item.name)
-        self._actions["fitting"].setEnabled(False)
+        self._actions["data_explorer"].setEnabled(False)
 
         # Re-enable after 3 seconds
-        QtCore.QTimer.singleShot(3000, lambda: self._actions["fitting"].setEnabled(True))
+        QtCore.QTimer.singleShot(3000, lambda: self._actions["data_explorer"].setEnabled(True))
 
 class PlotterBase(QtWidgets.QWidget):
     #TODO: Describe what this class is


### PR DESCRIPTION
## Description

This PR restricts the functionality of the button known as "send to fitting" (now named "send to data explorer") to make sure it does not send data to perspectives, which has caused a number of bugs.

Fixes #3827

## How Has This Been Tested?

Manually tested the procedure in #3827, the error does not occur. No data is sent to perspectives.

## Review Checklist:

[if using the editor, use `[x]` in place of `[ ]` to check a box]

**Documentation** (check at least one)
- [ ] There is **nothing** that needs documenting
- [ ] Documentation changes are **in this PR**
- [x] There is an **issue** open for the documentation #3792

**Installers**
- [ ] There is a chance this will affect the **installers**, if so
  - [ ] **Windows** installer (GH artifact) has been tested (installed and worked) 
  - [ ] **MacOSX** installer (GH artifact) has been tested (installed and worked)
  - [ ] **Wheels** installer (GH artifact) has been tested (installed and worked)

**Licensing** (untick if necessary)
- [x] The introduced changes comply with SasView license (BSD 3-Clause)

