### PR TITLE
Fix display of job name for installer test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -507,7 +507,7 @@ jobs:
       matrix:
         include: ${{ fromJson(needs.matrix.outputs.installer-matrix-json) }}
 
-    name: Test installer
+    name: "Test ${{ matrix.job_name }}"
 
     runs-on: ${{ matrix.os }}
 


### PR DESCRIPTION
## Description

Cosmetic change to CI - recent jobs for the `test-installer` matrix have been identified as **CI / Test installer (Installer (ubuntu-22.04, 3.13), ubuntu-22.04, 3.13, 0, 1)** with this change, they are **CI / Test installer (ubuntu-22.04, 3.13)**

## How Has This Been Tested?

Look at CI titles in CI overview screen or in PR overview below.

## Review Checklist:

**Documentation** (check at least one)
- [x] There is **nothing** that needs documenting
- [ ] Documentation changes are **in this PR**
- [ ] There is an **issue** open for the documentation (link?)

**Installers**
- [ ] There is a chance this will affect the **installers**, if so
  - [ ] **Windows** installer (GH artifact) has been tested (installed and worked) 
  - [ ] **MacOSX** installer (GH artifact) has been tested (installed and worked)
  - [ ] **Wheels** installer (GH artifact) has been tested (installed and worked)

**Licensing** (untick if necessary)
- [x] The introduced changes comply with SasView license (BSD 3-Clause)

