### PR TITLE
# 3839 Fixed handling of None for logic.kernel_module

### DIFF
--- a/src/sas/qtgui/Perspectives/Fitting/FittingUtilities.py
+++ b/src/sas/qtgui/Perspectives/Fitting/FittingUtilities.py
@@ -791,6 +791,8 @@ def updateKernelWithResults(kernel, results):
     Takes model kernel and applies results dict to its parameters,
     returning the modified (deep) copy of the kernel.
     """
+    if kernel is None:
+        return None
     assert isinstance(results, dict)
     local_kernel = copy.deepcopy(kernel)
 

--- a/src/sas/qtgui/Perspectives/Fitting/FittingWidget.py
+++ b/src/sas/qtgui/Perspectives/Fitting/FittingWidget.py
@@ -1596,6 +1596,8 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
 
             # create local kernel_module
             kernel_module = FittingUtilities.updateKernelWithResults(self.logic.kernel_module, param_dict)
+            if kernel_module is None:
+                continue
             # pull out current data
             data = self._logic[res_index].data
 


### PR DESCRIPTION
## Description

Batch fitting is throwing a (harmless) error. This doesn't look nice.
The bug occurred because `self.logic.kernel_module` can be None during batch fitting, which caused an `AttributeError` when `updateKernelWithResults` tried to call `setParam()` on it.

Fixes #3839 

## How Has This Been Tested?

Local Win10 build

## Review Checklist:

[if using the editor, use `[x]` in place of `[ ]` to check a box]

**Documentation** (check at least one)
- [X] There is **nothing** that needs documenting
- [ ] Documentation changes are **in this PR**
- [ ] There is an **issue** open for the documentation (link?)

**Installers**
- [ ] There is a chance this will affect the **installers**, if so
  - [ ] **Windows** installer (GH artifact) has been tested (installed and worked) 
  - [ ] **MacOSX** installer (GH artifact) has been tested (installed and worked)
  - [ ] **Wheels** installer (GH artifact) has been tested (installed and worked)

**Licensing** (untick if necessary)
- [x] The introduced changes comply with SasView license (BSD 3-Clause)

