### PR TITLE
added Help context menu item, as the last item on the list

### DIFF
--- a/src/sas/qtgui/Plotting/Plotter.py
+++ b/src/sas/qtgui/Plotting/Plotter.py
@@ -476,6 +476,8 @@ class PlotterWidget(PlotterBase):
             self.actionToggleLegend.triggered.connect(self.onToggleLegend)
         self.actionCustomizeLabel.triggered.connect(self.onCusotmizeLabel)
 
+        self.addHelpToContextMenu()
+
     def addPlotsToContextMenu(self):
         """
         Adds operations on all plotted sets of data to the context menu
@@ -550,6 +552,8 @@ class PlotterWidget(PlotterBase):
         if self.show_legend:
             self.actionToggleLegend = self.contextMenu.addAction("Toggle Legend")
             self.actionToggleLegend.triggered.connect(self.onToggleLegend)
+
+        self.addHelpToContextMenu()
 
     def onScaleChange(self):
         """

--- a/src/sas/qtgui/Plotting/Plotter2D.py
+++ b/src/sas/qtgui/Plotting/Plotter2D.py
@@ -241,6 +241,8 @@ class Plotter2DWidget(PlotterBase):
         self.actionToggleMenu = self.contextMenu.addAction("Toggle Navigation Menu")
         self.actionToggleMenu.triggered.connect(self.onToggleMenu)
 
+        self.addHelpToContextMenu()
+
     def createContextMenuQuick(self):
         """
         Define context menu and associated actions for the quickplot MPL widget
@@ -256,6 +258,8 @@ class Plotter2DWidget(PlotterBase):
         self.actionChangeScale.triggered.connect(self.onToggleScale)
         if self.dimension == 2:
             self.actionToggleGrid.triggered.connect(self.onGridToggle)
+
+        self.addHelpToContextMenu()
 
     def onToggleMaskedData(self, event):
         """ Toggle the visibility of masked data points."""

--- a/src/sas/qtgui/Plotting/PlotterBase.py
+++ b/src/sas/qtgui/Plotting/PlotterBase.py
@@ -267,6 +267,14 @@ class PlotterBase(QtWidgets.QWidget):
         self.actionPrintImage.triggered.connect(self.onImagePrint)
         self.actionCopyToClipboard.triggered.connect(self.onClipboardCopy)
 
+    def addHelpToContextMenu(self):
+        """
+        Add Help option at the end of the context menu
+        """
+        self.contextMenu.addSeparator()
+        self.actionHelp = self.contextMenu.addAction("Help")
+        self.actionHelp.triggered.connect(self.onHelp)
+
     def createContextMenu(self):
         """
         Define common context menu and associated actions for the MPL widget
@@ -399,6 +407,13 @@ class PlotterBase(QtWidgets.QWidget):
         pixmap = QtGui.QPixmap(self.canvas.size())
         self.canvas.render(pixmap)
         bmp.setPixmap(pixmap)
+
+    def onHelp(self):
+        """
+        Display plotting help documentation
+        """
+        location = "/user/qtgui/MainWindow/graph_help.html"
+        self._help_window = GuiUtils.showHelp(location)
 
     def onGridToggle(self):
         """


### PR DESCRIPTION
## Description

"Help" now appears at the bottom of all plot context menus, after "Toggle Navigation Menu" (or the last item in quick menus)

Fixes #3803

## How Has This Been Tested?

Local win11 check

## Review Checklist:

[if using the editor, use `[x]` in place of `[ ]` to check a box]

**Documentation** (check at least one)
- [X] There is **nothing** that needs documenting
- [ ] Documentation changes are **in this PR**
- [ ] There is an **issue** open for the documentation (link?)

**Installers**
- [ ] There is a chance this will affect the **installers**, if so
  - [ ] **Windows** installer (GH artifact) has been tested (installed and worked) 
  - [ ] **MacOSX** installer (GH artifact) has been tested (installed and worked)
  - [ ] **Wheels** installer (GH artifact) has been tested (installed and worked)

**Licensing** (untick if necessary)
- [x] The introduced changes comply with SasView license (BSD 3-Clause)

