### PR TITLE
Solves polydispersity 2D bug

### DIFF
--- a/src/sas/qtgui/Perspectives/Fitting/FittingWidget.py
+++ b/src/sas/qtgui/Perspectives/Fitting/FittingWidget.py
@@ -1181,6 +1181,7 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         # Reset parameters to fit
         self.resetParametersToFit()
         self.has_error_column = False
+        self.polydispersity_widget.is2D = self.is2D
         self.polydispersity_widget.has_poly_error_column = False
         self.magnetism_widget.has_magnet_error_column = False
 


### PR DESCRIPTION
## Description

This PR fixes the bug introduced in SasView 6.1.0 where orientation parameters were not available in the polydispersity tab when the 2D view checkbox was checked. In SasView 6.1.x, only volume parameters were available regardless of the state of the 2D view checkbox.

## How Has This Been Tested?

Using a cylinder model I checked and unchecked the polydispersity and 2d view checkboxes and found that the orientation parameters appear/disappear from the polydispersity tab as expected.

## Review Checklist:

[if using the editor, use `[x]` in place of `[ ]` to check a box]

**Documentation** (check at least one)
- [x] There is **nothing** that needs documenting
- [ ] Documentation changes are **in this PR**
- [ ] There is an **issue** open for the documentation (link?)

**Installers**
- [ ] There is a chance this will affect the **installers**, if so
  - [ ] **Windows** installer (GH artifact) has been tested (installed and worked) 
  - [ ] **MacOSX** installer (GH artifact) has been tested (installed and worked)
  - [ ] **Wheels** installer (GH artifact) has been tested (installed and worked)

**Licensing** (untick if necessary)
- [x] The introduced changes comply with SasView license (BSD 3-Clause)

