### PR TITLE
Fix model reordering in Constrained Fitting widget

### DIFF
--- a/src/sas/qtgui/Perspectives/Fitting/ConstraintWidget.py
+++ b/src/sas/qtgui/Perspectives/Fitting/ConstraintWidget.py
@@ -94,8 +94,9 @@ class DnDTableWidget(QtWidgets.QTableWidget):
         elif rect.bottom() - pos.y() < margin:
             return True
 
+        flags = self.model().flags(index)
         return rect.contains(pos, True) and not \
-            (int(self.model().flags(index)) & QtCore.Qt.ItemIsDropEnabled) and \
+            bool(flags & QtCore.Qt.ItemIsDropEnabled) and \
             pos.y() >= rect.center().y()
 
 


### PR DESCRIPTION
## Description

`self.model().flags(index)` returns a Qt ItemFlag/ItemFlags object, which cannot be passed to int() — that caused the TypeError. Testing the flag via `flags & QtCore.Qt.ItemIsDropEnabled` and converting to bool avoids the error and is the correct bitmask check.

Fixes #3856

## How Has This Been Tested?

Local win11 test

## Review Checklist:

[if using the editor, use `[x]` in place of `[ ]` to check a box]

**Documentation** (check at least one)
- [X] There is **nothing** that needs documenting
- [ ] Documentation changes are **in this PR**
- [ ] There is an **issue** open for the documentation (link?)

**Installers**
- [ ] There is a chance this will affect the **installers**, if so
  - [ ] **Windows** installer (GH artifact) has been tested (installed and worked) 
  - [ ] **MacOSX** installer (GH artifact) has been tested (installed and worked)
  - [ ] **Wheels** installer (GH artifact) has been tested (installed and worked)

**Licensing** (untick if necessary)
- [x] The introduced changes comply with SasView license (BSD 3-Clause)

