### PR TITLE
Proper SliderPerspective implementation

### DIFF
--- a/src/sas/qtgui/Perspectives/Corfunc/CorfuncPerspective.py
+++ b/src/sas/qtgui/Perspectives/Corfunc/CorfuncPerspective.py
@@ -15,7 +15,7 @@ from sas.qtgui.Perspectives.Corfunc.IDFCanvas import IDFCanvas
 from sas.qtgui.Perspectives.Corfunc.QSpaceCanvas import QSpaceCanvas
 from sas.qtgui.Perspectives.Corfunc.RealSpaceCanvas import RealSpaceCanvas
 from sas.qtgui.Plotting.PlotterData import Data1D
-from sas.qtgui.Utilities.ExtrapolationSlider import ExtrapolationSlider
+from sas.qtgui.Utilities.ExtrapolationSlider import ExtrapolationSlider, SliderPerspective
 from sas.qtgui.Utilities.Reports import ReportBase
 from sas.qtgui.Utilities.Reports.reportdata import ReportData
 from sas.sascalc.corfunc.calculation_data import (
@@ -83,7 +83,7 @@ class CorfuncWindow(QtWidgets.QDialog, Ui_CorfuncDialog, Perspective):
         self._running = False
 
         # Add slider widget
-        self.slider = ExtrapolationSlider(lower_label="Guinier", upper_label="Porod", perspective ="Corfunc")
+        self.slider = ExtrapolationSlider(perspective=SliderPerspective.CORFUNC)
         self.sliderLayout.insertWidget(1, self.slider)
 
         # Plots

--- a/src/sas/qtgui/Perspectives/Invariant/InvariantPerspective.py
+++ b/src/sas/qtgui/Perspectives/Invariant/InvariantPerspective.py
@@ -10,7 +10,7 @@ from twisted.internet import reactor, threads
 import sas.qtgui.Utilities.GuiUtils as GuiUtils
 from sas.qtgui.Plotting import PlotterData
 from sas.qtgui.Plotting.PlotterData import Data1D, DataRole
-from sas.qtgui.Utilities.ExtrapolationSlider import ExtrapolationSlider
+from sas.qtgui.Utilities.ExtrapolationSlider import ExtrapolationSlider, SliderPerspective
 
 # sas-global
 from sas.sascalc.invariant import invariant
@@ -103,7 +103,7 @@ class InvariantWindow(QtWidgets.QDialog, Ui_tabbedInvariantUI, Perspective):
         self.no_extrapolation_plot: PlotterData | None = None
 
         # Slider
-        self.slider = ExtrapolationSlider(lower_label="Low-Q", upper_label="High-Q", perspective="Invariant")
+        self.slider = ExtrapolationSlider(perspective=SliderPerspective.INVARIANT)
         self.sliderLayout.insertWidget(1, self.slider)
 
         # no reason to have this widget resizable

--- a/src/sas/qtgui/Utilities/ExtrapolationSlider.py
+++ b/src/sas/qtgui/Utilities/ExtrapolationSlider.py
@@ -21,8 +21,6 @@ class ExtrapolationSlider(QtWidgets.QWidget):
     valueEditing = Signal(ExtrapolationInteractionState, name='valueEditing')
 
     def __init__(self,
-                 lower_label: str,
-                 upper_label: str,
                  perspective: SliderPerspective,
                  parameters: ExtrapolationParameters = ExtrapolationParameters(1,2,4,8,16,32,64),
                  enabled: bool = False,
@@ -50,10 +48,8 @@ class ExtrapolationSlider(QtWidgets.QWidget):
         if self._max is None:
             self._max = self._data_max
 
-        self._lower_label = lower_label
-        self._upper_label = upper_label
-
         self.perspective = perspective
+        self.set_labels()
 
         # Display Parameters
         self.vertical_size = 20
@@ -127,6 +123,16 @@ class ExtrapolationSlider(QtWidgets.QWidget):
 
         return None
 
+    def set_labels(self):
+        """ Set the labels according to perspective"""
+        if self.perspective == SliderPerspective.CORFUNC:
+            self._lower_label = "Guinier"
+            self._upper_label = "Porod"
+        elif self.perspective == SliderPerspective.INVARIANT:
+            self._lower_label = "Low-Q"
+            self._upper_label = "High-Q"
+        else:
+            raise ValueError(f"Unknown perspective: {self.perspective}")
 
     def enterEvent(self, a0: QtCore.QEvent) -> None:
         if self.isEnabled():
@@ -331,7 +337,7 @@ class ExtrapolationSlider(QtWidgets.QWidget):
         - Between point 2 and point 3 for invariant
         - Between point 3 and widget edge for corfunc
         """
-        if self.perspective == "Invariant":
+        if self.perspective == SliderPerspective.INVARIANT:
             return 0.5 * (self.transform(self._point_2) + self.transform(self._point_3))
 
         return 0.5 * (self.transform(self._point_3) + self.width())


### PR DESCRIPTION
## Description

Fixes a minor code quality-related issue.

`SliderPerspective` defined in `ExtrapolationSlider.py` is used to inform `ExtrapolationSlider` of the calling perspective. This is then used to set the labels for the slider ranges.

## How Has This Been Tested?

Manually ran both perspectives to check functionality.

## Review Checklist:

**Documentation**
- [x] There is **nothing** that needs documenting
- [ ] Documentation changes are **in this PR**
- [ ] There is an **issue** open for the documentation (link?)

**Installers**
- [ ] There is a chance this will affect the **installers**, if so
  - [ ] **Windows** installer (GH artifact) has been tested (installed and worked) 
  - [ ] **MacOSX** installer (GH artifact) has been tested (installed and worked)
  - [ ] **Wheels** installer (GH artifact) has been tested (installed and worked)

**Licensing** (untick if necessary)
- [x] The introduced changes comply with SasView license (BSD 3-Clause)

