### PR TITLE
2889: Fitting Optimizer Broken After Load Project Fix

### DIFF
--- a/src/sas/qtgui/MainWindow/GuiManager.py
+++ b/src/sas/qtgui/MainWindow/GuiManager.py
@@ -145,8 +145,8 @@ class GuiManager:
         self.logDockWidget.setWidget(self.listWidget)
         self._workspace.addDockWidget(Qt.BottomDockWidgetArea, self.logDockWidget)
 
-        # Preferences Panel must exist before perspectives are loaded
-        self.preferences = PreferencesPanel(self._parent)
+        # Preferences Panel initialized in loadAllPerspectives()
+        self.preferences = None
 
         # Load all perspectives - Preferences panel must exist
         self.loadAllPerspectives()
@@ -200,6 +200,7 @@ class GuiManager:
         """ Load all the perspectives"""
         # Close any existing perspectives to prevent multiple open instances
         self.closeAllPerspectives()
+        self.preferences = PreferencesPanel(self._parent)
         # Load all perspectives
         loaded_dict = {} # dictionary that will ultimately keep track of all perspective instances
         for name, perspective in Perspectives.PERSPECTIVES.items():
@@ -231,6 +232,7 @@ class GuiManager:
                     perspective.close()
                 except Exception as e:
                     logger.warning(f"Unable to close {name} perspective\n{e}")
+        self.preferences = None
         self.loadedPerspectives = {}
         self._current_perspective = None
 


### PR DESCRIPTION
## Description

When projects are loaded, all perspectives are closed and regenerated to allow a completely fresh start. In this process, the perspective-specific preference widgets were not being renewed, orphaning their signals. This ensures the preference panel is recreated during this process.

Fixes #2889 (Maybe...?)

Side note - If approved in time, I may test this on the 6.1.3 release branch.

## Review Checklist:

**Documentation** (check at least one)
- [x] There is **nothing** that needs documenting
- [ ] Documentation changes are **in this PR**
- [ ] There is an **issue** open for the documentation (link?)

**Installers**
- [x] There is a chance this will affect the **installers**, if so
  - [ ] **Windows** installer (GH artifact) has been tested (installed and worked) 
  - [ ] **MacOSX** installer (GH artifact) has been tested (installed and worked)
  - [ ] **Wheels** installer (GH artifact) has been tested (installed and worked)

**Licensing** (untick if necessary)
- [x] The introduced changes comply with SasView license (BSD 3-Clause)

