### PR TITLE
Brings back fold for sector slicers

### DIFF
--- a/src/sas/qtgui/Plotting/Slicers/SectorSlicer.py
+++ b/src/sas/qtgui/Plotting/Slicers/SectorSlicer.py
@@ -44,6 +44,8 @@ class SectorInteractor(BaseInteractor, SlicerModel, StackableMixin):
         # Connect the plot to event
         self.connect = self.base.connect
 
+        self.fold: bool = True
+
         # Compute qmax limit to reset the graph
         x = numpy.power(max(self.data.xmax, numpy.fabs(self.data.xmin)), 2)
         y = numpy.power(max(self.data.ymax, numpy.fabs(self.data.ymin)), 2)
@@ -146,6 +148,7 @@ class SectorInteractor(BaseInteractor, SlicerModel, StackableMixin):
         if nbins is None:
             nbins = self.nbins
         sect = SectorQ(r_min=0.0, r_max=radius, phi_min=phimin + numpy.pi, phi_max=phimax + numpy.pi, nbins=nbins)
+        sect.fold = self.fold
 
         sector = sect(self.data)
         # Create 1D data resulting from average
@@ -250,6 +253,7 @@ class SectorInteractor(BaseInteractor, SlicerModel, StackableMixin):
         params["Phi [deg]"] = self.main_line.theta * 180 / numpy.pi
         params["Delta_Phi [deg]"] = numpy.fabs(self.left_line.phi * 180 / numpy.pi)
         params["nbins"] = self.nbins
+        params["fold"] = self.fold
         return params
 
     def setParams(self, params):
@@ -269,6 +273,7 @@ class SectorInteractor(BaseInteractor, SlicerModel, StackableMixin):
             params["Delta_Phi [deg]"] = MIN_PHI
 
         self.nbins = int(params["nbins"])
+        self.fold = params["fold"]
         self.main_line.theta = main
         # Reset the slicer parameters
         self.main_line.update()


### PR DESCRIPTION
## Description

The `fold` option in the sector slicer parameters disappeared due to changes in [this commit](https://github.com/SasView/sasview/commit/2f392d5eb142b19efc3f983668131c28236ca597). This PR reinstates that.

## How Has This Been Tested?

Manually ran the software and tested the functionality of the fold checkbox fr sector slicers.

## Review Checklist:

**Documentation**
- [x] There is **nothing** that needs documenting
- [ ] Documentation changes are **in this PR**
- [ ] There is an **issue** open for the documentation (link?)

**Installers**
- [ ] There is a chance this will affect the **installers**, if so
  - [ ] **Windows** installer (GH artifact) has been tested (installed and worked) 
  - [ ] **MacOSX** installer (GH artifact) has been tested (installed and worked)
  - [ ] **Wheels** installer (GH artifact) has been tested (installed and worked)

**Licensing** (untick if necessary)
- [x] The introduced changes comply with SasView license (BSD 3-Clause)

