### PR TITLE
Inversion code clean up

### DIFF
--- a/src/sas/qtgui/Perspectives/Inversion/DMaxExplorerWidget.py
+++ b/src/sas/qtgui/Perspectives/Inversion/DMaxExplorerWidget.py
@@ -27,19 +27,24 @@ from .UI.DMaxExplorer import Ui_DmaxExplorer
 logger = logging.getLogger(__name__)
 
 
-W = enum( 'NPTS',      #0
-          'DMIN',      #1
-          'DMAX',      #2
-          'VARIABLE',  #3
+W = enum(
+    "NPTS",
+    "DMIN",
+    "DMAX",
+    "VARIABLE",
 )
 
+
 class DmaxWindow(QtWidgets.QDialog, Ui_DmaxExplorer):
-    # The controller which is responsible for managing signal slots connections
-    # for the gui and providing an interface to the data model.
+    """
+    The controller which is responsible for managing signal slot connections
+    for the GUI and providing an interface to the data model.
+    """
+
     name = "Dmax Explorer"  # For displaying in the combo box
 
-    def __init__(self, pr_state, nfunc, parent=None):
-        super(DmaxWindow, self).__init__()
+    def __init__(self, pr_state, nfunc: int, parent=None):
+        super().__init__()
         self.setupUi(self)
         self.parent = parent
 
@@ -50,11 +55,11 @@ class DmaxWindow(QtWidgets.QDialog, Ui_DmaxExplorer):
         self.setWindowIcon(icon)
 
         self.pr_state = pr_state
-        self.nfunc = nfunc
+        self.nfunc: int = nfunc
         self.communicator = GuiUtils.communicator
 
         self.plot = PlotterWidget(self, self)
-        self.hasPlot = False
+        self.hasPlot: bool = False
         self.plot.showLegend = False
         self.verticalLayout.insertWidget(0, self.plot)
 
@@ -72,35 +77,38 @@ class DmaxWindow(QtWidgets.QDialog, Ui_DmaxExplorer):
         # Set up the model.
         self.setupModel()
 
-        # # Set up the mapper
+        # Set up the mapper
         self.setupMapper()
 
-    def setupValidators(self):
-        """Add validators on relevant line edits"""
+    def setupValidators(self) -> None:
+        """Add validators on relevant line edits."""
         self.Npts.setValidator(QtGui.QIntValidator())
         self.minDist.setValidator(GuiUtils.DoubleValidator())
         self.maxDist.setValidator(GuiUtils.DoubleValidator())
 
-    def setupSlots(self):
+    def setupSlots(self) -> None:
+        """Connect UI signals to their corresponding slots."""
         self.closeButton.clicked.connect(self.close)
         self.model.itemChanged.connect(self.modelChanged)
-        self.dependentVariable.currentIndexChanged.connect(lambda:self.modelChanged(None))
+        self.dependentVariable.currentIndexChanged.connect(lambda: self.modelChanged(None))
 
-    def setupModel(self):
+    def setupModel(self) -> None:
+        """Populate the model with initial values derived from the current P(r) state."""
         self.model.blockSignals(True)
         self.model.setItem(W.NPTS, QtGui.QStandardItem(str(self.nfunc)))
         self.model.blockSignals(False)
         self.model.blockSignals(True)
-        self.model.setItem(W.DMIN, QtGui.QStandardItem(f"{0.9*self.pr_state.dmax:.1f}"))
+        self.model.setItem(W.DMIN, QtGui.QStandardItem(f"{0.9 * self.pr_state.dmax:.1f}"))
         self.model.blockSignals(False)
         self.model.blockSignals(True)
-        self.model.setItem(W.DMAX, QtGui.QStandardItem(f"{1.1*self.pr_state.dmax:.1f}"))
+        self.model.setItem(W.DMAX, QtGui.QStandardItem(f"{1.1 * self.pr_state.dmax:.1f}"))
         self.model.blockSignals(False)
         self.model.blockSignals(True)
-        self.model.setItem(W.VARIABLE, QtGui.QStandardItem( "χ²/dof"))
+        self.model.setItem(W.VARIABLE, QtGui.QStandardItem("χ²/dof"))
         self.model.blockSignals(False)
 
-    def setupMapper(self):
+    def setupMapper(self) -> None:
+        """Configure the data widget mapper to bind model items to UI widgets."""
         self.mapper.setOrientation(QtCore.Qt.Vertical)
         self.mapper.setModel(self.model)
 
@@ -111,26 +119,28 @@ class DmaxWindow(QtWidgets.QDialog, Ui_DmaxExplorer):
 
         self.mapper.toFirst()
 
-    def modelChanged(self, item):
+    def modelChanged(self, item: QtGui.QStandardItem | None) -> None:
+        """Recompute and replot the D_max exploration results when the model changes."""
         if not self.mapper:
             return
 
-        iq0 = []
-        rg = []
-        pos = []
-        pos_err = []
-        osc = []
-        bck = []
-        chi2 = []
-        plotable_xs = [] #Introducing this to make sure size of x and y for plotting is the same.8
+        iq0: list[float] = []
+        rg: list[float] = []
+        pos: list[float] = []
+        pos_err: list[float] = []
+        osc: list[float] = []
+        bck: list[float] = []
+        chi2: list[float] = []
+        # Introducing this to make sure size of x and y for plotting is the same.
+        plotable_xs: list[float] = []
+
         try:
             dmin = float(self.model.item(W.DMIN).text())
             dmax = float(self.model.item(W.DMAX).text())
             npts = int(self.model.item(W.NPTS).text())
             xs = np.linspace(dmin, dmax, npts)
         except ValueError as e:
-            msg = (f"An input value is not correctly formatted. Please check {e.message}"
-                   )
+            msg = f"An input value is not correctly formatted. Please check {e.message}"
             logger.error(msg)
 
         original = self.pr_state.dmax
@@ -150,14 +160,14 @@ class DmaxWindow(QtWidgets.QDialog, Ui_DmaxExplorer):
                 plotable_xs.append(x)
             except Exception as ex:
                 # This inversion failed, skip this D_max value
-
-                msg = (f"ExploreDialog: inversion failed for D_max={x}\n"
-                       f"{ex}\n"
-                       f"Please adapt Inversion parameters")
-
+                msg = (
+                    f"ExploreDialog: inversion failed for D_max={x}\n"
+                    f"{ex}\n"
+                    f"Please adapt Inversion parameters"
+                )
                 logger.error(msg)
 
-        #Return the invertor to its original state
+        # Return the invertor to its original state
         self.pr_state.d_max = original
         try:
             self.pr_state.invert(self.nfunc)
@@ -205,13 +215,13 @@ class DmaxWindow(QtWidgets.QDialog, Ui_DmaxExplorer):
             self.plot.removePlot(data.name)
         self.hasPlot = True
         data.title = plotter
-        data._xaxis= x_label
+        data._xaxis = x_label
         data._xunit = x_unit
         data._yaxis = y_label
         data._yunit = y_unit
         self.plot.plot(data=data, marker="-")
 
-    def closeEvent(self, event):
-        """Override close event"""
+    def closeEvent(self, event: QtCore.QEvent) -> None:
+        """Override close event to clear the parent's reference to this window."""
         self.parent.dmaxWindow = None
         event.accept()

--- a/src/sas/qtgui/Perspectives/Inversion/DMaxExplorerWidget.py
+++ b/src/sas/qtgui/Perspectives/Inversion/DMaxExplorerWidget.py
@@ -43,7 +43,7 @@ class DmaxWindow(QtWidgets.QDialog, Ui_DmaxExplorer):
 
     name = "Dmax Explorer"  # For displaying in the combo box
 
-    def __init__(self, pr_state, nfunc: int, parent=None):
+    def __init__(self, pr_state: "Invertor", nfunc: int, parent=None):
         super().__init__()
         self.setupUi(self)
         self.parent = parent
@@ -140,7 +140,7 @@ class DmaxWindow(QtWidgets.QDialog, Ui_DmaxExplorer):
             npts = int(self.model.item(W.NPTS).text())
             xs = np.linspace(dmin, dmax, npts)
         except ValueError as e:
-            msg = f"An input value is not correctly formatted. Please check {e.message}"
+            msg = f"An input value is not correctly formatted. Please check {e}"
             logger.error(msg)
 
         original = self.pr_state.dmax

--- a/src/sas/qtgui/Perspectives/Inversion/InversionLogic.py
+++ b/src/sas/qtgui/Perspectives/Inversion/InversionLogic.py
@@ -115,7 +115,7 @@ class InversionLogic:
 
         return new_plot
 
-    def newPRPlot(self, out, pr, cov=None) -> Data1D:
+    def newPRPlot(self, out: np.ndarray, pr: "Invertor", cov: np.ndarray | None = None) -> Data1D:
         """Create a new P(r) plot from the inversion results."""
         x = np.arange(0.0, pr.dmax, pr.dmax / PR_PLOT_PTS)
 

--- a/src/sas/qtgui/Perspectives/Inversion/InversionLogic.py
+++ b/src/sas/qtgui/Perspectives/Inversion/InversionLogic.py
@@ -5,6 +5,7 @@ from PySide6.QtGui import QStandardItem
 
 from sas.qtgui.Plotting.PlotterData import Data1D
 from sas.qtgui.Utilities.GuiUtils import dataFromItem
+from sas.sascalc.pr.invertor import Invertor
 
 PR_FIT_LABEL = r"$P_{fit}(r)$"
 PR_LOADED_LABEL = r"$P_{loaded}(r)$"
@@ -49,7 +50,9 @@ class InversionLogic:
         """Return whether data has been loaded into this logic instance."""
         return self.data_is_loaded
 
-    def new1DPlot(self, tab_id: int = 1, out=None, pr=None, q=None) -> Data1D:
+    def new1DPlot(
+        self, tab_id: int = 1, out: np.ndarray | None = None, pr: Invertor | None = None, q: np.ndarray | None = None
+    ) -> Data1D:
         """Create a new 1D data instance based on fitting results."""
         qtemp = pr.x
         if q is not None:
@@ -115,7 +118,7 @@ class InversionLogic:
 
         return new_plot
 
-    def newPRPlot(self, out: np.ndarray, pr: "Invertor", cov: np.ndarray | None = None) -> Data1D:
+    def newPRPlot(self, out: np.ndarray, pr: Invertor, cov: np.ndarray | None = None) -> Data1D:
         """Create a new P(r) plot from the inversion results."""
         x = np.arange(0.0, pr.dmax, pr.dmax / PR_PLOT_PTS)
 

--- a/src/sas/qtgui/Perspectives/Inversion/InversionLogic.py
+++ b/src/sas/qtgui/Perspectives/Inversion/InversionLogic.py
@@ -19,49 +19,43 @@ logger = logging.getLogger(__name__)
 
 
 class InversionLogic:
-    """
-    All the data-related logic. This class deals exclusively with Data1D/2D
-    No QStandardModelIndex here.
-    """
+    """All the data-related logic. This class deals exclusively with Data1D/2D. No QStandardModelIndex here."""
+
     _data_item: QStandardItem | None
 
-    def __init__(self, data_item=None):
+    def __init__(self, data_item: QStandardItem | None = None):
         self._data_item = data_item
-        self.data_is_loaded = False
-        if data_item is not None:
-            self.data_is_loaded = True
-        self.qmin = 0.0
-        self.qmax = np.inf
+        self.data_is_loaded: bool = data_item is not None
+        self.qmin: float = 0.0
+        self.qmax: float = np.inf
 
     @property
     def data_item(self) -> QStandardItem | None:
+        """Return the raw QStandardItem held by this logic instance."""
         return self._data_item
 
     @property
     def data(self) -> Data1D:
+        """Return the Data1D object extracted from the current data item."""
         return dataFromItem(self._data_item)
 
     @data.setter
-    def data(self, value: QStandardItem):
-        """ data setter """
+    def data(self, value: QStandardItem) -> None:
+        """Set the data item and update the loaded flag accordingly."""
         self._data_item = value
-        self.data_is_loaded = (self._data_item is not None)
+        self.data_is_loaded = self._data_item is not None
 
-    def isLoadedData(self):
-        """ accessor """
+    def isLoadedData(self) -> bool:
+        """Return whether data has been loaded into this logic instance."""
         return self.data_is_loaded
 
-    def new1DPlot(self, tab_id=1, out=None, pr=None, q=None):
-        """
-        Create a new 1D data instance based on fitting results
-        """
+    def new1DPlot(self, tab_id: int = 1, out=None, pr=None, q=None) -> Data1D:
+        """Create a new 1D data instance based on fitting results."""
         qtemp = pr.x
         if q is not None:
             qtemp = q
 
-        # Make a plot
         maxq = max(qtemp)
-
         minq = min(qtemp)
 
         # Check for user min/max
@@ -84,16 +78,15 @@ class InversionLogic:
         new_plot.is_data = False
         new_plot.dy = np.zeros(len(y))
         new_plot.name = "%s [%s]" % (IQ_FIT_LABEL, self.data.name)
-        new_plot.xaxis("\\rm{Q}", 'A^{-1}')
+        new_plot.xaxis("\\rm{Q}", "A^{-1}")
         new_plot.yaxis("\\rm{Intensity} ", "cm^{-1}")
         title = "I(q)"
         new_plot.title = title
 
         # If we have a group ID, use it
-        if 'plot_group_id' in pr.info:
+        if "plot_group_id" in pr.info:
             new_plot.group_id = pr.info["plot_group_id"]
-        new_plot.id = str(tab_id) +IQ_FIT_LABEL
-
+        new_plot.id = str(tab_id) + IQ_FIT_LABEL
 
         # If we have used slit smearing, plot the smeared I(q) too
         if pr.slit_width > 0 or pr.slit_height > 0:
@@ -109,25 +102,21 @@ class InversionLogic:
 
             new_plot = Data1D(x, y)
             new_plot.name = IQ_SMEARED_LABEL
-            new_plot.xaxis("\\rm{Q}", 'A^{-1}')
+            new_plot.xaxis("\\rm{Q}", "A^{-1}")
             new_plot.yaxis("\\rm{Intensity} ", "cm^{-1}")
             # If we have a group ID, use it
-            if 'plot_group_id' in pr.info:
+            if "plot_group_id" in pr.info:
                 new_plot.group_id = pr.info["plot_group_id"]
             new_plot.id = IQ_SMEARED_LABEL
             new_plot.title = title
 
-        new_plot.symbol = 'Line'
+        new_plot.symbol = "Line"
         new_plot.hide_error = True
 
         return new_plot
 
-
-
-    def newPRPlot(self, out, pr, cov=None):
-        """
-        """
-        # Show P(r)
+    def newPRPlot(self, out, pr, cov=None) -> Data1D:
+        """Create a new P(r) plot from the inversion results."""
         x = np.arange(0.0, pr.dmax, pr.dmax / PR_PLOT_PTS)
 
         if cov is None:
@@ -138,7 +127,7 @@ class InversionLogic:
             new_plot = Data1D(x, y, dy=dy)
 
         new_plot.name = "%s [%s]" % (PR_FIT_LABEL, self.data.name)
-        new_plot.xaxis("\\rm{r}", 'A')
+        new_plot.xaxis("\\rm{r}", "A")
         new_plot.yaxis("\\rm{P(r)} ", "cm^{-3}")
         new_plot.title = "P(r) fit"
         new_plot.id = PR_FIT_LABEL
@@ -148,52 +137,40 @@ class InversionLogic:
 
         return new_plot
 
-    def add_errors(self, sigma=0.05):
-        """
-        Adds errors to data set is they are not available.
-        """
+    def add_errors(self, sigma: float = 0.05) -> np.ndarray:
+        """Add errors to the data set if they are not available."""
         if self.data.dy is None or self.data.dy.size == 0.0:
-            self.data.dy = np.sqrt(np.fabs(self.data.y))*sigma
+            self.data.dy = np.sqrt(np.fabs(self.data.y)) * sigma
 
         if self.data.dy is not None:
-            self.data.dy = np.where(self.data.dy < 0.0, np.sqrt(np.fabs(self.data.y))*sigma, self.data.dy)
+            self.data.dy = np.where(self.data.dy < 0.0, np.sqrt(np.fabs(self.data.y)) * sigma, self.data.dy)
             self.data.dy = np.where(np.fabs(self.data.dy) < 1e-16, 1e-16, self.data.dy)
         return self.data.dy
 
-    def computeDataRange(self):
-        """
-        Wrapper for calculating the data range based on local dataset
-        """
+    def computeDataRange(self) -> tuple[float | None, float | None]:
+        """Compute the data range based on the local dataset."""
         return self.computeRangeFromData(self.data)
 
-    def computeRangeFromData(self, data):
-        """
-        Compute the minimum and the maximum range of the data
-        return the npts contains in data
-        """
+    def computeRangeFromData(self, data: Data1D) -> tuple[float | None, float | None]:
+        """Compute the minimum and maximum range of the data. Returns the (qmin, qmax) tuple."""
         qmin, qmax = None, None
         if isinstance(data, Data1D):
             try:
                 qmax = max(data.x)
-                #set q values where Intensity is zero,
-                #to qmax and exclude from minimum accepted q
-                #to avoid dodgy points around beam stop
-                usable_qrange=np.where(data.y <= 0, qmax, data.x)
+                # Set q values where intensity is zero to qmax and exclude from minimum accepted q
+                # to avoid dodgy points around beam stop.
+                usable_qrange = np.where(data.y <= 0, qmax, data.x)
                 qmin = min(usable_qrange)
-
             except (ValueError, TypeError):
-                msg = "Unable to find min/max/length of \n data named %s" % \
-                            self.data.filename
+                msg = "Unable to find min/max/length of \n data named %s" % self.data.filename
                 raise ValueError(msg)
-
         else:
             qmin = 0
             try:
                 x = max(np.fabs(data.xmin), np.fabs(data.xmax))
                 y = max(np.fabs(data.ymin), np.fabs(data.ymax))
             except (ValueError, TypeError):
-                msg = "Unable to find min/max of \n data named %s" % \
-                            self.data.filename
+                msg = "Unable to find min/max of \n data named %s" % self.data.filename
                 raise ValueError(msg)
             qmax = np.sqrt(x * x + y * y)
         return qmin, qmax

--- a/src/sas/qtgui/Perspectives/Inversion/InversionPerspective.py
+++ b/src/sas/qtgui/Perspectives/Inversion/InversionPerspective.py
@@ -22,8 +22,7 @@ logger = logging.getLogger(__name__)
 class InversionWindow(QtWidgets.QTabWidget, Perspective):
     """
     The main window for the P(r) Inversion perspective.
-    This is the main window where the tabs for each of the widgets are shown
-
+    This is the main window where the tabs for each of the widgets are shown.
     """
 
     name = "Inversion"
@@ -31,6 +30,7 @@ class InversionWindow(QtWidgets.QTabWidget, Perspective):
 
     @property
     def title(self) -> str:
+        """Returns the title of the perspective."""
         return "P(r) Inversion"
 
     def __init__(self, parent=None, data=None):
@@ -86,10 +86,7 @@ class InversionWindow(QtWidgets.QTabWidget, Perspective):
     # Batch Mode and Tab Functions
 
     def resetTab(self, index: int) -> None:
-        """
-        Adds a new tab and removes the last tab
-        as a way of resetting the tabs
-        """
+        """Adds a new tab and removes the last tab as a way of resetting the tabs."""
         # If data on tab empty - do nothing
         if index in self.tabs and not self.tabs[index].data:
             return
@@ -99,19 +96,14 @@ class InversionWindow(QtWidgets.QTabWidget, Perspective):
         self.tabCloses(index)
 
     def tabCloses(self, index: int) -> None:
-        """
-        Update local bookkeeping on tab close
-        """
+        """Update local bookkeeping on tab close."""
         # If we're removing the last tab, create a new empty tab.
         if len(self.tabs) <= 1:
             self.addData(None)
         self.closeTabByIndex(index)
 
     def closeTabByIndex(self, index: int) -> None:
-        """
-        Close/delete a tab with the given index.
-        No checks on validity of the index.
-        """
+        """Close/delete a tab with the given index. No checks on validity of the index."""
         try:
             self.removeTab(index)
             del self.tabs[index]
@@ -121,9 +113,7 @@ class InversionWindow(QtWidgets.QTabWidget, Perspective):
             pass
 
     def closeTabByName(self, tab_name: str) -> None:
-        """
-        Given name of the tab - close it
-        """
+        """Given name of the tab - close it."""
         for tab_index in range(len(self.tabs)):
             if self.tabText(tab_index) == tab_name:
                 self.tabCloses(tab_index)
@@ -132,11 +122,7 @@ class InversionWindow(QtWidgets.QTabWidget, Perspective):
     ######################################################################
 
     def serializeAll(self) -> dict:
-        """
-        Serialize the inversion state so data can be saved
-        serialize all active inversion pages and return
-        a dictionary: {data-id: {self.name: {inversion-state}}}
-        """
+        """Serialize the inversion state so data can be saved. Serialize all active inversion pages and return a dictionary: {data-id: {self.name: {inversion-state}}}"""
         state = {}
         tab_ids = [tab.tab_id for tab in self.tabs]
         batch_warned = False
@@ -147,20 +133,21 @@ class InversionWindow(QtWidgets.QTabWidget, Perspective):
                 _ = QtWidgets.QMessageBox.warning(
                     self,
                     "Batch Serialisation",
-                    "Saving of projects with batch inversion tabs is currently not supported.Support will be added in a later version of SasView but please note that in the meantime, these tabs will be excluded from the saved project.",
+                    (
+                        "Saving projects with batch inversion tabs is currently not supported. "
+                        "Support will be added in a later version of SasView. "
+                        "In the meantime, these tabs will be excluded from the saved project."
+                    ),
                 )
             state.update(tab_state)
         return state
 
     def serializeCurrentPage(self) -> tuple[dict, bool]:
-        # serialize current (active) page
+        """Serialize current (active) page."""
         return self.getSerializePage(self.currentIndex())
 
     def getSerializePage(self, index: int | None = None) -> tuple[dict, bool]:
-        """
-        Serialize and return a dictionary of {tab_id: inversion-state}
-        Return original dictionary if no data
-        """
+        """Serialize and return a dictionary of {tab_id: inversion-state}. Return original dictionary if no data."""
         state = {}
         # If any tabs are batch tabs, these are not supported for serialisation so this needs to be true.
         if index is None:
@@ -180,47 +167,38 @@ class InversionWindow(QtWidgets.QTabWidget, Perspective):
 
     @property
     def supports_reports(self) -> bool:
+        """Tell caller perspective supports reports."""
         return True
 
     @property
     def supports_fitting(self) -> bool:
+        """Tell caller perspective does not support fitting."""
         return False
 
     def allowBatch(self):
-        """
-        Tell the caller we accept batch mode
-        """
+        """Tell the caller perspective accepts batch mode."""
         return True
 
     def allowSwap(self) -> bool:
-        """
-        Tell the caller we accept swapping data
-        """
+        """Tell the caller perspective accepts swapping data."""
         return True
 
     def setClosable(self, value: bool = True) -> None:
-        """
-        Allow outsiders close this widget
-        """
+        """Allow outsiders close this widget."""
         assert isinstance(value, bool)
         self._allowClose = value
 
     def isClosable(self) -> bool:
-        """
-        Allow outsiders close this widget
-        """
+        """Allow outsiders close this widget."""
         return self._allowClose
 
     def isSerializable(self) -> bool:
-        """
-        Tell the caller that this perspective writes its state
-        """
+        """Tell the caller that this perspective writes its state."""
         return True
 
     def closeEvent(self, event: QtCore.QEvent) -> None:
-        """
-        Overwrite QDialog close method to allow for custom widget close
-        """
+        """Overwrite QDialog close method to allow for custom widget close."""
+
         # Close report widgets before closing/minimizing main widget
         self.closeDMax()
         self.closeBatchResults()
@@ -247,9 +225,7 @@ class InversionWindow(QtWidgets.QTabWidget, Perspective):
     ######################################################################
 
     def getTabName(self, is_batch: bool = False) -> str:
-        """
-        Get the new tab name, based on the number of fitting tabs so far
-        """
+        """Get the new tab name, based on the number of fitting tabs so far."""
         page_name = "PrBatchPage" if is_batch else "PrPage"
         page_name = page_name + str(self.maxIndex)
         return page_name
@@ -258,9 +234,7 @@ class InversionWindow(QtWidgets.QTabWidget, Perspective):
     # GUI Interaction Events
 
     def help(self) -> None:
-        """
-        Open the P(r) Inversion help browser
-        """
+        """Open the P(r) Inversion help browser."""
         tree_location = "/user/qtgui/Perspectives/Inversion/pr_help.html"
 
         # Actual file anchor will depend on the combo box index
@@ -275,9 +249,9 @@ class InversionWindow(QtWidgets.QTabWidget, Perspective):
         self, data_item: list[QtGui.QStandardItem] | None = None, is_batch: bool = False, tab_index: int | None = None
     ) -> None:
         """
-        Assign new data set(s) to the P(r) perspective
-        Obtain a QStandardItem object and parse it to get Data1D/2D
-        Pass it over to the calculator
+        Assign new data set(s) to the P(r) perspective.
+        Obtain a QStandardItem object and parse it to get Data1D/2D.
+        Pass it over to the calculator.
         """
         assert data_item is not None
 
@@ -288,11 +262,6 @@ class InversionWindow(QtWidgets.QTabWidget, Perspective):
         if not isinstance(data_item[0], QtGui.QStandardItem):
             msg = "Incorrect type passed to the P(r) Perspective"
             raise AttributeError(msg)
-
-        #        if is_batch:
-        #            # Just create a new fit tab. No empty batchFit tabs
-        #            self.addData(data_item, is_batch=is_batch)
-        #            return
 
         items = [data_item] if (is_batch and len(data_item) > 1) else data_item
         for data in items:
@@ -322,9 +291,7 @@ class InversionWindow(QtWidgets.QTabWidget, Perspective):
                 self.addData(data=data, is_batch=is_batch, tab_index=tab_index)
 
     def swapData(self, data: QtGui.QStandardItem | None = None, tab_index: int | None = None) -> None:
-        """
-        Replace the data from the current tab
-        """
+        """Replace the data from the current tab."""
         if not isinstance(self.currentWidget(), InversionWidget):
             msg = "Current tab is not  an Inversion widget"
             raise TypeError(msg)
@@ -342,19 +309,17 @@ class InversionWindow(QtWidgets.QTabWidget, Perspective):
 
     @property
     def currentTab(self) -> InversionWidget:
-        """
-        Returns the tab widget currently shown
-        """
+        """Returns the tab widget currently shown."""
         return self.currentWidget()
 
     def currentTabDataId(self) -> list:
-        """
-        Returns the data ID of the current tab
-        """
+        """Returns the data ID of the current tab."""
         tab_id = [item.logic.data.id for item in self.currentTab.results]
         return tab_id
 
     def removeData(self, data_list: list[QtGui.QStandardItem]) -> None:
+        """Remove data from the perspective for requested data items."""
+
         # We need this list because we can't modify the tabs list while looping over it.
         tabs_to_remove: list[InversionWidget] = []
         for datum in data_list:
@@ -367,9 +332,7 @@ class InversionWindow(QtWidgets.QTabWidget, Perspective):
     def addData(
         self, data: QtGui.QStandardItem | None = None, is_batch: bool = False, tab_index: int | None = None
     ) -> None:
-        """
-        Add a new tab for passed data
-        """
+        """Add a new tab for passed data."""
 
         if tab_index is None:
             tab_index = self.maxIndex
@@ -377,10 +340,8 @@ class InversionWindow(QtWidgets.QTabWidget, Perspective):
             self.maxIndex = tab_index
 
         # Create tab
-        # tab = InversionWidget(parent=self.parent, data=data, tab_id=tab_index)
         tab_name = self.getTabName(is_batch=is_batch)
         tab = InversionWidget(self, self.parent, data, tab_index, tab_name)
-        # ObjectLibrary.addObject(tab_name, tab)
         icon = QtGui.QIcon()
         # Setting UP batch Mode for 1D data
         if is_batch:
@@ -397,14 +358,13 @@ class InversionWindow(QtWidgets.QTabWidget, Perspective):
         self.setCurrentWidget(tab)
 
     def updateFromParameters(self, params: dict) -> None:
+        """"Update the current tab from parameters"""
         inversion_widget = self.currentWidget()
         if isinstance(inversion_widget, InversionWidget):
             inversion_widget.updateFromParameters(params)
 
     def reset(self) -> None:
-        """
-        Reset the Inversion perspective to an empty state
-        """
+        """Reset the Inversion perspective to an empty state"""
         self.tabs.clear()
         self.clear()
         self.maxIndex = 1

--- a/src/sas/qtgui/Perspectives/Inversion/InversionPerspective.py
+++ b/src/sas/qtgui/Perspectives/Inversion/InversionPerspective.py
@@ -30,7 +30,7 @@ class InversionWindow(QtWidgets.QTabWidget, Perspective):
     ext = "pr"
 
     @property
-    def title(self):
+    def title(self) -> str:
         return "P(r) Inversion"
 
     def __init__(self, parent=None, data=None):
@@ -39,7 +39,7 @@ class InversionWindow(QtWidgets.QTabWidget, Perspective):
         self.setWindowTitle("P(r) Inversion Perspective")
 
         # Max index for adding new, non-clashing tab names
-        self.maxIndex = 1
+        self.maxIndex: int = 1
         # Needed for Batch inversion
         self.parent = parent
         self.communicator = GuiUtils.communicator
@@ -51,7 +51,7 @@ class InversionWindow(QtWidgets.QTabWidget, Perspective):
         self.setTabsClosable(True)
 
         # The window should not close
-        self._allowClose = False
+        self._allowClose: bool = False
 
         # Visible data items
         # current QStandardItem showing on the panel
@@ -59,17 +59,17 @@ class InversionWindow(QtWidgets.QTabWidget, Perspective):
 
         # Mapping for all data items
         # Dictionary mapping data to all parameters
-        self._dataList = {}
+        self._dataList: dict = {}
 
-        self.dataDeleted = False
+        self.dataDeleted: bool = False
 
         self.model = QtGui.QStandardItemModel(self)
         self.mapper = QtWidgets.QDataWidgetMapper(self)
 
         # Batch parameters
-        self.is_batch = False
+        self.is_batch: bool = False
         self.batchResultsWindow = None
-        self.batchResults = {}
+        self.batchResults: dict = {}
 
         self.logic = InversionLogic()
 
@@ -85,7 +85,7 @@ class InversionWindow(QtWidgets.QTabWidget, Perspective):
     ######################################################################
     # Batch Mode and Tab Functions
 
-    def resetTab(self, index):
+    def resetTab(self, index: int) -> None:
         """
         Adds a new tab and removes the last tab
         as a way of resetting the tabs
@@ -98,7 +98,7 @@ class InversionWindow(QtWidgets.QTabWidget, Perspective):
         # Remove the previous last tab
         self.tabCloses(index)
 
-    def tabCloses(self, index):
+    def tabCloses(self, index: int) -> None:
         """
         Update local bookkeeping on tab close
         """
@@ -107,7 +107,7 @@ class InversionWindow(QtWidgets.QTabWidget, Perspective):
             self.addData(None)
         self.closeTabByIndex(index)
 
-    def closeTabByIndex(self, index):
+    def closeTabByIndex(self, index: int) -> None:
         """
         Close/delete a tab with the given index.
         No checks on validity of the index.
@@ -120,7 +120,7 @@ class InversionWindow(QtWidgets.QTabWidget, Perspective):
             # The tab might have already been deleted previously
             pass
 
-    def closeTabByName(self, tab_name):
+    def closeTabByName(self, tab_name: str) -> None:
         """
         Given name of the tab - close it
         """
@@ -131,7 +131,7 @@ class InversionWindow(QtWidgets.QTabWidget, Perspective):
 
     ######################################################################
 
-    def serializeAll(self):
+    def serializeAll(self) -> dict:
         """
         Serialize the inversion state so data can be saved
         serialize all active inversion pages and return
@@ -147,18 +147,16 @@ class InversionWindow(QtWidgets.QTabWidget, Perspective):
                 _ = QtWidgets.QMessageBox.warning(
                     self,
                     "Batch Serialisation",
-                    """Saving of projects with batch inversion
-tabs is currently not supported. Support will be added in a later version of SasView but please note
-that in the meantime, these tabs will be excluded from the saved project.""",
+                    "Saving of projects with batch inversion tabs is currently not supported.Support will be added in a later version of SasView but please note that in the meantime, these tabs will be excluded from the saved project.",
                 )
             state.update(tab_state)
         return state
 
-    def serializeCurrentPage(self):
+    def serializeCurrentPage(self) -> tuple[dict, bool]:
         # serialize current (active) page
         return self.getSerializePage(self.currentIndex())
 
-    def getSerializePage(self, index=None) -> tuple[dict, bool]:
+    def getSerializePage(self, index: int | None = None) -> tuple[dict, bool]:
         """
         Serialize and return a dictionary of {tab_id: inversion-state}
         Return original dictionary if no data
@@ -181,11 +179,11 @@ that in the meantime, these tabs will be excluded from the saved project.""",
     # Base Perspective Class Definitions
 
     @property
-    def supports_reports(self):
+    def supports_reports(self) -> bool:
         return True
 
     @property
-    def supports_fitting(self):
+    def supports_fitting(self) -> bool:
         return False
 
     def allowBatch(self):
@@ -194,32 +192,32 @@ that in the meantime, these tabs will be excluded from the saved project.""",
         """
         return True
 
-    def allowSwap(self):
+    def allowSwap(self) -> bool:
         """
         Tell the caller we accept swapping data
         """
         return True
 
-    def setClosable(self, value=True):
+    def setClosable(self, value: bool = True) -> None:
         """
         Allow outsiders close this widget
         """
         assert isinstance(value, bool)
         self._allowClose = value
 
-    def isClosable(self):
+    def isClosable(self) -> bool:
         """
         Allow outsiders close this widget
         """
         return self._allowClose
 
-    def isSerializable(self):
+    def isSerializable(self) -> bool:
         """
         Tell the caller that this perspective writes its state
         """
         return True
 
-    def closeEvent(self, event):
+    def closeEvent(self, event: QtCore.QEvent) -> None:
         """
         Overwrite QDialog close method to allow for custom widget close
         """
@@ -238,17 +236,17 @@ that in the meantime, these tabs will be excluded from the saved project.""",
             # Maybe we should just minimize
             self.setWindowState(QtCore.Qt.WindowMinimized)
 
-    def closeDMax(self):
+    def closeDMax(self) -> None:
         if self.currentTab.dmaxWindow is not None:
             self.currentTab.dmaxWindow.close()
 
-    def closeBatchResults(self):
+    def closeBatchResults(self) -> None:
         if self.batchResultsWindow is not None:
             self.batchResultsWindow.close()
 
     ######################################################################
 
-    def getTabName(self, is_batch=False):
+    def getTabName(self, is_batch: bool = False) -> str:
         """
         Get the new tab name, based on the number of fitting tabs so far
         """
@@ -259,7 +257,7 @@ that in the meantime, these tabs will be excluded from the saved project.""",
     ######################################################################
     # GUI Interaction Events
 
-    def help(self):
+    def help(self) -> None:
         """
         Open the P(r) Inversion help browser
         """
@@ -273,7 +271,9 @@ that in the meantime, these tabs will be excluded from the saved project.""",
     ######################################################################
     # Response Actions
 
-    def setData(self, data_item=None, is_batch=False, tab_index=None):
+    def setData(
+        self, data_item: list[QtGui.QStandardItem] | None = None, is_batch: bool = False, tab_index: int | None = None
+    ) -> None:
         """
         Assign new data set(s) to the P(r) perspective
         Obtain a QStandardItem object and parse it to get Data1D/2D
@@ -321,7 +321,7 @@ that in the meantime, these tabs will be excluded from the saved project.""",
             else:
                 self.addData(data=data, is_batch=is_batch, tab_index=tab_index)
 
-    def swapData(self, data=None, tab_index=None):
+    def swapData(self, data: QtGui.QStandardItem | None = None, tab_index: int | None = None) -> None:
         """
         Replace the data from the current tab
         """
@@ -347,14 +347,14 @@ that in the meantime, these tabs will be excluded from the saved project.""",
         """
         return self.currentWidget()
 
-    def currentTabDataId(self):
+    def currentTabDataId(self) -> list:
         """
         Returns the data ID of the current tab
         """
         tab_id = [item.logic.data.id for item in self.currentTab.results]
         return tab_id
 
-    def removeData(self, data_list: list[QtGui.QStandardItem]):
+    def removeData(self, data_list: list[QtGui.QStandardItem]) -> None:
         # We need this list because we can't modify the tabs list while looping over it.
         tabs_to_remove: list[InversionWidget] = []
         for datum in data_list:
@@ -364,7 +364,9 @@ that in the meantime, these tabs will be excluded from the saved project.""",
         for to_remove in tabs_to_remove:
             self.closeTabByName(to_remove.tab_name)
 
-    def addData(self, data=None, is_batch=False, tab_index=None):
+    def addData(
+        self, data: QtGui.QStandardItem | None = None, is_batch: bool = False, tab_index: int | None = None
+    ) -> None:
         """
         Add a new tab for passed data
         """
@@ -394,12 +396,12 @@ that in the meantime, these tabs will be excluded from the saved project.""",
         self.maxIndex = max([tab.tab_id for tab in self.tabs], default=0) + 1
         self.setCurrentWidget(tab)
 
-    def updateFromParameters(self, params):
+    def updateFromParameters(self, params: dict) -> None:
         inversion_widget = self.currentWidget()
         if isinstance(inversion_widget, InversionWidget):
             inversion_widget.updateFromParameters(params)
 
-    def reset(self):
+    def reset(self) -> None:
         """
         Reset the Inversion perspective to an empty state
         """

--- a/src/sas/qtgui/Perspectives/Inversion/InversionPerspective.py
+++ b/src/sas/qtgui/Perspectives/Inversion/InversionPerspective.py
@@ -122,7 +122,11 @@ class InversionWindow(QtWidgets.QTabWidget, Perspective):
     ######################################################################
 
     def serializeAll(self) -> dict:
-        """Serialize the inversion state so data can be saved. Serialize all active inversion pages and return a dictionary: {data-id: {self.name: {inversion-state}}}"""
+        """Serialize the inversion state for all active inversion pages.
+
+        Returns a dictionary mapping data IDs to inversion state:
+        {data-id: {self.name: {inversion-state}}}.
+        """
         state = {}
         tab_ids = [tab.tab_id for tab in self.tabs]
         batch_warned = False
@@ -358,13 +362,13 @@ class InversionWindow(QtWidgets.QTabWidget, Perspective):
         self.setCurrentWidget(tab)
 
     def updateFromParameters(self, params: dict) -> None:
-        """"Update the current tab from parameters"""
+        """Update the current tab from parameters"""
         inversion_widget = self.currentWidget()
         if isinstance(inversion_widget, InversionWidget):
             inversion_widget.updateFromParameters(params)
 
     def reset(self) -> None:
-        """Reset the Inversion perspective to an empty state"""
+        """Reset the Inversion perspective to an empty state."""
         self.tabs.clear()
         self.clear()
         self.maxIndex = 1

--- a/src/sas/qtgui/Perspectives/Inversion/InversionPerspective.py
+++ b/src/sas/qtgui/Perspectives/Inversion/InversionPerspective.py
@@ -188,12 +188,12 @@ class InversionWindow(QtWidgets.QTabWidget, Perspective):
         return True
 
     def setClosable(self, value: bool = True) -> None:
-        """Allow outsiders close this widget."""
+        """Set the closability flag."""
         assert isinstance(value, bool)
         self._allowClose = value
 
     def isClosable(self) -> bool:
-        """Allow outsiders close this widget."""
+        """Tell the caller if the widget can be closed."""
         return self._allowClose
 
     def isSerializable(self) -> bool:
@@ -242,7 +242,7 @@ class InversionWindow(QtWidgets.QTabWidget, Perspective):
         tree_location = "/user/qtgui/Perspectives/Inversion/pr_help.html"
 
         # Actual file anchor will depend on the combo box index
-        # Note that we can be clusmy here, since bad current_fitter_id
+        # Note that we can be clumsy here, since bad current_fitter_id
         # will just make the page displayed from the top
         self.parent.showHelp(tree_location)
 

--- a/src/sas/qtgui/Perspectives/Inversion/InversionPerspective.py
+++ b/src/sas/qtgui/Perspectives/Inversion/InversionPerspective.py
@@ -18,13 +18,13 @@ from .InversionLogic import InversionLogic
 
 logger = logging.getLogger(__name__)
 
+
 class InversionWindow(QtWidgets.QTabWidget, Perspective):
     """
     The main window for the P(r) Inversion perspective.
     This is the main window where the tabs for each of the widgets are shown
 
     """
-
 
     name = "Inversion"
     ext = "pr"
@@ -33,9 +33,8 @@ class InversionWindow(QtWidgets.QTabWidget, Perspective):
     def title(self):
         return "P(r) Inversion"
 
-    def __init__(self, parent=None,data=None):
+    def __init__(self, parent=None, data=None):
         super().__init__()
-
 
         self.setWindowTitle("P(r) Inversion Perspective")
 
@@ -51,15 +50,12 @@ class InversionWindow(QtWidgets.QTabWidget, Perspective):
         self.tabs: list[InversionWidget] = []
         self.setTabsClosable(True)
 
-
         # The window should not close
         self._allowClose = False
 
         # Visible data items
         # current QStandardItem showing on the panel
         self._data = data
-
-
 
         # Mapping for all data items
         # Dictionary mapping data to all parameters
@@ -76,7 +72,6 @@ class InversionWindow(QtWidgets.QTabWidget, Perspective):
         self.batchResults = {}
 
         self.logic = InversionLogic()
-
 
         # The tabs need to be closeable
         self.setTabsClosable(True)
@@ -132,7 +127,8 @@ class InversionWindow(QtWidgets.QTabWidget, Perspective):
         for tab_index in range(len(self.tabs)):
             if self.tabText(tab_index) == tab_name:
                 self.tabCloses(tab_index)
-        pass # debug hook
+        pass  # debug hook
+
     ######################################################################
 
     def serializeAll(self):
@@ -148,9 +144,13 @@ class InversionWindow(QtWidgets.QTabWidget, Perspective):
             tab_state, warn_batch = self.getSerializePage(index)
             if not batch_warned and warn_batch:
                 batch_warned = True
-                _ = QtWidgets.QMessageBox.warning(self, "Batch Serialisation", """Saving of projects with batch inversion
+                _ = QtWidgets.QMessageBox.warning(
+                    self,
+                    "Batch Serialisation",
+                    """Saving of projects with batch inversion
 tabs is currently not supported. Support will be added in a later version of SasView but please note
-that in the meantime, these tabs will be excluded from the saved project.""")
+that in the meantime, these tabs will be excluded from the saved project.""",
+                )
             state.update(tab_state)
         return state
 
@@ -173,14 +173,12 @@ that in the meantime, these tabs will be excluded from the saved project.""")
             if tab.is_batch:
                 return {}, True
             tab_data = tab.getPage()
-            data_id = tab_data.pop('data_id', '')
-            state[data_id] = {'pr_params': tab_data}
+            data_id = tab_data.pop("data_id", "")
+            state[data_id] = {"pr_params": tab_data}
         return state, False
-
 
     ######################################################################
     # Base Perspective Class Definitions
-
 
     @property
     def supports_reports(self):
@@ -258,12 +256,8 @@ that in the meantime, these tabs will be excluded from the saved project.""")
         page_name = page_name + str(self.maxIndex)
         return page_name
 
-
-
-
     ######################################################################
     # GUI Interaction Events
-
 
     def help(self):
         """
@@ -276,25 +270,16 @@ that in the meantime, these tabs will be excluded from the saved project.""")
         # will just make the page displayed from the top
         self.parent.showHelp(tree_location)
 
-
-
-
-
-
-
     ######################################################################
     # Response Actions
 
     def setData(self, data_item=None, is_batch=False, tab_index=None):
-
         """
         Assign new data set(s) to the P(r) perspective
         Obtain a QStandardItem object and parse it to get Data1D/2D
         Pass it over to the calculator
         """
         assert data_item is not None
-
-
 
         if not isinstance(data_item, list):
             msg = "Incorrect type passed to the P(r) Perspective"
@@ -304,19 +289,17 @@ that in the meantime, these tabs will be excluded from the saved project.""")
             msg = "Incorrect type passed to the P(r) Perspective"
             raise AttributeError(msg)
 
-#        if is_batch:
-#            # Just create a new fit tab. No empty batchFit tabs
-#            self.addData(data_item, is_batch=is_batch)
-#            return
+        #        if is_batch:
+        #            # Just create a new fit tab. No empty batchFit tabs
+        #            self.addData(data_item, is_batch=is_batch)
+        #            return
 
-
-        items = [data_item] if (is_batch and len(data_item)>1) else data_item
+        items = [data_item] if (is_batch and len(data_item) > 1) else data_item
         for data in items:
             logic_data = GuiUtils.dataFromItem(data)
             if logic_data is not None and not isinstance(logic_data, Data1D):
                 msg = "Inversion cannot be computed with 2D data."
                 raise ValueError(msg)
-
 
             # Find the first unassigned tab.
             # If none, open a new tab.
@@ -324,25 +307,21 @@ that in the meantime, these tabs will be excluded from the saved project.""")
             tab_ids = [tab.tab_id for tab in self.tabs]
             if tab_index is not None:
                 if tab_index not in tab_ids:
-                    self.addData(data = data, is_batch=is_batch, tab_index=tab_index)
+                    self.addData(data=data, is_batch=is_batch, tab_index=tab_index)
                 else:
-                    self.setCurrentIndex(tab_index-1)
-                    self.swapData(data = data,tab_index=self.currentIndex())
+                    self.setCurrentIndex(tab_index - 1)
+                    self.swapData(data=data, tab_index=self.currentIndex())
                     return
-            #debug Batch mode, gives none Type has no attribute name
+            # debug Batch mode, gives none Type has no attribute name
             if not is_batch and np.any(available_tabs):
                 first_good_tab = available_tabs.index(True)
                 self.tabs[first_good_tab].data = data
-                self.tabs[first_good_tab].updateTab(data = data, tab_id=first_good_tab)
+                self.tabs[first_good_tab].updateTab(data=data, tab_id=first_good_tab)
 
             else:
-                self.addData(data = data, is_batch=is_batch, tab_index = tab_index)
+                self.addData(data=data, is_batch=is_batch, tab_index=tab_index)
 
-
-
-
-
-    def swapData(self, data = None, tab_index=None):
+    def swapData(self, data=None, tab_index=None):
         """
         Replace the data from the current tab
         """
@@ -359,10 +338,7 @@ that in the meantime, these tabs will be excluded from the saved project.""")
             raise RuntimeError(msg)
 
         self.currentTab.data = data
-        self.currentTab.updateTab(data = data, tab_id= tab_index)
-
-
-
+        self.currentTab.updateTab(data=data, tab_id=tab_index)
 
     @property
     def currentTab(self) -> InversionWidget:
@@ -389,7 +365,6 @@ that in the meantime, these tabs will be excluded from the saved project.""")
             self.closeTabByName(to_remove.tab_name)
 
     def addData(self, data=None, is_batch=False, tab_index=None):
-
         """
         Add a new tab for passed data
         """
@@ -403,13 +378,13 @@ that in the meantime, these tabs will be excluded from the saved project.""")
         # tab = InversionWidget(parent=self.parent, data=data, tab_id=tab_index)
         tab_name = self.getTabName(is_batch=is_batch)
         tab = InversionWidget(self, self.parent, data, tab_index, tab_name)
-        #ObjectLibrary.addObject(tab_name, tab)
+        # ObjectLibrary.addObject(tab_name, tab)
         icon = QtGui.QIcon()
         # Setting UP batch Mode for 1D data
         if is_batch:
             icon.addPixmap(QtGui.QPixmap("src/sas/qtgui/images/icons/layers.svg"))
         if data is not None:
-            tab.updateTab(data = data, tab_id=tab_index)
+            tab.updateTab(data=data, tab_id=tab_index)
 
         self.addTab(tab, icon, tab.tab_name)
         tab.enableButtons()

--- a/src/sas/qtgui/Perspectives/Inversion/InversionUtils.py
+++ b/src/sas/qtgui/Perspectives/Inversion/InversionUtils.py
@@ -1,31 +1,32 @@
 from sas.qtgui.Utilities.GuiUtils import enum
 
-WIDGETS = enum( 'W_FILENAME',               #0
-                'W_BACKGROUND_INPUT',             #1
-                'W_ESTIMATE',               #2
-                'W_MANUAL_INPUT',           #3
-                'W_Q_MIN',                   #4
-                'W_Q_MAX',                   #5
-                'W_SLIT_HEIGHT',            #6
-                'W_SLIT_WIDTH',             #7
-                'W_NO_TERMS',               #8
-                'W_NO_TERMS_SUGGEST',       #9
-                'W_REGULARIZATION',         #10
-                'W_REGULARIZATION_SUGGEST', #11
-                'W_MAX_DIST',               #12
-                'W_EXPLORE',                #13
-                # results
-                'W_RG',
-                'W_I_ZERO',
-                'W_BACKGROUND_OUTPUT',
-                'W_COMP_TIME',
-                'W_CHI_SQUARED',
-                'W_OSCILLATION',
-                'W_POS_FRACTION',
-                'W_SIGMA_POS_FRACTION',
-                # bottom buttons
-                'W_REMOVE',
-                'W_CALCULATE_ALL',
-                'W_CALCULATE_VISIBLE',
-                'W_HELP'
+WIDGETS = enum(
+    'W_FILENAME',
+    'W_BACKGROUND_INPUT',
+    'W_ESTIMATE',
+    'W_MANUAL_INPUT',
+    'W_Q_MIN',
+    'W_Q_MAX',
+    'W_SLIT_HEIGHT',
+    'W_SLIT_WIDTH',
+    'W_NO_TERMS',
+    'W_NO_TERMS_SUGGEST',
+    'W_REGULARIZATION',
+    'W_REGULARIZATION_SUGGEST',
+    'W_MAX_DIST',
+    'W_EXPLORE',
+    # results
+    'W_RG',
+    'W_I_ZERO',
+    'W_BACKGROUND_OUTPUT',
+    'W_COMP_TIME',
+    'W_CHI_SQUARED',
+    'W_OSCILLATION',
+    'W_POS_FRACTION',
+    'W_SIGMA_POS_FRACTION',
+    # bottom buttons
+    'W_REMOVE',
+    'W_CALCULATE_ALL',
+    'W_CALCULATE_VISIBLE',
+    'W_HELP'
 )

--- a/src/sas/qtgui/Perspectives/Inversion/UnitTesting/InversionPerspectiveTest.py
+++ b/src/sas/qtgui/Perspectives/Inversion/UnitTesting/InversionPerspectiveTest.py
@@ -1,4 +1,5 @@
 import logging
+from collections.abc import Generator
 
 import matplotlib as mpl
 import numpy as np
@@ -17,21 +18,21 @@ logger = logging.getLogger(__name__)
 
 
 class InversionTest:
-    """ Test the Inversion Perspective GUI """
+    """Test the Inversion Perspective GUI."""
 
     @pytest.fixture(autouse=True)
-    def widget(self, qapp, mocker):
-        '''Create/Destroy the InversionWindow'''
+    def widget(self, qapp, mocker) -> Generator[InversionWindow, None, None]:
+        """Create and destroy the InversionWindow for each test."""
 
-        class dummy_manager:
+        class DummyManager:
             HELP_DIRECTORY_LOCATION = "html"
             communicator = communicator
 
-        w = InversionWindow(parent=dummy_manager())
+        w = InversionWindow(parent=DummyManager())
         w._parent = QtWidgets.QMainWindow()
-        mocker.patch.object(w.currentTab, 'showBatchCalculationWindow')
-        mocker.patch.object(w.currentTab, 'startThread')
-        mocker.patch.object(w.currentTab, 'startThreadAll')
+        mocker.patch.object(w.currentTab, "showBatchCalculationWindow")
+        mocker.patch.object(w.currentTab, "startThread")
+        mocker.patch.object(w.currentTab, "startThreadAll")
         w.show()
 
         self.fakeData1 = GuiUtils.HashableStandardItem("A")
@@ -47,18 +48,17 @@ class InversionTest:
 
         yield w
 
-        """ Destroy the InversionWindow """
         w.setClosable(False)
         w.close()
 
-    def removeAllData(self, widget):
-        """ Cleanup method to restore widget to its base state """
+    def removeAllData(self, widget: InversionWindow) -> None:
+        """Cleanup method to restore widget to its base state."""
         while len(widget.currentTab.results) > 0:
             remove_me = list(widget._dataList.keys())
             widget.removeData(remove_me)
 
-    def baseGUIState(self, widget):
-        """ Testing base state of Inversion """
+    def baseGUIState(self, widget: InversionWindow) -> None:
+        """Assert the base GUI state of the Inversion perspective."""
         # base class information
         assert isinstance(widget, QtWidgets.QWidget)
         assert widget.windowTitle() == "P(r) Inversion Perspective"
@@ -92,16 +92,16 @@ class InversionTest:
         assert widget.currentTab.results[0].pr_plot is None
         assert widget.currentTab.results[0].data_plot is None
 
-    def baseBatchState(self, widget):
-        """ Testing the base batch fitting state """
+    def baseBatchState(self, widget: InversionWindow) -> None:
+        """Assert the base batch fitting state."""
         assert not widget.allowBatch()
         assert not widget.currentTab.is_batch
         assert not widget.currentTab.calculateAllButton.isEnabled()
         assert len(widget.batchResults) == 0
         widget.closeBatchResults()
 
-    def zeroDataSetState(self, widget):
-        """ Testing the base data state of the GUI """
+    def zeroDataSetState(self, widget: InversionWindow) -> None:
+        """Assert the base data state of the GUI with no data loaded."""
         # data variables
         assert widget._data is None
         # inputs
@@ -113,8 +113,8 @@ class InversionTest:
         assert widget.currentTab.noOfTermsInput.text() == "10"
         assert widget.currentTab.maxDistanceInput.text() == "180"
 
-    def oneDataSetState(self, widget):
-        """ Testing the base data state of the GUI """
+    def oneDataSetState(self, widget: InversionWindow) -> None:
+        """Assert the GUI state with exactly one data set loaded."""
         # Test the globals after first sent
         assert widget.currentTab.dataList.count() == 1
         # See that the buttons are now enabled properly
@@ -124,8 +124,8 @@ class InversionTest:
         assert widget.currentTab.removeButton.isEnabled()
         assert widget.currentTab.explorerButton.isEnabled()
 
-    def twoDataSetState(self, widget):
-        """ Testing the base data state of the GUI """
+    def twoDataSetState(self, widget: InversionWindow) -> None:
+        """Assert the GUI state with exactly two data sets loaded."""
         # Test the globals after first sent
         assert widget.currentTab.dataList.count() == 1
         # See that the buttons are now enabled properly
@@ -135,15 +135,15 @@ class InversionTest:
         assert widget.currentTab.removeButton.isEnabled()
         assert widget.currentTab.explorerButton.isEnabled()
 
-    def testDefaults(self, widget):
-        """ Test the GUI in its default state """
+    def testDefaults(self, widget: InversionWindow) -> None:
+        """Test the GUI in its default state."""
         self.baseGUIState(widget)
         self.zeroDataSetState(widget)
         self.baseBatchState(widget)
         self.removeAllData(widget)
 
-    def notestAllowBatch(self, widget):
-        """ Batch P(r) Tests """
+    def notestAllowBatch(self, widget: InversionWindow) -> None:
+        """Batch P(r) tests."""
         self.baseBatchState(widget)
         widget.setData([self.fakeData1])
         self.oneDataSetState(widget)
@@ -173,8 +173,8 @@ class InversionTest:
         self.removeAllData(widget)
         self.baseBatchState(widget)
 
-    def testSetData(self, widget):
-        """ Check if sending data works as expected """
+    def testSetData(self, widget: InversionWindow) -> None:
+        """Check if sending data works as expected."""
         self.zeroDataSetState(widget)
         widget.setData([self.fakeData1])
         self.oneDataSetState(widget)
@@ -187,8 +187,8 @@ class InversionTest:
         self.removeAllData(widget)
 
     @pytest.mark.skip(reason="2022-09 already broken - causes Qt event loop exception")
-    def testRemoveData(self, widget):
-        """ Test data removal from widget """
+    def testRemoveData(self, widget: InversionWindow) -> None:
+        """Test data removal from widget."""
         widget.setData([self.fakeData1, self.fakeData2])
         self.twoDataSetState(widget)
         # Remove data 0
@@ -197,8 +197,8 @@ class InversionTest:
         self.removeAllData(widget)
 
     @pytest.mark.skip(reason="2026-02: Freezing on launch")
-    def testClose(self, widget):
-        """ Test methods related to closing the window """
+    def testClose(self, widget: InversionWindow) -> None:
+        """Test methods related to closing the window."""
         assert not widget.isClosable()
         widget.close()
         assert widget.isMinimized()
@@ -213,8 +213,8 @@ class InversionTest:
         assert widget.isClosable()
         self.removeAllData(widget)
 
-    def testSetCurrentData(self, widget):
-        """ test current data setter """
+    def testSetCurrentData(self, widget: InversionWindow) -> None:
+        """Test current data setter."""
         widget.setData([self.fakeData1, self.fakeData2])
 
         # Set the ref to none
@@ -228,8 +228,8 @@ class InversionTest:
         assert widget._data == self.fakeData1
         self.removeAllData(widget)
 
-    def testModelChanged(self, widget):
-        """ Test setting the input and the model and vice-versa """
+    def testModelChanged(self, widget: InversionWindow) -> None:
+        """Test setting the input and the model and vice-versa."""
         # Initial values
         assert widget.currentTab.currentResult.calculator.dmax == 180.0
         assert widget.currentTab.currentResult.calculator.q_max == np.inf
@@ -265,8 +265,8 @@ class InversionTest:
         self.removeAllData(widget)
 
     @pytest.mark.xfail(reason="2026-02: Throwing error")
-    def testOpenExplorerWindow(self, widget):
-        """ open Dx window """
+    def testOpenExplorerWindow(self, widget: InversionWindow) -> None:
+        """Open Dmax window."""
         assert widget.currentTab.dmaxWindow is None
         assert not widget.currentTab.explorerButton.isEnabled()
         widget.currentTab.openExplorerWindow()
@@ -274,9 +274,9 @@ class InversionTest:
         assert widget.currentTab.dmaxWindow.isVisible()
         assert widget.currentTab.dmaxWindow.windowTitle() == "Dmax Explorer"
 
-    def testSerialization(self, widget):
-        """ Serialization routines """
-        assert hasattr(widget, 'isSerializable')
+    def testSerialization(self, widget: InversionWindow) -> None:
+        """Test serialization routines."""
+        assert hasattr(widget, "isSerializable")
         assert widget.isSerializable()
         widget.setData([self.fakeData1])
         self.oneDataSetState(widget)
@@ -286,15 +286,15 @@ class InversionTest:
         state_one, _ = widget.serializeCurrentPage()
         page = widget.currentTab.getPage()
         # Pull out params from state
-        params = state_all[data_id]['pr_params']
+        params = state_all[data_id]["pr_params"]
         # Tests
         assert len(state_all) == len(state_one)
         assert len(state_all) == 1
         # getPage should include an extra param 'data_id' removed by serialize
         assert len(params) != len(page)
         assert len(params) == 21
-        assert params.get('data_id', None) is None
-        assert page.get('data_id', None) is not None
-        assert params.get('alpha', None) is not None
-        assert params.get('alpha', None) == page.get('alpha', None)
-        assert np.isnan(params.get('rg'))
+        assert params.get("data_id", None) is None
+        assert page.get("data_id", None) is not None
+        assert params.get("alpha", None) is not None
+        assert params.get("alpha", None) == page.get("alpha", None)
+        assert np.isnan(params.get("rg"))

--- a/src/sas/sascalc/pr/invertor.py
+++ b/src/sas/sascalc/pr/invertor.py
@@ -1,6 +1,7 @@
 import logging
 import math
 import time
+from collections.abc import Callable
 from copy import copy
 from typing import TYPE_CHECKING
 
@@ -22,6 +23,7 @@ Q_MAX_INPUT = 0.0
 MAX_DIST = 140.0
 
 logger = logging.getLogger(__name__)
+
 
 def help():
     """
@@ -58,91 +60,100 @@ def help():
 
     return info_txt
 
-class Invertor:
 
+class Invertor:
     def __init__(self, logic: "InversionLogic"):
         self.init_default_values()
         self.logic = logic
 
     # TODO: Add types.
     def init_default_values(self):
+        """Initialize default values for the invertor."""
         ## Chisqr of the last computation
-        self.chi2 = 0
+        self.chi2: float = 0
         ## Time elapsed for last computation
-        self.elapsed = 0
+        self.elapsed: float = 0
         ## Alpha to get the reg term the same size as the signal
-        self.suggested_alpha = 0.0
+        self.suggested_alpha: float = 0.0
         ## Last number of base functions used
-        self.nfunc = 10
+        self.nfunc: int = 10
         ## Last output values
-        self.out = None
+        self.out: npt.NDArray[np.float64] | None = None
         ## Last errors on output values
-        self.cov = None
+        self.cov: npt.NDArray[np.float64] | None = None
         ## Background value
-        self.background = 0
+        self.background: float = 0
         ## TODO: My suspicion is that this'll go.
         ## Information dictionary for application use
-        self.info = {}
+        self.info: dict = {}
 
         # Stuff that was on p_invertor
 
-        #Maximum distance between any two points in the system
-        self.dmax = 180
-        #Minimum q to include in inversion
-        self.q_min = 0
-        #Maximum q to include in inversion
-        self.q_max = np.inf
-        #Flag for whether or not to evaluate a constant background
-        #while inverting
-        self.est_bck = True
+        # Maximum distance between any two points in the system
+        self.dmax: float = 180.0
+        # Minimum q to include in inversion
+        self.q_min: float = 0.0
+        # Maximum q to include in inversion
+        self.q_max: float = np.inf
+        # Flag for whether or not to evaluate a constant background
+        # while inverting
+        self.est_bck: bool = True
         # TODO: Is there a reason this is called alpha, and not just regularization.
-        self.alpha = REGULARIZATION
-        #Slit height in units of q [A-1]
-        self.slit_height = 0.0
-        #Slit width in units of q [A-1]
-        self.slit_width = 0.0
+        self.alpha: float = REGULARIZATION
+        # Slit height in units of q [A-1]
+        self.slit_height: float = 0.0
+        # Slit width in units of q [A-1]
+        self.slit_width: float = 0.0
 
         # Stuff I've added that wasn't previously in the calculator.
-        self.noOfTerms = NUMBER_OF_TERMS
+        self.noOfTerms: int = NUMBER_OF_TERMS
 
     @property
     def x(self) -> npt.NDArray[np.float64]:
+        """Returns the x values of the data to be inverted."""
         return self.logic.data.x
 
     @property
     def y(self) -> npt.NDArray[np.float64]:
+        """Returns the y values of the data to be inverted."""
         return self.logic.data.y
 
     @property
     def err(self) -> npt.NDArray[np.float64]:
+        """Returns the error values of the data to be inverted."""
         return self.logic.data.dy
 
     @property
     def npoints(self) -> int:
+        """Returns the number of x values in the data to be inverted."""
         return len(self.x)
 
     @property
     def ny(self) -> int:
+        """Returns the number of y values in the data to be inverted."""
         return len(self.y)
 
     @property
     def nerr(self) -> int:
+        """Returns the number of error values in the data to be inverted."""
         return len(self.err)
 
     def is_valid(self) -> bool:
+        """Check whether the number of x, y, and error values are all the same."""
         return self.npoints == self.ny and self.npoints == self.nerr
 
     def clone(self) -> "Invertor":
+        """Returns a copy of the invertor."""
         return copy(self)
 
-    def lstsq(self, nfunc=5, nr=20):
+    def lstsq(self, nfunc: int = 5, nr: int = 20) -> tuple[npt.NDArray[np.float64], npt.NDArray[np.float64]]:
         """
-        The problem is solved by posing the problem as  Ax = b,
+        The problem is solved by posing the problem as Ax = b,
         where x is the set of coefficients we are looking for.
 
         Npts is the number of points.
 
-        In the following i refers to the ith base function coefficient.
+        In the following, i refers to the ith base function coefficient.
         The matrix has its entries j in its first Npts rows set to ::
 
             A[i][j] = (Fourier transformed base function for point j)
@@ -162,25 +173,27 @@ class Invertor:
 
         The result is found by using scipy.linalg.basic.lstsq to invert
         the matrix and find the coefficients x.
+        If the result does not allow us to compute the covariance matrix,
+        a matrix filled with zeros will be returned.
 
         :param nfunc: number of base functions to use.
         :param nr: number of r points to evaluate the 2nd derivative at for the reg. term.
 
-        If the result does not allow us to compute the covariance matrix,
-        a matrix filled with zeros will be returned.
-
+        :return: c_out, c_cov - the coefficients with covariance matrix
         """
+
         # Note: To make sure an array is contiguous:
         # blah = np.ascontiguousarray(blah_original)
         # ... before passing it to C
-        if self.is_valid() < 0:
-            msg = "Invertor: invalid data; incompatible data lengths."
-            raise RuntimeError(msg)
+        if not self.is_valid():
+            # msg = "Invertor: invalid data; incompatible data lengths."
+            # raise RuntimeError(msg)
+            logger.error("Invertor: invalid data; incompatible data lengths.")
 
         self.nfunc = nfunc
         # a -- An M x N matrix.
         # b -- An M x nrhs matrix or M vector.
-        npts = len(self.x)
+        npts = self.npoints
         nq = nr
         sqrt_alpha = math.sqrt(math.fabs(self.alpha))
         if sqrt_alpha < 0.0:
@@ -188,28 +201,23 @@ class Invertor:
 
         # If we need to fit the background, add a term
         if self.est_bck:
-            nfunc_0 = nfunc
             nfunc += 1
 
-        a = np.zeros([npts + nq, nfunc])
-        b = np.zeros(npts + nq)
-        err = np.zeros([nfunc, nfunc])
+        a = np.zeros((npts + nq, nfunc))
+        b = np.zeros((npts + nq,))
+        err = np.zeros((nfunc, nfunc))
 
         # Construct the a matrix and b vector that represent the problem
         t_0 = time.time()
         try:
             a, b = self._get_matrix(nfunc, nq)
         except Exception as exc:
-            raise RuntimeError("Invertor: could not invert I(Q)\n  %s" % str(exc))
+            # raise RuntimeError("Invertor: could not invert I(Q)\n  %s" % str(exc))
+            logger.error("Invertor: could not invert I(Q)\n  %s" % str(exc))
 
         # Perform the inversion (least square fit)
-        # CRUFT: numpy>=1.14.0 allows rcond=None for the following default
-
-        rcond = np.finfo(float).eps * max(a.shape)
-        if rcond is None:
-            rcond = -1
-        c, chi2, _, _ = lstsq(a, b, rcond=rcond)
-        chi2 = chi2[0] if chi2.shape == (1,) else -1.0
+        c, residuals, _, _ = lstsq(a, b, rcond=None)
+        chi2 = residuals[0] if residuals.shape == (1,) else -1.0
         self.chi2 = chi2
 
         # Get the covariance matrix, defined as inv_cov = a_transposed * a
@@ -236,9 +244,10 @@ class Invertor:
             self.out = c
             self.cov = err
         else:
+            # c is a vector of length nfunc+1; background is the first term, rest are the coefficients
             self.background = c[0]
 
-            err_0 = np.zeros([nfunc, nfunc])
+            err_0 = np.zeros((nfunc, nfunc))
             c_0 = np.zeros(nfunc)
 
             c_0[:-1] = c[1:]
@@ -252,41 +261,15 @@ class Invertor:
 
         return self.out, self.cov
 
-    def invert(self, nfunc=10, nr=20):
+    def invert(self, nfunc: int = 10, nr: int = 20) -> tuple[npt.NDArray[np.float64], npt.NDArray[np.float64]]:
         """
-        Perform inversion to P(r)
-
-        The problem is solved by posing the problem as  Ax = b,
-        where x is the set of coefficients we are looking for.
-
-        Npts is the number of points.
-
-        In the following i refers to the ith base function coefficient.
-        The matrix has its entries j in its first Npts rows set to ::
-
-            A[i][j] = (Fourier transformed base function for point j)
-
-        We then choose a number of r-points, n_r, to evaluate the second
-        derivative of P(r) at. This is used as our regularization term.
-        For a vector r of length n_r, the following n_r rows are set to ::
-
-            A[i+Npts][j] = (2nd derivative of P(r), d**2(P(r))/d(r)**2, evaluated at r[j])
-
-        The vector b has its first Npts entries set to ::
-
-            b[j] = (I(q) observed for point j)
-
-        The following n_r entries are set to zero.
-
-        The result is found by using scipy.linalg.basic.lstsq to invert
-        the matrix and find the coefficients x.
+        Perform inversion to P(r).
 
         :param nfunc: number of base functions to use.
         :param nr: number of r points to evaluate the 2nd derivative at for the reg. term.
-        :return: c_out, c_cov - the coefficients with covariance matrix
+
+        :return: c_out, c_cov - the coefficients with covariance matrix.
         """
-        # Reset the background value before proceeding
-        # self.background = 0.0
         if not self.est_bck:
             self.logic.data.y -= self.background
         out, cov = self.lstsq(nfunc, nr=nr)
@@ -294,30 +277,9 @@ class Invertor:
             self.logic.data.y += self.background
         return out, cov
 
-    def iq(self, pars, q):
+    def iq(self, pars: npt.ArrayLike, q: npt.ArrayLike) -> np.float64 | npt.NDArray[np.float64]:
         """
-        Function to call to evaluate the scattering intensity.
-
-        :param pars: c-parameters
-        :param q: q, scalar or vector.
-
-        :return: I(q)
-        """
-        from . import calc
-        q = np.float64(q)
-        pars = np.float64(pars)
-        pars = np.atleast_1d(pars)
-        q = np.atleast_1d(q)
-
-        iq_val = calc.iq(pars, self.dmax, q) + self.background
-        if iq_val.shape[0] == 1:
-            return iq_val[0]
-        return iq_val
-
-    def get_iq_smeared(self, pars, q):
-        """
-        Function to call to evaluate the scattering intensity.
-        The scattering intensity is slit-smeared.
+        Calculates the scattering intensity I(q) from the expansion coefficients.
 
         :param pars: c-parameters
         :param q: q, scalar or vector.
@@ -325,74 +287,81 @@ class Invertor:
         :return: I(q), either scalar or vector depending on q.
         """
         from . import calc
-        q = np.float64(q)
-        q = np.atleast_1d(q)
-        pars = np.float64(pars)
 
+        pars = np.atleast_1d(np.asarray(pars, dtype=np.float64))
+        q = np.atleast_1d(np.asarray(q, dtype=np.float64))
 
-        npts = 21
-        iq_val = calc.iq_smeared(pars, q, self.dmax, self.slit_height, self.slit_width, npts)
-        #If q was a scalar
+        iq_val = calc.iq(pars, self.dmax, q) + self.background
         if iq_val.shape[0] == 1:
             return iq_val[0]
         return iq_val
 
-    def pr(self, pars, r):
+    def get_iq_smeared(self, pars: npt.ArrayLike, q: npt.ArrayLike) -> np.float64 | npt.NDArray[np.float64]:
         """
-        Function to call to evaluate P(r).
+        Calculates the slit-smeared scattering intensity I(q) from the expansion coefficients.
+
+        :param pars: c-parameters
+        :param q: q, scalar or vector.
+
+        :return: I(q), either scalar or vector depending on q.
+        """
+        from . import calc
+
+        pars = np.atleast_1d(np.asarray(pars, dtype=np.float64))
+        q = np.atleast_1d(np.asarray(q, dtype=np.float64))
+
+        npts = 21
+        iq_val = calc.iq_smeared(pars, q, self.dmax, self.slit_height, self.slit_width, npts)
+
+        if iq_val.shape[0] == 1:
+            return iq_val[0]
+        return iq_val
+
+    def pr(self, pars: npt.ArrayLike, r: npt.ArrayLike) -> np.float64 | npt.NDArray[np.float64]:
+        """
+        Evaluates P(r).
 
         :param pars: c-parameters.
         :param r: r-value to evaluate P(r) at.
 
-        :return: P(r)
+        :return: P(r).
         """
         from . import calc
-        r = np.float64(r)
-        pars = np.float64(pars)
-        pars = np.atleast_1d(pars)
-        r = np.atleast_1d(r)
+
+        pars = np.atleast_1d(np.asarray(pars, dtype=np.float64))
+        r = np.atleast_1d(np.asarray(r, dtype=np.float64))
+
         pr_val = calc.pr(pars, self.dmax, r)
+
         if len(pr_val) == 1:
-            #scalar
             return pr_val[0]
         return pr_val
 
-    def get_pr_err(self, pars, pars_err, r):
+    def pr_err(self, c: npt.ArrayLike, c_cov: npt.ArrayLike | None, r: npt.ArrayLike) -> tuple[np.float64, np.float64]:
         """
-        Function to call to evaluate P(r) with errors.
+        Returns the value of P(r) for a given r, and base function coefficients, with error.
 
-        :param pars: c-parameters.
-        :param pars_err: pars_err.
-        :param r: r-value.
+        :param c: base function coefficients.
+        :param c_cov: covariance matrix of the base function coefficients.
+            If None, no error will be calculated.
+        :param r: r-value(s) at which P(r) is evaluated.
 
         :return: (P(r), dP(r))
         """
         from . import calc
-        pars = np.atleast_1d(np.float64(pars))
-        r = np.atleast_1d(np.float64(r))
 
-        if pars_err is None:
+        pars = np.atleast_1d(np.asarray(c, dtype=np.float64))
+        r = np.atleast_1d(np.asarray(r, dtype=np.float64))
+
+        if c_cov is None:
             return calc.pr(pars, self.dmax, r), 0.0
-        else:
-            pars_err = np.float64(pars_err)
-            return calc.pr_err(pars, pars_err, self.dmax, r)
 
-    def pr_err(self, c, c_cov, r):
-        """
-        Returns the value of P(r) for a given r, and base function
-        coefficients, with error.
+        cov = np.ascontiguousarray(np.asarray(c_cov, dtype=np.float64))
+        return calc.pr_err(pars, cov, self.dmax, r)
 
-        :param c: base function coefficients
-        :param c_cov: covariance matrice of the base function coefficients
-        :param r: r-value to evaluate P(r) at
-
-        :return: P(r)
-
-        """
-        c_cov = np.ascontiguousarray(c_cov)
-        return self.get_pr_err(c, c_cov, r)
-
-    def basefunc_ft(self, d_max, n, q):
+    def basefunc_ft(
+        self, d_max: float, n: int, q: float | npt.NDArray[np.float64]
+    ) -> np.float64 | npt.NDArray[np.float64]:
         """
         Returns the value of the nth Fourier transformed base function.
 
@@ -400,21 +369,22 @@ class Invertor:
         :param n: n.
         :param q: q, scalar or vector.
 
-        :return: nth Fourier transformed base function, evaluated at q.
+        :return: nth Fourier transformed base function, evaluated at q,
+            as a scalar or vector depending on q.
         """
         from . import calc
+
         d_max = np.float64(d_max)
         n = int(n)
-        q = np.float64(q)
-        q = np.atleast_1d(q)
+        q = np.atleast_1d(np.asarray(q, dtype=np.float64))
+
         ortho_val = calc.ortho_transformed(q, d_max, n)
 
         if ortho_val.shape[0] == 1:
-            #If the q input was scalar.
             return ortho_val[0]
         return ortho_val
 
-    def oscillations(self, pars):
+    def oscillations(self, pars: npt.ArrayLike) -> float:
         """
         Returns the value of the oscillation figure of merit for
         the given set of coefficients. For a sphere, the oscillation
@@ -424,15 +394,18 @@ class Invertor:
         :return: oscillation figure of merit.
         """
         from . import calc
-        nslice = 100
-        pars = np.float64(pars)
-        pars = np.atleast_1d(pars)
+
+        nslice: int = 100
+        pars = np.atleast_1d(np.asarray(pars, dtype=np.float64))
 
         oscill = calc.reg_term(pars, self.dmax, nslice)
         norm = calc.int_pr_square(pars, self.dmax, nslice)
-        return 0 if norm == 0 else np.sqrt(oscill/norm) / np.pi * self.dmax
 
-    def get_peaks(self, pars):
+        if norm == 8:
+            return 0
+        return np.sqrt(oscill / norm) / np.pi * self.dmax
+
+    def get_peaks(self, pars: npt.ArrayLike) -> int:
         """
         Returns the number of peaks in the output P(r) distribution
         for the given set of coefficients.
@@ -441,13 +414,14 @@ class Invertor:
         :return: number of P(r) peaks.
         """
         from . import calc
-        nslice = 100
-        pars = np.float64(pars)
+
+        nslice: int = 100
+        pars = np.asarray(pars, dtype=np.float64)
         count = calc.npeaks(pars, self.dmax, nslice)
 
         return count
 
-    def get_positive(self, pars):
+    def get_positive(self, pars: npt.ArrayLike) -> float:
         """
         Returns the fraction of P(r) that is positive over
         the full range of r for the given set of coefficients.
@@ -456,14 +430,14 @@ class Invertor:
         :return: fraction of P(r) that is positive.
         """
         from . import calc
-        nslice = 100
-        pars = np.float64(pars)
-        pars = np.atleast_1d(pars)
+
+        nslice: int = 100
+        pars = np.atleast_1d(np.asarray(pars, dtype=np.float64))
         fraction = calc.positive_integral(pars, self.dmax, nslice)
 
         return fraction
 
-    def get_pos_err(self, pars, pars_err):
+    def get_pos_err(self, pars: npt.ArrayLike, pars_err: npt.ArrayLike) -> float:
         """
         Returns the fraction of P(r) that is 1 standard deviation
         above zero over the full range of r for the given set of coefficients.
@@ -474,30 +448,32 @@ class Invertor:
         :return: fraction of P(r) that is positive.
         """
         from . import calc
-        nslice = 51
-        pars = np.float64(pars)
-        pars = np.atleast_1d(pars)
-        pars_err = np.float64(pars_err)
+
+        nslice: int = 51
+        pars = np.atleast_1d(np.asarray(pars, dtype=np.float64))
+        pars_err = np.asarray(pars_err, dtype=np.float64)
+
         fraction = calc.positive_errors(pars, pars_err, self.dmax, nslice)
 
         return fraction
 
-    def rg(self, pars):
+    def rg(self, pars: npt.ArrayLike) -> float:
         """
-        Returns the value of the radius of gyration Rg.
+        Returns the value of the radius of gyration, Rg.
 
         :param pars: c-parameters.
-        :return: Rg.
+        :return: Rg, the radius of gyration.
         """
         from . import calc
-        nslice = 101
-        pars = np.float64(pars)
-        pars = np.atleast_1d(pars)
+
+        nslice: int = 101
+        pars = np.atleast_1d(np.asarray(pars, dtype=np.float64))
+
         val = calc.rg(pars, self.dmax, nslice)
 
         return val
 
-    def iq0(self, pars):
+    def iq0(self, pars: npt.ArrayLike) -> float:
         """
         Returns the value of I(q=0).
 
@@ -505,72 +481,75 @@ class Invertor:
         :return: I(q=0)
         """
         from . import calc
-        nslice = 101
-        pars = np.float64(pars)
-        pars = np.atleast_1d(pars)
+
+        nslice: int = 101
+        pars = np.atleast_1d(np.asarray(pars, dtype=np.float64))
+
         val = np.float64(4.0 * np.pi * calc.int_pr(pars, self.dmax, nslice))
 
         return val
 
-    def accept_q(self, q):
+    def accept_q(self, q: npt.ArrayLike) -> bool | npt.NDArray[np.bool_]:
         """
         Check whether a q-value is within acceptable limits.
 
-        :return: 1 if accepted, 0 if rejected.
+        :return: Boolean or boolean array indicating acceptance.
+            True where q is within [q_min, q_max].
         """
         if self.q_min <= 0 and self.q_max <= 0:
             return True
         return (q >= self.q_min) & (q <= self.q_max)
 
-    def check_for_zero(self, x):
+    def check_for_zero(self, x: npt.ArrayLike) -> bool:
+        """
+        Check whether any value in the array is zero.
+
+        :param x: array to check.
+        :return: True if any value in x is zero, False otherwise.
+        """
         return (x == 0).any()
 
-    def estimate_numterms(self, isquit_func=None):
+    def estimate_numterms(self, isquit_func: Callable | None = None):
         """
-        Returns a reasonable guess for the
-        number of terms
+        Returns a reasonable guess for the number of terms.
 
-        :param isquit_func:
-          reference to thread function to call to check whether the computation needs to
-          be stopped.
+        :param isquit_func: reference to thread function
+            to call to check whether the computation needs to be stopped.
 
-        :return: number of terms, alpha, message
-
+        :return: number of terms, alpha, message.
         """
         from .num_term import NTermEstimator
+
         estimator = NTermEstimator(self.clone())
         try:
             return estimator.num_terms(isquit_func)
         except Exception as exc:
-            # If we fail, estimate alpha and return the default
-            # number of terms
+            # If we fail, estimate alpha and return the default  number of terms
             best_alpha, _, _ = self.estimate_alpha(self.nfunc)
             logger.warning("Invertor.estimate_numterms: %s" % exc)
             return self.nfunc, best_alpha, "Could not estimate number of terms"
 
-    def estimate_alpha(self, nfunc):
+    def estimate_alpha(self, nfunc: int) -> tuple[float, str | None, float]:
         """
-        Returns a reasonable guess for the
-        regularization constant alpha
+        Returns a reasonable guess for the regularization constant, alpha.
 
         :param nfunc: number of terms to use in the expansion.
 
         :return: alpha, message, elapsed
-
-        where alpha is the estimate for alpha,
-        message is a message for the user,
-        elapsed is the computation time
+            where, alpha is the estimate for alpha,
+            message is a message for the user,
+            elapsed is the computation time
         """
-        #import time
+        message = None
+        elapsed: float = 0.0
+
         try:
             pr = self.clone()
 
             # T_0 for computation time
             starttime = time.time()
-            elapsed = 0
 
-            # If the current alpha is zero, try
-            # another value
+            # If the current alpha is zero, try another value
             if pr.alpha <= 0:
                 pr.alpha = 0.0001
 
@@ -586,15 +565,10 @@ class Invertor:
             out, _ = pr.invert(nfunc)
 
             npeaks = pr.get_peaks(out)
-            # if more than one peak to start with
-            # just return the estimate
+            # if more than one peak to start with, just return the estimate
             if npeaks > 1:
-                #message = "Your P(r) is not smooth,
-                #please check your inversion parameters"
-                message = None
                 return pr.suggested_alpha, message, elapsed
             else:
-
                 # Look at smaller values
                 # We assume that for the suggested alpha, we have 1 peak
                 # if not, send a message to change parameters
@@ -612,42 +586,32 @@ class Invertor:
                     best_alpha = pr.alpha
 
                 # If we didn't find a turning point for alpha and
-                # the initial alpha already had only one peak,
-                # just return that
-                if not found and initial_peaks == 1 and \
-                    initial_alpha < best_alpha:
+                # the initial alpha already had only one peak, just return that
+                if not found and initial_peaks == 1 and initial_alpha < best_alpha:
                     best_alpha = initial_alpha
 
                 # Check whether the size makes sense
-                message = ''
-
-                if not found:
-                    message = None
-                elif best_alpha >= 0.5 * pr.suggested_alpha:
-                    # best alpha is too big, return a
-                    # reasonable value
-                    message = "The estimated alpha for your system is too "
-                    message += "large. "
+                if found and (best_alpha >= 0.5 * pr.suggested_alpha):
+                    # best alpha is too big, return a reasonable value
+                    message = "The estimated alpha for your system is too large."
                     message += "Try increasing your maximum distance."
 
                 return best_alpha, message, elapsed
-
         except Exception as exc:
             message = "Invertor.estimate_alpha: %s" % exc
             return 0, message, elapsed
 
-    def _get_matrix(self, nfunc, nr):
+    def _get_matrix(self, nfunc: int, nr: int) -> tuple[npt.NDArray[np.float64], npt.NDArray[np.float64]]:
         """
         Returns A matrix and b vector for least square problem.
 
         :param nfunc: number of base functions.
         :param nr: number of r-points used when evaluating reg term.
-        :param a: A array to fill.
-        :param b: b vector to fill.
 
-        :return: 0
+        :return: A, b - the A matrix and b vector for least square problem.
         """
         from . import calc
+
         nfunc = int(nfunc)
         nr = int(nr)
         a_obj = np.zeros([self.npoints + nr, nfunc])
@@ -655,83 +619,86 @@ class Invertor:
 
         sqrt_alpha = np.sqrt(math.fabs(self.alpha))
         pi = np.pi
-        offset = (1, 0)[self.est_bck == 1]
+        offset: int = (1, 0)[self.est_bck == 1]
 
         if self.check_for_zero(self.err):
-            raise RuntimeError("Pinvertor.get_matrix: Some I(Q) points have no error.")
+            # raise RuntimeError("Pinvertor.get_matrix: Some I(Q) points have no error.")
+            logger.error("Pinvertor.get_matrix: Some I(Q) points have no error.")
 
-        #Compute A
-        #Whether or not to use ortho_transformed_smeared.
+        # Compute A
+        # Whether or not to use ortho_transformed_smeared.
         smeared = False
         if self.slit_width > 0 or self.slit_height > 0:
             smeared = True
 
-        npts = 21
-        #Get accept_q vector across all q.
+        npts: int = 21
+        # Get accept_q vector across all q.
         q_accept_x = self.accept_q(self.x)
 
         if isinstance(q_accept_x, bool):
-            #In the case of q_min and q_max <= 0, so returns scalar, and returns True
+            # In the case of q_min and q_max <= 0, so returns scalar, and returns True
             q_accept_x = np.ones(self.npoints, dtype=bool)
-        #The x and a that will be used for the first part of 'a' calculation, given to ortho_transformed
+        # The x and a that will be used for the first part of 'a' calculation, given to ortho_transformed
         x_use = self.x[q_accept_x]
-        a_use = a_obj[0:self.npoints, :]
+        a_use = a_obj[0 : self.npoints, :]
 
         for j in range(nfunc):
             if self.est_bck == 1 and j == 0:
-                a_use[q_accept_x, j] = 1.0/self.err[q_accept_x]
+                a_use[q_accept_x, j] = 1.0 / self.err[q_accept_x]
             elif smeared:
-                a_use[q_accept_x, j] = calc.ortho_transformed_smeared(x_use, self.dmax, j+offset,
-                                                                      self.slit_height, self.slit_width, npts)/self.err[q_accept_x]
+                a_use[q_accept_x, j] = (
+                    calc.ortho_transformed_smeared(
+                        x_use, self.dmax, j + offset, self.slit_height, self.slit_width, npts
+                    )
+                    / self.err[q_accept_x]
+                )
             else:
-                a_use[q_accept_x, j] = calc.ortho_transformed(x_use, self.dmax, j+offset)/self.err[q_accept_x]
+                a_use[q_accept_x, j] = calc.ortho_transformed(x_use, self.dmax, j + offset) / self.err[q_accept_x]
 
-        a_obj[0:self.npoints, :] = a_use
+        a_obj[0 : self.npoints, :] = a_use
 
         for j in range(nfunc):
             i_r = np.arange(nr, dtype=np.float64)
 
-            #Implementing second stage A as a python vector operation with shape = [nr]
+            # Implementing second stage A as a python vector operation with shape = [nr]
             r = (self.dmax / nr) * i_r
-            tmp = pi * (j+offset) / self.dmax
-            res = (2.0 * sqrt_alpha * self.dmax/nr * tmp) * (2.0 * np.cos(tmp*r) + tmp * r * np.sin(tmp*r))
-            #Res should now be np vector size i_r.
-            a_obj[self.npoints:self.npoints+nr, j] = res
+            tmp = pi * (j + offset) / self.dmax
+            res = (2.0 * sqrt_alpha * self.dmax / nr * tmp) * (2.0 * np.cos(tmp * r) + tmp * r * np.sin(tmp * r))
+            # Res should now be np vector size i_r.
+            a_obj[self.npoints : self.npoints + nr, j] = res
 
-        #Compute B
+        # Compute B
         x_accept_index = self.accept_q(self.x)
-        #The part of b used for the vector operations, of the accepted q values.
-        b_used = b_obj[0:self.npoints]
+        # The part of b used for the vector operations, of the accepted q values.
+        b_used = b_obj[0 : self.npoints]
         b_used[x_accept_index] = self.y[x_accept_index] / self.err[x_accept_index]
-        b_obj[0:self.npoints] = b_used
+        b_obj[0 : self.npoints] = b_used
 
         return a_obj, b_obj
 
-    def _get_invcov_matrix(self, nfunc, nr, a_obj):
+    def _get_invcov_matrix(self, nfunc: int, nr: int, a_obj: npt.NDArray[np.float64]) -> npt.NDArray[np.float64]:
         """
         Compute the inverse covariance matrix, defined as inv_cov = a_transposed x a.
 
         :param nfunc: number of base functions.
         :param nr: number of r-points used when evaluating reg term.
-        :param a: A array to fill.
-        :param inv_cov: inverse covariance array to be filled.
+        :param a_obj: A array to compute inverse covariance matrix of.
 
-        :return: 0
+        :return: inv_cov matrix.
         """
         nfunc = int(nfunc)
         nr = int(nr)
         cov_obj = np.zeros([nfunc, nfunc])
         n_a = a_obj.size
-        n_cov = cov_obj.size
 
         if not n_a >= (nfunc * (nr + self.npoints)):
-            raise RuntimeError("Pinvertor._get_invcov_matrix: a array too small.")
+            # raise RuntimeError("Pinvertor._get_invcov_matrix: a array too small.")
+            logger.error("Pinvertor._get_invcov_matrix: a array too small.")
 
-        size = nr + self.npoints
         cov_obj[:, :] = np.dot(a_obj.T, a_obj)
         return cov_obj
 
-    def _get_reg_size(self, nfunc, nr, a_obj):
+    def _get_reg_size(self, nfunc: int, nr: int, a_obj: npt.NDArray[np.float64]) -> tuple[float, float]:
         """
         Computes sum_sig and sum_reg of input array given.
 
@@ -739,18 +706,19 @@ class Invertor:
         :param nr: number of r-points used when evaluating reg term.
         :param a_obj: Array to compute sum_sig and sum_reg of.
 
-        :return: Tuple of (sum_sig, sum_reg)
+        :return: Tuple of sum of signal and sum of regularization term, for the given array.
         """
         nfunc = int(nfunc)
         nr = int(nr)
 
         if not a_obj.size >= nfunc * (nr + self.npoints):
-            raise RuntimeError("Pinvertor._get_reg_size: input array too short for data.")
+            # raise RuntimeError("Pinvertor._get_reg_size: input array too short for data.")
+            logger.error("Pinvertor._get_reg_size: input array too short for data.")
 
         a_pass = self.accept_q(self.x)
-        a_use = a_obj[0:self.npoints, :]
+        a_use = a_obj[0 : self.npoints, :]
         a_use = a_use[a_pass, :]
-        sum_sig = np.sum(a_use ** 2)
-        sum_reg = np.sum(a_obj[self.npoints:self.npoints+nr, :] ** 2)
+        sum_sig = np.sum(a_use**2)
+        sum_reg = np.sum(a_obj[self.npoints : self.npoints + nr, :] ** 2)
 
         return sum_sig, sum_reg

--- a/src/sas/sascalc/pr/invertor.py
+++ b/src/sas/sascalc/pr/invertor.py
@@ -212,7 +212,7 @@ class Invertor:
         This is a thin wrapper around :meth:`lstsq` that handles temporary
         background subtraction when ``est_bck`` is disabled.
 
-        See :meth:`lstsq` for details of the linear system construction
+        See :math:`lstsq` for details of the linear system construction
         (including regularization) and the least-squares solve.
 
         :param nfunc: number of base functions to use.
@@ -474,7 +474,7 @@ class Invertor:
         try:
             return estimator.num_terms(isquit_func)
         except Exception as exc:
-            # If we fail, estimate alpha and return the default  number of terms
+            # If we fail, estimate alpha and return the default number of terms
             best_alpha, _, _ = self.estimate_alpha(self.nfunc)
             logger.warning("Invertor.estimate_numterms: %s" % exc)
             return self.nfunc, best_alpha, "Could not estimate number of terms"

--- a/src/sas/sascalc/pr/invertor.py
+++ b/src/sas/sascalc/pr/invertor.py
@@ -12,82 +12,32 @@ from numpy.linalg import lstsq
 if TYPE_CHECKING:
     from sas.qtgui.Perspectives.Inversion.InversionLogic import InversionLogic
 
-# TODO: Add docstrings later
-
 # Default Values for inputs
 NUMBER_OF_TERMS = 10
 REGULARIZATION = 0.0
-BACKGROUND_INPUT = 0.0
-Q_MIN_INPUT = 0.0
-Q_MAX_INPUT = 0.0
-MAX_DIST = 140.0
 
 logger = logging.getLogger(__name__)
 
 
-def help():
-    """
-    Provide general online help text
-    Future work: extend this function to allow topic selection
-    """
-    info_txt = "The inversion approach is based on Moore, J. Appl. Cryst. "
-    info_txt += "(1980) 13, 168-175.\n\n"
-    info_txt += "P(r) is set to be equal to an expansion of base functions "
-    info_txt += "of the type "
-    info_txt += "phi_n(r) = 2*r*sin(pi*n*r/D_max). The coefficient of each "
-    info_txt += "base functions "
-    info_txt += "in the expansion is found by performing a least square fit "
-    info_txt += "with the "
-    info_txt += "following fit function:\n\n"
-    info_txt += "chi**2 = sum_i[ I_meas(q_i) - I_th(q_i) ]**2/error**2 +"
-    info_txt += "Reg_term\n\n"
-    info_txt += "where I_meas(q) is the measured scattering intensity and "
-    info_txt += "I_th(q) is "
-    info_txt += "the prediction from the Fourier transform of the P(r) "
-    info_txt += "expansion. "
-    info_txt += "The Reg_term term is a regularization term set to the second"
-    info_txt += " derivative "
-    info_txt += "d**2P(r)/dr**2 integrated over r. It is used to produce "
-    info_txt += "a smooth P(r) output.\n\n"
-    info_txt += "The following are user inputs:\n\n"
-    info_txt += "   - Number of terms: the number of base functions in the P(r)"
-    info_txt += " expansion.\n\n"
-    info_txt += "   - Regularization constant: a multiplicative constant "
-    info_txt += "to set the size of "
-    info_txt += "the regularization term.\n\n"
-    info_txt += "   - Maximum distance: the maximum distance between any "
-    info_txt += "two points in the system.\n"
-
-    return info_txt
-
-
 class Invertor:
     def __init__(self, logic: "InversionLogic"):
-        self.init_default_values()
-        self.logic = logic
 
-    # TODO: Add types.
-    def init_default_values(self):
-        """Initialize default values for the invertor."""
-        ## Chisqr of the last computation
+        # Chisqr of the last computation
         self.chi2: float = 0
-        ## Time elapsed for last computation
+        # Time elapsed for last computation
         self.elapsed: float = 0
-        ## Alpha to get the reg term the same size as the signal
+        # Alpha to get the reg term the same size as the signal
         self.suggested_alpha: float = 0.0
-        ## Last number of base functions used
+        # Last number of base functions used
         self.nfunc: int = 10
-        ## Last output values
+        # Last output values
         self.out: npt.NDArray[np.float64] | None = None
-        ## Last errors on output values
+        # Last errors on output values
         self.cov: npt.NDArray[np.float64] | None = None
-        ## Background value
+        # Background value
         self.background: float = 0
-        ## TODO: My suspicion is that this'll go.
-        ## Information dictionary for application use
+        # Information dictionary for application use
         self.info: dict = {}
-
-        # Stuff that was on p_invertor
 
         # Maximum distance between any two points in the system
         self.dmax: float = 180.0
@@ -95,8 +45,7 @@ class Invertor:
         self.q_min: float = 0.0
         # Maximum q to include in inversion
         self.q_max: float = np.inf
-        # Flag for whether or not to evaluate a constant background
-        # while inverting
+        # Flag for whether or not to evaluate a constant background while inverting
         self.est_bck: bool = True
         # TODO: Is there a reason this is called alpha, and not just regularization.
         self.alpha: float = REGULARIZATION
@@ -105,8 +54,10 @@ class Invertor:
         # Slit width in units of q [A-1]
         self.slit_width: float = 0.0
 
-        # Stuff I've added that wasn't previously in the calculator.
+        # Number of terms to use in the expansion
         self.noOfTerms: int = NUMBER_OF_TERMS
+
+        self.logic = logic
 
     @property
     def x(self) -> npt.NDArray[np.float64]:
@@ -182,13 +133,9 @@ class Invertor:
         :return: c_out, c_cov - the coefficients with covariance matrix
         """
 
-        # Note: To make sure an array is contiguous:
-        # blah = np.ascontiguousarray(blah_original)
-        # ... before passing it to C
         if not self.is_valid():
-            # msg = "Invertor: invalid data; incompatible data lengths."
-            # raise RuntimeError(msg)
             logger.error("Invertor: invalid data; incompatible data lengths.")
+            return np.zeros(nfunc), np.zeros((nfunc, nfunc))
 
         self.nfunc = nfunc
         # a -- An M x N matrix.
@@ -203,17 +150,13 @@ class Invertor:
         if self.est_bck:
             nfunc += 1
 
-        a = np.zeros((npts + nq, nfunc))
-        b = np.zeros((npts + nq,))
-        err = np.zeros((nfunc, nfunc))
-
         # Construct the a matrix and b vector that represent the problem
         t_0 = time.time()
         try:
             a, b = self._get_matrix(nfunc, nq)
         except Exception as exc:
-            # raise RuntimeError("Invertor: could not invert I(Q)\n  %s" % str(exc))
             logger.error("Invertor: could not invert I(Q)\n  %s" % str(exc))
+            return np.zeros(nfunc), np.zeros((nfunc, nfunc))
 
         # Perform the inversion (least square fit)
         c, residuals, _, _ = lstsq(a, b, rcond=None)
@@ -238,6 +181,7 @@ class Invertor:
             # We were not able to estimate the errors
             # Return an empty error matrix
             logger.error(exc)
+            err = np.zeros((nfunc, nfunc))
 
         # Keep a copy of the last output
         if not self.est_bck:
@@ -401,7 +345,7 @@ class Invertor:
         oscill = calc.reg_term(pars, self.dmax, nslice)
         norm = calc.int_pr_square(pars, self.dmax, nslice)
 
-        if norm == 8:
+        if norm == 0:
             return 0
         return np.sqrt(oscill / norm) / np.pi * self.dmax
 
@@ -619,11 +563,11 @@ class Invertor:
 
         sqrt_alpha = np.sqrt(math.fabs(self.alpha))
         pi = np.pi
-        offset: int = (1, 0)[self.est_bck == 1]
+        offset: int = 0 if self.est_bck else 1
 
         if self.check_for_zero(self.err):
-            # raise RuntimeError("Pinvertor.get_matrix: Some I(Q) points have no error.")
             logger.error("Pinvertor.get_matrix: Some I(Q) points have no error.")
+            return np.zeros((nfunc, nfunc)), np.zeros(nfunc)
 
         # Compute A
         # Whether or not to use ortho_transformed_smeared.
@@ -643,7 +587,7 @@ class Invertor:
         a_use = a_obj[0 : self.npoints, :]
 
         for j in range(nfunc):
-            if self.est_bck == 1 and j == 0:
+            if self.est_bck and j == 0:
                 a_use[q_accept_x, j] = 1.0 / self.err[q_accept_x]
             elif smeared:
                 a_use[q_accept_x, j] = (
@@ -692,8 +636,8 @@ class Invertor:
         n_a = a_obj.size
 
         if not n_a >= (nfunc * (nr + self.npoints)):
-            # raise RuntimeError("Pinvertor._get_invcov_matrix: a array too small.")
             logger.error("Pinvertor._get_invcov_matrix: a array too small.")
+            return np.zeros((nfunc, nfunc))
 
         cov_obj[:, :] = np.dot(a_obj.T, a_obj)
         return cov_obj
@@ -712,8 +656,8 @@ class Invertor:
         nr = int(nr)
 
         if not a_obj.size >= nfunc * (nr + self.npoints):
-            # raise RuntimeError("Pinvertor._get_reg_size: input array too short for data.")
             logger.error("Pinvertor._get_reg_size: input array too short for data.")
+            return 0.0, 0.0
 
         a_pass = self.accept_q(self.x)
         a_use = a_obj[0 : self.npoints, :]

--- a/src/sas/sascalc/pr/invertor.py
+++ b/src/sas/sascalc/pr/invertor.py
@@ -209,6 +209,12 @@ class Invertor:
         """
         Perform inversion to P(r).
 
+        This is a thin wrapper around :meth:`lstsq` that handles temporary
+        background subtraction when ``est_bck`` is disabled.
+
+        See :meth:`lstsq` for details of the linear system construction
+        (including regularization) and the least-squares solve.
+
         :param nfunc: number of base functions to use.
         :param nr: number of r points to evaluate the 2nd derivative at for the reg. term.
 


### PR DESCRIPTION
## Description

This PR cleans up the code for the Inversion Perspective in the qtgui directory, which includes:

- ruff check and formatting
- type hinting
- proper doc string formatting
- removal of commented code

This also includes some work on `invertor.py`, #2974 

## How Has This Been Tested?

Manually ran SasView to test functionality is unchanged.

## Review Checklist:

**Documentation**
- [x] There is **nothing** that needs documenting
- [ ] Documentation changes are **in this PR**
- [ ] There is an **issue** open for the documentation (link?)

**Installers**
- [ ] There is a chance this will affect the **installers**, if so
  - [ ] **Windows** installer (GH artifact) has been tested (installed and worked) 
  - [ ] **MacOSX** installer (GH artifact) has been tested (installed and worked)
  - [ ] **Wheels** installer (GH artifact) has been tested (installed and worked)

**Licensing**
- [x] The introduced changes comply with SasView license (BSD 3-Clause)

