### PR TITLE
Fixes bug in scaling for updating 1D plots

### DIFF
--- a/src/sas/qtgui/Plotting/Plotter.py
+++ b/src/sas/qtgui/Plotting/Plotter.py
@@ -746,6 +746,8 @@ class PlotterWidget(PlotterBase):
         new_plot.custom_color = selected_plot.custom_color
         new_plot.markersize = selected_plot.markersize
         new_plot.symbol = selected_plot.symbol
+        new_plot.xtransform = selected_plot.xtransform
+        new_plot.ytransform = selected_plot.ytransform
         self.removePlot(id)
         self.plot(data=new_plot)
         # Apply user-defined plot range


### PR DESCRIPTION
## Description

When updating 1D plots, the transformation properties of the data are now also updated. The issue described in #3886 occurred because data presented on a log scale was correctly transformed to a linear scale, but when the data was updated it was transformed to log and then linear again, causing negative q values to be omitted.

Fixes #3886

## How Has This Been Tested?

Followed the procedure described in #3886 and observed the problem is solved.

## Review Checklist:

[if using the editor, use `[x]` in place of `[ ]` to check a box]

**Documentation** (check at least one)
- [x] There is **nothing** that needs documenting
- [ ] Documentation changes are **in this PR**
- [ ] There is an **issue** open for the documentation (link?)

**Installers**
- [ ] There is a chance this will affect the **installers**, if so
  - [ ] **Windows** installer (GH artifact) has been tested (installed and worked) 
  - [ ] **MacOSX** installer (GH artifact) has been tested (installed and worked)
  - [ ] **Wheels** installer (GH artifact) has been tested (installed and worked)

**Licensing** (untick if necessary)
- [x] The introduced changes comply with SasView license (BSD 3-Clause)

