### PR TITLE
Remove `DISPLAY: 99` value from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,8 +46,6 @@ env:
   INSTALLER_OLD_RUNID: 3204825457
   # The test-installer job can run with the pyinstaller debug bundle
   INSTALLER_USE_DEBUG: false
-  # https://pytest-qt.readthedocs.io/en/latest/troubleshooting.html - Required for PySide pytest runner
-  DISPLAY: ':99.0'
 
 jobs:
 


### PR DESCRIPTION
## Description

As noted by @llimeht in https://github.com/SasView/sasview/pull/3867#discussion_r2892715617, the CI environment variable is likely overridden during the GUI test runner and not used. I originally planned to open an issue for later, but though this was quicker.

## How Has This Been Tested?

CI on push passes.
