### PR TITLE
Fix for Dmax explorer plot turning into a scatter plot when resetting view

### DIFF
--- a/src/sas/qtgui/Perspectives/Inversion/DMaxExplorerWidget.py
+++ b/src/sas/qtgui/Perspectives/Inversion/DMaxExplorerWidget.py
@@ -14,6 +14,7 @@ from PySide6.QtCore import QSize
 from PySide6.QtGui import QIcon
 
 import sas.qtgui.Utilities.GuiUtils as GuiUtils
+from sas.qtgui.Plotting import PlotUtilities
 from sas.qtgui.Plotting.Plotter import PlotterWidget
 
 # sas-global
@@ -198,6 +199,8 @@ class DmaxWindow(QtWidgets.QDialog, Ui_DmaxExplorer):
             y_unit = "a.u."
 
         data = Data1D(plotable_xs, ys)
+        # Store the line symbol so re-renders (e.g. 'Reset original view') keep the line style
+        data.symbol = list(PlotUtilities.SHAPES.keys()).index('Line')
         if self.hasPlot:
             self.plot.removePlot(data.name)
         self.hasPlot = True


### PR DESCRIPTION
## Description

This PR fixes an issue with the Dmax explorer of the Inversion perspective.

Clicking the 'reset original view' (shown as a home icon under the plot) would turn the line graph into a scatter plot. This PR fixes it by storing the symbol.

Fixes #3202 

## How Has This Been Tested?

Manually tested functionality on Windows 11 following the steps in the issue.

## Review Checklist:

**Documentation**
- [x] There is **nothing** that needs documenting
- [ ] Documentation changes are **in this PR**
- [ ] There is an **issue** open for the documentation (link?)

**Installers**
- [x] There is a chance this will affect the **installers**, if so
  - [ ] **Windows** installer (GH artifact) has been tested (installed and worked) 
  - [ ] **MacOSX** installer (GH artifact) has been tested (installed and worked)
  - [ ] **Wheels** installer (GH artifact) has been tested (installed and worked)

**Licensing**
- [x] The introduced changes comply with SasView license (BSD 3-Clause)

