### PR TITLE
Fixes the error propagation in power law

### DIFF
--- a/src/sas/sascalc/invariant/invariant.py
+++ b/src/sas/sascalc/invariant/invariant.py
@@ -236,11 +236,13 @@ class PowerLaw(Transform):
         """
         Returns the error on I(q) for the given array of q-values
         :param x: array of q-values
+        :return: array of I(q) errors
         """
-        p1 = np.array([self.dscale * math.pow(q, -self.power) for q in x])
-        p2 = np.array([self.scale * self.power * math.pow(q, -self.power - 1) * self.dpower for q in x])
-        diq2 = p1 * p1 + p2 * p2
-        return np.array([math.sqrt(err) for err in diq2])
+        # term from scale: dI/ds * error in scale
+        p1 = self.dscale * x ** (-self.power)
+        # term from power: (dI/dp = I * (-log(x)) * error in power
+        p2 = - self.scale * x ** -self.power * np.log(x) * self.dpower
+        return np.sqrt(p1**2 + p2**2)
 
     def _power_law(self, x):
         """


### PR DESCRIPTION
## Description

As noted by Copilot in the review for #3897, the error propagation for power law is incorrect.

<img width="631" height="372" alt="image" src="https://github.com/user-attachments/assets/2a1b5064-f77b-4e4b-9b37-6551e6d081fe" />

## How Has This Been Tested?

Hand propagated the errors (shown above) and ran SasView to test manually.

## Review Checklist:

**Documentation**
- [x] There is **nothing** that needs documenting
- [ ] Documentation changes are **in this PR**
- [ ] There is an **issue** open for the documentation (link?)

**Installers**
- [ ] There is a chance this will affect the **installers**, if so
  - [ ] **Windows** installer (GH artifact) has been tested (installed and worked) 
  - [ ] **MacOSX** installer (GH artifact) has been tested (installed and worked)
  - [ ] **Wheels** installer (GH artifact) has been tested (installed and worked)

**Licensing**
- [x] The introduced changes comply with SasView license (BSD 3-Clause)

