### PR TITLE
3915: Trigger builds on push to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,8 @@ defaults:
 env:
   # Version of Python that will be used in the release builds
   RELEASE_PYVER: "3.13"
+  # Determine if this CI should build binaries. All non-push event types and all actions against main should trigger
+  BUILD_BINARIES: github.event_name != 'push' || github.ref == 'main'
   # Determine if this CI is being done during the release polishing steps
   RELEASE_BRANCH_BUILD: ${{
       (
@@ -339,7 +341,7 @@ jobs:
 
   installer-matrix:
     needs: [matrix, build-sasview]
-    if: github.event_name != 'push'
+    if: ${{ env.BUILD_BINARIES == 'true' }}
 
     strategy:
       fail-fast: false
@@ -511,7 +513,7 @@ jobs:
 
   test-installer:
     needs: [ matrix, installer-matrix ]
-    if: github.event_name != 'push'
+    if: ${{ env.BUILD_BINARIES == 'true' }}
 
     strategy:
       fail-fast: false


### PR DESCRIPTION
## Description

Add a CI environment variable that determines if the builds should run.

When the builds should not run:
- Any push to a branch that isn't main.

Fixes #3915 

## How Has This Been Tested?

Ideally, when merged, the nightly build CI should succeed.

## Review Checklist:

**Installers**
- [ ] There is a chance this will affect the **installers**, if so
  - [ ] **Windows** installer (GH artifact) has been tested (installed and worked) 
  - [ ] **MacOSX** installer (GH artifact) has been tested (installed and worked)
  - [ ] **Wheels** installer (GH artifact) has been tested (installed and worked)

**Licensing** (untick if necessary)
- [x] The introduced changes comply with SasView license (BSD 3-Clause)

