### PR TITLE
Remove print statements from sascalc tests

### DIFF
--- a/src/sas/sascalc/size_distribution/SizeDistribution.py
+++ b/src/sas/sascalc/size_distribution/SizeDistribution.py
@@ -517,7 +517,7 @@ class sizeDistribution:
                                                              sigma,
                                                                self.model_matrix,
                                                                  BinsBack,
-                                                                   self.iterMax, report=True)
+                                                                   self.iterMax, report=False)
 
                 ChiSq.append(chisq)
                 BinMag.append(bin_magnitude)

--- a/test/sascalculator/utest_sas_gen.py
+++ b/test/sascalculator/utest_sas_gen.py
@@ -337,7 +337,6 @@ class sas_gen_test(unittest.TestCase):
 
         np.random.seed(seed=1984)
         angles = stats.uniform(0, 2*np.pi).rvs([100, 3])
-        print(angles)
         for alpha, beta, gamma in angles:
             R_s2s = euler_rotation_matrix(alpha, beta, gamma)
             R_scipy_XYZ = Rotation.from_euler('ZYX', [gamma, beta, alpha]).as_matrix()


### PR DESCRIPTION
## Description

The tests run against the sascalc package display a couple debug statements that shouldn't be necessary. This removes them.

## How Has This Been Tested?

Ran tests locally and the extra statements are no longer displayed.