### PR TITLE
Adds dummy err_data to residual data for slicers to work

### DIFF
--- a/src/sas/qtgui/Perspectives/Fitting/FittingUtilities.py
+++ b/src/sas/qtgui/Perspectives/Fitting/FittingUtilities.py
@@ -595,7 +595,8 @@ def residualsData2D(reference_data, current_data, weight):
     residuals.qx_data = current_data.qx_data
     residuals.qy_data = current_data.qy_data
     residuals.q_data = current_data.q_data
-    residuals.err_data = None
+    # Slicers expect residuals to have err_data, so add dummy error data of ones
+    residuals.err_data = numpy.ones(len(residuals.data))
     residuals.xmin = min(residuals.qx_data)
     residuals.xmax = max(residuals.qx_data)
     residuals.ymin = min(residuals.qy_data)


### PR DESCRIPTION
## Description

Trying to average a residual plot using slicers would throw errors. This is because slicers expect an `err_data` array, which is set to `None` for residuals. 

This PR fixes that by adding a dummy `err_data` of ones for residual plots.

Fixes #3765 

## How Has This Been Tested?

Manually tested by attempting to reproduce the issue.

## Review Checklist:

**Documentation**
- [x] There is **nothing** that needs documenting
- [ ] Documentation changes are **in this PR**
- [ ] There is an **issue** open for the documentation (link?)

**Installers**
- [ ] There is a chance this will affect the **installers**, if so
  - [ ] **Windows** installer (GH artifact) has been tested (installed and worked) 
  - [ ] **MacOSX** installer (GH artifact) has been tested (installed and worked)
  - [ ] **Wheels** installer (GH artifact) has been tested (installed and worked)

**Licensing**
- [x] The introduced changes comply with SasView license (BSD 3-Clause)

