### PR TITLE
Upload Binaries On Tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,10 +41,6 @@ jobs:
           done
           mv SasView-Installer-ubuntu*/SasView6.tar.gz ./SasView-${{ github.event.release.tag_name }}-Ubuntu22.04.tar.gz
 
-      - name: Clean out old release
-        run: |
-          gh release delete nightly-build --cleanup-tag --yes || true
-
       - name: Upload Nightly Build Installer to GitHub releases
         uses: ncipollo/release-action@v1
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,59 @@
+name: release.yml
+on:
+  release
+jobs:
+
+  #Reuse ci.yml workflow on main branch and upload artifacts to release page
+  reuse_main_ci:
+    uses: ./.github/workflows/ci.yml
+    secrets: inherit
+
+  upload_nightly_builds:
+
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+    needs: reuse_main_ci
+
+    env:
+      GH_REPO: ${{ github.repository }}
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    steps:
+      - name: Retrieve saved artifacts
+        uses: actions/download-artifact@v8
+
+      - name: Display structure of downloaded files
+        run: ls -R
+        working-directory: .
+
+      - name: Copy wheel
+        run: |
+          mv build-dependency-*-wheel/*.whl ./
+
+      - name: Rename artifacts
+        run: |
+          mv SasView-Installer-windows*/setupSasView.exe ./SasView-${{ github.event.release.tag_name }}-Win64.exe
+          mv SasView-Installer-macos*/SasView6-*.dmg ./SasView-${{ github.event.release.tag_name }}-*.dmg
+          for file in $(ls *.dmg); do
+              mv $file ${file/SasView6-/SasView-nightly-MacOSX-}
+          done
+          mv SasView-Installer-ubuntu*/SasView6.tar.gz ./SasView-${{ github.event.release.tag_name }}-Ubuntu22.04.tar.gz
+
+      - name: Clean out old release
+        run: |
+          gh release delete nightly-build --cleanup-tag --yes || true
+
+      - name: Upload Nightly Build Installer to GitHub releases
+        uses: ncipollo/release-action@v1
+        with:
+          allowUpdates: true
+          replacesArtifacts: true
+          omitBodyDuringUpdate: true
+          omitDraftDuringUpdate: true
+          omitNameDuringUpdate: true
+          omitPrereleaseDuringUpdate: true
+          token: ${{ secrets.GITHUB_TOKEN }}
+          artifacts: "*.exe, *.dmg, *.tar.gz, *.whl"
+          tag: ${{ github.event.release.tag_name }}


### PR DESCRIPTION
## Description

This adds a new workflow that uploads binaries to releases when tags are created.

## How Has This Been Tested?

TBD - Needs CI and a tag to be generated

