### PR TITLE
SAXS fitter uses new communicator pattern

### DIFF
--- a/src/sas/qtgui/Calculators/GenericScatteringCalculator.py
+++ b/src/sas/qtgui/Calculators/GenericScatteringCalculator.py
@@ -1443,7 +1443,7 @@ class GenericScatteringCalculator(QtWidgets.QDialog, Ui_GenericScatteringCalcula
                 raise RuntimeError("No structure file is loaded! SAXS calculations require a structure file.")
             from sas.qtgui.Calculators.SAXSPluginModelGenerator import get_base_plugin_name, write_plugin_model
             write_plugin_model(self.datafile)
-            self.manager.communicator().customModelDirectoryChanged.emit() # notify that a new plugin model is available
+            self.communicator.customModelDirectoryChanged.emit() # notify that a new plugin model is available
 
             # try to bring the fit panel into focus and select the newly generated plugin
             try:


### PR DESCRIPTION
## Description

Two PRs (https://github.com/SasView/sasview/pull/3786 & https://github.com/SasView/sasview/pull/3863) seem to have been developed & merged in parallel, resulting in a broken SAXS fitting tool. This PR fixes this issue by making the SAXS fitting tool use the new communicator pattern. 

I thought about writing a small unit test to verify a model file is actually created from the GSC with the SAXS tool enabled, but the logic is too strongly tied to Qt which I'm not sure how to handle in the tests. 

Fixes https://github.com/SasView/sasview/issues/3933. 

## How Has This Been Tested?

Manually tested & verified working. 

## Review Checklist:

**Documentation**
- [x] There is **nothing** that needs documenting
- [ ] Documentation changes are **in this PR**
- [ ] There is an **issue** open for the documentation (link?)

**Installers**
- [ ] There is a chance this will affect the **installers**, if so
  - [ ] **Windows** installer (GH artifact) has been tested (installed and worked) 
  - [ ] **MacOSX** installer (GH artifact) has been tested (installed and worked)
  - [ ] **Wheels** installer (GH artifact) has been tested (installed and worked)

**Licensing**
- [x] The introduced changes comply with SasView license (BSD 3-Clause)

