### PR TITLE
Fix invocation of compile_licenses.py

### DIFF
--- a/build_tools/release_automation.py
+++ b/build_tools/release_automation.py
@@ -318,8 +318,8 @@ def update_credits(credits_file: Path):
     subprocess.check_call(
         [
             sys.executable,
+            SASVIEW_PATH / "build_tools" / "compile_licenses.py",
             "--minimal",
-            "build_tools/release_automation.py",
             credits_file,
         ])
 


### PR DESCRIPTION
## Description

As noted in #3919, the invocation of compile_licenses.py was quite wrong. This corrects that invocation.

Fixes #3919

## How Has This Been Tested?

With changes to release_automation.py, I figured out how to run it locally (and it ran just fine).

## Review Checklist:

[if using the editor, use `[x]` in place of `[ ]` to check a box]

**Documentation** (check at least one)
- [x] There is **nothing** that needs documenting
- [ ] Documentation changes are **in this PR**
- [ ] There is an **issue** open for the documentation (link?)

**Installers**
- [ ] There is a chance this will affect the **installers**, if so
  - [ ] **Windows** installer (GH artifact) has been tested (installed and worked) 
  - [ ] **MacOSX** installer (GH artifact) has been tested (installed and worked)
  - [ ] **Wheels** installer (GH artifact) has been tested (installed and worked)

**Licensing** (untick if necessary)
- [x] The introduced changes comply with SasView license (BSD 3-Clause)

