### PR TITLE
3208: Fix copy/paste structure factor errors

### DIFF
--- a/src/sas/qtgui/Perspectives/Fitting/FittingWidget.py
+++ b/src/sas/qtgui/Perspectives/Fitting/FittingWidget.py
@@ -3444,6 +3444,7 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         if 'model_name' not in line_dict:
             return
         model = line_dict['model_name'][0]
+        structure_factor = line_dict['fitpage_structure'][0]
         context = {}
 
         if 'multiplicity' in line_dict:
@@ -3466,7 +3467,7 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
 
         # Create the context dictionary for parameters
         # Exclude multiplicity and number of shells params from context
-        context = {k: v for (k, v) in line_dict.items() if len(v) > 3 and k != model}
+        context = {k: v for (k, v) in line_dict.items() if len(v) > 3 and k not in [model, structure_factor]}
         context['model_name'] = model
 
         if warn_user and str(self.cbModel.currentText()) != str(context['model_name']):

--- a/src/sas/qtgui/Perspectives/Fitting/FittingWidget.py
+++ b/src/sas/qtgui/Perspectives/Fitting/FittingWidget.py
@@ -3543,9 +3543,10 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
             if param_name not in list(param_dict) or row == self._n_shells_row:
                 # Skip magnetic, polydisperse (.pd), and shell parameters - they are handled elsewhere
                 return
-            # checkbox state
-            param_checked = QtCore.Qt.Checked if param_dict[param_name][0] == "True" else QtCore.Qt.Unchecked
-            self._model_model.item(row, 0).setCheckState(param_checked)
+            # checkbox state - None means no checkbox present so don't modify
+            if param_dict[param_name][0] != "None":
+                param_checked = QtCore.Qt.Checked if param_dict[param_name][0] == "True" else QtCore.Qt.Unchecked
+                self._model_model.item(row, 0).setCheckState(param_checked)
 
             # parameter value can be either just a value or text on the combobox
             param_text = param_dict[param_name][1]


### PR DESCRIPTION
## Description

This fix excludes the structure factor parameter from the items being updated during a copy/paste operation in the fitting widget. This was manifesting in multiple ways and this should fix them all. This also fixes an issue with copy/paste where checkboxes were added to parameters that previously did not have checkboxes.

Fixes #3208
Fixes #3558
Fixes #3939

## How Has This Been Tested?

Tested locally.

## Review Checklist:

**Documentation** (check at least one)
- [x] There is **nothing** that needs documenting
- [ ] Documentation changes are **in this PR**
- [ ] There is an **issue** open for the documentation (link?)

**Installers**
- [ ] There is a chance this will affect the **installers**, if so
  - [ ] **Windows** installer (GH artifact) has been tested (installed and worked) 
  - [ ] **MacOSX** installer (GH artifact) has been tested (installed and worked)
  - [ ] **Wheels** installer (GH artifact) has been tested (installed and worked)

**Licensing** (untick if necessary)
- [x] The introduced changes comply with SasView license (BSD 3-Clause)

