### PR TITLE
TST: 3921 - Use Node 24 for all actions to be sure no issues

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,7 @@ env:
   INSTALLER_OLD_RUNID: 3204825457
   # The test-installer job can run with the pyinstaller debug bundle
   INSTALLER_USE_DEBUG: false
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
 


### PR DESCRIPTION
## Description

Node.js 20 is being deprecated. This forces all actions to use Node 24. If all actions are successful, the issue can be closed. The transition will happen automatically, so this PR does not need to be merged.

Fixes #3921

## How Has This Been Tested?

CI: If it passes, we are good. If it fails, we need to find alternates to whatever actions fail.
