### PR TITLE
3887: MPL Hooks

### DIFF
--- a/installers/sasview.spec
+++ b/installers/sasview.spec
@@ -57,6 +57,17 @@ hiddenimports = [
     'tccbox',
 ]
 
+hooksconfig = {
+    "matplotlib": {
+        "backends": [
+            # interactive - just the one sasview uses
+            "QtAgg",
+            # static - all of them
+            "AGG", "PDF", "PS", "SVG", "PGF"
+        ],
+    },
+}
+
 if platform.system() == 'Windows':
     # Need win32 to run sasview from the command line.
     hiddenimports.extend([
@@ -70,6 +81,7 @@ a = Analysis(
     binaries=[],
     datas=datas,
     hiddenimports=hiddenimports,
+    hooksconfig=hooksconfig,
     hookspath=[],
     runtime_hooks=[],
     excludes=[],


### PR DESCRIPTION
## Description

This adds `matplotlib` hooks for saving different image files.

Currently, at least on Windows, saving as PGF is not working, but all other formats are. The PGF format requires a LaTeX backend to be installed, so this might only be an issue on a case-by-case basis.

Fixes #3887

## How Has This Been Tested?

CI succeeds, and the Windows installer can save to every format except PGF.

## Review Checklist:

**Documentation** (check at least one)
- [ ] There is **nothing** that needs documenting
- [x] Documentation changes are **in this PR**
- [ ] There is an **issue** open for the documentation (link?)

**Installers**
- [x] There is a chance this will affect the **installers**, if so
  - [ ] **Windows** installer (GH artifact) has been tested (installed and worked) 
  - [ ] **MacOSX** installer (GH artifact) has been tested (installed and worked)
  - [ ] **Wheels** installer (GH artifact) has been tested (installed and worked)

**Licensing** (untick if necessary)
- [x] The introduced changes comply with SasView license (BSD 3-Clause)

