### PR TITLE
Redraw Box Sum after Parameters are Updated

### DIFF
--- a/src/sas/qtgui/Plotting/Slicers/BoxSum.py
+++ b/src/sas/qtgui/Plotting/Slicers/BoxSum.py
@@ -299,6 +299,7 @@ class BoxSumCalculator(BaseInteractor):
         self.vertical_lines.update(center=self.center, width=x_max, height=y_max)
         # compute the new error and sum given values of params
         self.postData()
+        self.draw()
 
     def draw(self):
         """Redraw canvas"""


### PR DESCRIPTION
## Description

Fixes #3945 by redrawing the canvas with new parameters after updating the dict.

## How Has This Been Tested?

Manually tested on build.

## Review Checklist:

**Documentation**
- [x] There is **nothing** that needs documenting
- [ ] Documentation changes are **in this PR**
- [ ] There is an **issue** open for the documentation (link?)

**Installers**
- [ ] There is a chance this will affect the **installers**, if so
  - [ ] **Windows** installer (GH artifact) has been tested (installed and worked) 
  - [ ] **MacOSX** installer (GH artifact) has been tested (installed and worked)
  - [ ] **Wheels** installer (GH artifact) has been tested (installed and worked)

**Licensing**
- [x] The introduced changes comply with SasView license (BSD 3-Clause)

