### PR TITLE
Pins pyausaxs to earlier than 1.1.4

### DIFF
--- a/build_tools/requirements.txt
+++ b/build_tools/requirements.txt
@@ -16,7 +16,7 @@ numpy
 packaging
 periodictable
 platformdirs
-pyausaxs
+pyausaxs < 1.1.4
 pybind11
 pylint
 pyopencl


### PR DESCRIPTION
Recent CI runs fail due to changes made in pyausaxs version 1.1.4. This PR pins the version to earlier than that until the problems are resolved.