### PR TITLE
Unpin pyausaxs

### DIFF
--- a/build_tools/requirements.txt
+++ b/build_tools/requirements.txt
@@ -16,7 +16,7 @@ numpy
 packaging
 periodictable
 platformdirs
-pyausaxs < 1.1.4
+pyausaxs
 pybind11
 pylint
 pyopencl


### PR DESCRIPTION
## Description

I noticed a small bug in the SasView SAXS calculations for four-column datasets spanning beyond 1Å^-1 due to stale caching in the `AUSAXS` backend. While I managed to fix this stale caching in v1.1.4, I also introduced a new bug which disabled weighted bins for calculations at angles larger than 1Å^-1. This new issue was not caught by my own test suite, but triggered test failures here in SasView. 

The issue has been fixed in v1.1.5 and additional tests created to avoid this happening again. 

Fixes #3952 

## How Has This Been Tested?

Unit tests pass with unpinned `pyausaxs`.

## Review Checklist:

[if using the editor, use `[x]` in place of `[ ]` to check a box]

**Documentation** (check at least one)
- [x] There is **nothing** that needs documenting
- [ ] Documentation changes are **in this PR**
- [ ] There is an **issue** open for the documentation (link?)

**Installers**
- [ ] There is a chance this will affect the **installers**, if so
  - [ ] **Windows** installer (GH artifact) has been tested (installed and worked) 
  - [ ] **MacOSX** installer (GH artifact) has been tested (installed and worked)
  - [ ] **Wheels** installer (GH artifact) has been tested (installed and worked)

**Licensing** (untick if necessary)
- [x] The introduced changes comply with SasView license (BSD 3-Clause)

