### PR TITLE
Build installers on tag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -339,7 +339,7 @@ jobs:
 
   installer-matrix:
     needs: [matrix, build-sasview]
-    if: github.event_name != 'push' || github.ref_name == 'main'
+    if: github.event_name != 'push' || github.ref_name == 'main' || startsWith(github.ref, 'refs/tags/')
 
     strategy:
       fail-fast: false


### PR DESCRIPTION
This should fix the issue related to builds not proceeding when tags are generated.

Fixes #3958

