### PR TITLE
Don't include magnetism parameters in pure python models

### DIFF
--- a/src/sas/qtgui/Perspectives/Fitting/FittingWidget.py
+++ b/src/sas/qtgui/Perspectives/Fitting/FittingWidget.py
@@ -2043,11 +2043,8 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
 
         elif hasattr(kernel_module, 'parameters'):
             # built-in and custom models
-            self.logic.model_parameters = modelinfo.make_parameter_table(getattr(kernel_module, 'parameters', []))
-
-        elif hasattr(kernel_module, 'model_info'):
-            # for sum/multiply models
-            self.logic.model_parameters = kernel_module.model_info.parameters
+            info = modelinfo.make_model_info(kernel_module)
+            self.logic.model_parameters = info.parameters
 
         elif hasattr(kernel_module, 'Model') and hasattr(kernel_module.Model, "_model_info"):
             # this probably won't work if there's no model_info, but just in case

--- a/src/sas/qtgui/Perspectives/Fitting/UnitTesting/FittingUtilitiesTest.py
+++ b/src/sas/qtgui/Perspectives/Fitting/UnitTesting/FittingUtilitiesTest.py
@@ -37,18 +37,18 @@ class FittingUtilitiesTest:
         # Use a single-shell parameter
         model_name = "barbell"
         kernel_module = generate.load_kernel_module(model_name)
-        barbell_parameters = modelinfo.make_parameter_table(getattr(kernel_module, 'parameters', []))
+        info = modelinfo.make_model_info(kernel_module)
 
-        params = FittingUtilities.getIterParams(barbell_parameters)
+        params = FittingUtilities.getIterParams(info.parameters)
         # returns empty list
         assert params == []
 
         # Use a multi-shell parameter
         model_name = "core_multi_shell"
         kernel_module = generate.load_kernel_module(model_name)
-        multishell_parameters = modelinfo.make_parameter_table(getattr(kernel_module, 'parameters', []))
+        info = modelinfo.make_model_info(kernel_module)
 
-        params = FittingUtilities.getIterParams(multishell_parameters)
+        params = FittingUtilities.getIterParams(info.parameters)
         # returns a non-empty list
         assert params != []
         assert 'sld' in str(params)
@@ -61,9 +61,9 @@ class FittingUtilitiesTest:
         # Use a single-shell parameter
         model_name = "barbell"
         kernel_module = generate.load_kernel_module(model_name)
-        barbell_parameters = modelinfo.make_parameter_table(getattr(kernel_module, 'parameters', []))
+        info = modelinfo.make_model_info(kernel_module)
 
-        param_name, param_length = FittingUtilities.getMultiplicity(barbell_parameters)
+        param_name, param_length = FittingUtilities.getMultiplicity(info.parameters)
         # returns nothing
         assert param_name == ""
         assert param_length == 0
@@ -71,9 +71,9 @@ class FittingUtilitiesTest:
         # Use a multi-shell parameter
         model_name = "core_multi_shell"
         kernel_module = generate.load_kernel_module(model_name)
-        multishell_parameters = modelinfo.make_parameter_table(getattr(kernel_module, 'parameters', []))
+        info = modelinfo.make_model_info(kernel_module)
 
-        param_name, param_length = FittingUtilities.getMultiplicity(multishell_parameters)
+        param_name, param_length = FittingUtilities.getMultiplicity(info.parameters)
 
         assert param_name == "n"
         assert param_length == 10
@@ -92,9 +92,9 @@ class FittingUtilitiesTest:
             if model.name == model_name:
                 kernel_module_o = model()
         assert kernel_module_o is not None
-        barbell_parameters = modelinfo.make_parameter_table(getattr(kernel_module, 'parameters', []))
+        info = modelinfo.make_model_info(kernel_module)
 
-        params = FittingUtilities.addParametersToModel(barbell_parameters, kernel_module_o, True)
+        params = FittingUtilities.addParametersToModel(info.parameters, kernel_module_o, True)
 
         # Test the resulting model
         assert len(params) == 7
@@ -111,9 +111,9 @@ class FittingUtilitiesTest:
             if model.name == model_name:
                 kernel_module_o = model()
         assert kernel_module_o is not None
-        multi_parameters = modelinfo.make_parameter_table(getattr(kernel_module, 'parameters', []))
+        info = modelinfo.make_model_info(kernel_module)
 
-        params = FittingUtilities.addParametersToModel(multi_parameters, kernel_module_o, False)
+        params = FittingUtilities.addParametersToModel(info.parameters, kernel_module_o, False)
 
         # Test the resulting model
         assert len(params) == 3
@@ -135,9 +135,9 @@ class FittingUtilitiesTest:
             if model.name == model_name:
                 kernel_module_o = model()
         assert kernel_module_o is not None
-        multi_parameters = modelinfo.make_parameter_table(getattr(kernel_module, 'parameters', []))
+        info = modelinfo.make_model_info(kernel_module)
 
-        params = FittingUtilities.addParametersToModel(multi_parameters, kernel_module_o, True)
+        params = FittingUtilities.addParametersToModel(info.parameters, kernel_module_o, True)
 
         # Test the resulting model
         assert len(params) == 3
@@ -169,18 +169,18 @@ class FittingUtilitiesTest:
         # Use a multi-shell parameter to see that the method doesn't include shells
         model_name = "core_multi_shell"
         kernel_module = generate.load_kernel_module(model_name)
-        multi_parameters = modelinfo.make_parameter_table(getattr(kernel_module, 'parameters', []))
+        info = modelinfo.make_model_info(kernel_module)
 
         model = QtGui.QStandardItemModel()
 
         index = 2
-        FittingUtilities.addShellsToModel(multi_parameters, model, index)
+        FittingUtilities.addShellsToModel(info.parameters, model, index)
         # There should be index*len(multi_parameters) new rows
         assert model.rowCount() == 4
 
         model = QtGui.QStandardItemModel()
         index = 5
-        FittingUtilities.addShellsToModel(multi_parameters, model, index)
+        FittingUtilities.addShellsToModel(info.parameters, model, index)
         assert model.rowCount() == 10
 
         assert model.item(1).child(0).text() == "Polydispersity"

--- a/src/sas/qtgui/Perspectives/Fitting/UnitTesting/FittingWidgetTest.py
+++ b/src/sas/qtgui/Perspectives/Fitting/UnitTesting/FittingWidgetTest.py
@@ -659,11 +659,11 @@ class FittingWidgetTest:
         # Change the category index so we have a model available
         category_index = widget.cbCategory.findText("Sphere")
         widget.cbCategory.setCurrentIndex(category_index)
-        model_index = widget.cbModel.findText("adsorbed_layer")
+        model_index = widget.cbModel.findText("core_shell_sphere")
         widget.cbModel.setCurrentIndex(model_index)
 
         # Check the magnetic model
-        assert widget.magnetism_widget._magnet_model.rowCount() == 10
+        assert widget.magnetism_widget._magnet_model.rowCount() == 13
         assert widget.magnetism_widget._magnet_model.columnCount() == 5
 
         # Test the header

--- a/src/sas/qtgui/Utilities/ModelEditors/Dialogs/ModelSelector.py
+++ b/src/sas/qtgui/Utilities/ModelEditors/Dialogs/ModelSelector.py
@@ -167,7 +167,8 @@ class ModelSelector(QtWidgets.QDialog, Ui_ModelSelector):
             self.model_parameters = kernel_module.model_info.parameters
         elif hasattr(kernel_module, 'parameters'):
             # built-in and custom models
-            self.model_parameters = modelinfo.make_parameter_table(getattr(kernel_module, 'parameters', []))
+            info = modelinfo.make_model_info(kernel_module)
+            self.model_parameters = info.parameters
         elif hasattr(kernel_module, 'Model') and hasattr(kernel_module.Model, "_model_info"):
             # this probably won't work if there's no model_info, but just in case
             self.model_parameters = kernel_module.Model._model_info.parameters


### PR DESCRIPTION
## Description

Use the model info interpreter from sasmodels.modelinfo rather than calling the internal modelinfo.make_parameter_table directly.

Fixes [sasmodels #732](https://github.com/SasView/sasmodels/issues/732)

## How Has This Been Tested?

The new tetrahedron pure python model loads without magnetism support, and the exist cylinder model loads with magnetism support.

## Review Checklist:

[if using the editor, use `[x]` in place of `[ ]` to check a box]

**Documentation** (check at least one)
- [X] There is **nothing** that needs documenting
- [ ] Documentation changes are **in this PR**
- [ ] There is an **issue** open for the documentation (link?)

**Installers**
- [ ] There is a chance this will affect the **installers**, if so
  - [ ] **Windows** installer (GH artifact) has been tested (installed and worked) 
  - [ ] **MacOSX** installer (GH artifact) has been tested (installed and worked)
  - [ ] **Wheels** installer (GH artifact) has been tested (installed and worked)

**Licensing** (untick if necessary)
- [x] The introduced changes comply with SasView license (BSD 3-Clause)

