### PR TITLE
Fix free slicer

### DIFF
--- a/src/sas/qtgui/Plotting/BoxSum.py
+++ b/src/sas/qtgui/Plotting/BoxSum.py
@@ -44,4 +44,9 @@ class BoxSum(QtWidgets.QDialog, Ui_BoxSumUI):
         self.setFixedSize(self.minimumSizeHint())
 
         # Handle the Close button click
-        self.buttonBox.button(QtWidgets.QDialogButtonBox.Close).clicked.connect(lambda:self.closeWidgetSignal.emit())
+        self.buttonBox.button(QtWidgets.QDialogButtonBox.Close).clicked.connect(self.close)
+
+    def closeEvent(self, event):
+        """Emit the closeWidgetSignal when the dialog is closed via window manager."""
+        self.closeWidgetSignal.emit()
+        super(BoxSum, self).closeEvent(event)

--- a/src/sas/qtgui/Plotting/Plotter2D.py
+++ b/src/sas/qtgui/Plotting/Plotter2D.py
@@ -385,7 +385,11 @@ class Plotter2DWidget(PlotterBase):
         if (slicer_widget := getattr(self, 'slicer_widget', None)):
             slicer_widget.updateSlicersList()
 
-        self.canvas.draw()
+        try:
+            self.canvas.draw()
+        except RuntimeError:
+            # Canvas may have been destroyed already, ignore if so
+            pass
 
     def onEditSlicer(self):
         """

--- a/src/sas/qtgui/Plotting/Plotter2D.py
+++ b/src/sas/qtgui/Plotting/Plotter2D.py
@@ -303,6 +303,8 @@ class Plotter2DWidget(PlotterBase):
 
         # Notify the slicer parameters dialog (if open) so its list stays in sync
         if (slicer_widget := getattr(self, 'slicer_widget', None)):
+            slicer_widget.slicer_models.clear()
+            slicer_widget.setModel(None)
             slicer_widget.updateSlicersList()
 
         self.canvas.draw()
@@ -384,6 +386,18 @@ class Plotter2DWidget(PlotterBase):
         # Notify the slicer parameters dialog (if open) so its list stays in sync
         if (slicer_widget := getattr(self, 'slicer_widget', None)):
             slicer_widget.updateSlicersList()
+            if self.slicer is None:
+                slicer_widget.slicer_models.clear()
+                slicer_widget.setModel(None)
+            else:
+                # Select and display the model for the new active slicer
+                for slicer_name, slicer_obj in self.slicers.items():
+                    if slicer_obj is self.slicer:
+                        slicer_widget.checkSlicerByName(slicer_name)
+                        print("Checked slicer")
+                        break
+                if hasattr(self.slicer, 'model'):
+                     slicer_widget.setModel(self.slicer.model())
 
         try:
             self.canvas.draw()

--- a/src/sas/qtgui/Plotting/Plotter2D.py
+++ b/src/sas/qtgui/Plotting/Plotter2D.py
@@ -678,14 +678,22 @@ class Plotter2DWidget(PlotterBase):
         self.slicer.update()
 
         def boxWidgetClosed():
+            """
+            When the BoxSum widget is closed, clear the slicer.
+            """
             # Need to disconnect the signal!!
             self.boxwidget.closeWidgetSignal.disconnect()
-            # reset box on "Edit Slicer Parameters" window close
+            # Reset box on "Edit Slicer Parameters" window close
             self.manager.parent.workspace().removeSubWindow(self.boxwidget_subwindow)
-            self.boxwidget = None
-            # Clear the reference in the slicer
+
+            # If a BoxSum slicer still exists, clear it and redraw.
             if self.slicer is not None:
-                self.slicer.widget = None
+                self.slicer.clear()
+                self.slicer = None
+                self.canvas.draw()
+
+            # Clear stored widget reference
+            self.boxwidget = None
 
         # Get the BoxSumCalculator model.
         self.box_sum_model = self.slicer.model()

--- a/src/sas/qtgui/Plotting/Plotter2D.py
+++ b/src/sas/qtgui/Plotting/Plotter2D.py
@@ -301,6 +301,10 @@ class Plotter2DWidget(PlotterBase):
         self._slicer_color_index = 0
         self._removeSlicerPlots()
 
+        # Notify the slicer parameters dialog (if open) so its list stays in sync
+        if (slicer_widget := getattr(self, 'slicer_widget', None)):
+            slicer_widget.updateSlicersList()
+
         self.canvas.draw()
 
         # Close the box sum widget if it exists
@@ -376,6 +380,10 @@ class Plotter2DWidget(PlotterBase):
         # If no slicers remain, set self.slicer to None
         if self.slicer not in self.slicers.values():
             self.slicer = next(iter(self.slicers.values()), None)
+
+        # Notify the slicer parameters dialog (if open) so its list stays in sync
+        if (slicer_widget := getattr(self, 'slicer_widget', None)):
+            slicer_widget.updateSlicersList()
 
         self.canvas.draw()
 

--- a/src/sas/qtgui/Plotting/Plotter2D.py
+++ b/src/sas/qtgui/Plotting/Plotter2D.py
@@ -348,6 +348,37 @@ class Plotter2DWidget(PlotterBase):
                     break
         return slicer_plots
 
+    def removeSlicersForPlotWindow(self, plot_window):
+        """
+        Remove any slicers associated with a closed slicer plot window.
+        """
+        # Identify slicers associated with the closed plot window
+        removed_slicers = [
+            name for name, slicer in self.slicers.items()
+            if getattr(slicer, '_plot_window', None) is plot_window
+        ]
+
+        if not removed_slicers:
+            return
+
+        # Remove identified slicers from the parent plot's slicer list and clear them
+        for name in removed_slicers:
+            if slicer := self.slicers.pop(name, None):
+                slicer.clear() if hasattr(slicer, 'clear') else None
+
+
+        # Remove associated plots from the slicer_plots_dict
+        for name, window in list(getattr(self, 'slicer_plots_dict', {}).items()):
+            if window is plot_window:
+                del self.slicer_plots_dict[name]
+
+        # Switch to another remaining slicer if the current one was removed
+        # If no slicers remain, set self.slicer to None
+        if self.slicer not in self.slicers.values():
+            self.slicer = next(iter(self.slicers.values()), None)
+
+        self.canvas.draw()
+
     def onEditSlicer(self):
         """
         Present a dialog for manipulating the current slicer
@@ -529,8 +560,8 @@ class Plotter2DWidget(PlotterBase):
             item.removeRow(plot.row())
 
     def _removeSlicerPlots(self):
-        """  
-        Clear the previous slicer plots  
+        """
+        Clear the previous slicer plot
         """
         # Clear the old slicer plots so they don't reappear later
         if not hasattr(self, '_item'):
@@ -890,3 +921,9 @@ class Plotter2D(QtWidgets.QDialog, Plotter2DWidget):
         icon = QtGui.QIcon()
         icon.addPixmap(QtGui.QPixmap(":/res/ball.ico"), QtGui.QIcon.Normal, QtGui.QIcon.Off)
         self.setWindowIcon(icon)
+
+    def closeEvent(self, event):
+        """
+        Delegate close handling to the plotter widget implementation.
+        """
+        Plotter2DWidget.closeEvent(self, event)

--- a/src/sas/qtgui/Plotting/PlotterBase.py
+++ b/src/sas/qtgui/Plotting/PlotterBase.py
@@ -349,6 +349,15 @@ class PlotterBase(QtWidgets.QWidget):
         """
         Overwrite the close event adding helper notification
         """
+        data_list = self.data if isinstance(self.data, list) else [self.data]
+
+        # Clear the associated slicers, if any
+        for data in data_list:
+            if callable(slicer_owner := getattr(data, "slicerOwner", None)):
+                if owner := slicer_owner():
+                    owner.removeSlicersForPlotWindow(self)
+                    break
+
         self.clearQRangeSliders()
         # Please remove me from your database.
         PlotHelper.deletePlot(PlotHelper.idOfPlot(self))

--- a/src/sas/qtgui/Plotting/PlotterData.py
+++ b/src/sas/qtgui/Plotting/PlotterData.py
@@ -3,6 +3,7 @@ Adapters for fitting module
 """
 import copy
 import math
+import weakref
 from enum import Enum, auto
 
 import numpy
@@ -81,6 +82,19 @@ class Data1D(PlottableData1D, LoadData1D):
         self.slider_low_q_getter = []  # List of attributes that lead to a getter to tie a low Q method to the slider
         self.slider_high_q_setter = []  # List of attributes that lead to a setter to tie a high Q method to the slider
         self.slider_high_q_getter = []  # List of attributes that lead to a getter to tie a high Q method to the slider
+
+    def setSlicerOwner(self, owner):
+        """
+        Store the 2D plot window that owns a slicer-generated 1D plot.
+        """
+        self._slicer_owner_ref = weakref.ref(owner) if owner is not None else None
+
+    def slicerOwner(self):
+        """
+        Return the 2D plot window that owns this slicer plot, if it still exists.
+        """
+        owner_ref = getattr(self, "_slicer_owner_ref", None)
+        return owner_ref() if owner_ref is not None else None
 
     def copy_from_datainfo(self, data1d):
         """

--- a/src/sas/qtgui/Plotting/SlicerParameters.py
+++ b/src/sas/qtgui/Plotting/SlicerParameters.py
@@ -512,8 +512,17 @@ class SlicerParameters(QtWidgets.QDialog, Ui_SlicerParametersUI):
             return
         # Get the current slicer name
         slicer_item = self.getCheckedSlicer()
-        # Remove the slicer from the dictionary
-        if slicer_item in self.parent.slicers:
+        self._removeSlicers([slicer_item])
+
+    def _removeSlicers(self, slicer_names):
+        """
+        Remove one or more slicers from the dialog and the parent plot.
+        """
+        removed_any = False
+        for slicer_item in slicer_names:
+            if slicer_item not in self.parent.slicers:
+                continue
+
             slicer_obj = self.parent.slicers[slicer_item]
             # Clear only this slicer's markers without affecting other slicers
             # Use clear_markers() which uses connect.clear(*markers) instead of clearall()
@@ -523,21 +532,27 @@ class SlicerParameters(QtWidgets.QDialog, Ui_SlicerParametersUI):
             # Remove from slicer_models cache
             if slicer_item in self.slicer_models:
                 del self.slicer_models[slicer_item]
-            # update the canvas
-            self.parent.canvas.draw()
-            # update the slicer list
-            self.updateSlicersList()
-            # Select the next remaining slicer if any exist
-            if len(self.parent.slicers) > 0:
-                # Get the first remaining slicer
-                next_slicer_name = next(iter(self.parent.slicers.keys()))
-                # Update self.parent.slicer to point to the remaining slicer
-                self.parent.slicer = self.parent.slicers[next_slicer_name]
-                self.checkSlicerByName(next_slicer_name)
-            else:
-                # No slicers left, clear the model and slicer reference
-                self.parent.slicer = None
-                self.setModel(None)
+            removed_any = True
+
+        if not removed_any:
+            return
+
+        # Update the canvas
+        self.parent.canvas.draw()
+        # Update the slicers list
+        self.updateSlicersList()
+
+        # Select the next remaining slicer if any exist
+        if len(self.parent.slicers) > 0:
+            # Get the first remaining slicer
+            next_slicer_name = next(iter(self.parent.slicers.keys()))
+            # Update self.parent.slicer to point to the remaining slicer
+            self.parent.slicer = self.parent.slicers[next_slicer_name]
+            self.checkSlicerByName(next_slicer_name)
+        else:
+            # No slicers left, clear the model and slicer reference
+            self.parent.slicer = None
+            self.setModel(None)
 
     def deleteAllSlicerPlots(self, quiet=False):
         """

--- a/src/sas/qtgui/Plotting/Slicers/AnnulusSlicer.py
+++ b/src/sas/qtgui/Plotting/Slicers/AnnulusSlicer.py
@@ -77,7 +77,6 @@ class AnnulusInteractor(BaseInteractor, SlicerModel, StackableMixin):
         self.clear_markers()
         self.outer_circle.clear()
         self.inner_circle.clear()
-        self.base.connect.clearall()
 
     def update(self):
         """

--- a/src/sas/qtgui/Plotting/Slicers/BoxSum.py
+++ b/src/sas/qtgui/Plotting/Slicers/BoxSum.py
@@ -10,6 +10,7 @@ from sas.qtgui.Utilities.GuiUtils import formatNumber, toDouble
 
 logger = logging.getLogger(__name__)
 
+
 class BoxSumCalculator(BaseInteractor):
     """
     BoxSumCalculator Class computes properties (such as sum and average of
@@ -175,9 +176,9 @@ class BoxSumCalculator(BaseInteractor):
         Clear the slicer and all connected events related to this slicer
         """
         self.clear_markers()
-        self.horizontal_lines.clear()
-        self.vertical_lines.clear()
-        self.center.clear()
+        for lines in (self.horizontal_lines, self.vertical_lines, self.center):
+            if getattr(lines, "axes", None) is not None:
+                lines.clear()
         # Close the associated widget if it exists
         if self.widget is not None:
             self.widget.closeWidgetSignal.emit()
@@ -484,8 +485,9 @@ class VerticalDoubleLine(BaseInteractor):
         Clear this slicer  and its markers
         """
         self.clear_markers()
-        self.right_line.remove()
-        self.left_line.remove()
+        for line in (self.right_line, self.left_line):
+            if hasattr(line, "remove") and line in getattr(self.axes, "lines", []):
+                line.remove()
 
     def update(self, x1=None, x2=None, y1=None, y2=None, width=None, height=None, center=None):
         """
@@ -650,8 +652,9 @@ class HorizontalDoubleLine(BaseInteractor):
         Clear this figure and its markers
         """
         self.clear_markers()
-        self.bottom_line.remove()
-        self.top_line.remove()
+        for line in (self.bottom_line, self.top_line):
+            if hasattr(line, "remove") and line in getattr(self.axes, "lines", []):
+                line.remove()
 
     def update(self, x1=None, x2=None, y1=None, y2=None, width=None, height=None, center=None):
         """

--- a/src/sas/qtgui/Plotting/Slicers/SlicerUtils.py
+++ b/src/sas/qtgui/Plotting/Slicers/SlicerUtils.py
@@ -66,7 +66,7 @@ class StackableMixin:
         """
         Ensure data is returned as a list.
         Returns an empty list if data is None, a single-item list if data is a single item
-        
+
         :param data: Data which may be None, a single item, or a list
         :return: List of data items
         """
@@ -172,6 +172,7 @@ class StackableMixin:
         :return: The actual ID assigned to the plot
         """
         new_plot.custom_color = self.color
+        new_plot.setSlicerOwner(self.base)
 
         # Add to model
         GuiUtils.updateModelItemWithPlot(item, new_plot, new_plot.id)
@@ -197,6 +198,7 @@ class StackableMixin:
         :param item: The data explorer item
         """
         # Add to model
+        new_plot.setSlicerOwner(self.base)
         GuiUtils.updateModelItemWithPlot(item, new_plot, new_plot.id)
 
         # Signal to create plot

--- a/src/sas/qtgui/Plotting/UnitTesting/Plotter2DTest.py
+++ b/src/sas/qtgui/Plotting/UnitTesting/Plotter2DTest.py
@@ -155,6 +155,38 @@ class Plotter2DTest:
         assert plotter.boxwidget.isVisible()
         assert isinstance(plotter.boxwidget.model, QtGui.QStandardItemModel)
 
+    def testRemoveSlicersForPlotWindowIgnoresDeletedCanvas(self, plotter, mocker):
+        """ Cleanup should not crash if the canvas is already gone """
+        slicer_window = object()
+        slicer = mocker.MagicMock()
+        slicer._plot_window = slicer_window
+        plotter.slicers = {"slicer": slicer}
+        plotter.slicer = slicer
+        plotter.slicer_plots_dict = {"plot_one": mocker.MagicMock()}
+        mocker.patch.object(plotter.canvas, "draw", side_effect=RuntimeError("deleted"))
+
+        plotter.removeSlicersForPlotWindow(slicer_window)
+
+        slicer.clear.assert_called_once()
+        assert plotter.slicer is None
+
+    def testRemoveSlicersForPlotWindowRemovesMatchingEntry(self, plotter, mocker):
+        """ Closing a 1D slicer plot should remove the matching slicer from the owner """
+        slicer_window = mocker.MagicMock()
+        slicer = mocker.MagicMock()
+        slicer._plot_window = slicer_window
+        plotter.slicers = {"slicer": slicer}
+        plotter.slicer = slicer
+        plotter.slicer_plots_dict = {"plot_one": slicer_window}
+        mocker.patch.object(plotter.canvas, "draw")
+
+        plotter.removeSlicersForPlotWindow(slicer_window)
+
+        slicer.clear.assert_called_once()
+        assert plotter.slicers == {}
+        assert plotter.slicer is None
+        assert plotter.slicer_plots_dict == {}
+
     def testContextMenuQuickPlot(self, plotter, mocker):
         """ Test the right click menu """
         plotter.createContextMenuQuick()

--- a/src/sas/qtgui/Plotting/UnitTesting/PlotterBaseTest.py
+++ b/src/sas/qtgui/Plotting/UnitTesting/PlotterBaseTest.py
@@ -71,11 +71,21 @@ class PlotterBaseTest:
         with pytest.raises(NotImplementedError):
             plotter.plot()
 
-    def notestOnCloseEvent(self, plotter, mocker):
-        ''' test the plotter close behaviour '''
+    def testOnCloseEventRemovesOwnedSlicerPlot(self, plotter, mocker):
+        """ Test that closing a 1D plot asks its owner to remove the matching slicer. """
+        owner = mocker.Mock()
+        data = mocker.Mock()
+        data.slicerOwner = mocker.Mock(return_value=owner)
+        plotter._data = [data]
+        event = mocker.Mock()
+
         mocker.patch.object(PlotHelper, 'deletePlot')
-        plotter.closeEvent(None)
+
+        plotter.closeEvent(event)
+
+        owner.removeSlicersForPlotWindow.assert_called_once_with(plotter)
         PlotHelper.deletePlot.assert_called()
+        event.accept.assert_called_once()
 
     def notestOnImagePrint(self, plotter, mocker):
         ''' test the workspace print '''


### PR DESCRIPTION
## Description

This patch fixes an issue where closing a 1D slicer plot could leave its associated slicer visible on the original 2D plot, causing it to behave incorrectly when moved.

- Added slicer ownership tracking to slicer-generated `PlotterData` objects using a weak reference to the owning 2D plot.
- Updated the plot close event handling so that, when a slicer-generated 1D plot is closed, the owning 2D plot is notified.
- Added cleanup logic in `Plotter2D` to remove all slicers associated with the closed 1D plot window.
- Ensured plot-stacked slicer outputs are handled by checking all data objects in the closing 1D plot.
- Cleared slicers from the 2D canvas and the slicer parameter window

The BoxSum (which does not have a plot but a widget) also closes cleanly with its widget, so the associated slicer is removed too.

Fixes #3969 

## How Has This Been Tested?

Manually tested in build and added tests

## Review Checklist:

**Documentation**
- [x] There is **nothing** that needs documenting
- [ ] Documentation changes are **in this PR**
- [ ] There is an **issue** open for the documentation (link?)

**Installers**
- [ ] There is a chance this will affect the **installers**, if so
  - [ ] **Windows** installer (GH artifact) has been tested (installed and worked) 
  - [ ] **MacOSX** installer (GH artifact) has been tested (installed and worked)
  - [ ] **Wheels** installer (GH artifact) has been tested (installed and worked)

**Licensing**
- [x] The introduced changes comply with SasView license (BSD 3-Clause)

