### PR TITLE
preserve multiline log messages

### DIFF
--- a/src/sas/qtgui/MainWindow/GuiManager.py
+++ b/src/sas/qtgui/MainWindow/GuiManager.py
@@ -6,7 +6,7 @@ import webbrowser
 
 from packaging.version import Version
 from PySide6.QtCore import QLocale, Qt
-from PySide6.QtGui import QStandardItem
+from PySide6.QtGui import QStandardItem, QTextCursor
 from PySide6.QtWidgets import QDockWidget, QLabel, QMessageBox, QProgressBar, QTextBrowser
 from twisted.internet import reactor
 
@@ -80,9 +80,6 @@ class GuiManager:
         # Decide on a locale
         QLocale.setDefault(QLocale('en_US'))
 
-        # Redefine exception hook to not explicitly crash the app.
-        sys.excepthook = self.info
-
         # Ensure the user directory has all required layout and files
         create_user_files_if_needed()
 
@@ -124,9 +121,6 @@ class GuiManager:
         if self.WhatsNew.has_new_messages(): # Not a static method
             self.WhatsNew.show()
 
-    def info(self, type, value, tb):
-        logger.error("".join(traceback.format_exception(type, value, tb)))
-
     def addWidgets(self):
         """
         Populate the main window with widgets
@@ -139,6 +133,8 @@ class GuiManager:
         self.logDockWidget.setVisible(False)
 
         self.listWidget = QTextBrowser()
+        # We could put error log styling here:
+        # self.listWidget.setStyleSheet("QTextBrowser { line-height: 1.0; }")
         self.logDockWidget.setWidget(self.listWidget)
         self._workspace.addDockWidget(Qt.BottomDockWidgetArea, self.logDockWidget)
 
@@ -244,7 +240,6 @@ class GuiManager:
             model_list = ModelManager().cat_model_list()
             CategoryInstaller.check_install(model_list=model_list)
         except Exception:
-            import traceback
             logger.error("Category manager: could not load SasView models")
             logger.error(traceback.format_exc())
 
@@ -500,7 +495,18 @@ class GuiManager:
         """Appends a message to the list widget in the Log Explorer. Use this
         instead of listWidget.insertPlainText() to facilitate auto-scrolling"""
         (message, record) = signal
-        self.listWidget.append(message.strip())
+
+        # Move cursor to the end of text and append the next log message;
+        # Don't use append() to add the block since it messes up the formatting
+        # we do is SasviewLogger. Instead put a <br> between every entry.
+        # Scroll the text so that it is visible.
+        cursor = self.listWidget.textCursor()
+        cursor.movePosition(QTextCursor.End)
+        cursor.insertHtml(f"\n<br>\n{message.strip()}")
+        self.listWidget.ensureCursorVisible()
+
+        # Show the mess inside the log widget. Qt is doing too much!
+        # print("\n\n===log contains: ", self.listWidget.toHtml())
 
         # Display log if message is warning (30) or higher
         # 10: Debug
@@ -623,9 +629,6 @@ class GuiManager:
 
     def showWelcomeMessage(self):
         """ Show the Welcome panel, when required """
-        # Assure the welcome screen is requested
-        show_welcome_widget = True
-
         if config.SHOW_WELCOME_PANEL:
             self.actionWelcome()
 

--- a/src/sas/qtgui/MainWindow/MainWindow.py
+++ b/src/sas/qtgui/MainWindow/MainWindow.py
@@ -1,5 +1,6 @@
 import logging
 import sys
+import traceback
 from importlib import resources
 
 from PySide6.QtCore import Qt, QTimer
@@ -16,6 +17,9 @@ from ..Utilities.NewVersion.NewVersionAvailable import maybe_prompt_new_version_
 from .UI.MainWindowUI import Ui_SasView
 
 logger = logging.getLogger(__name__)
+def log_uncaught_exception(type, value, tb):
+    formatted_tb = "".join(traceback.format_exception(type, value, tb))
+    logger.error(f"--- Uncaught exception ---\n{formatted_tb.strip()}")
 
 class MainSasViewWindow(QMainWindow, Ui_SasView):
     # Main window of the application
@@ -112,6 +116,9 @@ def run_sasview(file_list: list[str] | None = None):
 
     # Show the main SV window
     mainwindow = MainSasViewWindow()
+
+    # Redirect uncaught exceptions to logger
+    sys.excepthook = log_uncaught_exception
 
     # no more splash screen
     splash.finish(mainwindow)

--- a/src/sas/qtgui/Perspectives/Fitting/FittingWidget.py
+++ b/src/sas/qtgui/Perspectives/Fitting/FittingWidget.py
@@ -102,9 +102,6 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         # Which tab is this widget displayed in?
         self.tab_id = tab_id
 
-        import sys
-        sys.excepthook = self.info
-
         # Globals
         self.initializeGlobals()
 
@@ -188,9 +185,6 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         new_font = 'font-family: -apple-system, "Helvetica Neue", "Ubuntu";'
         self.label_17.setStyleSheet(new_font)
         self.label_19.setStyleSheet(new_font)
-
-    def info(self, type: Any, value: Any, tb: Any) -> None:
-        logger.error("".join(traceback.format_exception(type, value, tb)))
 
     @property
     def logic(self) -> FittingLogic:

--- a/src/sas/qtgui/Utilities/ModelEditors/TabbedEditor/TabbedModelEditor.py
+++ b/src/sas/qtgui/Utilities/ModelEditors/TabbedEditor/TabbedModelEditor.py
@@ -466,10 +466,8 @@ class TabbedModelEditor(QtWidgets.QDialog, Ui_TabbedModelEditor):
             logger.error(msg)
             # print four last lines of the stack trace
             # this will point out the exact line failing
-            all_lines = traceback.format_exc().split("\n")
+            all_lines = traceback.format_exc().strip().split("\n")
             last_lines = all_lines[-4:]
-            traceback_to_show = "\n".join(last_lines)
-            logger.error(traceback_to_show)
 
             # Set the status bar message
             # GuiUtils.communicator.statusBarUpdateSignal.emit("Model check failed")

--- a/src/sas/qtgui/Utilities/SasviewLogger.py
+++ b/src/sas/qtgui/Utilities/SasviewLogger.py
@@ -16,7 +16,14 @@ class SasViewLogFormatter(logging.Formatter):
         if record.levelname in self.LOG_COLORS:
             level_style = f' style="color: {self.LOG_COLORS[record.levelname]}"'
 
-        return logging.Formatter(fmt=self.LOG_FORMAT.format(level_style), datefmt=self.DATE_FORMAT).format(record)
+        # Format the timestamp, etc.
+        msg = logging.Formatter(fmt=self.LOG_FORMAT.format(level_style), datefmt=self.DATE_FORMAT).format(record)
+
+        # If it is a multiline error message then put the additional lines in a <pre> block
+        if "\n" in msg:
+            lead, tail = msg.split("\n", 1)
+            msg = f"{lead}\n<pre>{tail}</pre>"
+        return msg
 
 class QtPostman(QObject):
     messageWritten = Signal(object)


### PR DESCRIPTION
## Description

Preserve line breaks in error messages displayed in the log explorer.

Cleans up uncaught exception handling so that it appears in one place.

Minor unrelated code cleanup, removing an unused variable.

Fixes #3219

## How Has This Been Tested?

Introduced an uncaught exception after plotting in the fitting widget so that uncaught exceptions could easily be generated (not included in the PR).

Created a plugin model with a c error so that compiler output could be checked.

## Review Checklist:

[if using the editor, use `[x]` in place of `[ ]` to check a box]

**Documentation** (check at least one)
- [X] There is **nothing** that needs documenting
- [ ] Documentation changes are **in this PR**
- [ ] There is an **issue** open for the documentation (link?)

**Installers**
- [ ] There is a chance this will affect the **installers**, if so
  - [ ] **Windows** installer (GH artifact) has been tested (installed and worked) 
  - [ ] **MacOSX** installer (GH artifact) has been tested (installed and worked)
  - [ ] **Wheels** installer (GH artifact) has been tested (installed and worked)

**Licensing** (untick if necessary)
- [x] The introduced changes comply with SasView license (BSD 3-Clause)

