### PR TITLE
Change docpath handling to accept absolute-looking paths within the d…

### DIFF
--- a/src/sas/system/_help.py
+++ b/src/sas/system/_help.py
@@ -1,4 +1,5 @@
 import logging
+import re
 import webbrowser
 from pathlib import Path
 
@@ -26,58 +27,82 @@ class _HelpSystem:
     def show_help(self, url: str | Path) -> None:
         """Open documentation in the system's default web browser.
 
-        Takes a relative documentation path (e.g.
-        ``user/qtgui/Perspectives/Fitting/fitting_help.html#anchor``),
-        resolves it against the local doc tree when available, and falls
-        back to the online docs at www.sasview.org otherwise.
+        :param url: a documentation path within the documentation tree (e.g.
+            ``/user/qtgui/Perspectives/Fitting/fitting_help.html#anchor``),
+            or an absolute path on the filesystem (e.g. ``/home/user/.sasview``)
+
+        The provided documentation path is resolved in the following order:
+        1. check if path exists within the documentation tree
+        2. check if the path exists on disk exactly as provided
+        3. fall back to online docs at www.sasview.org
         """
+        logger.info("Help URL: %s", url)
+
+        # get a POSIX (forward-slash) version of the resource if a WindowsPath
+        # was provided
         if isinstance(url, Path):
             url = url.as_posix()
 
-        # Separate any fragment (#anchor) from the path so Path operations
-        # don't treat it as part of the filename.
+        # Remove multiple / at the start of the path (would look like a
+        # UNC path on Windows)
+        url = re.sub("^/{2,}", "/", url)
+
         fragment = ""
         if "#" in url:
             url, fragment = url.rsplit("#", 1)
 
-        relative_path = Path(url)
+        try:
+            local_path = self._local_url(url)
+            if local_path:
+                target = local_path.as_uri()
+                if fragment:
+                    target += "#" + fragment
+                webbrowser.open(target)
+                return
 
-        # Preserve absolute paths long enough to detect and strip the local
-        # documentation root on POSIX platforms before normalizing relative
-        # help paths that may be passed with leading slashes.
-        if not relative_path.is_absolute():
-            relative_path = Path(url.lstrip("/"))
+            # Fall back to online documentation
+            webbrowser.open(self._online_url(url, fragment))
+        except Exception as ex:
+            logger.warning("Cannot display help: %s", ex)
+
+    def _local_url(self, resource: str) -> Path | None:
+        """turn a resource name into a file path for local resources
+
+        returns None if resource cannot be found locally
+        """
+        if self.path:
+            relative_path = Path(resource.lstrip("/"))
+            doc_path = self.path / relative_path
+            if doc_path.exists():
+                logger.debug("Resolved help resource %s to doc_path %s", resource, doc_path)
+                return doc_path
+
+        full_path = Path(resource)
+        if full_path.exists():
+            logger.debug("Resolved help resource %s to absolute path %s", resource, full_path)
+            return full_path
+
+        logger.debug("Resolved help resource %s not resolved", resource)
+        return None
+
+    def _online_url(self, resource: str, fragment: str = "") -> str:
+        """Construct the online documentation URL for the current version."""
+        from sas.system.version import __version__
 
         # Strip the local doc root if a caller accidentally passed an
         # absolute path that already includes it.
+        relative_path = Path(resource)
         if self.path and relative_path.is_absolute():
             try:
                 relative_path = relative_path.relative_to(self.path)
             except ValueError:
                 pass  # not under HELP_SYSTEM.path – use as-is
 
-        try:
-            if self.path:
-                local_path = self.path / relative_path
-                if local_path.exists():
-                    target = local_path.as_uri()
-                    if fragment:
-                        target += "#" + fragment
-                    webbrowser.open(target)
-                    return
-
-            # Fall back to online documentation
-            webbrowser.open(self._online_url(relative_path, fragment))
-        except Exception as ex:
-            logger.warning("Cannot display help: %s", ex)
-
-    def _online_url(self, relative_path: Path, fragment: str = "") -> str:
-        """Construct the online documentation URL for the current version."""
-        from sas.system.version import __version__
+        remote_resource = relative_path.as_posix().lstrip("/")
 
         version = _release_version(__version__)
         base = f"https://www.sasview.org/docs/v{version}"
-        url = f"{base}/{relative_path.as_posix()}"
+        url = f"{base}/{remote_resource}"
         if fragment:
             url += "#" + fragment
         return url

--- a/test/system/utest_help.py
+++ b/test/system/utest_help.py
@@ -3,6 +3,8 @@
 from pathlib import Path, PurePosixPath
 from unittest.mock import patch
 
+import pytest
+
 from sas.system._help import _HelpSystem, _release_version
 
 
@@ -40,7 +42,7 @@ class TestHelpSystemOnlineUrl:
     def test_online_url_basic(self, _mock):
         with patch("sas.system.version.__version__", "6.1.2"):
             url = self.hs._online_url(
-                Path("user/qtgui/Perspectives/Fitting/fitting_help.html")
+                "/user/qtgui/Perspectives/Fitting/fitting_help.html"
             )
         assert url == (
             "https://www.sasview.org/docs/v6.1.2"
@@ -50,7 +52,7 @@ class TestHelpSystemOnlineUrl:
     def test_online_url_dev_version(self):
         with patch("sas.system.version.__version__", "6.1.2.dev159+g77be83657"):
             url = self.hs._online_url(
-                Path("user/qtgui/Perspectives/Fitting/fitting_help.html")
+                "/user/qtgui/Perspectives/Fitting/fitting_help.html"
             )
         assert url.startswith("https://www.sasview.org/docs/v6.1.2/")
         assert "+g77be83657" not in url
@@ -59,17 +61,17 @@ class TestHelpSystemOnlineUrl:
     def test_online_url_with_fragment(self):
         with patch("sas.system.version.__version__", "6.1.2"):
             url = self.hs._online_url(
-                Path("user/qtgui/Perspectives/Fitting/fitting_help.html"),
+                "/user/qtgui/Perspectives/Fitting/fitting_help.html",
                 "simultaneous-fits",
             )
         assert url.endswith("fitting_help.html#simultaneous-fits")
 
-    def test_online_url_uses_posix_separators(self):
-        with patch("sas.system.version.__version__", "6.1.2"):
-            url = self.hs._online_url(
-                Path("user") / "qtgui" / "Perspectives" / "Fitting" / "fitting_help.html"
-            )
-        assert "\\" not in url
+
+testurls = [
+    "user/fitting.html",
+    "/user/fitting.html",
+    "//user/fitting.html",
+]
 
 
 class TestShowHelp:
@@ -78,64 +80,71 @@ class TestShowHelp:
     def setup_method(self):
         self.hs = _HelpSystem()
 
+    @pytest.mark.parametrize("url", testurls)
     @patch("sas.system._help.webbrowser")
-    def test_local_docs_opened(self, mock_wb, tmp_path):
+    def test_local_docs_opened(self, mock_wb, tmp_path, url):
         """When local docs exist, open them via file URI."""
         doc = tmp_path / "user" / "fitting.html"
         doc.parent.mkdir(parents=True)
         doc.write_text("<html></html>")
 
         self.hs.path = tmp_path
-        self.hs.show_help("user/fitting.html")
+        self.hs.show_help(url)
 
         mock_wb.open.assert_called_once()
         opened_url = mock_wb.open.call_args[0][0]
         assert opened_url.startswith("file:///")
         assert "fitting.html" in opened_url
+        assert "//user" not in opened_url
 
+    @pytest.mark.parametrize("url", testurls)
     @patch("sas.system._help.webbrowser")
-    def test_local_docs_with_fragment(self, mock_wb, tmp_path):
+    def test_local_docs_with_fragment(self, mock_wb, tmp_path, url):
         """Fragment (#anchor) must be preserved for local files."""
         doc = tmp_path / "user" / "fitting.html"
         doc.parent.mkdir(parents=True)
         doc.write_text("<html></html>")
 
         self.hs.path = tmp_path
-        self.hs.show_help("user/fitting.html#constraints")
+        self.hs.show_help(f"{url}#constraints")
 
         opened_url = mock_wb.open.call_args[0][0]
         assert opened_url.endswith("#constraints")
 
+    @pytest.mark.parametrize("url", testurls)
     @patch("sas.system._help.webbrowser")
-    def test_online_fallback_when_local_missing(self, mock_wb, tmp_path):
+    def test_online_fallback_when_local_missing(self, mock_wb, tmp_path, url):
         """When local docs don't exist, fall back to online URL."""
         self.hs.path = tmp_path  # empty dir — no docs
         with patch("sas.system.version.__version__", "6.1.2"):
-            self.hs.show_help("user/fitting.html")
+            self.hs.show_help(url)
 
         opened_url = mock_wb.open.call_args[0][0]
         assert opened_url == (
             "https://www.sasview.org/docs/v6.1.2/user/fitting.html"
         )
 
+    @pytest.mark.parametrize("url", testurls)
     @patch("sas.system._help.webbrowser")
-    def test_online_fallback_no_absolute_path_leak(self, mock_wb, tmp_path):
+    def test_online_fallback_no_absolute_path_leak(self, mock_wb, tmp_path, url):
         """The online URL must never contain the local filesystem path."""
         self.hs.path = tmp_path
         with patch("sas.system.version.__version__", "6.1.2"):
-            self.hs.show_help("user/fitting.html")
+            self.hs.show_help(url)
 
         opened_url = mock_wb.open.call_args[0][0]
         assert str(tmp_path) not in opened_url
         assert "C:" not in opened_url
         assert "Users" not in opened_url
+        assert "//user" not in opened_url
 
+    @pytest.mark.parametrize("url", testurls)
     @patch("sas.system._help.webbrowser")
-    def test_online_fallback_when_path_is_none(self, mock_wb):
+    def test_online_fallback_when_path_is_none(self, mock_wb, url):
         """When HELP_SYSTEM.path is None, fall back to online."""
         self.hs.path = None
         with patch("sas.system.version.__version__", "6.1.2"):
-            self.hs.show_help("user/fitting.html")
+            self.hs.show_help(url)
 
         opened_url = mock_wb.open.call_args[0][0]
         assert opened_url.startswith("https://www.sasview.org/docs/v6.1.2/")
@@ -169,27 +178,33 @@ class TestShowHelp:
             "https://www.sasview.org/docs/v6.1.2/user/fitting.html"
         )
 
+    @pytest.mark.parametrize("url", testurls)
     @patch("sas.system._help.webbrowser")
-    def test_leading_slashes_stripped(self, mock_wb, tmp_path):
+    def test_leading_slashes_stripped(self, mock_wb, tmp_path, url):
         """Leading slashes on the relative URL are stripped."""
         doc = tmp_path / "user" / "fitting.html"
         doc.parent.mkdir(parents=True)
         doc.write_text("<html></html>")
 
         self.hs.path = tmp_path
-        self.hs.show_help("//user/fitting.html")
+        self.hs.show_help(url)
 
         opened_url = mock_wb.open.call_args[0][0]
         assert "fitting.html" in opened_url
+        assert "//user" not in opened_url
 
+    @pytest.mark.parametrize("url", testurls)
     @patch("sas.system._help.webbrowser")
-    def test_path_object_accepted(self, mock_wb, tmp_path):
+    def test_path_object_accepted(self, mock_wb, tmp_path, url):
         """A Path object should be accepted as input."""
         doc = tmp_path / "user" / "fitting.html"
         doc.parent.mkdir(parents=True)
         doc.write_text("<html></html>")
 
         self.hs.path = tmp_path
-        self.hs.show_help(Path("user/fitting.html"))
+        self.hs.show_help(Path(url))
 
         mock_wb.open.assert_called_once()
+        opened_url = mock_wb.open.call_args[0][0]
+        assert "fitting.html" in opened_url
+        assert "//user" not in opened_url


### PR DESCRIPTION
## Description

Widgets pass absolute doc paths to the help system ('/user/qtgui/...'), but `show_help` docstring (and code) assumes that it is given a relative path. 

This PR changes the code to expect absolute paths for the doc location, differentiating between a pseudo-path for an internal resource vs real file on disk by whether they exist.

This PR also expands the test coverage of relative vs absolute vs accidental double-/ paths.

Fixes #3976

## How Has This Been Tested?

CI tests give some coverage for the logic in this code. Also tested on linux.

(needs testing on windows)

## Review Checklist:

[if using the editor, use `[x]` in place of `[ ]` to check a box]

**Documentation** (check at least one)
- [x] There is **nothing** that needs documenting
- [ ] Documentation changes are **in this PR**
- [ ] There is an **issue** open for the documentation (link?)

**Installers**
- [ ] There is a chance this will affect the **installers**, if so
  - [ ] **Windows** installer (GH artifact) has been tested (installed and worked) 
  - [ ] **MacOSX** installer (GH artifact) has been tested (installed and worked)
  - [ ] **Wheels** installer (GH artifact) has been tested (installed and worked)

**Licensing** (untick if necessary)
- [x] The introduced changes comply with SasView license (BSD 3-Clause)

