### PR TITLE
Fixes Invariant plot sliders

### DIFF
--- a/src/sas/qtgui/MainWindow/DataExplorer.py
+++ b/src/sas/qtgui/MainWindow/DataExplorer.py
@@ -1410,11 +1410,14 @@ class DataExplorerWindow(DroppableDataLoadWidget):
         Modify existing plot for immediate response and returns True.
         Returns false, if the plot does not exist already.
         """
-        try:  # there might be a list or a single value being passed
+        if isinstance(data, (list, tuple)):
+            if not data:
+                return False
             data = data[0]
-        except TypeError:
-            pass
-        assert type(data).__name__ in ['Data1D', 'Data2D']
+
+        if not isinstance(data, (Data1D, Data2D)):
+            logger.warning("updatePlot received unexpected type: %s", type(data).__name__)
+            return False
 
         ids_keys = list(self.active_plots.keys())
 

--- a/src/sas/qtgui/Perspectives/Invariant/InvariantPerspective.py
+++ b/src/sas/qtgui/Perspectives/Invariant/InvariantPerspective.py
@@ -153,6 +153,8 @@ class InvariantWindow(QtWidgets.QDialog, Ui_tabbedInvariantUI, Perspective):
 
         for plot in plots:
             plot_widget = active_plots.get(plot.name)
+            if plot_widget is None:
+                continue
             plot_widget.update_slider_positions(plot.name)
 
     def setup_tooltips(self) -> None:
@@ -397,10 +399,15 @@ class InvariantWindow(QtWidgets.QDialog, Ui_tabbedInvariantUI, Perspective):
         self.model = model
         self._data = GuiUtils.dataFromItem(self._model_item)
 
+        # Close the initial data plot that was created in setData()
+        if (self.high_extrapolation_plot or self.low_extrapolation_plot) and not self.extrapolation_made:
+            self._manager.filesWidget.closePlotsForItem(self._model_item)
+            self.extrapolation_made = True
+
         # Send the modified model item to replace initial plot
         plots = [self._model_item]
 
-        if self._high_extrapolate and self.high_extrapolation_plot is not None:
+        if self.high_extrapolation_plot:
             self.high_extrapolation_plot.plot_role = DataRole.ROLE_DEFAULT
             self.high_extrapolation_plot.symbol = "Line"
             self.high_extrapolation_plot.custom_color = "#2ca02c"
@@ -414,7 +421,7 @@ class InvariantWindow(QtWidgets.QDialog, Ui_tabbedInvariantUI, Perspective):
                 self._model_item, self.high_extrapolation_plot, self.high_extrapolation_plot.title
             )
             plots.append(self.high_extrapolation_plot)
-        if self._low_extrapolate and self.low_extrapolation_plot is not None:
+        if self.low_extrapolation_plot:
             self.low_extrapolation_plot.plot_role = DataRole.ROLE_DEFAULT
             self.low_extrapolation_plot.symbol = "Line"
             self.low_extrapolation_plot.custom_color = "#ff7f0e"
@@ -429,23 +436,7 @@ class InvariantWindow(QtWidgets.QDialog, Ui_tabbedInvariantUI, Perspective):
             plots.append(self.low_extrapolation_plot)
 
         if len(plots) > 1:
-            # Only emit a plot update if the composition of extrapolation plots has changed
-            # ie. both -> low only, high only -> none, etc.
-            current_mode = [self._low_extrapolate, self._high_extrapolate]
-            previous_mode = getattr(self, "_plotted_extrapolation_mode", None)
-            force_replot = getattr(self, "_force_extrapolation_replot", False)
-
-            if current_mode != previous_mode or force_replot:
-                self._manager.filesWidget.closePlotsForItem(self._model_item)
-                self.communicator.plotRequestedSignal.emit(plots)
-                self.extrapolation_made = True
-                self._plotted_extrapolation_mode = current_mode
-                self._force_extrapolation_replot = False
-            else:
-                # Update the existing extrapolation plots in place without re-emitting the whole plot
-                for plot in plots[1:]:
-                    self.communicator.plotUpdateSignal.emit([plot])
-                self._refresh_extrapolation_plots()
+            self.communicator.plotRequestedSignal.emit(plots)
 
         # Update the details dialog in case it is open
         self.update_details_widget()

--- a/src/sas/qtgui/Perspectives/Invariant/InvariantPerspective.py
+++ b/src/sas/qtgui/Perspectives/Invariant/InvariantPerspective.py
@@ -136,6 +136,12 @@ class InvariantWindow(QtWidgets.QDialog, Ui_tabbedInvariantUI, Perspective):
         self.slider = ExtrapolationSlider(perspective=SliderPerspective.INVARIANT)
         self.sliderLayout.insertWidget(1, self.slider)
 
+    def _refresh_extrapolation_plots(self) -> None:
+        """Refresh any visible extrapolation plots so the range markers stay in sync."""
+        plots = [plot for plot in [self.low_extrapolation_plot, self.high_extrapolation_plot] if plot is not None]
+        for plot in plots:
+            self.communicator.plotUpdateSignal.emit([plot])
+
     def setup_tooltips(self) -> None:
         """Setup tooltips for the widgets"""
         self.cmdStatus.setToolTip("Get more details of computation such as fraction from extrapolation")
@@ -387,6 +393,9 @@ class InvariantWindow(QtWidgets.QDialog, Ui_tabbedInvariantUI, Perspective):
             self.high_extrapolation_plot.show_errors = False
             self.high_extrapolation_plot.show_q_range_sliders = True
             self.high_extrapolation_plot.slider_draggable = False
+            self.high_extrapolation_plot.slider_perspective_name = "Invariant"
+            self.high_extrapolation_plot.slider_low_q_input = ["txtPorodStart_ex"]
+            self.high_extrapolation_plot.slider_high_q_input = ["txtPorodEnd_ex"]
             GuiUtils.updateModelItemWithPlot(
                 self._model_item, self.high_extrapolation_plot, self.high_extrapolation_plot.title
             )
@@ -398,6 +407,8 @@ class InvariantWindow(QtWidgets.QDialog, Ui_tabbedInvariantUI, Perspective):
             self.low_extrapolation_plot.show_errors = False
             self.low_extrapolation_plot.show_q_range_sliders = True
             self.low_extrapolation_plot.slider_draggable = False
+            self.low_extrapolation_plot.slider_perspective_name = "Invariant"
+            self.low_extrapolation_plot.slider_high_q_input = ["txtGuinierEnd_ex"]
             GuiUtils.updateModelItemWithPlot(
                 self._model_item, self.low_extrapolation_plot, self.low_extrapolation_plot.title
             )
@@ -900,12 +911,15 @@ class InvariantWindow(QtWidgets.QDialog, Ui_tabbedInvariantUI, Perspective):
         self.model.setItem(WIDGETS.W_POROD_START_EX, QtGui.QStandardItem(format_string % state.point_2))
         self.model.setItem(WIDGETS.W_POROD_END_EX, QtGui.QStandardItem(format_string % state.point_3))
         self.correct_extrapolation_values()
+        self._refresh_extrapolation_plots()
 
     def on_extrapolation_text_editing(self) -> None:
         """Handle when user edits any of the extrapolation text boxes."""
         if self.extrapolation_parameters is None or self._data is None:
             return
         self.check_extrapolation_values()
+        if not any(getattr(self, "validity_flags", [])):
+            self.apply_parameters_from_ui()
 
     def on_extrapolation_text_edited(self) -> None:
         """Handle when user finishes editing any of the extrapolation text boxes."""
@@ -1053,6 +1067,7 @@ class InvariantWindow(QtWidgets.QDialog, Ui_tabbedInvariantUI, Perspective):
 
         # re-validate to update any UI flags
         self.check_extrapolation_values()
+        self._refresh_extrapolation_plots()
 
     def checkVolFrac(self) -> None:
         """Check if volfrac1 is strictly between 0 and 1."""

--- a/src/sas/qtgui/Perspectives/Invariant/InvariantPerspective.py
+++ b/src/sas/qtgui/Perspectives/Invariant/InvariantPerspective.py
@@ -355,8 +355,10 @@ class InvariantWindow(QtWidgets.QDialog, Ui_tabbedInvariantUI, Perspective):
         def finish_calculation() -> None:
             self.plot_result(model)
 
-            # Recreate the initial plot if no extrapolation was used and plot was previously closed
-            if extrapolation is None and self.extrapolation_made:
+            no_extrapolation_plots = (self.low_extrapolation_plot is None) and (self.high_extrapolation_plot is None)
+
+            # Recreate the initial plot if no extrapolation plots are present
+            if self.extrapolation_made and no_extrapolation_plots:
                 self._manager.filesWidget.newPlot()
                 self.extrapolation_made = False
                 self._plotted_extrapolation_mode = None

--- a/src/sas/qtgui/Perspectives/Invariant/InvariantPerspective.py
+++ b/src/sas/qtgui/Perspectives/Invariant/InvariantPerspective.py
@@ -430,6 +430,7 @@ class InvariantWindow(QtWidgets.QDialog, Ui_tabbedInvariantUI, Perspective):
 
         if len(plots) > 1:
             # Only emit a plot update if the composition of extrapolation plots has changed
+            # ie. both -> low only, high only -> none, etc.
             current_mode = [self._low_extrapolate, self._high_extrapolate]
             previous_mode = getattr(self, "_plotted_extrapolation_mode", None)
             force_replot = getattr(self, "_force_extrapolation_replot", False)
@@ -656,12 +657,6 @@ class InvariantWindow(QtWidgets.QDialog, Ui_tabbedInvariantUI, Perspective):
             # Enable the status button (schedule on GUI thread)
             _ui(self.cmdStatus.setEnabled, True)
 
-            if calculation_failed:
-                # leave status disabled if something critical failed
-                _ui(self.cmdStatus.setEnabled, False)
-                logger.warning(f"Calculation failed: {msg}")
-                return self.model
-
             # add extrapolation plots (schedule GUI changes where needed)
             if low_success:
                 qmin_ext = float(self.extrapolation_parameters.ex_q_min)
@@ -702,6 +697,12 @@ class InvariantWindow(QtWidgets.QDialog, Ui_tabbedInvariantUI, Perspective):
                 self.high_extrapolation_plot._yunit = temp_data._yunit
                 if self._high_fit:
                     _safe_update_model(WIDGETS.W_HIGHQ_POWER_VALUE_EX, power_high)
+
+            if calculation_failed:
+                # leave status disabled if something critical failed
+                _ui(self.cmdStatus.setEnabled, False)
+                logger.warning(f"Calculation failed: {msg}")
+                return self.model
 
             # convert any "ERROR" to numeric zeros before summing
             if qstar_high == "ERROR":

--- a/src/sas/qtgui/Perspectives/Invariant/InvariantPerspective.py
+++ b/src/sas/qtgui/Perspectives/Invariant/InvariantPerspective.py
@@ -363,7 +363,6 @@ class InvariantWindow(QtWidgets.QDialog, Ui_tabbedInvariantUI, Perspective):
             if self.extrapolation_made and no_extrapolation_plots:
                 self._manager.filesWidget.newPlot()
                 self.extrapolation_made = False
-                self._plotted_extrapolation_mode = None
 
             self.check_status()
 

--- a/src/sas/qtgui/Perspectives/Invariant/InvariantPerspective.py
+++ b/src/sas/qtgui/Perspectives/Invariant/InvariantPerspective.py
@@ -130,7 +130,6 @@ class InvariantWindow(QtWidgets.QDialog, Ui_tabbedInvariantUI, Perspective):
         self.high_extrapolation_plot: Data1D | None = None
         self.low_extrapolation_plot: Data1D | None = None
         self.extrapolation_made: bool = False
-        self.force_extrapolation_replot: bool = False
 
     def setup_slider(self) -> None:
         """Setup the extrapolation slider."""
@@ -558,7 +557,6 @@ class InvariantWindow(QtWidgets.QDialog, Ui_tabbedInvariantUI, Perspective):
                         _ui(self._model_item.removeRow, item.row())
                         break
                 self.low_extrapolation_plot = None
-                self._force_extrapolation_replot = True
 
             _safe_update_model(WIDGETS.D_LOW_QSTAR, qstar_low)
             _safe_update_model(WIDGETS.D_LOW_QSTAR_ERR, qstar_low_err)
@@ -572,7 +570,6 @@ class InvariantWindow(QtWidgets.QDialog, Ui_tabbedInvariantUI, Perspective):
                         _ui(self._model_item.removeRow, item.row())
                         break
                 self.high_extrapolation_plot = None
-                self._force_extrapolation_replot = True
 
             _safe_update_model(WIDGETS.D_HIGH_QSTAR, qstar_high)
             _safe_update_model(WIDGETS.D_HIGH_QSTAR_ERR, qstar_high_err)

--- a/src/sas/qtgui/Perspectives/Invariant/InvariantPerspective.py
+++ b/src/sas/qtgui/Perspectives/Invariant/InvariantPerspective.py
@@ -10,6 +10,7 @@ from twisted.internet import reactor, threads
 from twisted.python.failure import Failure
 
 import sas.qtgui.Utilities.GuiUtils as GuiUtils
+import sas.qtgui.Utilities.ObjectLibrary as ol
 from sas.qtgui.Plotting import PlotterData
 from sas.qtgui.Plotting.PlotterData import Data1D, DataRole
 from sas.qtgui.Utilities.BackgroundColor import BG_DEFAULT, BG_ERROR
@@ -136,11 +137,23 @@ class InvariantWindow(QtWidgets.QDialog, Ui_tabbedInvariantUI, Perspective):
         self.slider = ExtrapolationSlider(perspective=SliderPerspective.INVARIANT)
         self.sliderLayout.insertWidget(1, self.slider)
 
-    def _refresh_extrapolation_plots(self) -> None:
-        """Refresh any visible extrapolation plots so the range markers stay in sync."""
+    def _refresh_extrapolation_plots(self, state=None) -> None:
+        """Refresh any visible extrapolation plot markers in place.
+
+        Updating the existing `QRangeSlider` artists is much cheaper than replacing the
+        whole plot, so use that path whenever the plot window is already open.
+        """
         plots = [plot for plot in [self.low_extrapolation_plot, self.high_extrapolation_plot] if plot is not None]
+        # Directly obtain the plot widget and update its slider positions.
+        data_explorer = ol.getObject("DataExplorer")
+
         for plot in plots:
-            self.communicator.plotUpdateSignal.emit([plot])
+            plot_widget = data_explorer.active_plots.get(plot.name)
+
+            if state is not None and getattr(state, "dragging_line_position", None) is not None:
+                plot_widget.update_slider_positions(plot.name, state)
+            else:
+                plot_widget.update_slider_positions(plot.name)
 
     def setup_tooltips(self) -> None:
         """Setup tooltips for the widgets"""
@@ -338,15 +351,19 @@ class InvariantWindow(QtWidgets.QDialog, Ui_tabbedInvariantUI, Perspective):
         self.check_status()
 
     def deferredPlot(self, model: QtGui.QStandardItemModel, extrapolation: str | None = None) -> None:
-        """Run the GUI/model update in the main thread"""
-        reactor.callFromThread(lambda: self.plot_result(model))
+        """Run the GUI/model update in the main thread."""
+        def finish_calculation() -> None:
+            self.plot_result(model)
 
-        # Recreate the initial plot if no extrapolation was used and plot was previously closed
-        if extrapolation is None and self.extrapolation_made:
-            reactor.callFromThread(lambda: self._manager.filesWidget.newPlot())
-            self.extrapolation_made = False
+            # Recreate the initial plot if no extrapolation was used and plot was previously closed
+            if extrapolation is None and self.extrapolation_made:
+                self._manager.filesWidget.newPlot()
+                self.extrapolation_made = False
+                self._plotted_extrapolation_mode = None
 
-        self.check_status()
+            self.check_status()
+
+        reactor.callFromThread(finish_calculation)
 
     def check_status(self) -> None:
         """
@@ -378,15 +395,10 @@ class InvariantWindow(QtWidgets.QDialog, Ui_tabbedInvariantUI, Perspective):
         self.model = model
         self._data = GuiUtils.dataFromItem(self._model_item)
 
-        # Close the initial data plot that was created in setData()
-        if (self.high_extrapolation_plot or self.low_extrapolation_plot) and not self.extrapolation_made:
-            self._manager.filesWidget.closePlotsForItem(self._model_item)
-            self.extrapolation_made = True
-
         # Send the modified model item to replace initial plot
         plots = [self._model_item]
 
-        if self.high_extrapolation_plot:
+        if self._high_extrapolate and self.high_extrapolation_plot:
             self.high_extrapolation_plot.plot_role = DataRole.ROLE_DEFAULT
             self.high_extrapolation_plot.symbol = "Line"
             self.high_extrapolation_plot.custom_color = "#2ca02c"
@@ -400,7 +412,7 @@ class InvariantWindow(QtWidgets.QDialog, Ui_tabbedInvariantUI, Perspective):
                 self._model_item, self.high_extrapolation_plot, self.high_extrapolation_plot.title
             )
             plots.append(self.high_extrapolation_plot)
-        if self.low_extrapolation_plot:
+        if self._low_extrapolate and self.low_extrapolation_plot:
             self.low_extrapolation_plot.plot_role = DataRole.ROLE_DEFAULT
             self.low_extrapolation_plot.symbol = "Line"
             self.low_extrapolation_plot.custom_color = "#ff7f0e"
@@ -415,7 +427,20 @@ class InvariantWindow(QtWidgets.QDialog, Ui_tabbedInvariantUI, Perspective):
             plots.append(self.low_extrapolation_plot)
 
         if len(plots) > 1:
-            self.communicator.plotRequestedSignal.emit(plots)
+            # Only emit a plot update if the composition of extrapolation plots has changed
+            current_mode = [self._low_extrapolate, self._high_extrapolate]
+            previous_mode = getattr(self, "_plotted_extrapolation_mode", None)
+
+            if current_mode != previous_mode:
+                self._manager.filesWidget.closePlotsForItem(self._model_item)
+                self.communicator.plotRequestedSignal.emit(plots)
+                self.extrapolation_made = True
+                self._plotted_extrapolation_mode = current_mode
+            else:
+                # Update the existing extrapolation plots in place without re-emitting the whole plot
+                for plot in plots[1:]:
+                    self.communicator.plotUpdateSignal.emit([plot])
+                self._refresh_extrapolation_plots()
 
         # Update the details dialog in case it is open
         self.update_details_widget()

--- a/src/sas/qtgui/Perspectives/Invariant/InvariantPerspective.py
+++ b/src/sas/qtgui/Perspectives/Invariant/InvariantPerspective.py
@@ -385,6 +385,8 @@ class InvariantWindow(QtWidgets.QDialog, Ui_tabbedInvariantUI, Perspective):
             self.high_extrapolation_plot.symbol = "Line"
             self.high_extrapolation_plot.custom_color = "#2ca02c"
             self.high_extrapolation_plot.show_errors = False
+            self.high_extrapolation_plot.show_q_range_sliders = True
+            self.high_extrapolation_plot.slider_draggable = False
             GuiUtils.updateModelItemWithPlot(
                 self._model_item, self.high_extrapolation_plot, self.high_extrapolation_plot.title
             )
@@ -394,6 +396,8 @@ class InvariantWindow(QtWidgets.QDialog, Ui_tabbedInvariantUI, Perspective):
             self.low_extrapolation_plot.symbol = "Line"
             self.low_extrapolation_plot.custom_color = "#ff7f0e"
             self.low_extrapolation_plot.show_errors = False
+            self.low_extrapolation_plot.show_q_range_sliders = True
+            self.low_extrapolation_plot.slider_draggable = False
             GuiUtils.updateModelItemWithPlot(
                 self._model_item, self.low_extrapolation_plot, self.low_extrapolation_plot.title
             )

--- a/src/sas/qtgui/Perspectives/Invariant/InvariantPerspective.py
+++ b/src/sas/qtgui/Perspectives/Invariant/InvariantPerspective.py
@@ -11,7 +11,6 @@ from twisted.python.failure import Failure
 
 import sas.qtgui.Utilities.GuiUtils as GuiUtils
 import sas.qtgui.Utilities.ObjectLibrary as ol
-from sas.qtgui.Plotting import PlotterData
 from sas.qtgui.Plotting.PlotterData import Data1D, DataRole
 from sas.qtgui.Utilities.BackgroundColor import BG_DEFAULT, BG_ERROR
 from sas.qtgui.Utilities.ExtrapolationSlider import ExtrapolationSlider, SliderPerspective
@@ -128,32 +127,33 @@ class InvariantWindow(QtWidgets.QDialog, Ui_tabbedInvariantUI, Perspective):
         self._high_power_value: float | None = DEFAULT_POWER_VALUE
 
         # Define plots
-        self.high_extrapolation_plot: PlotterData | None = None
-        self.low_extrapolation_plot: PlotterData | None = None
+        self.high_extrapolation_plot: Data1D | None = None
+        self.low_extrapolation_plot: Data1D | None = None
         self.extrapolation_made: bool = False
+        self.force_extrapolation_replot: bool = False
 
     def setup_slider(self) -> None:
         """Setup the extrapolation slider."""
         self.slider = ExtrapolationSlider(perspective=SliderPerspective.INVARIANT)
         self.sliderLayout.insertWidget(1, self.slider)
 
-    def _refresh_extrapolation_plots(self, state=None) -> None:
+    def _refresh_extrapolation_plots(self) -> None:
         """Refresh any visible extrapolation plot markers in place.
 
         Updating the existing `QRangeSlider` artists is much cheaper than replacing the
         whole plot, so use that path whenever the plot window is already open.
         """
-        plots = [plot for plot in [self.low_extrapolation_plot, self.high_extrapolation_plot] if plot is not None]
+        plots = [
+            plot for plot in [self.low_extrapolation_plot, self.high_extrapolation_plot]
+            if plot is not None
+        ]
         # Directly obtain the plot widget and update its slider positions.
         data_explorer = ol.getObject("DataExplorer")
+        active_plots = getattr(data_explorer, "active_plots", {})
 
         for plot in plots:
-            plot_widget = data_explorer.active_plots.get(plot.name)
-
-            if state is not None and getattr(state, "dragging_line_position", None) is not None:
-                plot_widget.update_slider_positions(plot.name, state)
-            else:
-                plot_widget.update_slider_positions(plot.name)
+            plot_widget = active_plots.get(plot.name)
+            plot_widget.update_slider_positions(plot.name)
 
     def setup_tooltips(self) -> None:
         """Setup tooltips for the widgets"""
@@ -398,7 +398,7 @@ class InvariantWindow(QtWidgets.QDialog, Ui_tabbedInvariantUI, Perspective):
         # Send the modified model item to replace initial plot
         plots = [self._model_item]
 
-        if self._high_extrapolate and self.high_extrapolation_plot:
+        if self._high_extrapolate and self.high_extrapolation_plot is not None:
             self.high_extrapolation_plot.plot_role = DataRole.ROLE_DEFAULT
             self.high_extrapolation_plot.symbol = "Line"
             self.high_extrapolation_plot.custom_color = "#2ca02c"
@@ -412,7 +412,7 @@ class InvariantWindow(QtWidgets.QDialog, Ui_tabbedInvariantUI, Perspective):
                 self._model_item, self.high_extrapolation_plot, self.high_extrapolation_plot.title
             )
             plots.append(self.high_extrapolation_plot)
-        if self._low_extrapolate and self.low_extrapolation_plot:
+        if self._low_extrapolate and self.low_extrapolation_plot is not None:
             self.low_extrapolation_plot.plot_role = DataRole.ROLE_DEFAULT
             self.low_extrapolation_plot.symbol = "Line"
             self.low_extrapolation_plot.custom_color = "#ff7f0e"
@@ -430,12 +430,14 @@ class InvariantWindow(QtWidgets.QDialog, Ui_tabbedInvariantUI, Perspective):
             # Only emit a plot update if the composition of extrapolation plots has changed
             current_mode = [self._low_extrapolate, self._high_extrapolate]
             previous_mode = getattr(self, "_plotted_extrapolation_mode", None)
+            force_replot = getattr(self, "_force_extrapolation_replot", False)
 
-            if current_mode != previous_mode:
+            if current_mode != previous_mode or force_replot:
                 self._manager.filesWidget.closePlotsForItem(self._model_item)
                 self.communicator.plotRequestedSignal.emit(plots)
                 self.extrapolation_made = True
                 self._plotted_extrapolation_mode = current_mode
+                self._force_extrapolation_replot = False
             else:
                 # Update the existing extrapolation plots in place without re-emitting the whole plot
                 for plot in plots[1:]:
@@ -563,6 +565,7 @@ class InvariantWindow(QtWidgets.QDialog, Ui_tabbedInvariantUI, Perspective):
                         _ui(self._model_item.removeRow, item.row())
                         break
                 self.low_extrapolation_plot = None
+                self._force_extrapolation_replot = True
 
             _safe_update_model(WIDGETS.D_LOW_QSTAR, qstar_low)
             _safe_update_model(WIDGETS.D_LOW_QSTAR_ERR, qstar_low_err)
@@ -576,6 +579,7 @@ class InvariantWindow(QtWidgets.QDialog, Ui_tabbedInvariantUI, Perspective):
                         _ui(self._model_item.removeRow, item.row())
                         break
                 self.high_extrapolation_plot = None
+                self._force_extrapolation_replot = True
 
             _safe_update_model(WIDGETS.D_HIGH_QSTAR, qstar_high)
             _safe_update_model(WIDGETS.D_HIGH_QSTAR_ERR, qstar_high_err)

--- a/src/sas/qtgui/Perspectives/Invariant/InvariantPerspective.py
+++ b/src/sas/qtgui/Perspectives/Invariant/InvariantPerspective.py
@@ -1062,6 +1062,9 @@ class InvariantWindow(QtWidgets.QDialog, Ui_tabbedInvariantUI, Perspective):
                 messages.append(f"The maximum value is {qmax:.7g}.")
                 self.txtPorodEnd_ex.setText(self.format_sig_fig(qmax))
 
+        # Re-validate to update any UI flags
+        self.check_extrapolation_values()
+
         if messages:
             messages.append("Values have been adjusted to the nearest valid value.")
             QtWidgets.QMessageBox.warning(self, "Invalid Extrapolation Values", "\n".join(messages))

--- a/src/sas/qtgui/Perspectives/Invariant/InvariantPerspective.py
+++ b/src/sas/qtgui/Perspectives/Invariant/InvariantPerspective.py
@@ -385,11 +385,6 @@ class InvariantWindow(QtWidgets.QDialog, Ui_tabbedInvariantUI, Perspective):
             self.high_extrapolation_plot.symbol = "Line"
             self.high_extrapolation_plot.custom_color = "#2ca02c"
             self.high_extrapolation_plot.show_errors = False
-            self.high_extrapolation_plot.show_q_range_sliders = True
-            self.high_extrapolation_plot.slider_update_on_move = False
-            self.high_extrapolation_plot.slider_perspective_name = self.name
-            self.high_extrapolation_plot.slider_low_q_input = self.txtPorodStart_ex.text()
-            self.high_extrapolation_plot.slider_high_q_input = self.txtPorodEnd_ex.text()
             GuiUtils.updateModelItemWithPlot(
                 self._model_item, self.high_extrapolation_plot, self.high_extrapolation_plot.title
             )
@@ -399,10 +394,6 @@ class InvariantWindow(QtWidgets.QDialog, Ui_tabbedInvariantUI, Perspective):
             self.low_extrapolation_plot.symbol = "Line"
             self.low_extrapolation_plot.custom_color = "#ff7f0e"
             self.low_extrapolation_plot.show_errors = False
-            self.low_extrapolation_plot.show_q_range_sliders = True
-            self.low_extrapolation_plot.slider_perspective_name = self.name
-            self.low_extrapolation_plot.slider_low_q_input = self.extrapolation_parameters.ex_q_min
-            self.low_extrapolation_plot.slider_high_q_input = self.txtGuinierEnd_ex.text()
             GuiUtils.updateModelItemWithPlot(
                 self._model_item, self.low_extrapolation_plot, self.low_extrapolation_plot.title
             )

--- a/src/sas/qtgui/Perspectives/Invariant/InvariantPerspective.py
+++ b/src/sas/qtgui/Perspectives/Invariant/InvariantPerspective.py
@@ -943,15 +943,12 @@ class InvariantWindow(QtWidgets.QDialog, Ui_tabbedInvariantUI, Perspective):
         if self.extrapolation_parameters is None or self._data is None:
             return
         self.check_extrapolation_values()
-        if not any(getattr(self, "validity_flags", [])):
-            self.apply_parameters_from_ui()
 
     def on_extrapolation_text_edited(self) -> None:
         """Handle when user finishes editing any of the extrapolation text boxes."""
-        # First update the model with new values
-        self.apply_parameters_from_ui()
-        # Then correct any invalid values
         self.correct_extrapolation_values()
+        self.apply_parameters_from_ui()
+        self._refresh_extrapolation_plots()
 
     def format_sig_fig(self, value: float) -> str:
         """Format a float to 7 significant figures as a string."""
@@ -1065,9 +1062,6 @@ class InvariantWindow(QtWidgets.QDialog, Ui_tabbedInvariantUI, Perspective):
                 messages.append(f"The maximum value is {qmax:.7g}.")
                 self.txtPorodEnd_ex.setText(self.format_sig_fig(qmax))
 
-        # update slider and model
-        self.apply_parameters_from_ui()
-
         if messages:
             messages.append("Values have been adjusted to the nearest valid value.")
             QtWidgets.QMessageBox.warning(self, "Invalid Extrapolation Values", "\n".join(messages))
@@ -1081,18 +1075,15 @@ class InvariantWindow(QtWidgets.QDialog, Ui_tabbedInvariantUI, Perspective):
         if self.extrapolation_parameters is None:
             return
         # update the slider (this may emit a signal that will call on_extrapolation_slider_changed)
-        self.slider.extrapolation_parameters = self.extrapolation_parameters._replace(
-            point_1=safe_float(p1), point_2=safe_float(p2), point_3=safe_float(p3)
-        )
+        with QtCore.QSignalBlocker(self.slider):
+            self.slider.extrapolation_parameters = self.extrapolation_parameters._replace(
+                point_1=safe_float(p1), point_2=safe_float(p2), point_3=safe_float(p3)
+            )
 
         # update model item text too
         self.model.setItem(WIDGETS.W_GUINIER_END_EX, QtGui.QStandardItem(p1))
         self.model.setItem(WIDGETS.W_POROD_START_EX, QtGui.QStandardItem(p2))
         self.model.setItem(WIDGETS.W_POROD_END_EX, QtGui.QStandardItem(p3))
-
-        # re-validate to update any UI flags
-        self.check_extrapolation_values()
-        self._refresh_extrapolation_plots()
 
     def checkVolFrac(self) -> None:
         """Check if volfrac1 is strictly between 0 and 1."""

--- a/src/sas/qtgui/Perspectives/Invariant/UnitTesting/CalculationTest.py
+++ b/src/sas/qtgui/Perspectives/Invariant/UnitTesting/CalculationTest.py
@@ -258,67 +258,48 @@ class TestInvariantCalculateThread(UIHelpersMixin):
             assert getattr(plot, "symbol", None) == "Line"
             assert getattr(plot, "has_errors", None) is False
 
+
     def test_plot_result(self, mocker):
-        """Test plot_result creates a combined extrapolation plot when extrapolation mode changes."""
+        """Test plot_result updates model item and emits plot request when extrapolation plots exist."""
+
+        mock_close = mocker.patch.object(self.window._manager.filesWidget, "closePlotsForItem")
         mock_update_model_item_with_plot = mocker.patch.object(
             Invariant.InvariantPerspective.GuiUtils, "updateModelItemWithPlot"
         )
-
-        requested = []
-        updated = []
-
-        self.window.communicator.plotRequestedSignal.connect(lambda plots: requested.append(plots))
-        self.window.communicator.plotUpdateSignal.connect(lambda plots: updated.append(plots))
-
+        emitted = []
+        self.window.communicator.plotRequestedSignal.connect(lambda plots: emitted.append(plots))
         mock_details = mocker.patch.object(self.window, "update_details_widget")
         mock_progress = mocker.patch.object(self.window, "update_progress_bars")
-        mock_close  = mocker.patch.object(self.window._manager.filesWidget, "closePlotsForItem")
 
         mock_calc = mocker.MagicMock()
         self.window._calculator = mock_calc
-
         extra_high = self.set_extra_high(mock_calc, mocker)
         extra_low = self.set_extra_low(mock_calc, mocker)
 
         self.window.high_extrapolation_plot = self.window._manager.createGuiData(extra_high)
-        high_title = "High-Q extrapolation"
-        self.window.high_extrapolation_plot.name = high_title
-        self.window.high_extrapolation_plot.title = high_title
+        title = "High-Q extrapolation"
+        self.window.high_extrapolation_plot.name = title
+        self.window.high_extrapolation_plot.title = title
 
         self.window.low_extrapolation_plot = self.window._manager.createGuiData(extra_low)
-        low_title = "Low-Q extrapolation"
-        self.window.low_extrapolation_plot.name = low_title
-        self.window.low_extrapolation_plot.title = low_title
-
-        self.window._high_extrapolate = True
-        self.window._low_extrapolate = True
-
-        # Simulate first extrapolation plot creation.
+        title = "Low-Q extrapolation"
+        self.window.low_extrapolation_plot.name = title
+        self.window.low_extrapolation_plot.title = title
         self.window.extrapolation_made = False
-        self.window._plotted_extrapolation_mode = None
 
         mock_model = mocker.Mock()
         mock_model.name = "test_model"
 
         self.window.plot_result(mock_model)
 
+        mock_close.assert_called_once_with(self.window._model_item)
+
         assert mock_update_model_item_with_plot.call_count == 2
 
-        assert len(requested) == 1
-        requested_arg = requested[0]
-
-        assert isinstance(requested_arg, list)
-        assert requested_arg[0] is self.window._model_item
-        assert self.window.high_extrapolation_plot in requested_arg
-        assert self.window.low_extrapolation_plot in requested_arg
-
-        # First plot creation should use plotRequestedSignal, not plotUpdateSignal.
-        assert updated == []
-
-        assert self.window.extrapolation_made is True
-        assert self.window._plotted_extrapolation_mode == [True, True]
-
-        mock_close.assert_called_once_with(self.window._model_item)
+        assert len(emitted) == 1
+        emitted_arg = emitted[0]
+        assert isinstance(emitted_arg, list)
+        assert emitted_arg[0] is self.window._model_item
 
         assert getattr(self.window.high_extrapolation_plot, "symbol", None) == "Line"
         assert getattr(self.window.low_extrapolation_plot, "symbol", None) == "Line"
@@ -328,20 +309,17 @@ class TestInvariantCalculateThread(UIHelpersMixin):
 
     def test_plot_result_updates_existing_extrapolation_plot_when_mode_unchanged(self, mocker):
         """Test plot_result updates existing extrapolation plots in place when only ranges change."""
-        mocker.patch.object(
-            Invariant.InvariantPerspective.GuiUtils, "updateModelItemWithPlot"
-        )
 
-        requested = []
-        updated = []
-
-        self.window.communicator.plotRequestedSignal.connect(lambda plots: requested.append(plots))
-        self.window.communicator.plotUpdateSignal.connect(lambda plots: updated.append(plots))
+        emitted = []
+        self.window.communicator.plotRequestedSignal.connect(lambda plots: emitted.append(plots))
 
         mocker.patch.object(self.window, "update_details_widget")
         mocker.patch.object(self.window, "update_progress_bars")
+
         mock_close_plots = mocker.patch.object(self.window._manager.filesWidget, "closePlotsForItem")
-        mock_refresh = mocker.patch.object(self.window, "_refresh_extrapolation_plots")
+        mock_update_model_item_with_plot = mocker.patch.object(
+            Invariant.InvariantPerspective.GuiUtils, "updateModelItemWithPlot"
+        )
 
         mock_calc = mocker.MagicMock()
         self.window._calculator = mock_calc
@@ -359,26 +337,21 @@ class TestInvariantCalculateThread(UIHelpersMixin):
 
         self.window._high_extrapolate = True
         self.window._low_extrapolate = True
-
-        # Simulate that the combined low+high plot already exists.
-        self.window.extrapolation_made = True
-        self.window._plotted_extrapolation_mode = [True, True]
+        self.window.extrapolation_made = False
 
         mock_model = mocker.Mock()
         mock_model.name = "test_model"
 
         self.window.plot_result(mock_model)
 
-        # Same mode should not recreate the plot.
-        assert requested == []
-        mock_close_plots.assert_not_called()
+        mock_close_plots.assert_called_once_with(self.window._model_item)
 
-        # Existing high and low extrapolation curves should be updated in place.
-        assert len(updated) == 2
-        assert [self.window.high_extrapolation_plot] in updated
-        assert [self.window.low_extrapolation_plot] in updated
+        assert mock_update_model_item_with_plot.call_count == 2
 
-        mock_refresh.assert_called_once()
+        assert len(emitted) == 1
+        emitted_arg = emitted[0]
+        assert isinstance(emitted_arg, list)
+        assert emitted_arg[0] is self.window._model_item
 
 @pytest.mark.parametrize("window_class", ["real_data"], indirect=True)
 @pytest.mark.usefixtures("window_class")

--- a/src/sas/qtgui/Perspectives/Invariant/UnitTesting/CalculationTest.py
+++ b/src/sas/qtgui/Perspectives/Invariant/UnitTesting/CalculationTest.py
@@ -259,46 +259,66 @@ class TestInvariantCalculateThread(UIHelpersMixin):
             assert getattr(plot, "has_errors", None) is False
 
     def test_plot_result(self, mocker):
-        """Test plot_result updates model item and emits plot request when extrapolation plots exist."""
-
-        mock_close = mocker.patch.object(self.window._manager.filesWidget, "closePlotsForItem")
+        """Test plot_result creates a combined extrapolation plot when extrapolation mode changes."""
         mock_update_model_item_with_plot = mocker.patch.object(
             Invariant.InvariantPerspective.GuiUtils, "updateModelItemWithPlot"
         )
-        emitted = []
-        self.window.communicator.plotRequestedSignal.connect(lambda plots: emitted.append(plots))
+
+        requested = []
+        updated = []
+
+        self.window.communicator.plotRequestedSignal.connect(lambda plots: requested.append(plots))
+        self.window.communicator.plotUpdateSignal.connect(lambda plots: updated.append(plots))
+
         mock_details = mocker.patch.object(self.window, "update_details_widget")
         mock_progress = mocker.patch.object(self.window, "update_progress_bars")
+        mock_close  = mocker.patch.object(self.window._manager.filesWidget, "closePlotsForItem")
 
         mock_calc = mocker.MagicMock()
         self.window._calculator = mock_calc
+
         extra_high = self.set_extra_high(mock_calc, mocker)
         extra_low = self.set_extra_low(mock_calc, mocker)
 
         self.window.high_extrapolation_plot = self.window._manager.createGuiData(extra_high)
-        title = "High-Q extrapolation"
-        self.window.high_extrapolation_plot.name = title
-        self.window.high_extrapolation_plot.title = title
+        high_title = "High-Q extrapolation"
+        self.window.high_extrapolation_plot.name = high_title
+        self.window.high_extrapolation_plot.title = high_title
 
         self.window.low_extrapolation_plot = self.window._manager.createGuiData(extra_low)
-        title = "Low-Q extrapolation"
-        self.window.low_extrapolation_plot.name = title
-        self.window.low_extrapolation_plot.title = title
+        low_title = "Low-Q extrapolation"
+        self.window.low_extrapolation_plot.name = low_title
+        self.window.low_extrapolation_plot.title = low_title
+
+        self.window._high_extrapolate = True
+        self.window._low_extrapolate = True
+
+        # Simulate first extrapolation plot creation.
         self.window.extrapolation_made = False
+        self.window._plotted_extrapolation_mode = None
 
         mock_model = mocker.Mock()
         mock_model.name = "test_model"
 
         self.window.plot_result(mock_model)
 
-        mock_close.assert_called_once_with(self.window._model_item)
-
         assert mock_update_model_item_with_plot.call_count == 2
 
-        assert len(emitted) == 1
-        emitted_arg = emitted[0]
-        assert isinstance(emitted_arg, list)
-        assert emitted_arg[0] is self.window._model_item
+        assert len(requested) == 1
+        requested_arg = requested[0]
+
+        assert isinstance(requested_arg, list)
+        assert requested_arg[0] is self.window._model_item
+        assert self.window.high_extrapolation_plot in requested_arg
+        assert self.window.low_extrapolation_plot in requested_arg
+
+        # First plot creation should use plotRequestedSignal, not plotUpdateSignal.
+        assert updated == []
+
+        assert self.window.extrapolation_made is True
+        assert self.window._plotted_extrapolation_mode == [True, True]
+
+        mock_close.assert_called_once_with(self.window._model_item)
 
         assert getattr(self.window.high_extrapolation_plot, "symbol", None) == "Line"
         assert getattr(self.window.low_extrapolation_plot, "symbol", None) == "Line"
@@ -306,6 +326,59 @@ class TestInvariantCalculateThread(UIHelpersMixin):
         mock_details.assert_called_once()
         mock_progress.assert_called_once()
 
+    def test_plot_result_updates_existing_extrapolation_plot_when_mode_unchanged(self, mocker):
+        """Test plot_result updates existing extrapolation plots in place when only ranges change."""
+        mocker.patch.object(
+            Invariant.InvariantPerspective.GuiUtils, "updateModelItemWithPlot"
+        )
+
+        requested = []
+        updated = []
+
+        self.window.communicator.plotRequestedSignal.connect(lambda plots: requested.append(plots))
+        self.window.communicator.plotUpdateSignal.connect(lambda plots: updated.append(plots))
+
+        mocker.patch.object(self.window, "update_details_widget")
+        mocker.patch.object(self.window, "update_progress_bars")
+        mock_close_plots = mocker.patch.object(self.window._manager.filesWidget, "closePlotsForItem")
+        mock_refresh = mocker.patch.object(self.window, "_refresh_extrapolation_plots")
+
+        mock_calc = mocker.MagicMock()
+        self.window._calculator = mock_calc
+
+        extra_high = self.set_extra_high(mock_calc, mocker)
+        extra_low = self.set_extra_low(mock_calc, mocker)
+
+        self.window.high_extrapolation_plot = self.window._manager.createGuiData(extra_high)
+        self.window.high_extrapolation_plot.name = "High-Q extrapolation"
+        self.window.high_extrapolation_plot.title = "High-Q extrapolation"
+
+        self.window.low_extrapolation_plot = self.window._manager.createGuiData(extra_low)
+        self.window.low_extrapolation_plot.name = "Low-Q extrapolation"
+        self.window.low_extrapolation_plot.title = "Low-Q extrapolation"
+
+        self.window._high_extrapolate = True
+        self.window._low_extrapolate = True
+
+        # Simulate that the combined low+high plot already exists.
+        self.window.extrapolation_made = True
+        self.window._plotted_extrapolation_mode = [True, True]
+
+        mock_model = mocker.Mock()
+        mock_model.name = "test_model"
+
+        self.window.plot_result(mock_model)
+
+        # Same mode should not recreate the plot.
+        assert requested == []
+        mock_close_plots.assert_not_called()
+
+        # Existing high and low extrapolation curves should be updated in place.
+        assert len(updated) == 2
+        assert [self.window.high_extrapolation_plot] in updated
+        assert [self.window.low_extrapolation_plot] in updated
+
+        mock_refresh.assert_called_once()
 
 @pytest.mark.parametrize("window_class", ["real_data"], indirect=True)
 @pytest.mark.usefixtures("window_class")
@@ -413,7 +486,7 @@ class TestInvariantCalculateHelpers(UIHelpersMixin):
 
         self.window.deferredPlot(mock_model, extrapolation=None)
 
-        assert sync_reactor.callFromThread.call_count == 2
+        assert sync_reactor.callFromThread.call_count == 1
         mock_plot.assert_called_once_with(mock_model)
         mock_check.assert_called_once()
         mock_newplot.assert_called_once()

--- a/src/sas/qtgui/Plotting/Plotter.py
+++ b/src/sas/qtgui/Plotting/Plotter.py
@@ -791,6 +791,21 @@ class PlotterWidget(PlotterBase):
             slider = self.sliders.get(id)
             slider.toggle()
 
+    def update_slider_positions(self, plot_name: str, state=None) -> None:
+        """Update slider artist positions for a given plot in-place and redraw the canvas."""
+        slider = self.sliders[plot_name]
+
+        if state is not None and getattr(state, "dragging_line_position", None) is not None:
+            if state.working_line_id == 0:
+                slider.line_min.update(x=state.dragging_line_position, draw=False)
+            else:
+                slider.line_max.update(x=state.dragging_line_position, draw=False)
+        else:
+            slider.line_min.inputChanged()
+            slider.line_max.inputChanged()
+
+        self.canvas.draw_idle()
+
     def onFreeze(self, id):
         """
         Freezes the selected plot to a separate chart

--- a/src/sas/qtgui/Plotting/PlotterData.py
+++ b/src/sas/qtgui/Plotting/PlotterData.py
@@ -70,6 +70,7 @@ class Data1D(PlottableData1D, LoadData1D):
         # Q-range slider definitions
         self.show_q_range_sliders = False  # Should sliders be shown?
         self.slider_update_on_move = True  # Should the gui update during the move?
+        self.slider_draggable = True  # Should the q-range slider lines respond to direct dragging?
         self.slider_perspective_name = ""  # Name of the perspective that this slider is associated with
         self.slider_tab_name = ""          # Name of the tab where the data set is
         # The following q-range slider variables are optional but help tie

--- a/src/sas/qtgui/Plotting/QRangeSlider.py
+++ b/src/sas/qtgui/Plotting/QRangeSlider.py
@@ -42,11 +42,11 @@ class QRangeSlider(BaseInteractor):
         self.line_min = LineInteractor(self, axes, zorder=zorder, x=self.x_min, y=self.y_marker_min,
                                        input=data.slider_low_q_input, setter=data.slider_low_q_setter,
                                        getter=data.slider_low_q_getter, perspective=data.slider_perspective_name,
-                                       tab=data.slider_tab_name)
+                                       tab=data.slider_tab_name, draggable=data.slider_draggable)
         self.line_max = LineInteractor(self, axes, zorder=zorder, x=self.x_max, y=self.y_marker_max,
                                        input=data.slider_high_q_input, setter=data.slider_high_q_setter,
                                        getter=data.slider_high_q_getter, perspective=data.slider_perspective_name,
-                                       tab=data.slider_tab_name)
+                                       tab=data.slider_tab_name, draggable=data.slider_draggable)
         self.has_move = True
         self.update()
 
@@ -110,7 +110,8 @@ class LineInteractor(BaseInteractor):
     Draw a single vertical line that can be dragged on a plot
     """
     def __init__(self, base: "Plotter", axes: "Plotter.ax", color: str = 'black', zorder: int = 5, x: float = 0.5, y: float = 0.5,
-                 input: list[str] = None, setter: list[str] = None, getter: list[str] = None, perspective: str = None, tab: str = None) -> None:
+                 input: list[str] = None, setter: list[str] = None, getter: list[str] = None, perspective: str = None,
+                 tab: str = None, draggable: bool = True) -> None:
         """ Initialize the line interactor object"""
         BaseInteractor.__init__(self, base, axes, color=color)
         # Plotter object
@@ -130,7 +131,7 @@ class LineInteractor(BaseInteractor):
         self.save_y = self.y_marker
         self.draw(zorder)
         # Is the slider able to move
-        self.has_move = True
+        self.has_move = draggable
         try:
             data_explorer = ol.getObject('DataExplorer')
             self.perspective = data_explorer.parent.loadedPerspectives.get(perspective, None)
@@ -268,6 +269,8 @@ class LineInteractor(BaseInteractor):
 
     def move(self, x: float, y: float, ev: QEvent) -> None:
         """ Process move to a new position, making sure that the move is allowed. """
+        if not self.has_move:
+            return
         self.has_move = True
         self.x = x
         if self.base.updateOnMove:
@@ -275,8 +278,16 @@ class LineInteractor(BaseInteractor):
         self.y_marker = self.base.data.y[(np.abs(self.base.data.x - self.x)).argmin()]
         self.update(draw=self.base.updateOnMove)
 
+    def onDrag(self, ev: QEvent) -> bool:
+        """Move the line unless direct dragging is disabled."""
+        if not self.has_move:
+            return True
+        return BaseInteractor.onDrag(self, ev)
+
     def onRelease(self, ev: QEvent) -> bool:
         """ Update the line position when the mouse button is released """
+        if not self.has_move:
+            return True
         # Set the Q value if a callable setter exists otherwise update the attached input
         self._set_q(self.x)
         self.update(draw=True)

--- a/src/sas/qtgui/Plotting/QRangeSlider.py
+++ b/src/sas/qtgui/Plotting/QRangeSlider.py
@@ -207,6 +207,9 @@ class LineInteractor(BaseInteractor):
 
     def _get_input_or_callback(self, connection_list: list[str] = None) -> QLineEdit | QTextEdit | None:
         """ Returns an input or callback method based on a list of inputs/commands """
+        # If no connection list provided, nothing to do
+        if not connection_list:
+            return None
         connection = None
         if isinstance(connection_list, list):
             connection = self.perspective
@@ -215,7 +218,8 @@ class LineInteractor(BaseInteractor):
                     connection = getattr(connection, item)
                 except Exception:
                     return None
-        return connection
+            return connection
+        return None
 
     def _set_q(self, value: float) -> None:
         """ Call the q setter callback method if it exists """


### PR DESCRIPTION
## Description

After the invariant refactor, the in-plot sliders were rendered non-functional, serving only as a visual guide. They were still movable, but reset to the extrapolation position based on the text field/in-window slider.

This PR converts the sliders into non-movable lines by updating the property of QRangeSliders. Some more work was done to optimise the performance by only updating the sliders when needed instead of the entire plot, which involved slight refactoring of the invariant plotting logic.


Fixes #3826 

## How Has This Been Tested?

Manually tested + pytest

## Review Checklist:

**Documentation**
- [x] There is **nothing** that needs documenting
- [ ] Documentation changes are **in this PR**
- [ ] There is an **issue** open for the documentation (link?)

**Installers**
- [ ] There is a chance this will affect the **installers**, if so
  - [ ] **Windows** installer (GH artifact) has been tested (installed and worked) 
  - [ ] **MacOSX** installer (GH artifact) has been tested (installed and worked)
  - [ ] **Wheels** installer (GH artifact) has been tested (installed and worked)

**Licensing**
- [x] The introduced changes comply with SasView license (BSD 3-Clause)

