### PR TITLE
3968: PD function shadowing [Release 6.2.0]

### DIFF
--- a/src/sas/qtgui/Perspectives/Fitting/FittingWidget.py
+++ b/src/sas/qtgui/Perspectives/Fitting/FittingWidget.py
@@ -2896,9 +2896,6 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
             val = GuiUtils.toDouble(row[1].text())
             self.logic.kernel_module.setParam(par, val)
 
-        # Change 'n' in the parameter model; also causes recalculation
-        self._model_model.item(self._n_shells_row, 1).setText(str(index))
-
         # Update relevant models
         self.polydispersity_widget.setPolyModel()
         if self.canHaveMagnetism():

--- a/src/sas/qtgui/Perspectives/Fitting/PolydispersityWidget.py
+++ b/src/sas/qtgui/Perspectives/Fitting/PolydispersityWidget.py
@@ -253,7 +253,7 @@ class PolydispersityWidget(QtWidgets.QWidget, Ui_PolydispersityWidgetUI):
         # Note: last argument needs extra space padding for decent display of the control
         checked_list = ["Distribution of " + param_name, str(width),
                         str(min), str(max),
-                        str(npts), str(nsigs), "gaussian      ",'']
+                        str(npts), str(nsigs), "",'']
         FittingUtilities.addCheckedListToModel(self.poly_model, checked_list)
 
         all_items = self.poly_model.rowCount()


### PR DESCRIPTION
## Description
Removes the initial text set in the PD list that caused the word `gaussian` to always overlay the combo box. The n_shells also had a similar issue that I've also fixed here.

Fixes #3968

## How Has This Been Tested?

Locally, I verified the shadowing was removed, tested changing the PD function results in the proper distributions, and tested the number of shells updates the table as required.

## Review Checklist:

**Documentation** (check at least one)
- [x] There is **nothing** that needs documenting
- [ ] Documentation changes are **in this PR**
- [ ] There is an **issue** open for the documentation (link?)

**Installers**
- [x] There is a chance this will affect the **installers**, if so
  - [ ] **Windows** installer (GH artifact) has been tested (installed and worked) 
  - [ ] **MacOSX** installer (GH artifact) has been tested (installed and worked)
  - [ ] **Wheels** installer (GH artifact) has been tested (installed and worked)

**Licensing** (untick if necessary)
- [x] The introduced changes comply with SasView license (BSD 3-Clause)

