### PR TITLE
4000: Disable the failing color map tests

### DIFF
--- a/src/sas/qtgui/Plotting/UnitTesting/ColorMapTest.py
+++ b/src/sas/qtgui/Plotting/UnitTesting/ColorMapTest.py
@@ -56,6 +56,7 @@ class ColorMapTest:
         '''Destroy the GUI'''
         w.close()
 
+    @pytest.mark.xfail(reason="2026-06: matplotlib changes to all_maps, maps, and rmaps")
     def testDefaults(self, widget):
         '''Test the GUI in its default state'''
         assert isinstance(widget, QtWidgets.QDialog)


### PR DESCRIPTION
## Description

This disables the failing GUI test. This allows the CI to pass but does not fix the issue.

Refs #4000

## How Has This Been Tested?

CI passes
