### PR TITLE
Refactors slicers to remove unecessary "updatePlot" calls

### DIFF
--- a/src/sas/qtgui/MainWindow/DataExplorer.py
+++ b/src/sas/qtgui/MainWindow/DataExplorer.py
@@ -1411,21 +1411,21 @@ class DataExplorerWindow(DroppableDataLoadWidget):
         assert type(data).__name__ in ['Data1D', 'Data2D']
 
         ids_keys = list(self.active_plots.keys())
-        #ids_vals = [val.data.name for val in self.active_plots.values()]
 
+        # We test for wheter the data_id starts with any of the plot_ids
+        # to account for additional slicers with an "_#" label
         data_id = data.name
-        if data_id in ids_keys:
+        plot_ids = [id for id in ids_keys if data_id.startswith(id)]
+
+        # if exactly one plot matches, update that plot
+        if len(plot_ids) == 1:
+            plot_id = plot_ids[0]
             # We have data, let's replace data that needs replacing
             if data.plot_role != DataRole.ROLE_DATA:
-                self.active_plots[data_id].replacePlot(data_id, data)
+                self.active_plots[plot_id].replacePlot(data_id, data)
                 # restore minimized window, if applicable
-                self.active_plots[data_id].showNormal()
+                self.active_plots[plot_id].showNormal()
             return True
-        #elif data_id in ids_vals:
-        #    if data.plot_role != DataRole.ROLE_DATA:
-        #        list(self.active_plots.values())[ids_vals.index(data_id)].replacePlot(data_id, data)
-        #        self.active_plots[data_id].showNormal()
-        #    return True
         return False
 
     def chooseFiles(self):

--- a/src/sas/qtgui/Plotting/Plotter2D.py
+++ b/src/sas/qtgui/Plotting/Plotter2D.py
@@ -68,6 +68,12 @@ class Plotter2DWidget(PlotterBase):
         self.slicer_widget = None
         self.stackplots = config.STACK_PLOTS  # whether to stack multiple slicer plots
         self.slicer_plots_dict = {}  # keep track of slicer plots
+        self.num_slicer_plots = {
+            "Annulus": 0,
+            "Box": 0,
+            "Sector": 0,
+            "Wedge": 0
+        }
         self.vmin = None
         self.vmax = None
         self.im = None
@@ -353,6 +359,21 @@ class Plotter2DWidget(PlotterBase):
                     slicer_plots[plot_id] = plot_window
                     break
         return slicer_plots
+
+    def incrementNumSlicerPlots(self, slicer_type: str):
+        """Add a new slicer plot to the appropriate index if one is being generated."""
+        if self.stackplots:
+            # Check whether the most recent plot of this slicer is active for stacking,
+            # otherwise generate a new plot
+            slicer_plots = self.getActiveSlicerPlots()
+            current_plot_string = f"Plot{self.num_slicer_plots[slicer_type]}"
+            for plot_id in slicer_plots:
+                if plot_id.startswith(slicer_type) and current_plot_string in plot_id:
+                    # We can stack the current plot on the existing one, so return
+                    return
+
+        # If we are not stacking or the final slicer plot is not active, generate a new one
+        self.num_slicer_plots[slicer_type] += 1
 
     def removeSlicersForPlotWindow(self, plot_window):
         """

--- a/src/sas/qtgui/Plotting/Slicers/AnnulusSlicer.py
+++ b/src/sas/qtgui/Plotting/Slicers/AnnulusSlicer.py
@@ -60,7 +60,7 @@ class AnnulusInteractor(BaseInteractor, SlicerModel, StackableMixin):
 
     def _get_slicer_type_id(self):
         """Return the slicer type identifier"""
-        return "AnnulusPhi" + self.data.name
+        return f"AnnulusPhi{self.data.name}Plot{str(self.base.num_slicer_plots["Annulus"])}"
 
     def set_layer(self, n):
         """
@@ -142,7 +142,8 @@ class AnnulusInteractor(BaseInteractor, SlicerModel, StackableMixin):
 
         # Assign unique id per slicer instance and use it as the display name
         if self._plot_id is None:
-            base_id = "AnnulusPhi" + self.data.name
+            self.base.incrementNumSlicerPlots("Annulus")
+            base_id = f"AnnulusPhi{self.data.name}Plot{str(self.base.num_slicer_plots["Annulus"])}"
             self._plot_id = generate_unique_plot_id(base_id, self._item)
 
         new_plot.id = self._plot_id

--- a/src/sas/qtgui/Plotting/Slicers/BoxSlicer.py
+++ b/src/sas/qtgui/Plotting/Slicers/BoxSlicer.py
@@ -172,7 +172,7 @@ class BoxInteractor(BaseInteractor, SlicerModel, StackableMixin):
         self.center.save(ev)
 
     def _get_slicer_type_id(self):
-        return f"BoxSlicer{self.direction}{self.data.name}"
+        return f"BoxSlicer{self.direction}{self.data.name}Plot{self.base.num_slicer_plots["Box"]}"
 
     def _post_data(self, new_slab=None, nbins=None, direction=None):
         """
@@ -269,7 +269,8 @@ class BoxInteractor(BaseInteractor, SlicerModel, StackableMixin):
 
         # Assign unique id per slicer instance and use it as the display name
         if self._plot_id is None:
-            base_id = "BoxAverage" + self.direction + self.data.name
+            self.base.incrementNumSlicerPlots("Box")
+            base_id = f"BoxAverage{self.direction}{self.data.name}Plot{str(self.base.num_slicer_plots["Box"])}"
             self._plot_id = generate_unique_plot_id(base_id, self._item)
 
         new_plot.id = self._plot_id

--- a/src/sas/qtgui/Plotting/Slicers/SectorSlicer.py
+++ b/src/sas/qtgui/Plotting/Slicers/SectorSlicer.py
@@ -127,7 +127,7 @@ class SectorInteractor(BaseInteractor, SlicerModel, StackableMixin):
 
     def _get_slicer_type_id(self):
         """Return the slicer type identifier"""
-        return "SectorQ" + self.data.name
+        return f"SectorQ{self.data.name}Plot{str(self.base.num_slicer_plots["Sector"])}"
 
     def _post_data(self, nbins=None):
         """
@@ -180,7 +180,8 @@ class SectorInteractor(BaseInteractor, SlicerModel, StackableMixin):
 
         # Assign unique id per slicer instance and use it as the display name
         if self._plot_id is None:
-            base_id = "SectorQ" + self.data.name
+            self.base.incrementNumSlicerPlots("Sector")
+            base_id = f"SectorQ{self.data.name}Plot{str(self.base.num_slicer_plots["Sector"])}"
             self._plot_id = generate_unique_plot_id(base_id, self._item)
 
         new_plot.id = self._plot_id

--- a/src/sas/qtgui/Plotting/Slicers/SlicerUtils.py
+++ b/src/sas/qtgui/Plotting/Slicers/SlicerUtils.py
@@ -47,7 +47,7 @@ def generate_unique_plot_id(base_id: str, item) -> str:
     parent_item = item if item.parent() is None else item.parent()
     existing = _count_matching_ids(parent_item, base_id)
 
-    return f"{base_id}_{existing}"
+    return base_id if existing == 0 else f"{base_id}_{existing}"
 
 
 class StackableMixin:
@@ -180,9 +180,6 @@ class StackableMixin:
         # Add to existing window
         plot_window.plot(data=new_plot, color=self.color, hide_error=False)
 
-        # Notify manager (batched when suspended)
-        self._emit_plot_update([new_plot])
-
         # Update slicer plots list if the slicer widget exists (do it only if not batching)
         if (slicer_widget := getattr(self.base, 'slicer_widget', None)):
             if not getattr(self.base.manager, "_suspend_plot_signals", False):
@@ -202,7 +199,6 @@ class StackableMixin:
         GuiUtils.updateModelItemWithPlot(item, new_plot, new_plot.id)
 
         # Signal to create plot
-        self._emit_plot_update([new_plot])
         self.base.manager.communicator.forcePlotDisplaySignal.emit([item, new_plot])
 
         # Store references
@@ -235,9 +231,6 @@ class StackableMixin:
 
         # Preserve color
         new_plot.custom_color = self.color
-
-        # Replace plot data
-        self._plot_window.replacePlot(new_plot.id, new_plot)
 
         # Update model
         GuiUtils.updateModelItemWithPlot(item, new_plot, new_plot.name)

--- a/src/sas/qtgui/Plotting/Slicers/WedgeSlicer.py
+++ b/src/sas/qtgui/Plotting/Slicers/WedgeSlicer.py
@@ -372,7 +372,7 @@ class WedgeInteractorQ(WedgeInteractor):
     def __init__(self, base, axes, item=None, color="black", zorder=3):
         WedgeInteractor.__init__(self, base, axes, item=item, color=color)
         self.base = base
-        super()._post_data()
+        #super()._post_data()
 
     def _post_data(self, new_sector=None, nbins=None):
         from sasdata.data_util.manipulations import SectorQ
@@ -390,7 +390,7 @@ class WedgeInteractorPhi(WedgeInteractor):
     def __init__(self, base, axes, item=None, color="black", zorder=3):
         WedgeInteractor.__init__(self, base, axes, item=item, color=color)
         self.base = base
-        super()._post_data()
+        #super()._post_data()
 
     def _post_data(self, new_sector=None, nbins=None):
         from sasdata.data_util.manipulations import SectorPhi

--- a/src/sas/qtgui/Plotting/Slicers/WedgeSlicer.py
+++ b/src/sas/qtgui/Plotting/Slicers/WedgeSlicer.py
@@ -149,7 +149,8 @@ class WedgeInteractor(BaseInteractor, SlicerModel, StackableMixin):
     def _get_slicer_type_id(self):
         """Return the slicer type identifier"""
         return (
-            f"Wedge{self.averager.__name__}" + self.data.name if self.averager is not None else "Wedge" + self.data.name
+            f"Wedge{self.averager.__name__}{self.data.name}Plot{str(self.base.num_slicer_plots["Wedge"])}" if self.averager is not None else
+            f"Wedge{self.data.name}Plot{str(self.base.num_slicer_plots["Wedge"])}"
         )
 
     def _post_data(self, new_sector=None, nbins=None):
@@ -228,7 +229,8 @@ class WedgeInteractor(BaseInteractor, SlicerModel, StackableMixin):
 
         # Assign unique id per slicer instance and use it as the display name
         if self._plot_id is None:
-            base_id = "Wedge" + self.averager.__name__ + self.data.name
+            self.base.incrementNumSlicerPlots("Wedge")
+            base_id = f"Wedge{self.averager.__name__}{self.data.name}Plot{str(self.base.num_slicer_plots["Wedge"])}"
             self._plot_id = generate_unique_plot_id(base_id, self._item)
 
         new_plot.id = self._plot_id
@@ -372,7 +374,6 @@ class WedgeInteractorQ(WedgeInteractor):
     def __init__(self, base, axes, item=None, color="black", zorder=3):
         WedgeInteractor.__init__(self, base, axes, item=item, color=color)
         self.base = base
-        #super()._post_data()
 
     def _post_data(self, new_sector=None, nbins=None):
         from sasdata.data_util.manipulations import SectorQ
@@ -390,7 +391,6 @@ class WedgeInteractorPhi(WedgeInteractor):
     def __init__(self, base, axes, item=None, color="black", zorder=3):
         WedgeInteractor.__init__(self, base, axes, item=item, color=color)
         self.base = base
-        #super()._post_data()
 
     def _post_data(self, new_sector=None, nbins=None):
         from sasdata.data_util.manipulations import SectorPhi


### PR DESCRIPTION
## Description

When slicer plots are updated, there are two calls to `replacePlot`, one direct, the other via a signal. The reason for the redundant call was that, for additional slicers, the signal call goes through `updatePlot` in `DataExplorer.py`. Additional slicers have a data name that is different from the plot name, so are not recognised by `updatePlot`.

I have therefore refactored `updatePlot` to ensure that it recognises additional slicers, so all update calls via signals work, and the direct, redundant calls to `replacePlot` or similar in slicers can be removed.

This addresses the first part of #4003. The second part will be in a separate PR.

## How Has This Been Tested?

Ran unit tests and checked signal calls for multiple slicers manually.

## Review Checklist:

[if using the editor, use `[x]` in place of `[ ]` to check a box]

**Documentation** (check at least one)
- [x] There is **nothing** that needs documenting
- [ ] Documentation changes are **in this PR**
- [ ] There is an **issue** open for the documentation (link?)

**Installers**
- [ ] There is a chance this will affect the **installers**, if so
  - [ ] **Windows** installer (GH artifact) has been tested (installed and worked) 
  - [ ] **MacOSX** installer (GH artifact) has been tested (installed and worked)
  - [ ] **Wheels** installer (GH artifact) has been tested (installed and worked)

**Licensing** (untick if necessary)
- [x] The introduced changes comply with SasView license (BSD 3-Clause)

