### PR TITLE
Make colormaptest robust against matplotlib changes

### DIFF
--- a/src/sas/qtgui/Plotting/UnitTesting/ColorMapTest.py
+++ b/src/sas/qtgui/Plotting/UnitTesting/ColorMapTest.py
@@ -61,17 +61,17 @@ class ColorMapTest:
         assert isinstance(widget, QtWidgets.QDialog)
 
         assert widget._cmap_orig == "jet"
-        assert len(widget.all_maps) == 150
-        assert len(widget.maps) == 75
-        assert len(widget.rmaps) == 75
+        assert len(widget.all_maps) >= 150
+        assert len(widget.maps) >= 75
+        assert len(widget.rmaps) >= 75
 
         assert widget.lblWidth.text() == "0"
         assert widget.lblHeight.text() == "0"
         assert widget.lblQmax.text() == "15.8"
         assert widget.lblStopRadius.text() == "1"
         assert not widget.chkReverse.isChecked()
-        assert widget.cbColorMap.count() == 75
-        assert widget.cbColorMap.currentIndex() == 52
+        assert widget.cbColorMap.count() >= 75
+        assert widget.cbColorMap.currentIndex() > 0
 
         # validators
         assert isinstance(widget.txtMinAmplitude.validator(), QtGui.QDoubleValidator)


### PR DESCRIPTION
## Description

Tweak tests of colormaps to be independent (or at least less dependent) on the matplotlib version, fixing current issues and saving future ones.

Fixes #4000 

## How Has This Been Tested?

CI tests now pass

## Review Checklist:

[if using the editor, use `[x]` in place of `[ ]` to check a box]

**Documentation** (check at least one)
- [x] There is **nothing** that needs documenting
- [ ] Documentation changes are **in this PR**
- [ ] There is an **issue** open for the documentation (link?)

**Installers**
- [ ] There is a chance this will affect the **installers**, if so
  - [ ] **Windows** installer (GH artifact) has been tested (installed and worked) 
  - [ ] **MacOSX** installer (GH artifact) has been tested (installed and worked)
  - [ ] **Wheels** installer (GH artifact) has been tested (installed and worked)

**Licensing** (untick if necessary)
- [x] The introduced changes comply with SasView license (BSD 3-Clause)

