### PR TITLE
Adds a trust bar for size distribution result plots

### DIFF
--- a/src/sas/qtgui/Perspectives/SizeDistribution/SizeDistributionLogic.py
+++ b/src/sas/qtgui/Perspectives/SizeDistribution/SizeDistributionLogic.py
@@ -159,7 +159,7 @@ class SizeDistributionLogic:
 
         return backgd_plot, backgd_subtr_plot, fit_plot
 
-    def newSizeDistrPlot(self, result: MaxEntResult, qmin: float, qmax: float) -> tuple[Data1D, Data1D]:
+    def newSizeDistrPlot(self, result: MaxEntResult, qmin: float, qmax: float) -> Data1D:
         """Create a new 1D data instance based on fitting results."""
         # Create the new plot
         # Bins are radius but plot is in diameter
@@ -180,19 +180,4 @@ class SizeDistributionLogic:
         new_plot.xaxis("\\rm{Diameter}", "A")
         new_plot.yaxis("\\rm{VolumeDistribution}", "")
 
-        # Create vertical lines for trusted range
-        x_trust = self.computeTrustRange(qmin, qmax)
-        y_max_trust = np.full_like(x_trust, max(y))  # lines start at 0.0 and end at y
-        trust_plot = Data1D(x=x_trust, y=y_max_trust)
-        trust_plot.is_data = False
-        trust_plot.symbol = "Vline"
-        trust_plot.custom_color = "Red"
-        trust_plot.xaxis("\\rm{Diameter}", "A")
-        trust_plot.yaxis("\\rm{VolumeDistribution}", "")
-        trust_plot.plot_role = DataRole.ROLE_SIZE_DISTRIBUTION
-
-        trust_plot.id = TRUST_RANGE_LABEL
-        trust_plot.group_id = GROUP_ID_SIZE_DISTR_FIT
-        trust_plot.name = TRUST_RANGE_LABEL + f"[{self._data.name}]"
-
-        return new_plot, trust_plot
+        return new_plot

--- a/src/sas/qtgui/Perspectives/SizeDistribution/SizeDistributionPerspective.py
+++ b/src/sas/qtgui/Perspectives/SizeDistribution/SizeDistributionPerspective.py
@@ -83,7 +83,6 @@ class SizeDistributionWindow(QtWidgets.QDialog, Ui_SizeDistribution, Perspective
         self.backgd_subtr_plot: Data1D | None = None
         self.fit_plot: Data1D | None = None
         self.size_distr_plot: Data1D | None = None
-        self.trust_plot: Data1D | None = None
 
         self.model = QtGui.QStandardItemModel(self)
         self.mapper = QtWidgets.QDataWidgetMapper(self)
@@ -526,7 +525,6 @@ class SizeDistributionWindow(QtWidgets.QDialog, Ui_SizeDistribution, Perspective
         self.backgd_plot = None
         self.fit_plot = None
         self.size_distr_plot = None
-        self.trust_plot = None
         self.setupModel()
         self.enableButtons()
         self.clearStatistics()
@@ -636,7 +634,7 @@ class SizeDistributionWindow(QtWidgets.QDialog, Ui_SizeDistribution, Perspective
         qmin_fit = float(self.txtMinRange.text())
         qmax_fit = float(self.txtMaxRange.text())
 
-        self.size_distr_plot, self.trust_plot = self.logic.newSizeDistrPlot(result, qmin_fit, qmax_fit)
+        self.size_distr_plot = self.logic.newSizeDistrPlot(result, qmin_fit, qmax_fit)
         if self.size_distr_plot is not None:
             # set the trust range for the size distribution plot
             self.size_distr_plot.show_trust_bar = True
@@ -649,11 +647,6 @@ class SizeDistributionWindow(QtWidgets.QDialog, Ui_SizeDistribution, Perspective
             title = self.size_distr_plot.name
             GuiUtils.updateModelItemWithPlot(self._model_item, self.size_distr_plot, title)
             plots.append(self.size_distr_plot)
-
-        if self.trust_plot is not None:
-            title = self.trust_plot.name
-            GuiUtils.updateModelItemWithPlot(self._model_item, self.trust_plot, title)
-            plots.append(self.trust_plot)
 
         self.communicator.plotRequestedSignal.emit(plots)
 

--- a/src/sas/qtgui/Perspectives/SizeDistribution/SizeDistributionPerspective.py
+++ b/src/sas/qtgui/Perspectives/SizeDistribution/SizeDistributionPerspective.py
@@ -635,15 +635,26 @@ class SizeDistributionWindow(QtWidgets.QDialog, Ui_SizeDistribution, Perspective
         plots = [self._model_item]
         qmin_fit = float(self.txtMinRange.text())
         qmax_fit = float(self.txtMaxRange.text())
+
         self.size_distr_plot, self.trust_plot = self.logic.newSizeDistrPlot(result, qmin_fit, qmax_fit)
         if self.size_distr_plot is not None:
+            # set the trust range for the size distribution plot
+            self.size_distr_plot.show_trust_bar = True
+            trust_range = self.logic.computeTrustRange(qmin_fit, qmax_fit)
+            self.size_distr_plot.trust_range = {
+                "d_low": trust_range[0],
+                "d_high": trust_range[1],
+            }
+
             title = self.size_distr_plot.name
             GuiUtils.updateModelItemWithPlot(self._model_item, self.size_distr_plot, title)
             plots.append(self.size_distr_plot)
+
         if self.trust_plot is not None:
             title = self.trust_plot.name
             GuiUtils.updateModelItemWithPlot(self._model_item, self.trust_plot, title)
             plots.append(self.trust_plot)
+
         self.communicator.plotRequestedSignal.emit(plots)
 
         # add fit to data plot

--- a/src/sas/qtgui/Plotting/Plotter.py
+++ b/src/sas/qtgui/Plotting/Plotter.py
@@ -22,6 +22,7 @@ from sas.qtgui.Plotting.PlotterData import Data1D, DataRole
 from sas.qtgui.Plotting.QRangeSlider import QRangeSlider
 from sas.qtgui.Plotting.ScaleProperties import ScaleProperties
 from sas.qtgui.Plotting.SetGraphRange import SetGraphRange
+from sas.qtgui.Plotting.TrustBar import TrustBar
 
 logger = logging.getLogger(__name__)
 
@@ -41,6 +42,8 @@ class PlotterWidget(PlotterBase):
         self.plot_lines = {}
         # Dictionary of slider interactors {plot_id:interactor}
         self.sliders = {}
+
+        self.trust_bar = TrustBar(self.ax, self.canvas)
 
         # Window for text add
         self.addText = AddText(self)
@@ -314,6 +317,10 @@ class PlotterWidget(PlotterBase):
             if existing_slider is not None and not existing_slider.is_visible:
                 sliders.toggle()
             self.sliders[data.name] = sliders
+
+        # Draw size-distribution trust bar if requested.
+        if data.show_trust_bar:
+            self.trust_bar.draw(data)
 
         # refresh canvas
         self.canvas.draw_idle()

--- a/src/sas/qtgui/Plotting/PlotterData.py
+++ b/src/sas/qtgui/Plotting/PlotterData.py
@@ -83,6 +83,9 @@ class Data1D(PlottableData1D, LoadData1D):
         self.slider_high_q_setter = []  # List of attributes that lead to a setter to tie a high Q method to the slider
         self.slider_high_q_getter = []  # List of attributes that lead to a getter to tie a high Q method to the slider
 
+        # Trust bar for size distribution perspective
+        self.show_trust_bar = False  # Should the trust bar be shown?
+
     def setSlicerOwner(self, owner):
         """
         Store the 2D plot window that owns a slicer-generated 1D plot.

--- a/src/sas/qtgui/Plotting/TrustBar.py
+++ b/src/sas/qtgui/Plotting/TrustBar.py
@@ -47,9 +47,11 @@ class TrustBar:
 
         if self.ax.get_xscale() == "log":
             x = np.geomspace(xmin, xmax, N)
+            xm = [np.sqrt(x[i] * x[i + 1]) for i in range(N - 1)]  # Geometric mean for color calculation in log scale
         else:
             x = np.linspace(xmin, xmax, N)
-            
+            xm = [0.5 * (x[i] + x[i + 1]) for i in range(N - 1)]  # Arithmetic mean for color calculation in linear scale
+
         # Create segments for the LineCollection.
         segments = [
             [(x[i], 0.5), (x[i + 1], 0.5)]
@@ -58,8 +60,8 @@ class TrustBar:
 
         # Get the color based on the midpoint of each segment
         colours = [
-            self.colour_at(0.5 * (x[i] + x[i + 1]), d_low, d_high)
-            for i in range(len(x) - 1)
+            self.colour_at(xm[i], d_low, d_high)
+            for i in range(len(xm))
         ]
         
         # Create an inset axis above the main plot for the trust bar.
@@ -94,18 +96,53 @@ class TrustBar:
         # to update the trust bar when the main plot is updated.
         self.xlim_cid = self.ax.callbacks.connect("xlim_changed", self.update)
 
-    def colour_at(self, x: float, d_low: float, d_high: float) -> tuple[float, float, float, float]:
+    def colour_at(self, x: float, d_low: float, d_high: float, tw: float = 0.5) -> tuple[float, float, float, float]:
         """
-        Determine the color of the trust bar at a given x position based on the trust range.
+        Determine the color at a given x position based on the trust range.
         
+        Gradient is defined as follows:
+        
+        red ---- yellow ---- green ---- yellow ---- red
+        -------- (low) ---------------- (high) --------
+        
+        :param x: The x position to evaluate.
+        :param d_low: The lower bound of the trust range.
+        :param d_high: The upper bound of the trust range.
+        :param tw: The transition width for color blending.
+        :return: A tuple representing the RGBA color at the given x position.
         """
-        if x < d_low:
-            return to_rgba("red")
-        elif x <= d_high:
-            return to_rgba("green")
-        else:
-            return to_rgba("red")
+        
+        # Handle logarithmic scale by transforming x, d_low, and d_high to log10 space.
+        if self.ax.get_xscale() == "log":
+            # Avoid taking log of non-positive values.
+            if x <= 0 or d_low <= 0 or d_high <= 0:
+                return to_rgba("red")
+            x = np.log10(x)
+            d_low = np.log10(d_low)
+            d_high = np.log10(d_high)
 
+        if x < d_low - tw or x > d_high + tw:
+            return to_rgba("red")
+        # Transition from red to yellow
+        if d_low - tw <= x < d_low:
+            a = (x - (d_low - tw)) / tw
+            return tuple((1 - a) * r + a * y for r, y in zip(to_rgba("red"), to_rgba("yellow")))
+        # Transition from yellow to green
+        if d_low <= x < d_low + tw:
+            a = (x - d_low) / tw
+            return tuple((1 - a) * y + a * g for y, g in zip(to_rgba("yellow"), to_rgba("green")))
+        if d_low + tw <= x <= d_high - tw:
+            return to_rgba("green")
+        # Transition from green to yellow
+        if d_high - tw < x <= d_high:
+            a = (x - (d_high - tw)) / tw
+            return tuple((1 - a) * g + a * y for g, y in zip(to_rgba("green"), to_rgba("yellow")))
+        # Transition from yellow to red
+        if d_high < x <= d_high + tw:
+            a = (x - d_high) / tw
+            return tuple((1 - a) * y + a * r for y, r in zip(to_rgba("yellow"), to_rgba("red")))
+        return to_rgba("red")
+        
     def clear(self) -> None:
         """
         Clear the trust bar from the plot. This method disconnects the xlim_changed callback

--- a/src/sas/qtgui/Plotting/TrustBar.py
+++ b/src/sas/qtgui/Plotting/TrustBar.py
@@ -41,7 +41,7 @@ class TrustBar:
 
         d_low = trust_range.get("d_low", xmin)
         d_high = trust_range.get("d_high", xmax)
-        
+
         # Create a set of x values for the trust bar. Use a logarithmic scale if the main plot is logarithmic.
         N = 1000
 
@@ -63,7 +63,7 @@ class TrustBar:
             self.colour_at(xm[i], d_low, d_high)
             for i in range(len(xm))
         ]
-        
+
         # Create an inset axis above the main plot for the trust bar.
         self.bar_ax = self.ax.inset_axes(
             (0.0, 1.02, 1.0, 0.02),
@@ -78,7 +78,7 @@ class TrustBar:
         )
 
         self.bar_ax.add_collection(self.bar)
-        
+
         # Match main plot x scaling and range.
         self.bar_ax.set_xscale(self.ax.get_xscale())
         self.bar_ax.set_xlim(self.ax.get_xlim())
@@ -111,7 +111,7 @@ class TrustBar:
         :param tw: The transition width for color blending.
         :return: A tuple representing the RGBA color at the given x position.
         """
-        
+
         # Handle logarithmic scale by transforming x, d_low, and d_high to log10 space.
         if self.ax.get_xscale() == "log":
             # Avoid taking log of non-positive values.
@@ -142,7 +142,7 @@ class TrustBar:
             a = (x - d_high) / tw
             return tuple((1 - a) * y + a * r for y, r in zip(to_rgba("yellow"), to_rgba("red")))
         return to_rgba("red")
-        
+
     def clear(self) -> None:
         """
         Clear the trust bar from the plot. This method disconnects the xlim_changed callback

--- a/src/sas/qtgui/Plotting/TrustBar.py
+++ b/src/sas/qtgui/Plotting/TrustBar.py
@@ -1,0 +1,184 @@
+"""Trust bar for displaying trust information above the results plot for Size Distribution perspective."""
+
+
+import numpy as np
+from matplotlib.axes import Axes
+from matplotlib.backend_bases import FigureCanvasBase
+from matplotlib.colors import LinearSegmentedColormap
+
+from sas.qtgui.Plotting.PlotterData import Data1D
+
+ColourStop = tuple[float, str]
+
+
+class TrustBar:
+
+    def __init__(self, ax: Axes, canvas: FigureCanvasBase) -> None:
+        self.ax = ax
+        self.canvas = canvas
+        self.data: Data1D | None = None
+        self.bar_ax: Axes | None = None
+        self.xlim_cid: int | None = None  # To store the callback ID for disconnecting later
+
+    def draw(self, data: Data1D) -> None:
+        """
+        Draw a simple green-yellow-red gradient bar above the main 1D plot.
+
+        :param data: The Data1D object containing the trust range information.
+        """
+
+        # Clear any existing trust bar before drawing a new one.
+        self.clear()
+
+        self.data = data
+
+        trust_range = getattr(data, "trust_range", None)
+        if trust_range is None:
+            return
+
+        # Get the current x limits of the main plot.
+        xmin, xmax = self.ax.get_xlim()
+
+        d_low = self._normalize_x(trust_range["d_low"], xmin, xmax)
+        d_high = self._normalize_x(trust_range["d_high"], xmin, xmax)
+
+        stops = self._make_colour_stops(d_low, d_high)
+
+        # Create a custom colormap from the colour stops.
+        cmap = LinearSegmentedColormap.from_list("trust_bar_gradient", stops)
+
+        # Create a gradient image for the trust bar.
+        gradient = np.linspace(0, 1, 256).reshape(1, -1)
+
+        # Create a thin inset axis above the main plot.
+        bar_ax = self.ax.inset_axes((0.0, 1.02, 1.0, 0.02), transform=self.ax.transAxes)
+
+        bar_ax.imshow(gradient, aspect="auto", cmap=cmap, extent=(xmin, xmax, 0, 1), origin="lower")
+
+        # Match main plot x scaling and range.
+        bar_ax.set_xscale(self.ax.get_xscale())
+        bar_ax.set_xlim(self.ax.get_xlim())
+
+        # Remove ticks and spines for a clean look.
+        bar_ax.set_yticks([])
+        bar_ax.set_xticks([])
+        bar_ax.minorticks_off()
+        for spine in bar_ax.spines.values():
+            spine.set_visible(False)
+
+        # Store the bar axis for later removal and connect the xlim_changed callback
+        # to update the trust bar when the main plot is updated.
+        self.xlim_cid = self.ax.callbacks.connect("xlim_changed", self.update)
+
+    def clear(self) -> None:
+        """
+        Clear the trust bar from the plot. This method disconnects the xlim_changed callback
+        and removes the bar axis if it exists.
+        """
+        if self.xlim_cid is not None:
+            try:
+                self.ax.callbacks.disconnect(self.xlim_cid)
+            except Exception:
+                pass
+            self.xlim_cid = None
+
+        if self.bar_ax is not None:
+            try:
+                self.bar_ax.remove()
+            except ValueError:
+                pass
+            self.bar_ax = None
+
+        self.data = None
+
+    def update(self, main_ax) -> None:
+        """
+        Update the trust bar when the main plot is updated.
+        """
+        if self.data is not None:
+            self.draw(self.data)
+            self.canvas.draw_idle()
+
+    def _normalize_x(self, x: float, xmin: float, xmax: float) -> float:
+        """Returns the normalized x value in the range [0, 1] based on the current x limits."""
+        return (x - xmin) / (xmax - xmin)
+
+    def _make_colour_stops(self, low: float, high: float, transition_width: float = 0.05) -> list[ColourStop]:
+        """Returns a list of colour stops for the trust bar gradient based on the low and high thresholds.
+
+            red ---- yellow ---- green ---- yellow ---- red
+                     (low)                  (high)
+
+        This function also handles cases where the low and high thresholds are outside the [0, 1] range.
+
+        :param low: The lower threshold for the trust bar (normalized to [0, 1]).
+        :param high: The upper threshold for the trust bar (normalized to [0, 1]).
+        :param transition_width: The width of the transition zone between colours. Default is 0.05.
+        :return: A list of tuples representing the colour stops for the gradient.
+        """
+
+        stops: list[ColourStop] = []
+
+        # Lower boundary: red to yellow to green
+        if low - transition_width >= 1.0:
+            return [(0.0, "red"), (1.0, "red")]
+        elif low + transition_width <= 0.0:
+            stops.append((0.0, "green"))
+        elif low <= 0.0:
+            stops.extend(
+                [
+                    (0.0, "yellow"),
+                    (low + transition_width, "green"),
+                ]
+            )
+        else:
+            stops.extend(
+                [
+                    (0.0, "red"),
+                    (low - transition_width, "red") if low - transition_width > 0.0 else (0.0, "red"),
+                    (low, "yellow"),
+                    (low + transition_width, "green"),
+                ]
+            )
+
+        # Upper boundary: green to yellow to red
+        if high + transition_width <= 0.0:
+            return [(0.0, "red"), (1.0, "red")]
+        elif high + transition_width >= 1.0:
+            stops.append((1.0, "green"))
+        elif high >= 1.0:
+            stops.extend(
+                [
+                    (high - transition_width, "green"),
+                    (1.0, "yellow"),
+                ]
+            )
+        else:
+            stops.extend(
+                [
+                    (high - transition_width, "green"),
+                    (high, "yellow"),
+                    (high + transition_width, "red") if high + transition_width < 1.0 else (1.0, "red"),
+                    (1.0, "red"),
+                ]
+            )
+
+        # Sort the stops by position to ensure they are in the correct order for the colormap.
+        stops = sorted(stops, key=lambda x: x[0])
+
+        # Remove duplicate and close stops to avoid issues with the colormap.
+        clean_stops: list[ColourStop] = []
+        for position, colour in stops:
+            if clean_stops and abs(clean_stops[-1][0] - position) < 1e-12:
+                clean_stops[-1] = (position, colour)
+            else:
+                clean_stops.append((position, colour))
+
+        # Handle the case where there is only one stop, which can cause issues with the colormap.
+        if len(clean_stops) == 1:
+            clean_stops = [
+                (0.0, clean_stops[0][1]),
+                (1.0, clean_stops[0][1]),
+            ]
+
+        return clean_stops

--- a/src/sas/qtgui/Plotting/TrustBar.py
+++ b/src/sas/qtgui/Plotting/TrustBar.py
@@ -4,11 +4,10 @@
 import numpy as np
 from matplotlib.axes import Axes
 from matplotlib.backend_bases import FigureCanvasBase
-from matplotlib.colors import LinearSegmentedColormap
+from matplotlib.collections import LineCollection
+from matplotlib.colors import to_rgba
 
 from sas.qtgui.Plotting.PlotterData import Data1D
-
-ColourStop = tuple[float, str]
 
 
 class TrustBar:
@@ -18,6 +17,7 @@ class TrustBar:
         self.canvas = canvas
         self.data: Data1D | None = None
         self.bar_ax: Axes | None = None
+        self.bar: LineCollection | None = None
         self.xlim_cid: int | None = None  # To store the callback ID for disconnecting later
 
     def draw(self, data: Data1D) -> None:
@@ -39,36 +39,72 @@ class TrustBar:
         # Get the current x limits of the main plot.
         xmin, xmax = self.ax.get_xlim()
 
-        d_low = self._normalize_x(trust_range["d_low"], xmin, xmax)
-        d_high = self._normalize_x(trust_range["d_high"], xmin, xmax)
+        d_low = trust_range.get("d_low", xmin)
+        d_high = trust_range.get("d_high", xmax)
+        
+        # Create a set of x values for the trust bar. Use a logarithmic scale if the main plot is logarithmic.
+        N = 1000
 
-        stops = self._make_colour_stops(d_low, d_high)
+        if self.ax.get_xscale() == "log":
+            x = np.geomspace(xmin, xmax, N)
+        else:
+            x = np.linspace(xmin, xmax, N)
+            
+        # Create segments for the LineCollection.
+        segments = [
+            [(x[i], 0.5), (x[i + 1], 0.5)]
+            for i in range(N - 1)
+        ]
 
-        # Create a custom colormap from the colour stops.
-        cmap = LinearSegmentedColormap.from_list("trust_bar_gradient", stops)
+        # Get the color based on the midpoint of each segment
+        colours = [
+            self.colour_at(0.5 * (x[i] + x[i + 1]), d_low, d_high)
+            for i in range(len(x) - 1)
+        ]
+        
+        # Create an inset axis above the main plot for the trust bar.
+        self.bar_ax = self.ax.inset_axes(
+            (0.0, 1.02, 1.0, 0.02),
+            transform=self.ax.transAxes,
+        )
 
-        # Create a gradient image for the trust bar.
-        gradient = np.linspace(0, 1, 256).reshape(1, -1)
+        self.bar = LineCollection(
+            segments,
+            colors=colours,
+            linewidths=8,
+            capstyle="butt"
+        )
 
-        # Create a thin inset axis above the main plot.
-        bar_ax = self.ax.inset_axes((0.0, 1.02, 1.0, 0.02), transform=self.ax.transAxes)
-
-        bar_ax.imshow(gradient, aspect="auto", cmap=cmap, extent=(xmin, xmax, 0, 1), origin="lower")
-
+        self.bar_ax.add_collection(self.bar)
+        
         # Match main plot x scaling and range.
-        bar_ax.set_xscale(self.ax.get_xscale())
-        bar_ax.set_xlim(self.ax.get_xlim())
+        self.bar_ax.set_xscale(self.ax.get_xscale())
+        self.bar_ax.set_xlim(self.ax.get_xlim())
+
+        self.bar_ax.set_ylim(0, 1)
 
         # Remove ticks and spines for a clean look.
-        bar_ax.set_yticks([])
-        bar_ax.set_xticks([])
-        bar_ax.minorticks_off()
-        for spine in bar_ax.spines.values():
+        self.bar_ax.set_yticks([])
+        self.bar_ax.set_xticks([])
+        self.bar_ax.minorticks_off()
+        for spine in self.bar_ax.spines.values():
             spine.set_visible(False)
 
         # Store the bar axis for later removal and connect the xlim_changed callback
         # to update the trust bar when the main plot is updated.
         self.xlim_cid = self.ax.callbacks.connect("xlim_changed", self.update)
+
+    def colour_at(self, x: float, d_low: float, d_high: float) -> tuple[float, float, float, float]:
+        """
+        Determine the color of the trust bar at a given x position based on the trust range.
+        
+        """
+        if x < d_low:
+            return to_rgba("red")
+        elif x <= d_high:
+            return to_rgba("green")
+        else:
+            return to_rgba("red")
 
     def clear(self) -> None:
         """
@@ -98,87 +134,3 @@ class TrustBar:
         if self.data is not None:
             self.draw(self.data)
             self.canvas.draw_idle()
-
-    def _normalize_x(self, x: float, xmin: float, xmax: float) -> float:
-        """Returns the normalized x value in the range [0, 1] based on the current x limits."""
-        return (x - xmin) / (xmax - xmin)
-
-    def _make_colour_stops(self, low: float, high: float, transition_width: float = 0.05) -> list[ColourStop]:
-        """Returns a list of colour stops for the trust bar gradient based on the low and high thresholds.
-
-            red ---- yellow ---- green ---- yellow ---- red
-                     (low)                  (high)
-
-        This function also handles cases where the low and high thresholds are outside the [0, 1] range.
-
-        :param low: The lower threshold for the trust bar (normalized to [0, 1]).
-        :param high: The upper threshold for the trust bar (normalized to [0, 1]).
-        :param transition_width: The width of the transition zone between colours. Default is 0.05.
-        :return: A list of tuples representing the colour stops for the gradient.
-        """
-
-        stops: list[ColourStop] = []
-
-        # Lower boundary: red to yellow to green
-        if low - transition_width >= 1.0:
-            return [(0.0, "red"), (1.0, "red")]
-        elif low + transition_width <= 0.0:
-            stops.append((0.0, "green"))
-        elif low <= 0.0:
-            stops.extend(
-                [
-                    (0.0, "yellow"),
-                    (low + transition_width, "green"),
-                ]
-            )
-        else:
-            stops.extend(
-                [
-                    (0.0, "red"),
-                    (low - transition_width, "red") if low - transition_width > 0.0 else (0.0, "red"),
-                    (low, "yellow"),
-                    (low + transition_width, "green"),
-                ]
-            )
-
-        # Upper boundary: green to yellow to red
-        if high + transition_width <= 0.0:
-            return [(0.0, "red"), (1.0, "red")]
-        elif high + transition_width >= 1.0:
-            stops.append((1.0, "green"))
-        elif high >= 1.0:
-            stops.extend(
-                [
-                    (high - transition_width, "green"),
-                    (1.0, "yellow"),
-                ]
-            )
-        else:
-            stops.extend(
-                [
-                    (high - transition_width, "green"),
-                    (high, "yellow"),
-                    (high + transition_width, "red") if high + transition_width < 1.0 else (1.0, "red"),
-                    (1.0, "red"),
-                ]
-            )
-
-        # Sort the stops by position to ensure they are in the correct order for the colormap.
-        stops = sorted(stops, key=lambda x: x[0])
-
-        # Remove duplicate and close stops to avoid issues with the colormap.
-        clean_stops: list[ColourStop] = []
-        for position, colour in stops:
-            if clean_stops and abs(clean_stops[-1][0] - position) < 1e-12:
-                clean_stops[-1] = (position, colour)
-            else:
-                clean_stops.append((position, colour))
-
-        # Handle the case where there is only one stop, which can cause issues with the colormap.
-        if len(clean_stops) == 1:
-            clean_stops = [
-                (0.0, clean_stops[0][1]),
-                (1.0, clean_stops[0][1]),
-            ]
-
-        return clean_stops


### PR DESCRIPTION
## Description

Fixes #3271

This PR adds a Trust Bar to the Size Distribution perspective, inspired by IRENA-style plots. The bar visually indicates which diameter region is reliable based on the fitted Q-range, using a smooth red/yellow/green gradient.

### Key changes

- Adds a horizontal trust bar above the size distribution plot.

- Uses two physical trust boundaries derived from the fit range as defined in `SizeDistributionLogic`:
  - D_low = 1.8 * pi / Qmax
  - D_high = 0.95 * pi / Qmin

- Displays:
  - red for out-of-range / unreliable diameters
  - yellow for transition regions
  - green for the trusted region

- A small helper class (TrustBar) handles:
  - drawing the gradient bar
  - clearing it
  - updating it when the x-axis limits change

- The bar stays aligned when the plot is zoomed or rescaled.

## How Has This Been Tested?

Manually tested functionality.

## Review Checklist:

**Documentation**
- [ ] There is **nothing** that needs documenting
- [ ] Documentation changes are **in this PR**
- [x] There is an **issue** open for the documentation #4016 

**Installers**
- [ ] There is a chance this will affect the **installers**, if so
  - [ ] **Windows** installer (GH artifact) has been tested (installed and worked) 
  - [ ] **MacOSX** installer (GH artifact) has been tested (installed and worked)
  - [ ] **Wheels** installer (GH artifact) has been tested (installed and worked)

**Licensing**
- [x] The introduced changes comply with SasView license (BSD 3-Clause)

