### PR TITLE
Adds code to replace plot data for modified slicers

### DIFF
--- a/src/sas/qtgui/Plotting/Plotter.py
+++ b/src/sas/qtgui/Plotting/Plotter.py
@@ -78,8 +78,13 @@ class PlotterWidget(PlotterBase):
     @data.setter
     def data(self, value):
         """ data setter """
-        #self._data = value
-        self._data.append(value)
+        data_names = [item.name for item in self._data]
+        if value.name in data_names:
+            data_index = data_names.index(value.name)
+            self._data[data_index] = value
+        else:
+            self._data.append(value)
+
         if value._xunit:
             self.xLabel = "%s(%s)"%(value._xaxis, value._xunit)
         else:
@@ -105,7 +110,7 @@ class PlotterWidget(PlotterBase):
 
         # Data1D
         if isinstance(data, Data1D):
-            self.data.append(data)
+            self.data = data
 
         is_fit = (data.id=="fit")
 

--- a/src/sas/qtgui/Plotting/Plotter.py
+++ b/src/sas/qtgui/Plotting/Plotter.py
@@ -85,20 +85,6 @@ class PlotterWidget(PlotterBase):
         else:
             self._data.append(value)
 
-        if value._xunit:
-            self.xLabel = "%s(%s)"%(value._xaxis, value._xunit)
-        else:
-            self.xLabel = "%s"%(value._xaxis)
-        if value._yunit:
-            self.yLabel = "%s(%s)"%(value._yaxis, value._yunit)
-        else:
-            self.yLabel = "%s"%(value._yaxis)
-
-        if value.scale == 'linear' or value.isSesans:
-            self.xscale = 'linear'
-            self.yscale = 'linear'
-        self.title(title=value.name)
-
     def plot(self, data=None, color=None, marker=None, hide_error=False, transform=True):
         """
         Add a new plot of self._data to the chart.

--- a/src/sas/qtgui/Plotting/UnitTesting/PlotterTest.py
+++ b/src/sas/qtgui/Plotting/UnitTesting/PlotterTest.py
@@ -44,15 +44,6 @@ class PlotterTest:
 
         yield p
 
-    def testDataProperty(self, plotter):
-        """ Adding data """
-        plotter.data = self.data
-
-        assert plotter.data[0] == self.data
-        assert plotter._title == self.data.name
-        assert plotter.xLabel == ""
-        assert plotter.yLabel == ""
-
     def testPlotWithErrors(self, plotter, mocker):
         """ Look at the plotting with error bars"""
         plotter.data = self.data


### PR DESCRIPTION
## Description

In #1371, code was introduced that appended plot data to the list of 1D data. This PR takes a find and replace approach uinstead, so that the number of entries is reasonable when pressing the "send to data explorer" button.

Fixes the second part of #4003

## How Has This Been Tested?

Test suite and manually examined changes to slicers.

## Review Checklist:

[if using the editor, use `[x]` in place of `[ ]` to check a box]

**Documentation** (check at least one)
- [x] There is **nothing** that needs documenting
- [ ] Documentation changes are **in this PR**
- [ ] There is an **issue** open for the documentation (link?)

**Installers**
- [ ] There is a chance this will affect the **installers**, if so
  - [ ] **Windows** installer (GH artifact) has been tested (installed and worked) 
  - [ ] **MacOSX** installer (GH artifact) has been tested (installed and worked)
  - [ ] **Wheels** installer (GH artifact) has been tested (installed and worked)

**Licensing** (untick if necessary)
- [x] The introduced changes comply with SasView license (BSD 3-Clause)

