### PR TITLE
Handle encoding issues in loading credits.html

### DIFF
--- a/src/sas/qtgui/Utilities/About/Credits.py
+++ b/src/sas/qtgui/Utilities/About/Credits.py
@@ -4,7 +4,7 @@ from PySide6.QtCore import QSize
 from PySide6.QtGui import QIcon, QPalette
 from PySide6.QtWidgets import QApplication, QDialog, QSizePolicy, QTextBrowser, QVBoxLayout
 
-from sas.system import SAS_RESOURCES
+from sas.system import legal
 
 logger = logging.getLogger(__name__)
 
@@ -54,8 +54,7 @@ class Credits(QDialog):
         """
         Modify the labels so the text corresponds to the current version
         """
-        with SAS_RESOURCES.resource("system/credits.html") as path:
-            credits = path.read_text()
+        credits = legal.credits_html
 
         if is_dark_mode():
             # Inject dark mode CSS into the credits HTML

--- a/src/sas/system/legal.py
+++ b/src/sas/system/legal.py
@@ -1,5 +1,4 @@
 import datetime
-from pathlib import Path
 
 from ._resources import SAS_RESOURCES
 
@@ -24,10 +23,17 @@ class Legal:
                     </body>
                 </html>"""
 
-
     @property
-    def credits_html(self) -> Path:
-        return SAS_RESOURCES.resource("system/credits.html")
+    def credits_html(self) -> str:
+        with SAS_RESOURCES.resource("system/credits.html") as res:
+            # The data from pip-licenses should already be normalised to UTF-8
+            # but it could have other encodings in it; here, we
+            # - ensure that UTF-8 is used for the file regardless of the quirks
+            #   of the underlying platform
+            # - ensure reading the file is robust by coercing the data to
+            #   UTF-8, replacing unknown codepoints with REPLACEMENT CHARACTER
+            #   markers.
+            return res.read_text(encoding='utf-8', errors='replace')
 
 
 legal = Legal()


### PR DESCRIPTION
## Description

Be defensive against non-UTF-8 chars that can creep into credits.html since it is compiled from lots of different sources, and force use of UTF-8 since the file should already be UTF-8 via `pip-licenses` and `build_tools/compile_licenses.py`.

This PR 
 - forces use of UTF-8 for credits.html since that is what it should be, working around the on-going obsession windows has with cp1252 (as spotted in the traceback in #4013) ... bring on Python 3.15 for that to finally change.
 - makes reading credits.html robust against malformed data by using replacement characters where it needs to, in order to ensure it can decode from UTF-8.
 - switches loading credits.html to the established code path within `system.legal`
 - fixes a latent bug in the credits_html function (function is not used elsewhere in the code bae)

Fixes #4013 

## How Has This Been Tested?

Tested locally on linux (but note that this is a windows-specific bug due to it still using cp1252):
```shell
. .venv/bin/activate
python build_tools/compile_licenses.py src/sas/system/credits.html
sasview
```

Have not tested from the installer because generating installer images has been disabled in CI.

Note that unrelated failing test on linux is #4000 which is waiting for PRs to be merged to fix.

## Review Checklist:

[if using the editor, use `[x]` in place of `[ ]` to check a box]

**Documentation** (check at least one)
- [x] There is **nothing** that needs documenting
- [ ] Documentation changes are **in this PR**
- [ ] There is an **issue** open for the documentation (link?)

**Installers**
- [ ] There is a chance this will affect the **installers**, if so
  - [ ] **Windows** installer (GH artifact) has been tested (installed and worked) 
  - [ ] **MacOSX** installer (GH artifact) has been tested (installed and worked)
  - [ ] **Wheels** installer (GH artifact) has been tested (installed and worked)

**Licensing** (untick if necessary)
- [x] The introduced changes comply with SasView license (BSD 3-Clause)

