### PR TITLE
Update Size Distribution UI to fit in screen

### DIFF
--- a/src/sas/qtgui/Perspectives/SizeDistribution/UI/SizeDistributionUI.ui
+++ b/src/sas/qtgui/Perspectives/SizeDistribution/UI/SizeDistributionUI.ui
@@ -7,11 +7,11 @@
     <x>0</x>
     <y>0</y>
     <width>577</width>
-    <height>634</height>
+    <height>586</height>
    </rect>
   </property>
   <property name="sizePolicy">
-   <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+   <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
     <horstretch>0</horstretch>
     <verstretch>0</verstretch>
    </sizepolicy>
@@ -113,6 +113,51 @@
        <string>Parameters</string>
       </attribute>
       <layout class="QGridLayout" name="gridLayout_6">
+       <item row="1" column="0">
+        <widget class="QGroupBox" name="boxModel">
+         <property name="title">
+          <string>Model</string>
+         </property>
+         <layout class="QGridLayout" name="gridLayout_5">
+          <item row="0" column="3">
+           <widget class="QLabel" name="lblAspectRatio">
+            <property name="text">
+             <string>Aspect ratio:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="1">
+           <widget class="QComboBox" name="cbModel">
+            <property name="toolTip">
+             <string>Select a model.</string>
+            </property>
+            <item>
+             <property name="text">
+              <string>Ellipsoid</string>
+             </property>
+            </item>
+           </widget>
+          </item>
+          <item row="0" column="0">
+           <widget class="QLabel" name="lblModel">
+            <property name="text">
+             <string>Model name</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="4">
+           <widget class="QLineEdit" name="txtAspectRatio">
+            <property name="enabled">
+             <bool>true</bool>
+            </property>
+            <property name="toolTip">
+             <string>Aspect ratio of the ellipsoid model (ratio of semi-axes).</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
        <item row="2" column="0">
         <widget class="QGroupBox" name="boxParameters">
          <property name="title">
@@ -226,51 +271,6 @@
             <property name="text">
              <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Å&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;
              </string>
-            </property>
-           </widget>
-          </item>
-         </layout>
-        </widget>
-       </item>
-       <item row="1" column="0">
-        <widget class="QGroupBox" name="boxModel">
-         <property name="title">
-          <string>Model</string>
-         </property>
-         <layout class="QGridLayout" name="gridLayout_5">
-          <item row="0" column="3">
-           <widget class="QLabel" name="lblAspectRatio">
-            <property name="text">
-             <string>Aspect ratio:</string>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="1">
-           <widget class="QComboBox" name="cbModel">
-            <property name="toolTip">
-             <string>Select a model.</string>
-            </property>
-            <item>
-             <property name="text">
-              <string>Ellipsoid</string>
-             </property>
-            </item>
-           </widget>
-          </item>
-          <item row="0" column="0">
-           <widget class="QLabel" name="lblModel">
-            <property name="text">
-             <string>Model name</string>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="4">
-           <widget class="QLineEdit" name="txtAspectRatio">
-            <property name="enabled">
-             <bool>true</bool>
-            </property>
-            <property name="toolTip">
-             <string>Aspect ratio of the ellipsoid model (ratio of semi-axes).</string>
             </property>
            </widget>
           </item>
@@ -467,19 +467,6 @@
          </layout>
         </widget>
        </item>
-       <item row="4" column="0">
-        <spacer name="verticalSpacer">
-         <property name="orientation">
-          <enum>Qt::Orientation::Vertical</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>20</width>
-           <height>10</height>
-          </size>
-         </property>
-        </spacer>
-       </item>
       </layout>
      </widget>
      <widget class="QWidget" name="tabOptions">
@@ -495,19 +482,32 @@
          <layout class="QHBoxLayout" name="horizontalLayout_9">
           <item>
            <layout class="QGridLayout" name="gridLayout_13">
+            <item row="0" column="1">
+             <widget class="QLineEdit" name="txtMinRange">
+              <property name="minimumSize">
+               <size>
+                <width>80</width>
+                <height>0</height>
+               </size>
+              </property>
+              <property name="toolTip">
+               <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Minimum
+                value of Q.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;
+               </string>
+              </property>
+             </widget>
+            </item>
+            <item row="0" column="0">
+             <widget class="QLabel" name="lblMinRange">
+              <property name="text">
+               <string>Min</string>
+              </property>
+             </widget>
+            </item>
             <item row="0" column="3">
              <widget class="QLabel" name="lblMaxRange">
               <property name="text">
                <string>Max</string>
-              </property>
-             </widget>
-            </item>
-            <item row="0" column="5">
-             <widget class="QLabel" name="label_15">
-              <property name="text">
-               <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Å&lt;span
-                style=&quot; vertical-align:super;&quot;&gt;-1&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;
-               </string>
               </property>
              </widget>
             </item>
@@ -526,17 +526,11 @@
               </property>
              </widget>
             </item>
-            <item row="0" column="1">
-             <widget class="QLineEdit" name="txtMinRange">
-              <property name="minimumSize">
-               <size>
-                <width>80</width>
-                <height>0</height>
-               </size>
-              </property>
-              <property name="toolTip">
-               <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Minimum
-                value of Q.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;
+            <item row="0" column="5">
+             <widget class="QLabel" name="label_15">
+              <property name="text">
+               <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Å&lt;span
+                style=&quot; vertical-align:super;&quot;&gt;-1&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;
                </string>
               </property>
              </widget>
@@ -547,13 +541,6 @@
                <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Å&lt;span
                 style=&quot; vertical-align:super;&quot;&gt;-1&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;
                </string>
-              </property>
-             </widget>
-            </item>
-            <item row="0" column="0">
-             <widget class="QLabel" name="lblMinRange">
-              <property name="text">
-               <string>Min</string>
               </property>
              </widget>
             </item>
@@ -579,31 +566,31 @@
          <property name="title">
           <string>Method parameters</string>
          </property>
-         <layout class="QHBoxLayout" name="horizontalLayout_10">
+         <layout class="QVBoxLayout" name="verticalLayout_6">
           <item>
-           <layout class="QHBoxLayout" name="horizontalLayout_6">
-            <item>
-             <widget class="QLabel" name="lblSkyBackgd">
-              <property name="text">
-               <string>MaxEnt Sky Background:</string>
-              </property>
-             </widget>
-            </item>
-            <item>
+           <layout class="QGridLayout" name="gridLayout">
+            <item row="0" column="1">
              <widget class="QLineEdit" name="txtSkyBackgd">
               <property name="toolTip">
                <string>Sky background parameter for the Maximum Entropy method (suggested: 1e-6)</string>
               </property>
              </widget>
             </item>
-            <item>
+            <item row="0" column="0">
+             <widget class="QLabel" name="lblSkyBackgd">
+              <property name="text">
+               <string>MaxEnt Sky Background:</string>
+              </property>
+             </widget>
+            </item>
+            <item row="1" column="0">
              <widget class="QLabel" name="lblIterations">
               <property name="text">
                <string>Iterations:</string>
               </property>
              </widget>
             </item>
-            <item>
+            <item row="1" column="1">
              <widget class="QLineEdit" name="txtIterations">
               <property name="toolTip">
                <string>Number of iterations for the Maximum Entropy method.</string>
@@ -621,25 +608,15 @@
           <string>Weighting</string>
          </property>
          <layout class="QGridLayout" name="gridLayout_20">
+          <item row="1" column="0">
+           <layout class="QHBoxLayout" name="horizontalLayout_5"/>
+          </item>
           <item row="0" column="0">
            <layout class="QGridLayout" name="verticalLayout">
-            <item row="0" column="1">
-             <widget class="QRadioButton" name="rbWeighting2">
+            <item row="3" column="1">
+             <widget class="QLineEdit" name="txtWgtPercent">
               <property name="toolTip">
-               <string>Weight data by its error values (dI).</string>
-              </property>
-              <property name="text">
-               <string>Use dI Data</string>
-              </property>
-             </widget>
-            </item>
-            <item row="0" column="2">
-             <widget class="QRadioButton" name="rbWeighting3">
-              <property name="toolTip">
-               <string>Weight data by the square root of intensity values.</string>
-              </property>
-              <property name="text">
-               <string>Use |sqrt(I Data)|</string>
+               <string>Percentage value for percentage-based weighting.</string>
               </property>
              </widget>
             </item>
@@ -656,11 +633,34 @@
               </property>
              </widget>
             </item>
-           </layout>
-          </item>
-          <item row="1" column="0">
-           <layout class="QHBoxLayout" name="horizontalLayout_5">
-            <item>
+            <item row="1" column="0">
+             <widget class="QRadioButton" name="rbWeighting2">
+              <property name="toolTip">
+               <string>Weight data by its error values (dI).</string>
+              </property>
+              <property name="text">
+               <string>Use dI Data</string>
+              </property>
+             </widget>
+            </item>
+            <item row="2" column="0">
+             <widget class="QRadioButton" name="rbWeighting3">
+              <property name="toolTip">
+               <string>Weight data by the square root of intensity values.</string>
+              </property>
+              <property name="text">
+               <string>Use |sqrt(I Data)|</string>
+              </property>
+             </widget>
+            </item>
+            <item row="2" column="3">
+             <widget class="QLineEdit" name="txtWgtFactor">
+              <property name="toolTip">
+               <string>Overall weighting factor to apply to the data.</string>
+              </property>
+             </widget>
+            </item>
+            <item row="3" column="0">
              <widget class="QRadioButton" name="rbWeighting4">
               <property name="toolTip">
                <string>Weight data as a percentage of intensity values.</string>
@@ -670,24 +670,10 @@
               </property>
              </widget>
             </item>
-            <item>
-             <widget class="QLineEdit" name="txtWgtPercent">
-              <property name="toolTip">
-               <string>Percentage value for percentage-based weighting.</string>
-              </property>
-             </widget>
-            </item>
-            <item>
+            <item row="2" column="2">
              <widget class="QLabel" name="lblWgtFactor">
               <property name="text">
                <string>Weight factor:</string>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <widget class="QLineEdit" name="txtWgtFactor">
-              <property name="toolTip">
-               <string>Overall weighting factor to apply to the data.</string>
               </property>
              </widget>
             </item>
@@ -697,15 +683,65 @@
         </widget>
        </item>
        <item>
+        <spacer name="verticalSpacer">
+         <property name="orientation">
+          <enum>Qt::Orientation::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>40</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+      </layout>
+     </widget>
+     <widget class="QWidget" name="tabBackground">
+      <property name="whatsThis">
+       <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+      </property>
+      <attribute name="title">
+       <string>Background</string>
+      </attribute>
+      <layout class="QVBoxLayout" name="verticalLayout_5">
+       <item>
         <widget class="QGroupBox" name="boxBackground">
          <property name="title">
-          <string>Background</string>
+          <string>Flat Background</string>
          </property>
-         <layout class="QGridLayout" name="gridLayout">
-          <item row="1" column="0" colspan="2">
+         <layout class="QVBoxLayout" name="verticalLayout_4">
+          <item>
+           <layout class="QHBoxLayout" name="horizontalLayout_7">
+            <item>
+             <widget class="QLabel" name="lblBackgd">
+              <property name="text">
+               <string>Flat background:</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QLineEdit" name="txtBackgd">
+              <property name="toolTip">
+               <string>Flat background value (constant background in cm^-1).</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QLabel" name="label_8">
+              <property name="text">
+               <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;cm&lt;span style=&quot;
+              vertical-align:super;&quot;&gt;-1&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;
+             </string>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </item>
+          <item>
            <widget class="QGroupBox" name="qRangeGroupBox">
             <property name="title">
-             <string>Fit flat background Q range</string>
+             <string>Q range</string>
             </property>
             <layout class="QGridLayout" name="gridLayout_3">
              <item row="0" column="0">
@@ -775,37 +811,69 @@
             </layout>
            </widget>
           </item>
-          <item row="0" column="1">
-           <layout class="QHBoxLayout" name="horizontalLayout_7">
+          <item>
+           <layout class="QHBoxLayout" name="horizontalLayout_12">
             <item>
-             <widget class="QLabel" name="lblBackgd">
-              <property name="text">
-               <string>Flat background:</string>
+             <spacer name="horizontalSpacer_2">
+              <property name="orientation">
+               <enum>Qt::Orientation::Horizontal</enum>
               </property>
-             </widget>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>40</width>
+                <height>20</height>
+               </size>
+              </property>
+             </spacer>
             </item>
             <item>
-             <widget class="QLineEdit" name="txtBackgd">
+             <widget class="QPushButton" name="cmdFitFlatBackground">
               <property name="toolTip">
-               <string>Flat background value (constant background in cm^-1).</string>
+               <string>Fit the flat background component to the data in the specified Q range.</string>
+              </property>
+              <property name="text">
+               <string>Fit Flat Background</string>
               </property>
              </widget>
             </item>
             <item>
-             <widget class="QLabel" name="label_8">
-              <property name="text">
-               <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;cm&lt;span style=&quot;
-              vertical-align:super;&quot;&gt;-1&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;
-             </string>
+             <spacer name="horizontalSpacer_4">
+              <property name="orientation">
+               <enum>Qt::Orientation::Horizontal</enum>
               </property>
-             </widget>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>40</width>
+                <height>20</height>
+               </size>
+              </property>
+             </spacer>
             </item>
            </layout>
           </item>
-          <item row="4" column="0" colspan="2">
+         </layout>
+        </widget>
+       </item>
+       <item>
+        <widget class="QCheckBox" name="chkLowQ">
+         <property name="toolTip">
+          <string>Subtract the low-Q power law.</string>
+         </property>
+         <property name="text">
+          <string>Subtract Low-Q Power Law</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QGroupBox" name="groupBox">
+         <property name="title">
+          <string>Power Law</string>
+         </property>
+         <layout class="QVBoxLayout" name="verticalLayout_3">
+          <item alignment="Qt::AlignmentFlag::AlignVCenter">
            <widget class="QGroupBox" name="powerLawQRangeGroupBox">
             <property name="title">
-             <string>Fit power law Q range</string>
+             <string>Q range</string>
             </property>
             <layout class="QGridLayout" name="gridLayout_4">
              <item row="0" column="0">
@@ -875,17 +943,16 @@
             </layout>
            </widget>
           </item>
-          <item row="3" column="0" colspan="2">
+          <item>
            <layout class="QGridLayout" name="gridLayout_14">
-            <item row="0" column="3">
-             <widget class="QLabel" name="lblScaleLowQ">
-              <property name="text">
-               <string>Scale:</string>
-              </property>
-             </widget>
-            </item>
             <item row="0" column="1">
              <widget class="QLineEdit" name="txtPowerLowQ">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
               <property name="toolTip">
                <string>Exponent applied to the power-law function.</string>
               </property>
@@ -919,8 +986,21 @@
               </item>
              </layout>
             </item>
-            <item row="0" column="4">
+            <item row="1" column="0">
+             <widget class="QLabel" name="lblScaleLowQ">
+              <property name="text">
+               <string>Scale:</string>
+              </property>
+             </widget>
+            </item>
+            <item row="1" column="1">
              <widget class="QLineEdit" name="txtScaleLowQ">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
               <property name="toolTip">
                <string>Scale applied to the power-law function.</string>
               </property>
@@ -928,27 +1008,20 @@
             </item>
            </layout>
           </item>
-          <item row="2" column="0" colspan="2">
-           <widget class="QCheckBox" name="chkLowQ">
-            <property name="toolTip">
-             <string>Subtract the low-Q power law.</string>
-            </property>
-            <property name="text">
-             <string>Subtract Low-Q Power Law</string>
-            </property>
-           </widget>
-          </item>
-          <item row="5" column="1">
-           <layout class="QHBoxLayout" name="horizontalLayout_12">
+          <item>
+           <layout class="QHBoxLayout" name="horizontalLayout_11">
             <item>
-             <widget class="QPushButton" name="cmdFitFlatBackground">
-              <property name="toolTip">
-               <string>Fit the flat background component to the data in the specified Q range.</string>
+             <spacer name="horizontalSpacer_5">
+              <property name="orientation">
+               <enum>Qt::Orientation::Horizontal</enum>
               </property>
-              <property name="text">
-               <string>Fit Flat Background</string>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>40</width>
+                <height>20</height>
+               </size>
               </property>
-             </widget>
+             </spacer>
             </item>
             <item>
              <widget class="QPushButton" name="cmdFitPowerLaw">
@@ -960,10 +1033,36 @@
               </property>
              </widget>
             </item>
+            <item>
+             <spacer name="horizontalSpacer_6">
+              <property name="orientation">
+               <enum>Qt::Orientation::Horizontal</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>40</width>
+                <height>20</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
            </layout>
           </item>
          </layout>
         </widget>
+       </item>
+       <item>
+        <spacer name="verticalSpacer_2">
+         <property name="orientation">
+          <enum>Qt::Orientation::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>40</height>
+          </size>
+         </property>
+        </spacer>
        </item>
       </layout>
      </widget>
@@ -972,6 +1071,38 @@
   </layout>
  </widget>
  <tabstops>
+  <tabstop>SizeDistributionTabWidget</tabstop>
+  <tabstop>txtName</tabstop>
+  <tabstop>cbModel</tabstop>
+  <tabstop>txtAspectRatio</tabstop>
+  <tabstop>txtMinDiameter</tabstop>
+  <tabstop>txtMaxDiameter</tabstop>
+  <tabstop>txtBinsDiameter</tabstop>
+  <tabstop>chkLogBinning</tabstop>
+  <tabstop>txtContrast</tabstop>
+  <tabstop>txtMinRange</tabstop>
+  <tabstop>txtMaxRange</tabstop>
+  <tabstop>cmdReset</tabstop>
+  <tabstop>txtSkyBackgd</tabstop>
+  <tabstop>txtIterations</tabstop>
+  <tabstop>rbWeighting1</tabstop>
+  <tabstop>rbWeighting2</tabstop>
+  <tabstop>rbWeighting3</tabstop>
+  <tabstop>txtWgtFactor</tabstop>
+  <tabstop>rbWeighting4</tabstop>
+  <tabstop>txtWgtPercent</tabstop>
+  <tabstop>txtBackgd</tabstop>
+  <tabstop>txtBackgdQMin</tabstop>
+  <tabstop>txtBackgdQMax</tabstop>
+  <tabstop>cmdFitFlatBackground</tabstop>
+  <tabstop>chkLowQ</tabstop>
+  <tabstop>txtPowerLawQMin</tabstop>
+  <tabstop>txtPowerLawQMax</tabstop>
+  <tabstop>txtPowerLowQ</tabstop>
+  <tabstop>rbFixPower</tabstop>
+  <tabstop>rbFitPower</tabstop>
+  <tabstop>txtScaleLowQ</tabstop>
+  <tabstop>cmdFitPowerLaw</tabstop>
   <tabstop>quickFitButton</tabstop>
   <tabstop>fullFitButton</tabstop>
   <tabstop>helpButton</tabstop>

--- a/src/sas/qtgui/Perspectives/SizeDistribution/UI/SizeDistributionUI.ui
+++ b/src/sas/qtgui/Perspectives/SizeDistribution/UI/SizeDistributionUI.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>577</width>
-    <height>671</height>
+    <height>600</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -32,6 +32,65 @@
    <string>Size Distribution</string>
   </property>
   <layout class="QGridLayout" name="gridLayout_7">
+   <item row="1" column="0">
+    <layout class="QHBoxLayout" name="horizontalLayout_8">
+     <property name="sizeConstraint">
+      <enum>QLayout::SizeConstraint::SetDefaultConstraint</enum>
+     </property>
+     <item>
+      <widget class="QPushButton" name="quickFitButton">
+       <property name="toolTip">
+        <string>Perform a quick fit using fixed iteration parameters.</string>
+       </property>
+       <property name="text">
+        <string>Quick fit</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="fullFitButton">
+       <property name="toolTip">
+        <string>Perform a full fit with all parameters optimized.</string>
+       </property>
+       <property name="text">
+        <string>Full fit</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <spacer name="horizontalSpacer">
+       <property name="orientation">
+        <enum>Qt::Orientation::Horizontal</enum>
+       </property>
+       <property name="sizeType">
+        <enum>QSizePolicy::Policy::Expanding</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>200</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item>
+      <widget class="QPushButton" name="helpButton">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="toolTip">
+        <string>Open the Size Distribution perspective help documentation.</string>
+       </property>
+       <property name="text">
+        <string>Help</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
    <item row="0" column="0">
     <widget class="QTabWidget" name="SizeDistributionTabWidget">
      <property name="sizePolicy">
@@ -251,7 +310,7 @@
          </layout>
         </widget>
        </item>
-       <item row="3" column="0" alignment="Qt::AlignTop">
+       <item row="3" column="0" alignment="Qt::AlignmentFlag::AlignTop">
         <widget class="QGroupBox" name="boxOutput">
          <property name="title">
           <string>Output</string>
@@ -392,14 +451,14 @@
             </property>
            </widget>
           </item>
-          <item row="1" column="3" rowspan="5">
-           <spacer name="horizontalSpacer_7">
+          <item row="3" column="3">
+           <spacer name="horizontalSpacer_3">
             <property name="orientation">
-             <enum>Qt::Horizontal</enum>
+             <enum>Qt::Orientation::Horizontal</enum>
             </property>
             <property name="sizeHint" stdset="0">
              <size>
-              <width>200</width>
+              <width>40</width>
               <height>20</height>
              </size>
             </property>
@@ -430,6 +489,28 @@
               </property>
              </widget>
             </item>
+            <item row="0" column="4">
+             <widget class="QLineEdit" name="txtMaxRange">
+              <property name="minimumSize">
+               <size>
+                <width>80</width>
+                <height>0</height>
+               </size>
+              </property>
+              <property name="toolTip">
+               <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Maximum
+                value of Q.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;
+               </string>
+              </property>
+             </widget>
+            </item>
+            <item row="0" column="3">
+             <widget class="QLabel" name="lblMaxRange">
+              <property name="text">
+               <string>Max range</string>
+              </property>
+             </widget>
+            </item>
             <item row="0" column="1">
              <widget class="QLineEdit" name="txtMinRange">
               <property name="minimumSize">
@@ -454,29 +535,7 @@
               </property>
              </widget>
             </item>
-            <item row="1" column="0">
-             <widget class="QLabel" name="lblMaxRange">
-              <property name="text">
-               <string>Max range</string>
-              </property>
-             </widget>
-            </item>
-            <item row="1" column="1">
-             <widget class="QLineEdit" name="txtMaxRange">
-              <property name="minimumSize">
-               <size>
-                <width>80</width>
-                <height>0</height>
-               </size>
-              </property>
-              <property name="toolTip">
-               <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Maximum
-                value of Q.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;
-               </string>
-              </property>
-             </widget>
-            </item>
-            <item row="1" column="2">
+            <item row="0" column="5">
              <widget class="QLabel" name="label_15">
               <property name="text">
                <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Å&lt;span
@@ -486,19 +545,6 @@
              </widget>
             </item>
            </layout>
-          </item>
-          <item row="0" column="1" rowspan="2">
-           <spacer name="horizontalSpacer_8">
-            <property name="orientation">
-             <enum>Qt::Horizontal</enum>
-            </property>
-            <property name="sizeHint" stdset="0">
-             <size>
-              <width>217</width>
-              <height>20</height>
-             </size>
-            </property>
-           </spacer>
           </item>
           <item row="0" column="2">
            <widget class="QPushButton" name="cmdReset">
@@ -521,130 +567,57 @@
           <string>Method parameters</string>
          </property>
          <layout class="QGridLayout" name="gridLayout_21">
-          <item row="0" column="0">
-           <widget class="QLabel" name="lblSkyBackgd">
-            <property name="text">
-             <string>MaxEnt Sky Background:</string>
-            </property>
-           </widget>
-          </item>
           <item row="0" column="1">
-           <widget class="QLineEdit" name="txtSkyBackgd">
-            <property name="toolTip">
-             <string>Sky background parameter for the Maximum Entropy method (suggested: 1e-6)</string>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="2">
-           <widget class="QLabel" name="label_9">
-            <property name="text">
-             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Suggested: 1e-6&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="0">
-           <widget class="QLabel" name="lblIterations">
-            <property name="text">
-             <string>Iterations:</string>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="1">
-           <widget class="QLineEdit" name="txtIterations">
-            <property name="toolTip">
-             <string>Number of iterations for the Maximum Entropy method.</string>
-            </property>
-           </widget>
-          </item>
-         </layout>
-        </widget>
-       </item>
-       <item row="2" column="0">
-        <widget class="QGroupBox" name="boxWeighting">
-         <property name="title">
-          <string>Weighting</string>
-         </property>
-         <layout class="QGridLayout" name="gridLayout_20">
-          <item row="0" column="0">
-           <layout class="QGridLayout" name="verticalLayout">
-            <item row="0" column="0">
-             <widget class="QRadioButton" name="rbWeighting1">
+           <layout class="QHBoxLayout" name="horizontalLayout_6">
+            <item>
+             <widget class="QLabel" name="lblSkyBackgd">
               <property name="text">
-               <string>None</string>
-              </property>
-              <property name="checked">
-               <bool>true</bool>
-              </property>
-              <property name="toolTip">
-               <string>No weighting applied to the data.</string>
+               <string>MaxEnt Sky Background:</string>
               </property>
              </widget>
             </item>
-            <item row="1" column="0">
-             <widget class="QRadioButton" name="rbWeighting2">
-              <property name="text">
-               <string>Use dI Data</string>
-              </property>
+            <item>
+             <widget class="QLineEdit" name="txtSkyBackgd">
               <property name="toolTip">
-               <string>Weight data by its error values (dI).</string>
+               <string>Sky background parameter for the Maximum Entropy method (suggested: 1e-6)</string>
               </property>
              </widget>
             </item>
-            <item row="2" column="0">
-             <widget class="QRadioButton" name="rbWeighting3">
+            <item>
+             <widget class="QLabel" name="label_9">
               <property name="text">
-               <string>Use |sqrt(I Data)|</string>
-              </property>
-              <property name="toolTip">
-               <string>Weight data by the square root of intensity values.</string>
+               <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Suggested: 1e-6&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
               </property>
              </widget>
             </item>
-            <item row="3" column="0">
-             <widget class="QRadioButton" name="rbWeighting4">
-              <property name="text">
-               <string>Use % |I Data|</string>
+            <item>
+             <spacer name="horizontalSpacer_2">
+              <property name="orientation">
+               <enum>Qt::Orientation::Horizontal</enum>
               </property>
-              <property name="toolTip">
-               <string>Weight data as a percentage of intensity values.</string>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>40</width>
+                <height>20</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+            <item>
+             <widget class="QLabel" name="lblIterations">
+              <property name="text">
+               <string>Iterations:</string>
               </property>
              </widget>
             </item>
-            <item row="3" column="1">
-             <widget class="QLineEdit" name="txtWgtPercent">
+            <item>
+             <widget class="QLineEdit" name="txtIterations">
               <property name="toolTip">
-               <string>Percentage value for percentage-based weighting.</string>
+               <string>Number of iterations for the Maximum Entropy method.</string>
               </property>
              </widget>
             </item>
            </layout>
-          </item>
-          <item row="0" column="1">
-           <widget class="QLabel" name="lblWgtFactor">
-            <property name="text">
-             <string>Weight factor:</string>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="2">
-           <widget class="QLineEdit" name="txtWgtFactor">
-            <property name="toolTip">
-             <string>Overall weighting factor to apply to the data.</string>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="3">
-           <spacer name="horizontalSpacer_9">
-            <property name="orientation">
-             <enum>Qt::Horizontal</enum>
-            </property>
-            <property name="sizeHint" stdset="0">
-             <size>
-              <width>50</width>
-              <height>20</height>
-             </size>
-            </property>
-           </spacer>
           </item>
          </layout>
         </widget>
@@ -655,17 +628,83 @@
           <string>Background</string>
          </property>
          <layout class="QGridLayout" name="gridLayout_12">
+          <item row="4" column="0" colspan="2">
+           <widget class="QGroupBox" name="powerLawQRangeGroupBox">
+            <property name="title">
+             <string>Fit power law Q range</string>
+            </property>
+            <layout class="QGridLayout" name="gridLayout_4">
+             <item row="0" column="0">
+              <layout class="QHBoxLayout" name="horizontalLayout_3">
+               <item>
+                <widget class="QLabel" name="label_7">
+                 <property name="text">
+                  <string>Min:</string>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <widget class="QLineEdit" name="txtPowerLawQMin">
+                 <property name="enabled">
+                  <bool>true</bool>
+                 </property>
+                 <property name="sizePolicy">
+                  <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                   <horstretch>0</horstretch>
+                   <verstretch>0</verstretch>
+                  </sizepolicy>
+                 </property>
+                 <property name="toolTip">
+                  <string>Minimum Q value for fitting the power-law background.</string>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <widget class="QLabel" name="label_12">
+                 <property name="text">
+                  <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Å&lt;span style=&quot; vertical-align:super;&quot;&gt;-1&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <widget class="QLabel" name="label_14">
+                 <property name="text">
+                  <string>Max:</string>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <widget class="QLineEdit" name="txtPowerLawQMax">
+                 <property name="enabled">
+                  <bool>true</bool>
+                 </property>
+                 <property name="sizePolicy">
+                  <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                   <horstretch>0</horstretch>
+                   <verstretch>0</verstretch>
+                  </sizepolicy>
+                 </property>
+                 <property name="toolTip">
+                  <string>Maximum Q value for fitting the power-law background.</string>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <widget class="QLabel" name="label_17">
+                 <property name="text">
+                  <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Å&lt;span style=&quot; vertical-align:super;&quot;&gt;-1&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                 </property>
+                </widget>
+               </item>
+              </layout>
+             </item>
+            </layout>
+           </widget>
+          </item>
           <item row="0" column="0">
            <widget class="QLabel" name="lblBackgd">
             <property name="text">
              <string>Flat background:</string>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="1">
-           <widget class="QLineEdit" name="txtBackgd">
-            <property name="toolTip">
-             <string>Flat background value (constant background in cm^-1).</string>
             </property>
            </widget>
           </item>
@@ -675,6 +714,13 @@
              <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;cm&lt;span style=&quot;
               vertical-align:super;&quot;&gt;-1&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;
              </string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="1">
+           <widget class="QLineEdit" name="txtBackgd">
+            <property name="toolTip">
+             <string>Flat background value (constant background in cm^-1).</string>
             </property>
            </widget>
           </item>
@@ -688,15 +734,18 @@
             </property>
            </widget>
           </item>
-          <item row="3" column="0" colspan="3">
+          <item row="1" column="3">
+           <widget class="QPushButton" name="cmdFitFlatBackground">
+            <property name="toolTip">
+             <string>Fit the flat background component to the data in the specified Q range.</string>
+            </property>
+            <property name="text">
+             <string>Fit flat background</string>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="0" colspan="4">
            <layout class="QGridLayout" name="gridLayout_14">
-            <item row="0" column="0">
-             <widget class="QLabel" name="lblPowerLowQ">
-              <property name="text">
-               <string>Power:</string>
-              </property>
-             </widget>
-            </item>
             <item row="0" column="1">
              <widget class="QLineEdit" name="txtPowerLowQ">
               <property name="toolTip">
@@ -726,29 +775,20 @@
              </layout>
             </item>
             <item row="0" column="3">
-             <spacer name="horizontalSpacer">
-              <property name="orientation">
-               <enum>Qt::Horizontal</enum>
-              </property>
-              <property name="sizeType">
-               <enum>QSizePolicy::Expanding</enum>
-              </property>
-              <property name="sizeHint" stdset="0">
-               <size>
-                <width>100</width>
-                <height>20</height>
-               </size>
-              </property>
-             </spacer>
-            </item>
-            <item row="1" column="0">
              <widget class="QLabel" name="lblScaleLowQ">
               <property name="text">
                <string>Scale:</string>
               </property>
              </widget>
             </item>
-            <item row="1" column="1">
+            <item row="0" column="0">
+             <widget class="QLabel" name="lblPowerLowQ">
+              <property name="text">
+               <string>Power:</string>
+              </property>
+             </widget>
+            </item>
+            <item row="0" column="4">
              <widget class="QLineEdit" name="txtScaleLowQ">
               <property name="toolTip">
                <string>Scale applied to the power-law function.</string>
@@ -757,7 +797,17 @@
             </item>
            </layout>
           </item>
-          <item row="1" column="0" colspan="2">
+          <item row="4" column="3">
+           <widget class="QPushButton" name="cmdFitPowerLaw">
+            <property name="toolTip">
+             <string>Fit the power-law component to the data in the specified Q range.</string>
+            </property>
+            <property name="text">
+             <string>Fit power law</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="0" colspan="3">
            <widget class="QGroupBox" name="qRangeGroupBox">
             <property name="title">
              <string>Fit flat background Q range</string>
@@ -777,14 +827,14 @@
                  <property name="enabled">
                   <bool>true</bool>
                  </property>
-                 <property name="toolTip">
-                  <string>Minimum Q value for fitting the flat background.</string>
-                 </property>
                  <property name="sizePolicy">
                   <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
                    <horstretch>0</horstretch>
                    <verstretch>0</verstretch>
                   </sizepolicy>
+                 </property>
+                 <property name="toolTip">
+                  <string>Minimum Q value for fitting the flat background.</string>
                  </property>
                 </widget>
                </item>
@@ -807,14 +857,14 @@
                  <property name="enabled">
                   <bool>true</bool>
                  </property>
-                 <property name="toolTip">
-                  <string>Maximum Q value for fitting the flat background.</string>
-                 </property>
                  <property name="sizePolicy">
                   <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
                    <horstretch>0</horstretch>
                    <verstretch>0</verstretch>
                   </sizepolicy>
+                 </property>
+                 <property name="toolTip">
+                  <string>Maximum Q value for fitting the flat background.</string>
                  </property>
                 </widget>
                </item>
@@ -830,98 +880,86 @@
             </layout>
            </widget>
           </item>
-          <item row="1" column="3">
-           <widget class="QPushButton" name="cmdFitFlatBackground">
-            <property name="text">
-             <string>Fit flat background</string>
-            </property>
-            <property name="toolTip">
-             <string>Fit the flat background component to the data in the specified Q range.</string>
-            </property>
-           </widget>
+         </layout>
+        </widget>
+       </item>
+       <item row="2" column="0">
+        <widget class="QGroupBox" name="boxWeighting">
+         <property name="title">
+          <string>Weighting</string>
+         </property>
+         <layout class="QGridLayout" name="gridLayout_20">
+          <item row="0" column="0">
+           <layout class="QGridLayout" name="verticalLayout">
+            <item row="0" column="1">
+             <widget class="QRadioButton" name="rbWeighting2">
+              <property name="toolTip">
+               <string>Weight data by its error values (dI).</string>
+              </property>
+              <property name="text">
+               <string>Use dI Data</string>
+              </property>
+             </widget>
+            </item>
+            <item row="0" column="0">
+             <widget class="QRadioButton" name="rbWeighting1">
+              <property name="toolTip">
+               <string>No weighting applied to the data.</string>
+              </property>
+              <property name="text">
+               <string>None</string>
+              </property>
+              <property name="checked">
+               <bool>true</bool>
+              </property>
+             </widget>
+            </item>
+            <item row="0" column="2">
+             <widget class="QRadioButton" name="rbWeighting3">
+              <property name="toolTip">
+               <string>Weight data by the square root of intensity values.</string>
+              </property>
+              <property name="text">
+               <string>Use |sqrt(I Data)|</string>
+              </property>
+             </widget>
+            </item>
+           </layout>
           </item>
-          <item row="4" column="0" colspan="2">
-           <widget class="QGroupBox" name="powerLawQRangeGroupBox">
-            <property name="title">
-             <string>Fit power law Q range</string>
-            </property>
-            <layout class="QGridLayout" name="gridLayout_4">
-             <item row="0" column="0">
-              <layout class="QHBoxLayout" name="horizontalLayout_3">
-               <item>
-                <widget class="QLabel" name="label_7">
-                 <property name="text">
-                  <string>Min:</string>
-                 </property>
-                </widget>
-               </item>
-               <item>
-                <widget class="QLineEdit" name="txtPowerLawQMin">
-                 <property name="enabled">
-                  <bool>true</bool>
-                 </property>
-                 <property name="toolTip">
-                  <string>Minimum Q value for fitting the power-law background.</string>
-                 </property>
-                 <property name="sizePolicy">
-                  <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-                   <horstretch>0</horstretch>
-                   <verstretch>0</verstretch>
-                  </sizepolicy>
-                 </property>
-                </widget>
-               </item>
-               <item>
-                <widget class="QLabel" name="label_12">
-                 <property name="text">
-                  <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Å&lt;span style=&quot; vertical-align:super;&quot;&gt;-1&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                 </property>
-                </widget>
-               </item>
-               <item>
-                <widget class="QLabel" name="label_14">
-                 <property name="text">
-                  <string>Max:</string>
-                 </property>
-                </widget>
-               </item>
-               <item>
-                <widget class="QLineEdit" name="txtPowerLawQMax">
-                 <property name="enabled">
-                  <bool>true</bool>
-                 </property>
-                 <property name="toolTip">
-                  <string>Maximum Q value for fitting the power-law background.</string>
-                 </property>
-                 <property name="sizePolicy">
-                  <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-                   <horstretch>0</horstretch>
-                   <verstretch>0</verstretch>
-                  </sizepolicy>
-                 </property>
-                </widget>
-               </item>
-               <item>
-                <widget class="QLabel" name="label_17">
-                 <property name="text">
-                  <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Å&lt;span style=&quot; vertical-align:super;&quot;&gt;-1&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                 </property>
-                </widget>
-               </item>
-              </layout>
-             </item>
-            </layout>
-           </widget>
-          </item>
-          <item row="4" column="3">
-           <widget class="QPushButton" name="cmdFitPowerLaw">
-            <property name="text">
-             <string>Fit power law</string>
-            </property>
-            <property name="toolTip">
-             <string>Fit the power-law component to the data in the specified Q range.</string>
-            </property>
-           </widget>
+          <item row="1" column="0">
+           <layout class="QHBoxLayout" name="horizontalLayout_5">
+            <item>
+             <widget class="QRadioButton" name="rbWeighting4">
+              <property name="toolTip">
+               <string>Weight data as a percentage of intensity values.</string>
+              </property>
+              <property name="text">
+               <string>Use % |I Data|:</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QLineEdit" name="txtWgtPercent">
+              <property name="toolTip">
+               <string>Percentage value for percentage-based weighting.</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QLabel" name="lblWgtFactor">
+              <property name="text">
+               <string>Weight factor:</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QLineEdit" name="txtWgtFactor">
+              <property name="toolTip">
+               <string>Overall weighting factor to apply to the data.</string>
+              </property>
+             </widget>
+            </item>
+           </layout>
           </item>
          </layout>
         </widget>
@@ -929,65 +967,6 @@
       </layout>
      </widget>
     </widget>
-   </item>
-   <item row="1" column="0">
-    <layout class="QHBoxLayout" name="horizontalLayout_8">
-     <property name="sizeConstraint">
-      <enum>QLayout::SetDefaultConstraint</enum>
-     </property>
-     <item>
-      <widget class="QPushButton" name="quickFitButton">
-       <property name="text">
-        <string>Quick fit</string>
-       </property>
-       <property name="toolTip">
-        <string>Perform a quick fit using fixed iteration parameters.</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QPushButton" name="fullFitButton">
-       <property name="text">
-        <string>Full fit</string>
-       </property>
-       <property name="toolTip">
-        <string>Perform a full fit with all parameters optimized.</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <spacer name="horizontalSpacer">
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-       <property name="sizeType">
-        <enum>QSizePolicy::Expanding</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>200</width>
-         <height>20</height>
-        </size>
-       </property>
-      </spacer>
-     </item>
-     <item>
-      <widget class="QPushButton" name="helpButton">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="text">
-        <string>Help</string>
-       </property>
-       <property name="toolTip">
-        <string>Open the Size Distribution perspective help documentation.</string>
-       </property>
-      </widget>
-     </item>
-    </layout>
    </item>
   </layout>
  </widget>

--- a/src/sas/qtgui/Perspectives/SizeDistribution/UI/SizeDistributionUI.ui
+++ b/src/sas/qtgui/Perspectives/SizeDistribution/UI/SizeDistributionUI.ui
@@ -469,234 +469,6 @@
        </item>
       </layout>
      </widget>
-     <widget class="QWidget" name="tabOptions">
-      <attribute name="title">
-       <string>Options</string>
-      </attribute>
-      <layout class="QVBoxLayout" name="verticalLayout_2">
-       <item>
-        <widget class="QGroupBox" name="boxFittingRange">
-         <property name="title">
-          <string>Fitting range</string>
-         </property>
-         <layout class="QHBoxLayout" name="horizontalLayout_9">
-          <item>
-           <layout class="QGridLayout" name="gridLayout_13">
-            <item row="0" column="1">
-             <widget class="QLineEdit" name="txtMinRange">
-              <property name="minimumSize">
-               <size>
-                <width>80</width>
-                <height>0</height>
-               </size>
-              </property>
-              <property name="toolTip">
-               <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Minimum
-                value of Q.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;
-               </string>
-              </property>
-             </widget>
-            </item>
-            <item row="0" column="0">
-             <widget class="QLabel" name="lblMinRange">
-              <property name="text">
-               <string>Min</string>
-              </property>
-             </widget>
-            </item>
-            <item row="0" column="3">
-             <widget class="QLabel" name="lblMaxRange">
-              <property name="text">
-               <string>Max</string>
-              </property>
-             </widget>
-            </item>
-            <item row="0" column="4">
-             <widget class="QLineEdit" name="txtMaxRange">
-              <property name="minimumSize">
-               <size>
-                <width>80</width>
-                <height>0</height>
-               </size>
-              </property>
-              <property name="toolTip">
-               <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Maximum
-                value of Q.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;
-               </string>
-              </property>
-             </widget>
-            </item>
-            <item row="0" column="5">
-             <widget class="QLabel" name="label_15">
-              <property name="text">
-               <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Å&lt;span
-                style=&quot; vertical-align:super;&quot;&gt;-1&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;
-               </string>
-              </property>
-             </widget>
-            </item>
-            <item row="0" column="2">
-             <widget class="QLabel" name="label_13">
-              <property name="text">
-               <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Å&lt;span
-                style=&quot; vertical-align:super;&quot;&gt;-1&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;
-               </string>
-              </property>
-             </widget>
-            </item>
-            <item row="0" column="6">
-             <widget class="QPushButton" name="cmdReset">
-              <property name="toolTip">
-               <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Reset
-              the Q range to the default.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;
-             </string>
-              </property>
-              <property name="text">
-               <string>Reset</string>
-              </property>
-             </widget>
-            </item>
-           </layout>
-          </item>
-         </layout>
-        </widget>
-       </item>
-       <item>
-        <widget class="QGroupBox" name="boxAdvancedParameters">
-         <property name="title">
-          <string>Method parameters</string>
-         </property>
-         <layout class="QVBoxLayout" name="verticalLayout_6">
-          <item>
-           <layout class="QGridLayout" name="gridLayout">
-            <item row="0" column="1">
-             <widget class="QLineEdit" name="txtSkyBackgd">
-              <property name="toolTip">
-               <string>Sky background parameter for the Maximum Entropy method (suggested: 1e-6)</string>
-              </property>
-             </widget>
-            </item>
-            <item row="0" column="0">
-             <widget class="QLabel" name="lblSkyBackgd">
-              <property name="text">
-               <string>MaxEnt Sky Background:</string>
-              </property>
-             </widget>
-            </item>
-            <item row="1" column="0">
-             <widget class="QLabel" name="lblIterations">
-              <property name="text">
-               <string>Iterations:</string>
-              </property>
-             </widget>
-            </item>
-            <item row="1" column="1">
-             <widget class="QLineEdit" name="txtIterations">
-              <property name="toolTip">
-               <string>Number of iterations for the Maximum Entropy method.</string>
-              </property>
-             </widget>
-            </item>
-           </layout>
-          </item>
-         </layout>
-        </widget>
-       </item>
-       <item>
-        <widget class="QGroupBox" name="boxWeighting">
-         <property name="title">
-          <string>Weighting</string>
-         </property>
-         <layout class="QGridLayout" name="gridLayout_20">
-          <item row="1" column="0">
-           <layout class="QHBoxLayout" name="horizontalLayout_5"/>
-          </item>
-          <item row="0" column="0">
-           <layout class="QGridLayout" name="verticalLayout">
-            <item row="3" column="1">
-             <widget class="QLineEdit" name="txtWgtPercent">
-              <property name="toolTip">
-               <string>Percentage value for percentage-based weighting.</string>
-              </property>
-             </widget>
-            </item>
-            <item row="0" column="0">
-             <widget class="QRadioButton" name="rbWeighting1">
-              <property name="toolTip">
-               <string>No weighting applied to the data.</string>
-              </property>
-              <property name="text">
-               <string>None</string>
-              </property>
-              <property name="checked">
-               <bool>true</bool>
-              </property>
-             </widget>
-            </item>
-            <item row="1" column="0">
-             <widget class="QRadioButton" name="rbWeighting2">
-              <property name="toolTip">
-               <string>Weight data by its error values (dI).</string>
-              </property>
-              <property name="text">
-               <string>Use dI Data</string>
-              </property>
-             </widget>
-            </item>
-            <item row="2" column="0">
-             <widget class="QRadioButton" name="rbWeighting3">
-              <property name="toolTip">
-               <string>Weight data by the square root of intensity values.</string>
-              </property>
-              <property name="text">
-               <string>Use |sqrt(I Data)|</string>
-              </property>
-             </widget>
-            </item>
-            <item row="2" column="3">
-             <widget class="QLineEdit" name="txtWgtFactor">
-              <property name="toolTip">
-               <string>Overall weighting factor to apply to the data.</string>
-              </property>
-             </widget>
-            </item>
-            <item row="3" column="0">
-             <widget class="QRadioButton" name="rbWeighting4">
-              <property name="toolTip">
-               <string>Weight data as a percentage of intensity values.</string>
-              </property>
-              <property name="text">
-               <string>Use % |I Data|:</string>
-              </property>
-             </widget>
-            </item>
-            <item row="2" column="2">
-             <widget class="QLabel" name="lblWgtFactor">
-              <property name="text">
-               <string>Weight factor:</string>
-              </property>
-             </widget>
-            </item>
-           </layout>
-          </item>
-         </layout>
-        </widget>
-       </item>
-       <item>
-        <spacer name="verticalSpacer">
-         <property name="orientation">
-          <enum>Qt::Orientation::Vertical</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>20</width>
-           <height>40</height>
-          </size>
-         </property>
-        </spacer>
-       </item>
-      </layout>
-     </widget>
      <widget class="QWidget" name="tabBackground">
       <property name="whatsThis">
        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
@@ -1053,6 +825,234 @@
        </item>
        <item>
         <spacer name="verticalSpacer_2">
+         <property name="orientation">
+          <enum>Qt::Orientation::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>40</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+      </layout>
+     </widget>
+     <widget class="QWidget" name="tabOptions">
+      <attribute name="title">
+       <string>Options</string>
+      </attribute>
+      <layout class="QVBoxLayout" name="verticalLayout_2">
+       <item>
+        <widget class="QGroupBox" name="boxFittingRange">
+         <property name="title">
+          <string>Fitting range</string>
+         </property>
+         <layout class="QHBoxLayout" name="horizontalLayout_9">
+          <item>
+           <layout class="QGridLayout" name="gridLayout_13">
+            <item row="0" column="1">
+             <widget class="QLineEdit" name="txtMinRange">
+              <property name="minimumSize">
+               <size>
+                <width>80</width>
+                <height>0</height>
+               </size>
+              </property>
+              <property name="toolTip">
+               <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Minimum
+                value of Q.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;
+               </string>
+              </property>
+             </widget>
+            </item>
+            <item row="0" column="0">
+             <widget class="QLabel" name="lblMinRange">
+              <property name="text">
+               <string>Min</string>
+              </property>
+             </widget>
+            </item>
+            <item row="0" column="3">
+             <widget class="QLabel" name="lblMaxRange">
+              <property name="text">
+               <string>Max</string>
+              </property>
+             </widget>
+            </item>
+            <item row="0" column="4">
+             <widget class="QLineEdit" name="txtMaxRange">
+              <property name="minimumSize">
+               <size>
+                <width>80</width>
+                <height>0</height>
+               </size>
+              </property>
+              <property name="toolTip">
+               <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Maximum
+                value of Q.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;
+               </string>
+              </property>
+             </widget>
+            </item>
+            <item row="0" column="5">
+             <widget class="QLabel" name="label_15">
+              <property name="text">
+               <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Å&lt;span
+                style=&quot; vertical-align:super;&quot;&gt;-1&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;
+               </string>
+              </property>
+             </widget>
+            </item>
+            <item row="0" column="2">
+             <widget class="QLabel" name="label_13">
+              <property name="text">
+               <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Å&lt;span
+                style=&quot; vertical-align:super;&quot;&gt;-1&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;
+               </string>
+              </property>
+             </widget>
+            </item>
+            <item row="0" column="6">
+             <widget class="QPushButton" name="cmdReset">
+              <property name="toolTip">
+               <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Reset
+              the Q range to the default.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;
+             </string>
+              </property>
+              <property name="text">
+               <string>Reset</string>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item>
+        <widget class="QGroupBox" name="boxAdvancedParameters">
+         <property name="title">
+          <string>Method parameters</string>
+         </property>
+         <layout class="QVBoxLayout" name="verticalLayout_6">
+          <item>
+           <layout class="QGridLayout" name="gridLayout">
+            <item row="0" column="1">
+             <widget class="QLineEdit" name="txtSkyBackgd">
+              <property name="toolTip">
+               <string>Sky background parameter for the Maximum Entropy method (suggested: 1e-6)</string>
+              </property>
+             </widget>
+            </item>
+            <item row="0" column="0">
+             <widget class="QLabel" name="lblSkyBackgd">
+              <property name="text">
+               <string>MaxEnt Sky Background:</string>
+              </property>
+             </widget>
+            </item>
+            <item row="1" column="0">
+             <widget class="QLabel" name="lblIterations">
+              <property name="text">
+               <string>Iterations:</string>
+              </property>
+             </widget>
+            </item>
+            <item row="1" column="1">
+             <widget class="QLineEdit" name="txtIterations">
+              <property name="toolTip">
+               <string>Number of iterations for the Maximum Entropy method.</string>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item>
+        <widget class="QGroupBox" name="boxWeighting">
+         <property name="title">
+          <string>Weighting</string>
+         </property>
+         <layout class="QGridLayout" name="gridLayout_20">
+          <item row="1" column="0">
+           <layout class="QHBoxLayout" name="horizontalLayout_5"/>
+          </item>
+          <item row="0" column="0">
+           <layout class="QGridLayout" name="verticalLayout">
+            <item row="3" column="1">
+             <widget class="QLineEdit" name="txtWgtPercent">
+              <property name="toolTip">
+               <string>Percentage value for percentage-based weighting.</string>
+              </property>
+             </widget>
+            </item>
+            <item row="0" column="0">
+             <widget class="QRadioButton" name="rbWeighting1">
+              <property name="toolTip">
+               <string>No weighting applied to the data.</string>
+              </property>
+              <property name="text">
+               <string>None</string>
+              </property>
+              <property name="checked">
+               <bool>true</bool>
+              </property>
+             </widget>
+            </item>
+            <item row="1" column="0">
+             <widget class="QRadioButton" name="rbWeighting2">
+              <property name="toolTip">
+               <string>Weight data by its error values (dI).</string>
+              </property>
+              <property name="text">
+               <string>Use dI Data</string>
+              </property>
+             </widget>
+            </item>
+            <item row="2" column="0">
+             <widget class="QRadioButton" name="rbWeighting3">
+              <property name="toolTip">
+               <string>Weight data by the square root of intensity values.</string>
+              </property>
+              <property name="text">
+               <string>Use |sqrt(I Data)|</string>
+              </property>
+             </widget>
+            </item>
+            <item row="2" column="3">
+             <widget class="QLineEdit" name="txtWgtFactor">
+              <property name="toolTip">
+               <string>Overall weighting factor to apply to the data.</string>
+              </property>
+             </widget>
+            </item>
+            <item row="3" column="0">
+             <widget class="QRadioButton" name="rbWeighting4">
+              <property name="toolTip">
+               <string>Weight data as a percentage of intensity values.</string>
+              </property>
+              <property name="text">
+               <string>Use % |I Data|:</string>
+              </property>
+             </widget>
+            </item>
+            <item row="2" column="2">
+             <widget class="QLabel" name="lblWgtFactor">
+              <property name="text">
+               <string>Weight factor:</string>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item>
+        <spacer name="verticalSpacer">
          <property name="orientation">
           <enum>Qt::Orientation::Vertical</enum>
          </property>

--- a/src/sas/qtgui/Perspectives/SizeDistribution/UI/SizeDistributionUI.ui
+++ b/src/sas/qtgui/Perspectives/SizeDistribution/UI/SizeDistributionUI.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>577</width>
-    <height>600</height>
+    <height>634</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -67,7 +67,7 @@
        </property>
        <property name="sizeHint" stdset="0">
         <size>
-         <width>200</width>
+         <width>50</width>
          <height>20</height>
         </size>
        </property>
@@ -113,6 +113,327 @@
        <string>Parameters</string>
       </attribute>
       <layout class="QGridLayout" name="gridLayout_6">
+       <item row="2" column="0">
+        <widget class="QGroupBox" name="boxParameters">
+         <property name="title">
+          <string>Distribution parameters</string>
+         </property>
+         <layout class="QGridLayout" name="gridLayout_9">
+          <item row="0" column="1">
+           <widget class="QLineEdit" name="txtMinDiameter">
+            <property name="enabled">
+             <bool>true</bool>
+            </property>
+            <property name="toolTip">
+             <string>Minimum diameter of particles in the size distribution (in Angstroms).</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="3" colspan="2">
+           <widget class="QCheckBox" name="chkLogBinning">
+            <property name="enabled">
+             <bool>true</bool>
+            </property>
+            <property name="toolTip">
+             <string>Use logarithmic binning for the diameter distribution.</string>
+            </property>
+            <property name="text">
+             <string>Logarithmic binning</string>
+            </property>
+            <property name="checkable">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="1">
+           <widget class="QLineEdit" name="txtBinsDiameter">
+            <property name="enabled">
+             <bool>true</bool>
+            </property>
+            <property name="toolTip">
+             <string>Number of bins to use in the diameter distribution.</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="3">
+           <widget class="QLabel" name="lblMaxDiameter">
+            <property name="text">
+             <string>Max Diameter:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="2">
+           <widget class="QLabel" name="label_2">
+            <property name="text">
+             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Å&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;
+             </string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="0">
+           <widget class="QLabel" name="lblBinsDiameter">
+            <property name="text">
+             <string>Bins in diameter:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="0">
+           <widget class="QLabel" name="lblContrast">
+            <property name="text">
+             <string>Contrast:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="0">
+           <widget class="QLabel" name="lblMinDiameter">
+            <property name="text">
+             <string>Min Diameter:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="2" colspan="2">
+           <widget class="QLabel" name="label_4">
+            <property name="text">
+             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;10&lt;span
+              style=&quot; vertical-align:super;&quot;&gt;-6&lt;/span&gt;/Å&lt;span
+              style=&quot; vertical-align:super;&quot;&gt;2&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;
+             </string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="4">
+           <widget class="QLineEdit" name="txtMaxDiameter">
+            <property name="enabled">
+             <bool>true</bool>
+            </property>
+            <property name="toolTip">
+             <string>Maximum diameter of particles in the size distribution (in Angstroms).</string>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="1">
+           <widget class="QLineEdit" name="txtContrast">
+            <property name="enabled">
+             <bool>true</bool>
+            </property>
+            <property name="toolTip">
+             <string>Scattering length density contrast between particles and solvent (10^-6 / Å^2).</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="5">
+           <widget class="QLabel" name="label_3">
+            <property name="text">
+             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Å&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;
+             </string>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item row="1" column="0">
+        <widget class="QGroupBox" name="boxModel">
+         <property name="title">
+          <string>Model</string>
+         </property>
+         <layout class="QGridLayout" name="gridLayout_5">
+          <item row="0" column="3">
+           <widget class="QLabel" name="lblAspectRatio">
+            <property name="text">
+             <string>Aspect ratio:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="1">
+           <widget class="QComboBox" name="cbModel">
+            <property name="toolTip">
+             <string>Select a model.</string>
+            </property>
+            <item>
+             <property name="text">
+              <string>Ellipsoid</string>
+             </property>
+            </item>
+           </widget>
+          </item>
+          <item row="0" column="0">
+           <widget class="QLabel" name="lblModel">
+            <property name="text">
+             <string>Model name</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="4">
+           <widget class="QLineEdit" name="txtAspectRatio">
+            <property name="enabled">
+             <bool>true</bool>
+            </property>
+            <property name="toolTip">
+             <string>Aspect ratio of the ellipsoid model (ratio of semi-axes).</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item row="3" column="0" alignment="Qt::AlignmentFlag::AlignTop">
+        <widget class="QGroupBox" name="boxOutput">
+         <property name="title">
+          <string>Output</string>
+         </property>
+         <layout class="QGridLayout" name="gridLayout_8">
+          <item row="3" column="1">
+           <widget class="QLineEdit" name="txtDiameterMean">
+            <property name="enabled">
+             <bool>true</bool>
+            </property>
+            <property name="toolTip">
+             <string>Mean diameter of the size distribution.</string>
+            </property>
+            <property name="readOnly">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="0">
+           <widget class="QLabel" name="lblVolume">
+            <property name="text">
+             <string>Total volume fraction: </string>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="2">
+           <widget class="QLabel" name="label_6">
+            <property name="text">
+             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Å&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+            </property>
+           </widget>
+          </item>
+          <item row="5" column="1">
+           <widget class="QLineEdit" name="txtDiameterMode">
+            <property name="enabled">
+             <bool>true</bool>
+            </property>
+            <property name="toolTip">
+             <string>Mode diameter of the size distribution (most frequently occurring size).</string>
+            </property>
+            <property name="readOnly">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="1">
+           <widget class="QLineEdit" name="txtChiSq">
+            <property name="enabled">
+             <bool>true</bool>
+            </property>
+            <property name="toolTip">
+             <string>Chi-squared value indicating fit quality (lower is better).</string>
+            </property>
+            <property name="readOnly">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+          <item row="5" column="2">
+           <widget class="QLabel" name="label_20">
+            <property name="text">
+             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Å&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+            </property>
+           </widget>
+          </item>
+          <item row="4" column="1">
+           <widget class="QLineEdit" name="txtDiameterMedian">
+            <property name="enabled">
+             <bool>true</bool>
+            </property>
+            <property name="toolTip">
+             <string>Median diameter of the size distribution (50th percentile).</string>
+            </property>
+            <property name="readOnly">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="0" colspan="4">
+           <widget class="QLabel" name="lblConvergence">
+            <property name="text">
+             <string/>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="0">
+           <widget class="QLabel" name="lblChiSq">
+            <property name="text">
+             <string>ChiSq: </string>
+            </property>
+           </widget>
+          </item>
+          <item row="4" column="2">
+           <widget class="QLabel" name="label_19">
+            <property name="text">
+             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Å&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+            </property>
+           </widget>
+          </item>
+          <item row="5" column="0">
+           <widget class="QLabel" name="lblDiameterMode">
+            <property name="text">
+             <string>Mode diameter:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="2">
+           <widget class="QLabel" name="label_5">
+            <property name="text">
+             <string>%</string>
+            </property>
+           </widget>
+          </item>
+          <item row="4" column="0">
+           <widget class="QLabel" name="lblDiameterMedian">
+            <property name="text">
+             <string>Median diameter:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="1">
+           <widget class="QLineEdit" name="txtVolume">
+            <property name="enabled">
+             <bool>true</bool>
+            </property>
+            <property name="toolTip">
+             <string>Total particle volume fraction in the sample (%).</string>
+            </property>
+            <property name="readOnly">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="0">
+           <widget class="QLabel" name="lblDiameterMean">
+            <property name="text">
+             <string>Mean diameter:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="3">
+           <spacer name="horizontalSpacer_3">
+            <property name="orientation">
+             <enum>Qt::Orientation::Horizontal</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>40</width>
+              <height>20</height>
+             </size>
+            </property>
+           </spacer>
+          </item>
+         </layout>
+        </widget>
+       </item>
        <item row="0" column="0">
         <widget class="QGroupBox" name="boxData">
          <property name="title">
@@ -146,326 +467,18 @@
          </layout>
         </widget>
        </item>
-       <item row="1" column="0">
-        <widget class="QGroupBox" name="boxModel">
-         <property name="title">
-          <string>Model</string>
+       <item row="4" column="0">
+        <spacer name="verticalSpacer">
+         <property name="orientation">
+          <enum>Qt::Orientation::Vertical</enum>
          </property>
-         <layout class="QGridLayout" name="gridLayout_5">
-          <item row="0" column="0">
-           <widget class="QLabel" name="lblModel">
-            <property name="text">
-             <string>Model name</string>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="1">
-           <widget class="QComboBox" name="cbModel">
-            <property name="toolTip">
-             <string>Select a model.</string>
-            </property>
-            <item>
-             <property name="text">
-              <string>Ellipsoid</string>
-             </property>
-            </item>
-           </widget>
-          </item>
-          <item row="0" column="3">
-           <widget class="QLabel" name="lblAspectRatio">
-            <property name="text">
-             <string>Aspect ratio:</string>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="4">
-           <widget class="QLineEdit" name="txtAspectRatio">
-            <property name="enabled">
-             <bool>true</bool>
-            </property>
-            <property name="toolTip">
-             <string>Aspect ratio of the ellipsoid model (ratio of semi-axes).</string>
-            </property>
-           </widget>
-          </item>
-         </layout>
-        </widget>
-       </item>
-       <item row="2" column="0">
-        <widget class="QGroupBox" name="boxParameters">
-         <property name="title">
-          <string>Distribution parameters</string>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>10</height>
+          </size>
          </property>
-         <layout class="QGridLayout" name="gridLayout_9">
-          <item row="0" column="0">
-           <widget class="QLabel" name="lblMinDiameter">
-            <property name="text">
-             <string>Minimum diameter:</string>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="1">
-           <widget class="QLineEdit" name="txtMinDiameter">
-            <property name="enabled">
-             <bool>true</bool>
-            </property>
-            <property name="toolTip">
-             <string>Minimum diameter of particles in the size distribution (in Angstroms).</string>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="2">
-           <widget class="QLabel" name="label_2">
-            <property name="text">
-             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Å&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;
-             </string>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="3">
-           <widget class="QLabel" name="lblMaxDiameter">
-            <property name="text">
-             <string>Maximum diameter:</string>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="4">
-           <widget class="QLineEdit" name="txtMaxDiameter">
-            <property name="enabled">
-             <bool>true</bool>
-            </property>
-            <property name="toolTip">
-             <string>Maximum diameter of particles in the size distribution (in Angstroms).</string>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="5">
-           <widget class="QLabel" name="label_3">
-            <property name="text">
-             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Å&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;
-             </string>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="0">
-           <widget class="QLabel" name="lblBinsDiameter">
-            <property name="text">
-             <string>Bins in diameter:</string>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="1">
-           <widget class="QLineEdit" name="txtBinsDiameter">
-            <property name="enabled">
-             <bool>true</bool>
-            </property>
-            <property name="toolTip">
-             <string>Number of bins to use in the diameter distribution.</string>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="3" colspan="2">
-           <widget class="QCheckBox" name="chkLogBinning">
-            <property name="enabled">
-             <bool>true</bool>
-            </property>
-            <property name="toolTip">
-             <string>Use logarithmic binning for the diameter distribution.</string>
-            </property>
-            <property name="text">
-             <string>Logarithmic binning?</string>
-            </property>
-            <property name="checkable">
-             <bool>true</bool>
-            </property>
-           </widget>
-          </item>
-          <item row="4" column="0">
-           <widget class="QLabel" name="lblContrast">
-            <property name="text">
-             <string>Contrast:</string>
-            </property>
-           </widget>
-          </item>
-          <item row="4" column="1">
-           <widget class="QLineEdit" name="txtContrast">
-            <property name="enabled">
-             <bool>true</bool>
-            </property>
-            <property name="toolTip">
-             <string>Scattering length density contrast between particles and solvent (10^-6 / Å^2).</string>
-            </property>
-           </widget>
-          </item>
-          <item row="4" column="2">
-           <widget class="QLabel" name="label_4">
-            <property name="text">
-             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;10&lt;span
-              style=&quot; vertical-align:super;&quot;&gt;-6&lt;/span&gt;/Å&lt;span
-              style=&quot; vertical-align:super;&quot;&gt;2&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;
-             </string>
-            </property>
-           </widget>
-          </item>
-         </layout>
-        </widget>
-       </item>
-       <item row="3" column="0" alignment="Qt::AlignmentFlag::AlignTop">
-        <widget class="QGroupBox" name="boxOutput">
-         <property name="title">
-          <string>Output</string>
-         </property>
-         <layout class="QGridLayout" name="gridLayout_8">
-          <item row="0" column="0" colspan="4">
-           <widget class="QLabel" name="lblConvergence">
-            <property name="text">
-             <string/>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="0">
-           <widget class="QLabel" name="lblChiSq">
-            <property name="text">
-             <string>ChiSq: </string>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="1">
-           <widget class="QLineEdit" name="txtChiSq">
-            <property name="enabled">
-             <bool>true</bool>
-            </property>
-            <property name="readOnly">
-             <bool>true</bool>
-            </property>
-            <property name="toolTip">
-             <string>Chi-squared value indicating fit quality (lower is better).</string>
-            </property>
-           </widget>
-          </item>
-          <item row="2" column="0">
-           <widget class="QLabel" name="lblVolume">
-            <property name="text">
-             <string>Total volume fraction: </string>
-            </property>
-           </widget>
-          </item>
-          <item row="2" column="1">
-           <widget class="QLineEdit" name="txtVolume">
-            <property name="enabled">
-             <bool>true</bool>
-            </property>
-            <property name="readOnly">
-             <bool>true</bool>
-            </property>
-            <property name="toolTip">
-             <string>Total particle volume fraction in the sample (%).</string>
-            </property>
-           </widget>
-          </item>
-          <item row="2" column="2">
-           <widget class="QLabel" name="label_5">
-            <property name="text">
-             <string>%</string>
-            </property>
-           </widget>
-          </item>
-          <item row="3" column="0">
-           <widget class="QLabel" name="lblDiameterMean">
-            <property name="text">
-             <string>Mean diameter:</string>
-            </property>
-           </widget>
-          </item>
-          <item row="3" column="1">
-           <widget class="QLineEdit" name="txtDiameterMean">
-            <property name="enabled">
-             <bool>true</bool>
-            </property>
-            <property name="readOnly">
-             <bool>true</bool>
-            </property>
-            <property name="toolTip">
-             <string>Mean diameter of the size distribution.</string>
-            </property>
-           </widget>
-          </item>
-          <item row="3" column="2">
-           <widget class="QLabel" name="label_6">
-            <property name="text">
-             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Å&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-            </property>
-           </widget>
-          </item>
-          <item row="4" column="0">
-           <widget class="QLabel" name="lblDiameterMedian">
-            <property name="text">
-             <string>Median diameter:</string>
-            </property>
-           </widget>
-          </item>
-          <item row="4" column="1">
-           <widget class="QLineEdit" name="txtDiameterMedian">
-            <property name="enabled">
-             <bool>true</bool>
-            </property>
-            <property name="readOnly">
-             <bool>true</bool>
-            </property>
-            <property name="toolTip">
-             <string>Median diameter of the size distribution (50th percentile).</string>
-            </property>
-           </widget>
-          </item>
-          <item row="4" column="2">
-           <widget class="QLabel" name="label_19">
-            <property name="text">
-             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Å&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-            </property>
-           </widget>
-          </item>
-          <item row="5" column="0">
-           <widget class="QLabel" name="lblDiameterMode">
-            <property name="text">
-             <string>Mode diameter:</string>
-            </property>
-           </widget>
-          </item>
-          <item row="5" column="1">
-           <widget class="QLineEdit" name="txtDiameterMode">
-            <property name="enabled">
-             <bool>true</bool>
-            </property>
-            <property name="readOnly">
-             <bool>true</bool>
-            </property>
-            <property name="toolTip">
-             <string>Mode diameter of the size distribution (most frequently occurring size).</string>
-            </property>
-           </widget>
-          </item>
-          <item row="5" column="2">
-           <widget class="QLabel" name="label_20">
-            <property name="text">
-             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Å&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-            </property>
-           </widget>
-          </item>
-          <item row="3" column="3">
-           <spacer name="horizontalSpacer_3">
-            <property name="orientation">
-             <enum>Qt::Orientation::Horizontal</enum>
-            </property>
-            <property name="sizeHint" stdset="0">
-             <size>
-              <width>40</width>
-              <height>20</height>
-             </size>
-            </property>
-           </spacer>
-          </item>
-         </layout>
-        </widget>
+        </spacer>
        </item>
       </layout>
      </widget>
@@ -473,19 +486,28 @@
       <attribute name="title">
        <string>Options</string>
       </attribute>
-      <layout class="QGridLayout" name="gridLayout_10">
-       <item row="0" column="0">
+      <layout class="QVBoxLayout" name="verticalLayout_2">
+       <item>
         <widget class="QGroupBox" name="boxFittingRange">
          <property name="title">
           <string>Fitting range</string>
          </property>
-         <layout class="QGridLayout" name="gridLayout_11">
-          <item row="0" column="0" rowspan="2">
+         <layout class="QHBoxLayout" name="horizontalLayout_9">
+          <item>
            <layout class="QGridLayout" name="gridLayout_13">
-            <item row="0" column="0">
-             <widget class="QLabel" name="lblMinRange">
+            <item row="0" column="3">
+             <widget class="QLabel" name="lblMaxRange">
               <property name="text">
-               <string>Min range</string>
+               <string>Max</string>
+              </property>
+             </widget>
+            </item>
+            <item row="0" column="5">
+             <widget class="QLabel" name="label_15">
+              <property name="text">
+               <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Å&lt;span
+                style=&quot; vertical-align:super;&quot;&gt;-1&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;
+               </string>
               </property>
              </widget>
             </item>
@@ -501,13 +523,6 @@
                <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Maximum
                 value of Q.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;
                </string>
-              </property>
-             </widget>
-            </item>
-            <item row="0" column="3">
-             <widget class="QLabel" name="lblMaxRange">
-              <property name="text">
-               <string>Max range</string>
               </property>
              </widget>
             </item>
@@ -535,39 +550,37 @@
               </property>
              </widget>
             </item>
-            <item row="0" column="5">
-             <widget class="QLabel" name="label_15">
+            <item row="0" column="0">
+             <widget class="QLabel" name="lblMinRange">
               <property name="text">
-               <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Å&lt;span
-                style=&quot; vertical-align:super;&quot;&gt;-1&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;
-               </string>
+               <string>Min</string>
+              </property>
+             </widget>
+            </item>
+            <item row="0" column="6">
+             <widget class="QPushButton" name="cmdReset">
+              <property name="toolTip">
+               <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Reset
+              the Q range to the default.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;
+             </string>
+              </property>
+              <property name="text">
+               <string>Reset</string>
               </property>
              </widget>
             </item>
            </layout>
           </item>
-          <item row="0" column="2">
-           <widget class="QPushButton" name="cmdReset">
-            <property name="toolTip">
-             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Reset
-              the Q range to the default.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;
-             </string>
-            </property>
-            <property name="text">
-             <string>Reset</string>
-            </property>
-           </widget>
-          </item>
          </layout>
         </widget>
        </item>
-       <item row="1" column="0">
+       <item>
         <widget class="QGroupBox" name="boxAdvancedParameters">
          <property name="title">
           <string>Method parameters</string>
          </property>
-         <layout class="QGridLayout" name="gridLayout_21">
-          <item row="0" column="1">
+         <layout class="QHBoxLayout" name="horizontalLayout_10">
+          <item>
            <layout class="QHBoxLayout" name="horizontalLayout_6">
             <item>
              <widget class="QLabel" name="lblSkyBackgd">
@@ -582,26 +595,6 @@
                <string>Sky background parameter for the Maximum Entropy method (suggested: 1e-6)</string>
               </property>
              </widget>
-            </item>
-            <item>
-             <widget class="QLabel" name="label_9">
-              <property name="text">
-               <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Suggested: 1e-6&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <spacer name="horizontalSpacer_2">
-              <property name="orientation">
-               <enum>Qt::Orientation::Horizontal</enum>
-              </property>
-              <property name="sizeHint" stdset="0">
-               <size>
-                <width>40</width>
-                <height>20</height>
-               </size>
-              </property>
-             </spacer>
             </item>
             <item>
              <widget class="QLabel" name="lblIterations">
@@ -622,12 +615,193 @@
          </layout>
         </widget>
        </item>
-       <item row="3" column="0">
+       <item>
+        <widget class="QGroupBox" name="boxWeighting">
+         <property name="title">
+          <string>Weighting</string>
+         </property>
+         <layout class="QGridLayout" name="gridLayout_20">
+          <item row="0" column="0">
+           <layout class="QGridLayout" name="verticalLayout">
+            <item row="0" column="1">
+             <widget class="QRadioButton" name="rbWeighting2">
+              <property name="toolTip">
+               <string>Weight data by its error values (dI).</string>
+              </property>
+              <property name="text">
+               <string>Use dI Data</string>
+              </property>
+             </widget>
+            </item>
+            <item row="0" column="2">
+             <widget class="QRadioButton" name="rbWeighting3">
+              <property name="toolTip">
+               <string>Weight data by the square root of intensity values.</string>
+              </property>
+              <property name="text">
+               <string>Use |sqrt(I Data)|</string>
+              </property>
+             </widget>
+            </item>
+            <item row="0" column="0">
+             <widget class="QRadioButton" name="rbWeighting1">
+              <property name="toolTip">
+               <string>No weighting applied to the data.</string>
+              </property>
+              <property name="text">
+               <string>None</string>
+              </property>
+              <property name="checked">
+               <bool>true</bool>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </item>
+          <item row="1" column="0">
+           <layout class="QHBoxLayout" name="horizontalLayout_5">
+            <item>
+             <widget class="QRadioButton" name="rbWeighting4">
+              <property name="toolTip">
+               <string>Weight data as a percentage of intensity values.</string>
+              </property>
+              <property name="text">
+               <string>Use % |I Data|:</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QLineEdit" name="txtWgtPercent">
+              <property name="toolTip">
+               <string>Percentage value for percentage-based weighting.</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QLabel" name="lblWgtFactor">
+              <property name="text">
+               <string>Weight factor:</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QLineEdit" name="txtWgtFactor">
+              <property name="toolTip">
+               <string>Overall weighting factor to apply to the data.</string>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item>
         <widget class="QGroupBox" name="boxBackground">
          <property name="title">
           <string>Background</string>
          </property>
-         <layout class="QGridLayout" name="gridLayout_12">
+         <layout class="QGridLayout" name="gridLayout">
+          <item row="1" column="0" colspan="2">
+           <widget class="QGroupBox" name="qRangeGroupBox">
+            <property name="title">
+             <string>Fit flat background Q range</string>
+            </property>
+            <layout class="QGridLayout" name="gridLayout_3">
+             <item row="0" column="0">
+              <layout class="QHBoxLayout" name="horizontalLayout_2">
+               <item>
+                <widget class="QLabel" name="label_18">
+                 <property name="text">
+                  <string>Min:</string>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <widget class="QLineEdit" name="txtBackgdQMin">
+                 <property name="enabled">
+                  <bool>true</bool>
+                 </property>
+                 <property name="sizePolicy">
+                  <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                   <horstretch>0</horstretch>
+                   <verstretch>0</verstretch>
+                  </sizepolicy>
+                 </property>
+                 <property name="toolTip">
+                  <string>Minimum Q value for fitting the flat background.</string>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <widget class="QLabel" name="label_11">
+                 <property name="text">
+                  <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Å&lt;span style=&quot; vertical-align:super;&quot;&gt;-1&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <widget class="QLabel" name="label_10">
+                 <property name="text">
+                  <string>Max:</string>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <widget class="QLineEdit" name="txtBackgdQMax">
+                 <property name="enabled">
+                  <bool>true</bool>
+                 </property>
+                 <property name="sizePolicy">
+                  <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                   <horstretch>0</horstretch>
+                   <verstretch>0</verstretch>
+                  </sizepolicy>
+                 </property>
+                 <property name="toolTip">
+                  <string>Maximum Q value for fitting the flat background.</string>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <widget class="QLabel" name="label_16">
+                 <property name="text">
+                  <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Å&lt;span style=&quot; vertical-align:super;&quot;&gt;-1&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                 </property>
+                </widget>
+               </item>
+              </layout>
+             </item>
+            </layout>
+           </widget>
+          </item>
+          <item row="0" column="1">
+           <layout class="QHBoxLayout" name="horizontalLayout_7">
+            <item>
+             <widget class="QLabel" name="lblBackgd">
+              <property name="text">
+               <string>Flat background:</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QLineEdit" name="txtBackgd">
+              <property name="toolTip">
+               <string>Flat background value (constant background in cm^-1).</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QLabel" name="label_8">
+              <property name="text">
+               <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;cm&lt;span style=&quot;
+              vertical-align:super;&quot;&gt;-1&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;
+             </string>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </item>
           <item row="4" column="0" colspan="2">
            <widget class="QGroupBox" name="powerLawQRangeGroupBox">
             <property name="title">
@@ -701,55 +875,26 @@
             </layout>
            </widget>
           </item>
-          <item row="0" column="0">
-           <widget class="QLabel" name="lblBackgd">
-            <property name="text">
-             <string>Flat background:</string>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="2" colspan="2">
-           <widget class="QLabel" name="label_8">
-            <property name="text">
-             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;cm&lt;span style=&quot;
-              vertical-align:super;&quot;&gt;-1&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;
-             </string>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="1">
-           <widget class="QLineEdit" name="txtBackgd">
-            <property name="toolTip">
-             <string>Flat background value (constant background in cm^-1).</string>
-            </property>
-           </widget>
-          </item>
-          <item row="2" column="0" colspan="2">
-           <widget class="QCheckBox" name="chkLowQ">
-            <property name="toolTip">
-             <string>Subtract the low-Q power law.</string>
-            </property>
-            <property name="text">
-             <string>Subtract Low-Q power law</string>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="3">
-           <widget class="QPushButton" name="cmdFitFlatBackground">
-            <property name="toolTip">
-             <string>Fit the flat background component to the data in the specified Q range.</string>
-            </property>
-            <property name="text">
-             <string>Fit flat background</string>
-            </property>
-           </widget>
-          </item>
-          <item row="3" column="0" colspan="4">
+          <item row="3" column="0" colspan="2">
            <layout class="QGridLayout" name="gridLayout_14">
+            <item row="0" column="3">
+             <widget class="QLabel" name="lblScaleLowQ">
+              <property name="text">
+               <string>Scale:</string>
+              </property>
+             </widget>
+            </item>
             <item row="0" column="1">
              <widget class="QLineEdit" name="txtPowerLowQ">
               <property name="toolTip">
                <string>Exponent applied to the power-law function.</string>
+              </property>
+             </widget>
+            </item>
+            <item row="0" column="0">
+             <widget class="QLabel" name="lblPowerLowQ">
+              <property name="text">
+               <string>Power:</string>
               </property>
              </widget>
             </item>
@@ -774,20 +919,6 @@
               </item>
              </layout>
             </item>
-            <item row="0" column="3">
-             <widget class="QLabel" name="lblScaleLowQ">
-              <property name="text">
-               <string>Scale:</string>
-              </property>
-             </widget>
-            </item>
-            <item row="0" column="0">
-             <widget class="QLabel" name="lblPowerLowQ">
-              <property name="text">
-               <string>Power:</string>
-              </property>
-             </widget>
-            </item>
             <item row="0" column="4">
              <widget class="QLineEdit" name="txtScaleLowQ">
               <property name="toolTip">
@@ -797,165 +928,35 @@
             </item>
            </layout>
           </item>
-          <item row="4" column="3">
-           <widget class="QPushButton" name="cmdFitPowerLaw">
+          <item row="2" column="0" colspan="2">
+           <widget class="QCheckBox" name="chkLowQ">
             <property name="toolTip">
-             <string>Fit the power-law component to the data in the specified Q range.</string>
+             <string>Subtract the low-Q power law.</string>
             </property>
             <property name="text">
-             <string>Fit power law</string>
+             <string>Subtract Low-Q Power Law</string>
             </property>
            </widget>
           </item>
-          <item row="1" column="0" colspan="3">
-           <widget class="QGroupBox" name="qRangeGroupBox">
-            <property name="title">
-             <string>Fit flat background Q range</string>
-            </property>
-            <layout class="QGridLayout" name="gridLayout_3">
-             <item row="0" column="0">
-              <layout class="QHBoxLayout" name="horizontalLayout_2">
-               <item>
-                <widget class="QLabel" name="label_18">
-                 <property name="text">
-                  <string>Min:</string>
-                 </property>
-                </widget>
-               </item>
-               <item>
-                <widget class="QLineEdit" name="txtBackgdQMin">
-                 <property name="enabled">
-                  <bool>true</bool>
-                 </property>
-                 <property name="sizePolicy">
-                  <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-                   <horstretch>0</horstretch>
-                   <verstretch>0</verstretch>
-                  </sizepolicy>
-                 </property>
-                 <property name="toolTip">
-                  <string>Minimum Q value for fitting the flat background.</string>
-                 </property>
-                </widget>
-               </item>
-               <item>
-                <widget class="QLabel" name="label_11">
-                 <property name="text">
-                  <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Å&lt;span style=&quot; vertical-align:super;&quot;&gt;-1&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                 </property>
-                </widget>
-               </item>
-               <item>
-                <widget class="QLabel" name="label_10">
-                 <property name="text">
-                  <string>Max:</string>
-                 </property>
-                </widget>
-               </item>
-               <item>
-                <widget class="QLineEdit" name="txtBackgdQMax">
-                 <property name="enabled">
-                  <bool>true</bool>
-                 </property>
-                 <property name="sizePolicy">
-                  <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-                   <horstretch>0</horstretch>
-                   <verstretch>0</verstretch>
-                  </sizepolicy>
-                 </property>
-                 <property name="toolTip">
-                  <string>Maximum Q value for fitting the flat background.</string>
-                 </property>
-                </widget>
-               </item>
-               <item>
-                <widget class="QLabel" name="label_16">
-                 <property name="text">
-                  <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Å&lt;span style=&quot; vertical-align:super;&quot;&gt;-1&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                 </property>
-                </widget>
-               </item>
-              </layout>
-             </item>
-            </layout>
-           </widget>
-          </item>
-         </layout>
-        </widget>
-       </item>
-       <item row="2" column="0">
-        <widget class="QGroupBox" name="boxWeighting">
-         <property name="title">
-          <string>Weighting</string>
-         </property>
-         <layout class="QGridLayout" name="gridLayout_20">
-          <item row="0" column="0">
-           <layout class="QGridLayout" name="verticalLayout">
-            <item row="0" column="1">
-             <widget class="QRadioButton" name="rbWeighting2">
-              <property name="toolTip">
-               <string>Weight data by its error values (dI).</string>
-              </property>
-              <property name="text">
-               <string>Use dI Data</string>
-              </property>
-             </widget>
-            </item>
-            <item row="0" column="0">
-             <widget class="QRadioButton" name="rbWeighting1">
-              <property name="toolTip">
-               <string>No weighting applied to the data.</string>
-              </property>
-              <property name="text">
-               <string>None</string>
-              </property>
-              <property name="checked">
-               <bool>true</bool>
-              </property>
-             </widget>
-            </item>
-            <item row="0" column="2">
-             <widget class="QRadioButton" name="rbWeighting3">
-              <property name="toolTip">
-               <string>Weight data by the square root of intensity values.</string>
-              </property>
-              <property name="text">
-               <string>Use |sqrt(I Data)|</string>
-              </property>
-             </widget>
-            </item>
-           </layout>
-          </item>
-          <item row="1" column="0">
-           <layout class="QHBoxLayout" name="horizontalLayout_5">
+          <item row="5" column="1">
+           <layout class="QHBoxLayout" name="horizontalLayout_12">
             <item>
-             <widget class="QRadioButton" name="rbWeighting4">
+             <widget class="QPushButton" name="cmdFitFlatBackground">
               <property name="toolTip">
-               <string>Weight data as a percentage of intensity values.</string>
+               <string>Fit the flat background component to the data in the specified Q range.</string>
               </property>
               <property name="text">
-               <string>Use % |I Data|:</string>
+               <string>Fit Flat Background</string>
               </property>
              </widget>
             </item>
             <item>
-             <widget class="QLineEdit" name="txtWgtPercent">
+             <widget class="QPushButton" name="cmdFitPowerLaw">
               <property name="toolTip">
-               <string>Percentage value for percentage-based weighting.</string>
+               <string>Fit the power-law component to the data in the specified Q range.</string>
               </property>
-             </widget>
-            </item>
-            <item>
-             <widget class="QLabel" name="lblWgtFactor">
               <property name="text">
-               <string>Weight factor:</string>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <widget class="QLineEdit" name="txtWgtFactor">
-              <property name="toolTip">
-               <string>Overall weighting factor to apply to the data.</string>
+               <string>Fit Power Law</string>
               </property>
              </widget>
             </item>


### PR DESCRIPTION
## Description

The size distribution perspective UI has been reorganised to fit on the screen without needing to scroll. 

This includes reorganisation, renaming and removal of UI elements wherever necessary.

Will update screenshots in documentation once UI changes have been reviewed and finalised.

## How Has This Been Tested?

Manually tested.

## Review Checklist:

**Documentation** (check at least one)
- [ ] There is **nothing** that needs documenting
- [ ] Documentation changes are **in this PR**
- [x] There is an **issue** open for the documentation #4016 

**Installers**
- [ ] There is a chance this will affect the **installers**, if so
  - [ ] **Windows** installer (GH artifact) has been tested (installed and worked) 
  - [ ] **MacOSX** installer (GH artifact) has been tested (installed and worked)
  - [ ] **Wheels** installer (GH artifact) has been tested (installed and worked)

**Licensing**
- [x] The introduced changes comply with SasView license (BSD 3-Clause)

