### PR TITLE
3976: Enable the mac read/write access entitlement

### DIFF
--- a/build_tools/entitlements.plist
+++ b/build_tools/entitlements.plist
@@ -14,5 +14,8 @@
 		<!-- Disable Executable Page Protection Entitlement -->
 		<key>com.apple.security.cs.disable-executable-page-protection</key>
 		<true/>
+        <!-- Allows read access to user-selected files/folders -->
+        <key>com.apple.security.files.user-selected.read-write</key>
+        <true/>
 	</dict>
 </plist>


### PR DESCRIPTION
## Description

This is a test build that attempts to fix the Mac documentation issues by enabling user file read/write access entitlement.

Fixes #3976

## How Has This Been Tested?

Need to test CI build

## Review Checklist:

**Documentation** (check at least one)
- [x] There is **nothing** that needs documenting
- [ ] Documentation changes are **in this PR**
- [ ] There is an **issue** open for the documentation (link?)

**Installers**
- [x] There is a chance this will affect the **installers**, if so
  - [ ] **MacOSX** installer (GH artifact) has been tested (installed and worked)

**Licensing** (untick if necessary)
- [x] The introduced changes comply with SasView license (BSD 3-Clause)

