### PR TITLE
Fixes bugs for cloned slicer plots

### DIFF
--- a/src/sas/qtgui/MainWindow/DataExplorer.py
+++ b/src/sas/qtgui/MainWindow/DataExplorer.py
@@ -5,6 +5,7 @@ import logging
 import os
 import sys
 import time
+from contextlib import suppress
 from pathlib import Path
 
 from PySide6 import QtCore, QtGui, QtWidgets
@@ -845,8 +846,8 @@ class DataExplorerWindow(DroppableDataLoadWidget):
 
     def freezeFromName(self, search_name: str = None):
         """
-        Convert target_plot-data into a separate dataset (CustomNavigation-Button: "sendToDataExplorer").
-        It searches the target_plot-data in the model and creates a new dataset in the Explorer. 
+        Convert target_plot-data into a separate dataset (CustomNavigation-Button: "freezeDatasets").
+        It searches the target_plot-data in the model and creates a new dataset in the Data Explorer. 
 
         :param search_name: <class 'str'>
         """
@@ -931,7 +932,7 @@ class DataExplorerWindow(DroppableDataLoadWidget):
         Convert checked results (fitted model, residuals) into separate dataset.
         """
         outer_index = -1
-        theories_copied = 0
+        items_copied = 0
         orig_model_size = self.model.rowCount()
         while outer_index < orig_model_size:
             outer_index += 1
@@ -952,20 +953,20 @@ class DataExplorerWindow(DroppableDataLoadWidget):
                 if inner_item.checkState() != QtCore.Qt.Checked:
                     continue
                 self.model.beginResetModel()
-                theories_copied += 1
+                items_copied += 1
                 new_item = self.cloneTheory(inner_item)
                 self.model.appendRow(new_item)
                 self.model.endResetModel()
 
         freeze_msg = ""
-        if theories_copied == 0:
+        if items_copied == 0:
             return
-        elif theories_copied == 1:
-            freeze_msg = "1 theory copied to a separate data set"
-        elif theories_copied > 1:
-            freeze_msg = "%i theories copied to separate data sets" % theories_copied
+        elif items_copied == 1:
+            freeze_msg = "1 item copied to a separate data set"
+        elif items_copied > 1:
+            freeze_msg = f"{items_copied} items copied to separate data sets"
         else:
-            freeze_msg = "Unexpected number of theories copied: %i" % theories_copied
+            freeze_msg = f"Unexpected number of items copied: {items_copied}"
             raise AttributeError(freeze_msg)
         self.communicator.statusBarUpdateSignal.emit(freeze_msg)
 
@@ -998,9 +999,9 @@ class DataExplorerWindow(DroppableDataLoadWidget):
         elif theories_copied == 1:
             freeze_msg = "1 theory copied from the Theory tab as a data set"
         elif theories_copied > 1:
-            freeze_msg = "%i theories copied from the Theory tab as data sets" % theories_copied
+            freeze_msg = f"{theories_copied} theories copied from the Theory tab as data sets"
         else:
-            freeze_msg = "Unexpected number of theories copied: %i" % theories_copied
+            freeze_msg = f"Unexpected number of theories copied: {theories_copied}"
             raise AttributeError(freeze_msg)
         self.communicator.statusBarUpdateSignal.emit(freeze_msg)
         # Actively switch tabs
@@ -1025,13 +1026,18 @@ class DataExplorerWindow(DroppableDataLoadWidget):
         new_name = new_item.text() + '_@' + time_bit
         new_item.setText(new_name)
         # Change the underlying data so it is no longer a theory
-        try:
+        with suppress(AttributeError):
             new_item.child(0).data().is_data = True
             new_item.child(0).data().symbol = 'Circle'
             new_item.child(0).data().id = new_name
-        except AttributeError:
-            # no data here, pass
-            pass
+            new_item.child(0).data().name = f"Frozen{orig_data.name}"
+            new_item.child(0).data().title = f"Frozen{orig_data.title}"
+        # Ensure data from slicer plots will not be identified as
+        # a slicer plot when replotted
+        with suppress(AttributeError):
+            delattr(new_item.child(0).data(), "type_id")
+            delattr(new_item.child(0).data(), "custom_color")
+
         return new_item
 
     def recursivelyCloneItem(self, item):
@@ -1411,8 +1417,9 @@ class DataExplorerWindow(DroppableDataLoadWidget):
         assert type(data).__name__ in ['Data1D', 'Data2D']
 
         ids_keys = list(self.active_plots.keys())
-        #ids_vals = [val.data.name for val in self.active_plots.values()]
 
+        # We test for whether the data_id starts with any of the plot_ids
+        # to account for additional slicers with an "_#" label
         data_id = data.name
         if data_id in ids_keys:
             # We have data, let's replace data that needs replacing
@@ -1421,11 +1428,6 @@ class DataExplorerWindow(DroppableDataLoadWidget):
                 # restore minimized window, if applicable
                 self.active_plots[data_id].showNormal()
             return True
-        #elif data_id in ids_vals:
-        #    if data.plot_role != DataRole.ROLE_DATA:
-        #        list(self.active_plots.values())[ids_vals.index(data_id)].replacePlot(data_id, data)
-        #        self.active_plots[data_id].showNormal()
-        #    return True
         return False
 
     def chooseFiles(self):

--- a/src/sas/qtgui/MainWindow/media/graph_help.rst
+++ b/src/sas/qtgui/MainWindow/media/graph_help.rst
@@ -200,9 +200,12 @@ displayed in the status bar at the very bottom-left of the SasView window.
 Sending data to Explorer
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
-Clicking the button sends the current plot data to the Data Explorer.
-This feature is primarily useful for generated 1D plots during slicing, as 
-data must be selected in the Explorer before it can be sent to the Fitting tool.
+Clicking the "Freeze Datasets" button sends the current plot data to the Data Explorer.
+This can also be done by right clicking on a child dataset in the Data Explorer and
+selecting "Freeze Results", or by selecting the dataset(s) of interest in the Data Explorer
+and selecting "Edit>Freeze Fit Results". This feature is primarily useful for generated
+1D plots during slicing, as data must be selected in the Data Explorer before it can be
+sent to the Fitting tool.
 
 .. ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ
 

--- a/src/sas/qtgui/Plotting/PlotterBase.py
+++ b/src/sas/qtgui/Plotting/PlotterBase.py
@@ -22,7 +22,7 @@ class CustomToolbar(NavigationToolbar):
     Adding custom Actions to the NavigationToolbar, which are visible in 1D/2D plots.
     
     Currently added actions:
-    - "Send to Data Explorer":
+    - "Freeze Datasets":
     :param canvas: Matplotlib canvas
     :param parent: Parent Qt widget
     :emit: <class 'str'> name of 1D/2D plot 
@@ -31,18 +31,15 @@ class CustomToolbar(NavigationToolbar):
     def __init__(self, canvas, parent=None):
         super().__init__(canvas, parent)
         self.parent = parent
-        self.addAction_SendToExplorer()
-
-    def addAction_SendToExplorer(self):
         custom_icon = QtGui.QIcon()  # You can load an icon here if you want e.g., QtGui.QIcon("path/to/icon.png")
-        custom_action = QtGui.QAction(custom_icon, "Send to Data Explorer", self)
-        custom_action.setToolTip("Send all data to the Data Explorer")
-        custom_action.triggered.connect(self.sendToDataExplorer)
+        custom_action = QtGui.QAction(custom_icon, "Freeze Datasets", self)
+        custom_action.setToolTip("Send all datasets to the Data Explorer")
+        custom_action.triggered.connect(self.freezeDatasets)
         self.insertAction(self.actions()[-1], custom_action)
 
-    def sendToDataExplorer(self):
-        for item in self.parent.data:
-            GuiUtils.communicator.freezeDataNameSignal.emit(item.name)
+    def freezeDatasets(self):
+        for dataset in self.parent.data:
+            GuiUtils.communicator.freezeDataNameSignal.emit(dataset.name)
 
 class PlotterBase(QtWidgets.QWidget):
     #TODO: Describe what this class is

--- a/src/sas/qtgui/Plotting/Slicers/SlicerUtils.py
+++ b/src/sas/qtgui/Plotting/Slicers/SlicerUtils.py
@@ -236,6 +236,9 @@ class StackableMixin:
         # Preserve color
         new_plot.custom_color = self.color
 
+        # Set slicer owner
+        new_plot.setSlicerOwner(self.base)
+
         # Replace plot data
         self._plot_window.replacePlot(new_plot.id, new_plot)
 


### PR DESCRIPTION
## Description

This PR adds code to the `cloneTheory` routine to ensure frozen datasets are named as such and hence SasView will not confuse them with the original datasets/plots.

Given the now very close functionality with "Freeze Results" and "Freeze Fit Results", the "Send to Data Explorer" button has been renamed "Freeze Datasets".

Fixes #4018

## How Has This Been Tested?

Produced slicer plots a fit of the 2D dataset "SILIC010", used the "Freeze Datasets" button on slicer plots, plotted the new dataset and ensured the new plots did not interfere with the proper slicer plot functionality.

## Review Checklist:

[if using the editor, use `[x]` in place of `[ ]` to check a box]

**Documentation** (check at least one)
- [ ] There is **nothing** that needs documenting
- [x] Documentation changes are **in this PR**
- [ ] There is an **issue** open for the documentation (link?)

**Installers**
- [ ] There is a chance this will affect the **installers**, if so
  - [ ] **Windows** installer (GH artifact) has been tested (installed and worked) 
  - [ ] **MacOSX** installer (GH artifact) has been tested (installed and worked)
  - [ ] **Wheels** installer (GH artifact) has been tested (installed and worked)

**Licensing** (untick if necessary)
- [x] The introduced changes comply with SasView license (BSD 3-Clause)

