### PR TITLE
Fixes mask editor bug

### DIFF
--- a/src/sas/qtgui/Plotting/MaskEditor.py
+++ b/src/sas/qtgui/Plotting/MaskEditor.py
@@ -122,10 +122,13 @@ class MaskEditor(QtWidgets.QDialog, Ui_MaskEditorUI):
         self.figure.canvas.draw()
         self.current_slicer.update()
 
-    def onMask(self, slicer=None, inside=True):
+    def onMask(self, checked, slicer=None, inside=True):
         """
         Clear the previous mask and create a new one.
         """
+        # Note that the "checked" argument is required because it is
+        # emitted by the radio button "toggled" signal.
+
         self.clearSlicer()
         # modifying data in-place
         self.slicer_z += 1


### PR DESCRIPTION
## Description

When setting up radio buttons in the mask editor, the parameter emitted by the `toggled` signal was not accounted for. This PR fixes that.

Fixes #4022

## How Has This Been Tested?

Ran procedure in #4022, the desired circle now appears on the plot.

## Review Checklist:

[if using the editor, use `[x]` in place of `[ ]` to check a box]

**Documentation** (check at least one)
- [x] There is **nothing** that needs documenting
- [ ] Documentation changes are **in this PR**
- [ ] There is an **issue** open for the documentation (link?)

**Installers**
- [ ] There is a chance this will affect the **installers**, if so
  - [ ] **Windows** installer (GH artifact) has been tested (installed and worked) 
  - [ ] **MacOSX** installer (GH artifact) has been tested (installed and worked)
  - [ ] **Wheels** installer (GH artifact) has been tested (installed and worked)

**Licensing** (untick if necessary)
- [x] The introduced changes comply with SasView license (BSD 3-Clause)

