### PR TITLE
getting example data from sasdata 

### DIFF
--- a/installers/sasview.spec
+++ b/installers/sasview.spec
@@ -16,6 +16,7 @@ datas.append((os.path.join(PYTHON_PACKAGES, 'debugpy'), 'debugpy'))
 datas.append((os.path.join(PYTHON_PACKAGES, 'jedi'), 'jedi'))
 datas.append((os.path.join(PYTHON_PACKAGES, 'zmq'), 'zmq'))
 datas.append(('../src/sas/example_data', './example_data'))
+datas.append((os.path.join(PYTHON_PACKAGES, 'sas/example_data'), './example_data'))
 
 # clobber the minimal file with the full one for the installer bundle
 datas.append(('credits.html', 'sas/system/'))

--- a/installers/sasview.spec
+++ b/installers/sasview.spec
@@ -15,8 +15,6 @@ datas = []
 datas.append((os.path.join(PYTHON_PACKAGES, 'debugpy'), 'debugpy'))
 datas.append((os.path.join(PYTHON_PACKAGES, 'jedi'), 'jedi'))
 datas.append((os.path.join(PYTHON_PACKAGES, 'zmq'), 'zmq'))
-datas.append(('../src/sas/example_data', './example_data'))
-datas.append((os.path.join(PYTHON_PACKAGES, 'sas/example_data'), './example_data'))
 
 # clobber the minimal file with the full one for the installer bundle
 datas.append(('credits.html', 'sas/system/'))

--- a/src/sas/__pyinstaller/hook-sas.py
+++ b/src/sas/__pyinstaller/hook-sas.py
@@ -24,6 +24,7 @@ try:
         ('sas/qtgui/images', "sas/qtgui/images"),
         ('sas/qtgui/Utilities/Reports/report_style.css', 'sas/qtgui/Utilities/Reports'),
         ('sas/qtgui/Perspectives/Fitting/plugin_models', 'plugin_models'),
+        ('sas/example_data', 'example_data'),
         ('sas/qtgui/Utilities/WhatsNew/messages', 'sas/qtgui/Utilities/WhatsNew/messages'),
         ('sas/qtgui/Utilities/WhatsNew/css/style.css', 'sas/qtgui/Utilities/WhatsNew/css'),
         ('sas/qtgui/Utilities/About/images', 'sas/qtgui/Utilities/About/images'),


### PR DESCRIPTION
## Description

This PR fixes #3982 by getting example data from sasdata. Currently it seems that the installer only takes the example data folder shipped with sasview.

## How Has This Been Tested?

Click load data. Navigate to the example_data folder of sasview and check that folder like 1D and 2D data exist.

## Review Checklist:

[if using the editor, use `[x]` in place of `[ ]` to check a box]

**Documentation** (check at least one)
- [X ] There is **nothing** that needs documenting
- [ ] Documentation changes are **in this PR**
- [ ] There is an **issue** open for the documentation (link?)

**Installers**
- [ ] There is a chance this will affect the **installers**, if so
  - [ ] **Windows** installer (GH artifact) has been tested (installed and worked) 
  - [ ] **MacOSX** installer (GH artifact) has been tested (installed and worked)
  - [ ] **Wheels** installer (GH artifact) has been tested (installed and worked)

**Licensing** (untick if necessary)
- [x] The introduced changes comply with SasView license (BSD 3-Clause)

