### PR TITLE
Remove old cards in What's New

### DIFF
--- a/src/sas/qtgui/Utilities/WhatsNew/WhatsNew.py
+++ b/src/sas/qtgui/Utilities/WhatsNew/WhatsNew.py
@@ -151,7 +151,7 @@ class WhatsNewWidget(QDialog, Ui_WhatsNewUI):
             )
 
         self.all_messages = []
-            
+
         for version in new_message_directories:
             self.all_messages.extend(
                 sorted(new_messages[version], key=lambda path: path.name)

--- a/src/sas/qtgui/Utilities/WhatsNew/WhatsNew.py
+++ b/src/sas/qtgui/Utilities/WhatsNew/WhatsNew.py
@@ -132,13 +132,31 @@ class WhatsNewWidget(QDialog, Ui_WhatsNewUI):
 
         # # Gather new files
         new_messages = whats_new_messages(only_recent=only_recent)
-        new_message_directories = [key for key in new_messages]
-        new_message_directories.sort(key=reduced_version, reverse=True)
+
+        if only_recent:
+            # Only show the current version, if there are any messages for it
+            current_version = reduced_version(sasview_version)
+
+            new_message_directories = [
+                version
+                for version in new_messages
+                if reduced_version(version) == current_version
+            ]
+        else:
+            # Show all messages, sorted by version, newest first
+            new_message_directories = sorted(
+                new_messages,
+                key=reduced_version,
+                reverse=True,
+            )
 
         self.all_messages = []
 
         for version in new_message_directories:
-            self.all_messages += new_messages[version]
+            self.all_messages.extend(new_messages[version])
+
+        for version in new_message_directories:
+            self.all_messages.extend(new_messages[version])
 
         self.max_index = len(self.all_messages)
         self.current_index = 0

--- a/src/sas/qtgui/Utilities/WhatsNew/WhatsNew.py
+++ b/src/sas/qtgui/Utilities/WhatsNew/WhatsNew.py
@@ -151,12 +151,11 @@ class WhatsNewWidget(QDialog, Ui_WhatsNewUI):
             )
 
         self.all_messages = []
-
+            
         for version in new_message_directories:
-            self.all_messages.extend(new_messages[version])
-
-        for version in new_message_directories:
-            self.all_messages.extend(new_messages[version])
+            self.all_messages.extend(
+                sorted(new_messages[version], key=lambda path: path.name)
+            )
 
         self.max_index = len(self.all_messages)
         self.current_index = 0


### PR DESCRIPTION
## Description

Updated the logic to only include the messages for the latest release if the flag is set to `only_recent`.

Fixes #3985 

## How Has This Been Tested?

Manually tested in the build.

## Review Checklist:

**Documentation**
- [x] There is **nothing** that needs documenting
- [ ] Documentation changes are **in this PR**
- [ ] There is an **issue** open for the documentation (link?)

**Installers**
- [ ] There is a chance this will affect the **installers**, if so
  - [ ] **Windows** installer (GH artifact) has been tested (installed and worked) 
  - [ ] **MacOSX** installer (GH artifact) has been tested (installed and worked)
  - [ ] **Wheels** installer (GH artifact) has been tested (installed and worked)

**Licensing**
- [x] The introduced changes comply with SasView license (BSD 3-Clause)

