### PR TITLE
Reorganises Shape2SAS UI for plots

### DIFF
--- a/src/sas/qtgui/Calculators/Shape2SAS/DesignWindow.py
+++ b/src/sas/qtgui/Calculators/Shape2SAS/DesignWindow.py
@@ -2,7 +2,7 @@
 import re
 from types import MethodType
 
-from PySide6.QtCore import Qt
+from PySide6.QtCore import Qt, QTimer
 from PySide6.QtWidgets import (
     QCheckBox,
     QDialog,
@@ -76,7 +76,6 @@ class DesignWindow(QDialog, Ui_Shape2SAS, Perspective):
         self.modelTabButtonOptions.horizontalLayout_5.insertWidget(1, self.checkTheoreticalScattering)
         self.plot = QPushButton("Plot")
         self.modelTabButtonOptions.horizontalLayout_5.insertWidget(1, self.plot)
-        self.modelTabButtonOptions.horizontalLayout_5.insertWidget(1, self.plot)
 
         self.line2 = QFrame()
         self.line2.setFrameShape(QFrame.VLine)
@@ -109,28 +108,58 @@ class DesignWindow(QDialog, Ui_Shape2SAS, Perspective):
             QSizePolicy.Policy.Expanding,
         )
 
-        # Model viewer tab
-        self.viewerTab = QWidget()
-        viewerTabLayout = QVBoxLayout(self.viewerTab)
-        viewerTabLayout.setContentsMargins(0, 0, 0, 0)
+        # The plots are shared between the tabs, so we create them once and
+        # move them into the appropriate tab when the user switches tabs.
 
-        viewerTabLayout.addWidget(
+        # Reusable viewer panel
+        self.viewerPanel = QWidget()
+        self.viewerPanel.setSizePolicy(
+            QSizePolicy.Policy.Expanding,
+            QSizePolicy.Policy.Expanding,
+        )
+
+        viewerPanelLayout = QVBoxLayout(self.viewerPanel)
+        viewerPanelLayout.setContentsMargins(0, 0, 0, 0)
+
+        viewerPanelLayout.addWidget(
             self.viewerModel.scatterContainer,
             stretch=1,
         )
-        viewerTabLayout.addWidget(self.viewerModel.viewerButtons)
-        viewerTabLayout.addWidget(self.viewerModel.viewerModelRadius)
+        viewerPanelLayout.addWidget(self.viewerModel.viewerButtons)
+        viewerPanelLayout.addWidget(self.viewerModel.viewerModelRadius)
 
-        # Theoretical scattering tab
-        self.scatteringTab = QWidget()
-        scatteringTabLayout = QVBoxLayout(self.scatteringTab)
-        scatteringTabLayout.setContentsMargins(0, 0, 0, 0)
+        # Reusable scattering-profile panel
+        self.profilePanel = QWidget()
+        self.profilePanel.setSizePolicy(
+            QSizePolicy.Policy.Expanding,
+            QSizePolicy.Policy.Expanding,
+        )
 
-        scatteringTabLayout.addWidget(
+        profilePanelLayout = QVBoxLayout(self.profilePanel)
+        profilePanelLayout.setContentsMargins(0, 0, 0, 0)
+
+        profilePanelLayout.addWidget(
             self.viewerModel.scattering,
             stretch=1,
         )
 
+        # Model viewer tab
+        self.viewerTab = QWidget()
+        self.viewerTabLayout = QVBoxLayout(self.viewerTab)
+        self.viewerTabLayout.setContentsMargins(0, 0, 0, 0)
+
+        # Scattering-profile tab
+        self.scatteringTab = QWidget()
+        self.scatteringTabLayout = QVBoxLayout(self.scatteringTab)
+        self.scatteringTabLayout.setContentsMargins(0, 0, 0, 0)
+
+        # Combined viewer/profile tab
+        self.combinedTab = QWidget()
+        self.combinedTabLayout = QVBoxLayout(self.combinedTab)
+        self.combinedTabLayout.setContentsMargins(0, 0, 0, 0)
+        self.combinedTabLayout.setSpacing(5)
+
+        # Add tabs
         self.plotTabs.addTab(
             self.viewerTab,
             "Model Viewer",
@@ -139,7 +168,16 @@ class DesignWindow(QDialog, Ui_Shape2SAS, Perspective):
             self.scatteringTab,
             "Scattering Profile",
         )
+        self.plotTabs.addTab(
+            self.combinedTab,
+            "Combined",
+        )
+
+        self.plotTabs.currentChanged.connect(self.onPlotTabChanged)
         self.plotTabs.setCurrentWidget(self.viewerTab)
+
+        # Perform the initial widget placement
+        self.onPlotTabChanged(self.plotTabs.currentIndex())
 
         # Left-hand table and right-hand tabs
         modelHbox.addWidget(self.subunitTable)
@@ -191,7 +229,6 @@ class DesignWindow(QDialog, Ui_Shape2SAS, Perspective):
         )
         self.SAXSExperiment.setLayout(self.gridLayout_2)
 
-
         # TODO: implement in a future project
         # Building Constraint window
         self.constraint = Constraints(parent=self)
@@ -201,7 +238,6 @@ class DesignWindow(QDialog, Ui_Shape2SAS, Perspective):
         self.setupTooltips()
 
         self.enableButtons(False)
-
 
     def setupSlots(self):
         """Connect signals and slots for the GUI."""
@@ -240,6 +276,83 @@ class DesignWindow(QDialog, Ui_Shape2SAS, Perspective):
         self.SAXSTabButtons.reset.setToolTip("Reset this page to default")
         self.plotSAXS.setToolTip("Plot simulated SAXS data")
         self.sendSimToSasView.setToolTip("Send simulated SAXS data to SasView Data Explorer")
+
+    def onPlotTabChanged(self, index):
+        """Move the viewer and profile panels into the selected tab."""
+
+        current_tab = self.plotTabs.widget(index)
+
+        if current_tab is self.viewerTab:
+            # Move the viewer panel into the viewer-only tab
+            self.viewerTabLayout.addWidget(
+                self.viewerPanel,
+                stretch=1,
+            )
+
+            self.viewerPanel.show()
+            self.profilePanel.hide()
+
+            # Q3DScatter is a native window and must be explicitly shown
+            self.viewerModel.scatterContainer.show()
+            self.viewerModel.scatter.setVisible(True)
+            self.viewerModel.scatter.requestUpdate()
+
+        elif current_tab is self.scatteringTab:
+            # Move the profile panel into the profile-only tab
+            self.scatteringTabLayout.addWidget(
+                self.profilePanel,
+                stretch=1,
+            )
+
+            self.viewerPanel.hide()
+            self.profilePanel.show()
+
+            # Explicitly hide the native 3D window to prevent overlays
+            self.viewerModel.scatter.setVisible(False)
+            self.viewerModel.scatterContainer.hide()
+
+            # Wait until the tab has its final size before fitting the plot
+            QTimer.singleShot(0, self.fitScatteringProfile)
+
+        elif current_tab is self.combinedTab:
+            # Move both panels into the combined tab
+            self.combinedTabLayout.addWidget(self.viewerPanel, stretch=1)
+            self.combinedTabLayout.addWidget(self.profilePanel, stretch=1)
+
+            self.viewerPanel.show()
+            self.profilePanel.show()
+
+            self.viewerModel.scatterContainer.show()
+            self.viewerModel.scatter.setVisible(True)
+            self.viewerModel.scatter.requestUpdate()
+
+            QTimer.singleShot(0, self.fitScatteringProfile)
+
+    def fitScatteringProfile(self):
+        """Fit the scattering scene to the available profile-view area."""
+
+        scattering_view = self.viewerModel.scattering
+
+        # Use ResponsiveGraphicsView.fitScene() when available
+        if hasattr(scattering_view, "fitScene"):
+            scattering_view.fitScene()
+            return
+
+        scene = scattering_view.scene()
+
+        if scene is None:
+            return
+
+        scene_rect = scene.itemsBoundingRect()
+
+        if scene_rect.isEmpty():
+            return
+
+        scattering_view.setSceneRect(scene_rect)
+        scattering_view.fitInView(
+            scene_rect,
+            Qt.AspectRatioMode.KeepAspectRatio,
+        )
 
     def showConstraintWindow(self):
         """Get the Constraint window"""
@@ -630,6 +743,9 @@ class DesignWindow(QDialog, Ui_Shape2SAS, Perspective):
 
         else:
             self.viewerModel.setClearScatteringPlot()
+
+        # Restore the correct native-window visibility and plot sizing
+        self.onPlotTabChanged(self.plotTabs.currentIndex())
 
     def onSubunitTableReset(self):
         """Reset subunit table to default."""

--- a/src/sas/qtgui/Calculators/Shape2SAS/DesignWindow.py
+++ b/src/sas/qtgui/Calculators/Shape2SAS/DesignWindow.py
@@ -11,6 +11,7 @@ from PySide6.QtWidgets import (
     QLineEdit,
     QPushButton,
     QSizePolicy,
+    QTabWidget,
     QVBoxLayout,
     QWidget,
 )
@@ -80,6 +81,7 @@ class DesignWindow(QDialog, Ui_Shape2SAS, Perspective):
         self.plot = QPushButton("Plot")
         self.modelTabButtonOptions.horizontalLayout_5.insertWidget(1, self.plot)
         self.plot.setToolTip("Plot the model")
+        self.modelTabButtonOptions.horizontalLayout_5.insertWidget(1, self.plot)
 
         self.line2 = QFrame()
         self.line2.setFrameShape(QFrame.VLine)
@@ -110,15 +112,71 @@ class DesignWindow(QDialog, Ui_Shape2SAS, Perspective):
         modelVbox.setContentsMargins(10,10,10,10)
         modelHbox.setContentsMargins(10,10,10,10)
         modelSection = QWidget()
-        modelHbox.addWidget(self.subunitTable)
-        modelHbox.addWidget(self.viewerModel.Viewmodel_modul)
-        modelSection.setLayout(modelHbox)
 
-        modelVbox.addWidget(modelSection)
-        modelVbox.addWidget(self.modelTabButtonOptions)
+        # Right-hand tabbed plot area
+        self.plotTabs = QTabWidget()
+        self.plotTabs.setObjectName("plotTabs")
+        self.plotTabs.setSizePolicy(
+            QSizePolicy.Policy.Expanding,
+            QSizePolicy.Policy.Expanding,
+        )
+
+        # Model viewer tab
+        self.viewerTab = QWidget()
+        viewerTabLayout = QVBoxLayout(self.viewerTab)
+        viewerTabLayout.setContentsMargins(0, 0, 0, 0)
+
+        viewerTabLayout.addWidget(
+            self.viewerModel.scatterContainer,
+            stretch=1,
+        )
+        viewerTabLayout.addWidget(self.viewerModel.viewerButtons)
+        viewerTabLayout.addWidget(self.viewerModel.viewerModelRadius)
+
+        # Theoretical scattering tab
+        self.scatteringTab = QWidget()
+        scatteringTabLayout = QVBoxLayout(self.scatteringTab)
+        scatteringTabLayout.setContentsMargins(0, 0, 0, 0)
+
+        scatteringTabLayout.addWidget(
+            self.viewerModel.scattering,
+            stretch=1,
+        )
+
+        self.plotTabs.addTab(
+            self.viewerTab,
+            "Model Viewer",
+        )
+        self.plotTabs.addTab(
+            self.scatteringTab,
+            "Scattering Profile",
+        )
+        self.plotTabs.setCurrentWidget(self.viewerTab)
+
+        # Left-hand table and right-hand tabs
+        modelHbox.addWidget(self.subunitTable)
+        modelHbox.addWidget(self.plotTabs)
+
+        modelHbox.setStretch(0, 1)
+        modelHbox.setStretch(1, 2)
+
+        modelSection.setLayout(modelHbox)
+        modelSection.setSizePolicy(
+            QSizePolicy.Policy.Expanding,
+            QSizePolicy.Policy.Expanding,
+        )
+
+        modelVbox.addWidget(modelSection, stretch=1)
+        modelVbox.addWidget(
+            self.modelTabButtonOptions,
+            stretch=0,
+        )
+
         self.model.setLayout(modelVbox)
 
-        #plot scene
+        ### Build Virtual SAXS Experiment tab
+
+        # This is the separate simulated SAXS plot area.
         self.scatteringProf = QWidget()
         self.scatteringProf.setContentsMargins(0, 0, 0, 0)
         self.scatteringProf.setObjectName("scatteringProf")
@@ -768,7 +826,7 @@ class DesignWindow(QDialog, Ui_Shape2SAS, Perspective):
         self.setFig.grid(True)
 
         self.scatteringScene.addWidget(self.canvas)
-        self.scatteringProf.setLayout(self.scatteringScene)
+        self.canvas.draw_idle()
 
     def sendSimulatedSAXSToDataExplorer(self):
         """Send simulated data to the Data Explorer in SasView"""

--- a/src/sas/qtgui/Calculators/Shape2SAS/DesignWindow.py
+++ b/src/sas/qtgui/Calculators/Shape2SAS/DesignWindow.py
@@ -176,6 +176,10 @@ class DesignWindow(QDialog, Ui_Shape2SAS, Perspective):
             self.combinedTab,
             "Combined",
         )
+        
+        # Keep tabs disabled until include scattering is checked
+        self.plotTabs.setTabEnabled(1, False)
+        self.plotTabs.setTabEnabled(2, False)
 
         self.plotTabs.currentChanged.connect(self.onPlotTabChanged)
         self.plotTabs.setCurrentWidget(self.viewerTab)
@@ -188,11 +192,8 @@ class DesignWindow(QDialog, Ui_Shape2SAS, Perspective):
 
         self.modelSplitter.addWidget(self.subunitTable)
         self.modelSplitter.addWidget(self.plotTabs)
-
-        # Initial relative sizing: 40% table, 60% plots
         self.modelSplitter.setStretchFactor(0, 2)
         self.modelSplitter.setStretchFactor(1, 3)
-        # self.modelSplitter.setSizes([500, 750])
 
         # Prevent either side from being completely collapsed
         self.modelSplitter.setCollapsible(0, False)
@@ -257,6 +258,7 @@ class DesignWindow(QDialog, Ui_Shape2SAS, Perspective):
         self.plot.clicked.connect(self.onClickingPlot)
         self.plugin.clicked.connect(self.showConstraintWindow)
         self.structureFactor.currentIndexChanged.connect(self.showStructureFactorOptions)
+        self.checkTheoreticalScattering.toggled.connect(self.onTheoreticalScatteringChanged)
         self.plotSAXS.clicked.connect(self.showSimulatedSAXSData)
         self.sendSimToSasView.clicked.connect(self.sendSimulatedSAXSToDataExplorer)
         self.SAXSTabButtons.closePage.clicked.connect(self.onClickingClose)
@@ -287,6 +289,23 @@ class DesignWindow(QDialog, Ui_Shape2SAS, Perspective):
         self.SAXSTabButtons.reset.setToolTip("Reset this page to default")
         self.plotSAXS.setToolTip("Plot simulated SAXS data")
         self.sendSimToSasView.setToolTip("Send simulated SAXS data to SasView Data Explorer")
+
+    def onTheoreticalScatteringChanged(self, checked: bool):
+        """Handle changes to the 'Include Scattering' checkbox."""
+        print(f"Checkbox state changed: {checked}")
+        if checked:
+            print("Include Scattering checked")
+            self.plotTabs.setTabEnabled(1, True)
+            self.plotTabs.setTabEnabled(2, True)
+            self.plotTabs.setCurrentWidget(self.combinedTab)
+
+            # Replot to ensure the scattering profile is generated when the checkbox is checked
+            self.onClickingPlot()
+        else:
+            print("Include Scattering unchecked")
+            self.plotTabs.setTabEnabled(1, False)
+            self.plotTabs.setTabEnabled(2, False)
+            self.plotTabs.setCurrentWidget(self.viewerTab)
 
     def onPlotTabChanged(self, index):
         """Move the viewer and profile panels into the selected tab."""

--- a/src/sas/qtgui/Calculators/Shape2SAS/DesignWindow.py
+++ b/src/sas/qtgui/Calculators/Shape2SAS/DesignWindow.py
@@ -2,7 +2,7 @@
 import re
 from types import MethodType
 
-from PySide6.QtCore import QSize, Qt
+from PySide6.QtCore import Qt
 from PySide6.QtWidgets import (
     QCheckBox,
     QDialog,
@@ -190,8 +190,8 @@ class DesignWindow(QDialog, Ui_Shape2SAS, Perspective):
             self.SAXSTabButtons, 2, 0, 1, 2, Qt.AlignmentFlag.AlignBottom | Qt.AlignmentFlag.AlignRight
         )
         self.SAXSExperiment.setLayout(self.gridLayout_2)
-        
-        
+
+
         # TODO: implement in a future project
         # Building Constraint window
         self.constraint = Constraints(parent=self)

--- a/src/sas/qtgui/Calculators/Shape2SAS/DesignWindow.py
+++ b/src/sas/qtgui/Calculators/Shape2SAS/DesignWindow.py
@@ -143,7 +143,7 @@ class DesignWindow(QDialog, Ui_Shape2SAS, Perspective):
         profilePanelLayout.setContentsMargins(0, 0, 0, 0)
 
         profilePanelLayout.addWidget(
-            self.viewerModel.scattering,
+            self.viewerModel.scatteringContainer,
             stretch=1,
         )
 
@@ -176,7 +176,7 @@ class DesignWindow(QDialog, Ui_Shape2SAS, Perspective):
             self.combinedTab,
             "Combined",
         )
-        
+
         # Keep tabs disabled until include scattering is checked
         self.plotTabs.setTabEnabled(1, False)
         self.plotTabs.setTabEnabled(2, False)
@@ -347,7 +347,7 @@ class DesignWindow(QDialog, Ui_Shape2SAS, Perspective):
         elif current_tab is self.combinedTab:
             # Move both panels into the combined tab
             self.combinedTabLayout.addWidget(self.viewerPanel, stretch=1)
-            self.combinedTabLayout.addWidget(self.profilePanel, stretch=1)
+            self.combinedTabLayout.addWidget(self.profilePanel, stretch=2)
 
             self.viewerPanel.show()
             self.profilePanel.show()
@@ -359,30 +359,8 @@ class DesignWindow(QDialog, Ui_Shape2SAS, Perspective):
             QTimer.singleShot(0, self.fitScatteringProfile)
 
     def fitScatteringProfile(self):
-        """Fit the scattering scene to the available profile-view area."""
-
-        scattering_view = self.viewerModel.scattering
-
-        # Use ResponsiveGraphicsView.fitScene() when available
-        if hasattr(scattering_view, "fitScene"):
-            scattering_view.fitScene()
-            return
-
-        scene = scattering_view.scene()
-
-        if scene is None:
-            return
-
-        scene_rect = scene.itemsBoundingRect()
-
-        if scene_rect.isEmpty():
-            return
-
-        scattering_view.setSceneRect(scene_rect)
-        scattering_view.fitInView(
-            scene_rect,
-            Qt.AspectRatioMode.KeepAspectRatio,
-        )
+        """Redraw the profile after its tab or layout changes."""
+        self.viewerModel.scattering.draw_idle()
 
     def showConstraintWindow(self):
         """Get the Constraint window"""

--- a/src/sas/qtgui/Calculators/Shape2SAS/DesignWindow.py
+++ b/src/sas/qtgui/Calculators/Shape2SAS/DesignWindow.py
@@ -2,7 +2,7 @@
 import re
 from types import MethodType
 
-from PySide6.QtCore import Qt
+from PySide6.QtCore import QSize, Qt
 from PySide6.QtWidgets import (
     QCheckBox,
     QDialog,
@@ -50,7 +50,7 @@ class DesignWindow(QDialog, Ui_Shape2SAS, Perspective):
 
     @property
     def title(self) -> str:
-        """ Window title"""
+        """Window title"""
         return "Shape2SAS"
 
     def __init__(self, parent=None):
@@ -62,13 +62,10 @@ class DesignWindow(QDialog, Ui_Shape2SAS, Perspective):
         self._manager = parent
         self.communicator = communicator
 
-        ############Building GUI##############
-        ###create build model tab
-        #Add buttons to the modelTabButtonOptions
+        ############ Building GUI ##############
+        # Create build model tab
+        # Add buttons to the modelTabButtonOptions
         self.modelTabButtonOptions = ButtonOptions()
-        self.modelTabButtonOptions.help.setToolTip("Go to help page")
-        self.modelTabButtonOptions.closePage.setToolTip("Close Shape2SAS")
-        self.modelTabButtonOptions.reset.setToolTip("Reset this page to default")
         self.modelTabButtonOptions.horizontalLayout_5.setContentsMargins(0, 0, 10, 10)
 
         self.line1 = QFrame()
@@ -76,11 +73,9 @@ class DesignWindow(QDialog, Ui_Shape2SAS, Perspective):
         self.modelTabButtonOptions.horizontalLayout_5.insertWidget(1, self.line1)
 
         self.checkTheoreticalScattering = QCheckBox("Include Scattering")
-        self.checkTheoreticalScattering.setToolTip("Include a theoretical scattering profile when plotting the model")
         self.modelTabButtonOptions.horizontalLayout_5.insertWidget(1, self.checkTheoreticalScattering)
         self.plot = QPushButton("Plot")
         self.modelTabButtonOptions.horizontalLayout_5.insertWidget(1, self.plot)
-        self.plot.setToolTip("Plot the model")
         self.modelTabButtonOptions.horizontalLayout_5.insertWidget(1, self.plot)
 
         self.line2 = QFrame()
@@ -89,28 +84,21 @@ class DesignWindow(QDialog, Ui_Shape2SAS, Perspective):
 
         self.plugin = QPushButton("To plugin model")
         self.plugin.setMinimumSize(110, 24)
-        self.plugin.setToolTip("Go to the plugin model page")
         self.plugin.setEnabled(False)
         self.modelTabButtonOptions.horizontalLayout_5.insertWidget(1, self.plugin)
 
         self.plugin.setHidden(True)
         self.line2.setHidden(True)
 
-        #connect buttons
-        self.modelTabButtonOptions.reset.clicked.connect(self.onSubunitTableReset)
-        self.modelTabButtonOptions.closePage.clicked.connect(self.onClickingClose)
-        self.plot.clicked.connect(self.onClickingPlot)
-        self.plugin.clicked.connect(self.showConstraintWindow)
-
-        #create layout for build model tab
+        # Create layout for build model tab
         self.viewerModel = ViewerModel()
         self.subunitTable = SubunitTable(self.onClickingPlot)
 
         modelVbox = QVBoxLayout()
         modelHbox = QHBoxLayout()
 
-        modelVbox.setContentsMargins(10,10,10,10)
-        modelHbox.setContentsMargins(10,10,10,10)
+        modelVbox.setContentsMargins(10, 10, 10, 10)
+        modelHbox.setContentsMargins(10, 10, 10, 10)
         modelSection = QWidget()
 
         # Right-hand tabbed plot area
@@ -174,8 +162,7 @@ class DesignWindow(QDialog, Ui_Shape2SAS, Perspective):
 
         self.model.setLayout(modelVbox)
 
-        ### Build Virtual SAXS Experiment tab
-
+        # Build Virtual SAXS Experiment tab
         # This is the separate simulated SAXS plot area.
         self.scatteringProf = QWidget()
         self.scatteringProf.setContentsMargins(0, 0, 0, 0)
@@ -189,40 +176,43 @@ class DesignWindow(QDialog, Ui_Shape2SAS, Perspective):
         self.plotBoxLayout.addWidget(self.scatteringProf)
         self.group2.setLayout(self.plotBoxLayout)
 
-        ###Building Virtual SAXS Experiment tab
-        #create and set layout for buttons
+        # Create and set layout for buttons
         self.SAXSTabButtons = ButtonOptions()
-        self.SAXSTabButtons.help.setToolTip("Go to help page")
-        self.SAXSTabButtons.help.clicked.connect(self.onHelp)
-        self.SAXSTabButtons.closePage.setToolTip("Close Shape2SAS")
-        self.SAXSTabButtons.reset.setToolTip("Reset this page to default")
-        self.SAXSTabButtons.reset.clicked.connect(self.onSAXSExperimentReset)
         self.plotSAXS = QPushButton("Plot SAXS")
         self.plotSAXS.setMinimumSize(110, 24)
-        self.plotSAXS.setToolTip("Plot simulated SAXS data")
         self.SAXSTabButtons.horizontalLayout_5.insertWidget(1, self.plotSAXS)
         self.sendSimToSasView = QPushButton("Create SAXS file")
         self.sendSimToSasView.setMinimumSize(110, 24)
-        self.sendSimToSasView.setToolTip("Send simulated SAXS data to SasView Data Explorer")
         self.sendSimToSasView.setEnabled(False)
         self.SAXSTabButtons.horizontalLayout_5.setContentsMargins(0, 0, 0, 0)
         self.SAXSTabButtons.horizontalLayout_5.insertWidget(1, self.sendSimToSasView)
-        self.gridLayout_2.addWidget(self.SAXSTabButtons, 2, 0, 1, 2, Qt.AlignmentFlag.AlignBottom | Qt.AlignmentFlag.AlignRight)
+        self.gridLayout_2.addWidget(
+            self.SAXSTabButtons, 2, 0, 1, 2, Qt.AlignmentFlag.AlignBottom | Qt.AlignmentFlag.AlignRight
+        )
         self.SAXSExperiment.setLayout(self.gridLayout_2)
+        
+        
+        # TODO: implement in a future project
+        # Building Constraint window
+        self.constraint = Constraints(parent=self)
+        self.constraint.setWindowFlags(Qt.Window | Qt.Tool)
 
-        #connect buttons
+        self.setupSlots()
+        self.setupTooltips()
+
+        self.enableButtons(False)
+
+
+    def setupSlots(self):
+        """Connect signals and slots for the GUI."""
+        self.modelTabButtonOptions.reset.clicked.connect(self.onSubunitTableReset)
+        self.modelTabButtonOptions.closePage.clicked.connect(self.onClickingClose)
+        self.plot.clicked.connect(self.onClickingPlot)
+        self.plugin.clicked.connect(self.showConstraintWindow)
         self.structureFactor.currentIndexChanged.connect(self.showStructureFactorOptions)
         self.plotSAXS.clicked.connect(self.showSimulatedSAXSData)
         self.sendSimToSasView.clicked.connect(self.sendSimulatedSAXSToDataExplorer)
         self.SAXSTabButtons.closePage.clicked.connect(self.onClickingClose)
-        self.enableButtons(False)
-
-        ###Building Virtual SANS Experiment tab
-        #TODO: implement in a future project
-
-        ###Building Constraint window
-        self.constraint = Constraints(parent=self)
-        self.constraint.setWindowFlags(Qt.Window | Qt.Tool)
         self.subunitTable.add.clicked.connect(self.addToVariableTable)
         self.subunitTable.deleteButton.clicked.connect(self.deleteFromVariableTable)
         self.subunitTable.table.clicked.connect(self.updateDeleteButton)
@@ -232,20 +222,35 @@ class DesignWindow(QDialog, Ui_Shape2SAS, Perspective):
         self.constraint.buttonOptions.reset.clicked.connect(self.onConstraintReset)
         self.constraint.buttonOptions.closePage.clicked.connect(self.constraint.onClosingConstraints)
         self.constraint.buttonOptions.help.clicked.connect(self.onHelp)
-
-        #create png of each tab
         self.modelTabButtonOptions.help.clicked.connect(self.onHelp)
+        self.SAXSTabButtons.help.clicked.connect(self.onHelp)
+        self.SAXSTabButtons.reset.clicked.connect(self.onSAXSExperimentReset)
+
+    def setupTooltips(self):
+        """Set up tooltips for the GUI elements."""
+
+        self.modelTabButtonOptions.help.setToolTip("Go to help page")
+        self.modelTabButtonOptions.closePage.setToolTip("Close Shape2SAS")
+        self.modelTabButtonOptions.reset.setToolTip("Reset this page to default")
+        self.checkTheoreticalScattering.setToolTip("Include a theoretical scattering profile when plotting the model")
+        self.plot.setToolTip("Plot the model")
+        self.plugin.setToolTip("Go to the plugin model page")
+        self.SAXSTabButtons.help.setToolTip("Go to help page")
+        self.SAXSTabButtons.closePage.setToolTip("Close Shape2SAS")
+        self.SAXSTabButtons.reset.setToolTip("Reset this page to default")
+        self.plotSAXS.setToolTip("Plot simulated SAXS data")
+        self.sendSimToSasView.setToolTip("Send simulated SAXS data to SasView Data Explorer")
 
     def showConstraintWindow(self):
         """Get the Constraint window"""
-
         self.constraint.setScreen(self.screen())
-        self.constraint.move(self.pos().x()+50, self.pos().y()+50)
+        self.constraint.move(self.pos().x() + 50, self.pos().y() + 50)
         self.constraint.show()
 
     def checkedVariables(self):
-        """Get checked variables from the variable table
-        with inserted restricted rows"""
+        """
+        Get checked variables from the variable table with inserted restricted rows.
+        """
 
         columns = self.constraint.variableTable.getCheckedVariables()
         for column in range(len(columns)):
@@ -255,21 +260,21 @@ class DesignWindow(QDialog, Ui_Shape2SAS, Perspective):
         return columns
 
     def getConstraintsToTextEditor(self):
-        """Set translation and parameters constraints to the text editor"""
+        """Set translation and parameters constraints to the text editor."""
         columns = self.checkedVariables()
 
-        #no subunits inputted
+        # No subunits inputted
         if not columns:
             return
 
-        #no parameters inputted
+        # No parameters inputted
         if not any(any(column) for column in columns):
             return
 
-        toTextEditor = ['# name, units, default, [min, max], type, description']
+        toTextEditor = ["# name, units, default, [min, max], type, description"]
 
         dimPos = [OptionLayout.x, OptionLayout.y, OptionLayout.z]
-        #create parameter lists for the text editor to be edited
+        # Create parameter lists for the text editor to be edited
         for column in range(len(columns)):
             for row in range(len(columns[column])):
                 if columns[column][row]:
@@ -280,18 +285,24 @@ class DesignWindow(QDialog, Ui_Shape2SAS, Perspective):
                     else:
                         val = enumMember.value
 
-                    #get units, bounds and types from method
+                    # Get units, bounds and types from method
                     attr = getattr(OptionLayout, val)
                     method = MethodType(attr, OptionLayout)
                     _, _, units, _, types, bounds = method()
 
-                    #get inputted value from cell
+                    # Get inputted value from cell
                     inputVal = self.getSubunitTableCell(row, column)
                     inputName = self.getTableName(column, row)
 
-                    #create parameter list
-                    parameter = [inputName, units[enumMember], inputVal, bounds[enumMember],
-                                 types[enumMember], f"{inputName} for column {column + 1}"]
+                    # Create parameter list
+                    parameter = [
+                        inputName,
+                        units[enumMember],
+                        inputVal,
+                        bounds[enumMember],
+                        types[enumMember],
+                        f"{inputName} for column {column + 1}",
+                    ]
 
                     toTextEditor.append(parameter)
 
@@ -300,112 +311,114 @@ class DesignWindow(QDialog, Ui_Shape2SAS, Perspective):
         return formatted
 
     def setConstraintsToTextEditor(self):
-        """Set constraints to the text editor"""
-
+        """Set constraints to the text editor."""
         constraints = self.getConstraintsToTextEditor()
         if constraints:
             formatted = constraints
             self.constraint.setConstraints(formatted)
 
-    def checkStateOfConstraints(self, fitPar: list[str], modelPars: list[list[str]], modelVals: list[list[float]],
-                                checkedPars: list[list[bool]]) -> tuple[str, str, str]:
-        """Check if the user has written constraints. Otherwise return Default"""
+    def checkStateOfConstraints(
+        self, fitPar: list[str], modelPars: list[list[str]], modelVals: list[list[float]], checkedPars: list[list[bool]]
+    ) -> tuple[str, str, str]:
+        """Check if the user has written constraints. Otherwise return Default."""
 
         constraintsStr = self.constraint.constraintTextEditor.txtEditor.toPlainText()
 
-        #Has anything been written to the text editor
+        # Has anything been written to the text editor
         if constraintsStr:
             self.constraint.log_embedded("Parsing constraints...")
             return self.constraint.parseConstraintsText(constraintsStr, fitPar, modelPars, modelVals, checkedPars)
 
-        #Did the user only check parameters and click generate plugin
+        # Did the user only check parameters and click generate plugin
         elif fitPar:
-            #Get default constraints
+            # Get default constraints
             fitParLists = self.getConstraintsToTextEditor()
             defaultConstraintsStr = self.constraint.getConstraintText(fitParLists)
             self.constraint.log_embedded("No constraints text found. Creating unconstrained model")
             return self.constraint.getConstraints(defaultConstraintsStr, fitPar, modelPars, modelVals, checkedPars)
 
-        #If not, return empty
+        # If not, return empty
         else:
-            #all parameters are constant
+            # all parameters are constant
             self.constraint.log_embedded("Creating unconstrained model.")
             return "", "", "", checkedPars
 
     def enableButtons(self, toggle: bool):
+        """Enable or disable buttons based on the toggle value."""
         self.plot.setEnabled(toggle)
         self.plugin.setEnabled(toggle)
         self.plotSAXS.setEnabled(toggle)
 
     def addToVariableTable(self):
-        """Set up parameters to the variable table"""
-        column = self.subunitTable.model.columnCount() - 1 #-1 to account for the added column
+        """Set up parameters to the variable table."""
+        column = self.subunitTable.model.columnCount() - 1  # -1 to account for the added column
         names = self.getTableNames(self.ifEmptyName, column)
 
         self.enableButtons(column >= 0)
 
-        #set variables in variable table
+        # set variables in variable table
         self.constraint.variableTable.setVariableTableData(names, column)
 
     def updateDeleteButton(self):
+        """Update the selected column in the subunit table and enable delete button."""
         selection_model = self.subunitTable.table.selectionModel()
         selected_indexes = selection_model.selectedIndexes()
         column = selected_indexes[0].column()
         self.subunitTable.selected.setValue(int(column) + 1)
 
     def deleteFromVariableTable(self):
-        """Delete parameters from the variable table"""
-        selected_column = self.subunitTable.selected_val - 1 #SubunitTable column index position
+        """Delete parameters from the variable table."""
+        selected_column = self.subunitTable.selected_val - 1  # SubunitTable column index position
         row_pos = self.constraint.variableTable.getAllTableColumnsPos()
 
-        #if no columns in the subunit table
+        # If no columns in the subunit table
         if not self.subunitTable.model.columnCount():
             numNames = self.constraint.variableTable.variableModel.rowCount()
 
-        #if selected column is the last column
+        # If selected column is the last column
         elif row_pos[selected_column] == row_pos[-1]:
             numNames = self.constraint.variableTable.variableModel.rowCount() - row_pos[-1]
 
         else:
             numNames = row_pos[selected_column + 1] - row_pos[selected_column]
 
-        #Delete rows associated with the subunit table column from variable table
+        # Delete rows associated with the subunit table column from variable table
         for delete in [row_pos[selected_column] for _ in range(numNames)]:
             self.constraint.variableTable.removeTableData(delete)
 
         self.enableButtons(self.subunitTable.model.columnCount() > 0)
 
-        #Update column number in table
-        columnNum = selected_column + 1 #column number name
-        for row in row_pos[selected_column + 1:]: #get all values after selected_column
+        # Update column number in table
+        columnNum = selected_column + 1  # column number name
+        for row in row_pos[selected_column + 1 :]:  # get all values after selected_column
             row = row - numNames
             self.constraint.variableTable.variableModel.item(row, 1).setText(str(columnNum))
             columnNum += 1
 
     def showStructureFactorOptions(self):
-        """Show options for structure factor"""
-        #get chosen structure factor
+        """Show options for structure factor."""
+        # Get chosen structure factor
         index = self.structureFactor.currentIndex()
-        #show options for chosen structure factor
+        # Show options for chosen structure factor
         self.stackedWidget.setCurrentIndex(index)
 
     def getStructureFactorValues(self):
         """
-        Read structure factor options from chosen structure
-        factor in Virtual SAXS experiment tab
+        Read structure factor options from chosen structure factor in Virtual SAXS experiment tab.
         """
         S_vals = []
 
-        #get chosen structure factor
+        # Get chosen structure factor
         index = self.structureFactor.currentIndex()
-        #find chosen widget containing the chosen structure factor options
+        # Find chosen widget containing the chosen structure factor options
         self.stackedWidget.setCurrentIndex(index)
         currentWidget = self.stackedWidget.currentWidget()
         lineEdits = currentWidget.findChildren(QLineEdit)
 
-        #get concentration value for Hardsphere case
-        #TODO: concentration is already an input value. Maybe add
-        #a texbox to explain that to the user if stackedWidget chosen?
+        # Get concentration value for Hardsphere case
+
+        # TODO: concentration is already an input value. Maybe add
+        # a texbox to explain that to the user if stackedWidget chosen?
         if index == 1:
             conc = self.volumeFraction
             S_vals.append(float(conc.text()))
@@ -421,17 +434,17 @@ class DesignWindow(QDialog, Ui_Shape2SAS, Perspective):
 
     @staticmethod
     def ifEmptyValue(value: float | str, values: list[float | str], *args, **kwargs):
-        """condition method. Append if not empty"""
+        """Condition method. Append if not empty."""
         if not value == "":
             values.append(value)
 
     @staticmethod
     def ifFitPar(value: float | str, values: list[float | str], *args, **kwargs):
-        """condition method. Append FitPar if condition. Otherwise append constant"""
+        """Condition method. Append FitPar if condition. Otherwise append constant."""
 
-        conditionFitPar = kwargs['conditionFitPar'] #list[list[str]]
-        conditionBool = kwargs['conditionBool'] #list[list[bool]]
-        row, column = args #int, int
+        conditionFitPar: list[list[str]] = kwargs["conditionFitPar"]
+        conditionBool: list[list[bool]] = kwargs["conditionBool"]
+        row, column = args  # int, int
 
         if not value == "":
             if conditionBool[column][row]:
@@ -440,7 +453,7 @@ class DesignWindow(QDialog, Ui_Shape2SAS, Perspective):
                 values.append(value)
 
     def getSubunitTableRow(self, condition: MethodType, row: int, **kwargs) -> list[float | str]:
-        """Get model data from a single row"""
+        """Get model data from a single row."""
 
         values = []
         columns = self.subunitTable.model.columnCount()
@@ -451,7 +464,7 @@ class DesignWindow(QDialog, Ui_Shape2SAS, Perspective):
         return values
 
     def getSubunitTableSets(self, condition: MethodType, rows: list[int], **kwargs) -> list[list[float | str]]:
-        """Get a set of rows per column in subunit table"""
+        """Get a set of rows per column in subunit table."""
 
         sets = []
         columns = self.subunitTable.model.columnCount()
@@ -465,7 +478,7 @@ class DesignWindow(QDialog, Ui_Shape2SAS, Perspective):
         return sets
 
     def getStandardReadOfTableData(self) -> list[list[float | str]]:
-        """Get a standard data read from subunit TableView"""
+        """Get a standard data read from subunit TableView."""
 
         columns = self.subunitTable.model.columnCount()
         if not self.subunitTable.model.item(1, columns - 1):
@@ -473,7 +486,7 @@ class DesignWindow(QDialog, Ui_Shape2SAS, Perspective):
 
         model = self.subunitTable.model
         layout = list(OptionLayout)
-        layout.remove(OptionLayout.Colour) #TODO: features may be in another Enum
+        layout.remove(OptionLayout.Colour)  # TODO: features may be in another Enum
         rows = len(layout)
         columns = model.columnCount()
 
@@ -488,33 +501,57 @@ class DesignWindow(QDialog, Ui_Shape2SAS, Perspective):
         return data
 
     def getModelData(self, condition: MethodType, **kwargs) -> list[list[float | str]]:
-        """Get all data in the subunit table"""
+        """Get all data in the subunit table."""
 
-        #no subunits inputted
+        # No subunits inputted
         columns = self.subunitTable.model.columnCount()
         if not self.subunitTable.model.item(1, columns - 1):
             return
 
         subunit = self.getSubunitTableRow(condition, OptionLayout.get_position(OptionLayout.Subunit), **kwargs)
-        dimensions = self.getSubunitTableSets(condition, [OptionLayout.get_position(OptionLayout.x),
-                                                        OptionLayout.get_position(OptionLayout.y),
-                                                        OptionLayout.get_position(OptionLayout.z)], **kwargs)
+        dimensions = self.getSubunitTableSets(
+            condition,
+            [
+                OptionLayout.get_position(OptionLayout.x),
+                OptionLayout.get_position(OptionLayout.y),
+                OptionLayout.get_position(OptionLayout.z),
+            ],
+            **kwargs,
+        )
 
         p_s = self.getSubunitTableRow(condition, OptionLayout.get_position(OptionLayout.ΔSLD), **kwargs)
 
-        com = self.getSubunitTableSets(condition, [OptionLayout.get_position(OptionLayout.COM_x),
-                                                OptionLayout.get_position(OptionLayout.COM_y),
-                                                OptionLayout.get_position(OptionLayout.COM_z)], **kwargs)
+        com = self.getSubunitTableSets(
+            condition,
+            [
+                OptionLayout.get_position(OptionLayout.COM_x),
+                OptionLayout.get_position(OptionLayout.COM_y),
+                OptionLayout.get_position(OptionLayout.COM_z),
+            ],
+            **kwargs,
+        )
 
-        rotation_points = self.getSubunitTableSets(condition, [OptionLayout.get_position(OptionLayout.RP_x),
-                                                OptionLayout.get_position(OptionLayout.RP_y),
-                                                OptionLayout.get_position(OptionLayout.RP_z)], **kwargs)
+        rotation_points = self.getSubunitTableSets(
+            condition,
+            [
+                OptionLayout.get_position(OptionLayout.RP_x),
+                OptionLayout.get_position(OptionLayout.RP_y),
+                OptionLayout.get_position(OptionLayout.RP_z),
+            ],
+            **kwargs,
+        )
 
-        rotation = self.getSubunitTableSets(condition, [OptionLayout.get_position(OptionLayout.α),
-                                            OptionLayout.get_position(OptionLayout.β),
-                                            OptionLayout.get_position(OptionLayout.γ)], **kwargs)
+        rotation = self.getSubunitTableSets(
+            condition,
+            [
+                OptionLayout.get_position(OptionLayout.α),
+                OptionLayout.get_position(OptionLayout.β),
+                OptionLayout.get_position(OptionLayout.γ),
+            ],
+            **kwargs,
+        )
 
-        #set bool to checkbox
+        # Set bool to checkbox
         if self.subunitTable.overlap.isChecked():
             exclude_overlap = True
         else:
@@ -523,15 +560,24 @@ class DesignWindow(QDialog, Ui_Shape2SAS, Perspective):
         return [subunit, dimensions, p_s, com, rotation_points, rotation, exclude_overlap]
 
     def getModelProfile(self, condition: MethodType, **kwargs) -> ModelProfile:
-        """Get model profile"""
+        """Get model profile."""
 
-        subunit, dimensions, p_s, com, rotation_points, rotation, exclude_overlap = self.getModelData(condition, **kwargs)
+        subunit, dimensions, p_s, com, rotation_points, rotation, exclude_overlap = self.getModelData(
+            condition, **kwargs
+        )
 
-        return ModelProfile(subunits=subunit, p_s=p_s, dimensions=dimensions, com=com,
-                           rotation_points=rotation_points, rotation=rotation, exclude_overlap=exclude_overlap)
+        return ModelProfile(
+            subunits=subunit,
+            p_s=p_s,
+            dimensions=dimensions,
+            com=com,
+            rotation_points=rotation_points,
+            rotation=rotation,
+            exclude_overlap=exclude_overlap,
+        )
 
     def getViewFeatures(self) -> ViewerPlotDesign:
-        """Get values affecting the illustrative aspect of Viewer"""
+        """Get values affecting the illustrative aspect of Viewer."""
         colour = []
 
         columns = self.subunitTable.model.columnCount()
@@ -541,8 +587,10 @@ class DesignWindow(QDialog, Ui_Shape2SAS, Perspective):
         return ViewerPlotDesign(colour=colour)
 
     def onClickingPlot(self):
-        """Get 3D plot of the designed model in the Build model tab.
-        If checked, plot theoretical scattering from the designed model."""
+        """
+        Get 3D plot of the designed model in the Build model tab.
+        If checked, plot theoretical scattering from the designed model.
+        """
         columns = self.subunitTable.model.columnCount()
         self.plugin.setEnabled(columns > 0)
 
@@ -558,19 +606,25 @@ class DesignWindow(QDialog, Ui_Shape2SAS, Perspective):
         self.viewerModel.setPlot(modelDistribution, plotDesign)
 
         # Save the Q3DScatter plot to a PNG file
-        #NOTE: The resolution is very low for this image!
-        #scatter_plot = self.viewerModel.scatter  # Assuming scatter is the Q3DScatter instance
-        #dpi = 3000
-        #image = scatter_plot.renderToImage(dpi)
-        #image.save("scatter_plot.png")
+        # NOTE: The resolution is very low for this image!
+        # scatter_plot = self.viewerModel.scatter  # Assuming scatter is the Q3DScatter instance
+        # dpi = 3000
+        # image = scatter_plot.renderToImage(dpi)
+        # image.save("scatter_plot.png")
 
-        #on being checked, plot theoretical scattering
+        # on being checked, plot theoretical scattering
         if self.checkTheoreticalScattering.isChecked():
-            scattering = TheoreticalScatteringCalculation(System=ModelSystem(PointDistribution=modelDistribution,
-                                                                        Stype="None", par=[],
-                                                                        polydispersity=0.0, conc=0.02,
-                                                                        sigma_r=0.0),
-                                                                        Calculation=SimulationParameters())
+            scattering = TheoreticalScatteringCalculation(
+                System=ModelSystem(
+                    PointDistribution=modelDistribution,
+                    Stype="None",
+                    par=[],
+                    polydispersity=0.0,
+                    conc=0.02,
+                    sigma_r=0.0,
+                ),
+                Calculation=SimulationParameters(),
+            )
             theoreticalScattering = getTheoreticalScattering(scattering)
             self.viewerModel.setScatteringPlot(theoreticalScattering)
 
@@ -578,7 +632,7 @@ class DesignWindow(QDialog, Ui_Shape2SAS, Perspective):
             self.viewerModel.setClearScatteringPlot()
 
     def onSubunitTableReset(self):
-        """Reset subunit table to default"""
+        """Reset subunit table to default."""
         self.subunitTable.onClearSubunitTable()
         self.constraint.variableTable.onClearTable()
         self.viewerModel.setClearScatteringPlot()
@@ -589,7 +643,7 @@ class DesignWindow(QDialog, Ui_Shape2SAS, Perspective):
         self.enableButtons(False)
 
     def onSAXSExperimentReset(self):
-        """Reset Virtual SAXS Experiment tab to default"""
+        """Reset Virtual SAXS Experiment tab to default."""
         self.interfaceRoughness.setText("0.0")
         self.polydispersity.setText("0.0")
         self.volumeFraction.setText("0.02")
@@ -608,12 +662,12 @@ class DesignWindow(QDialog, Ui_Shape2SAS, Perspective):
         self.sendSimToSasView.setEnabled(False)
 
         # Clear the plot in the Virtual SAXS Experiment tab if it has already been generated
-        if hasattr(self, 'canvas'):
+        if hasattr(self, "canvas"):
             self.canvas.figure.clf()
             self.canvas.draw()
 
     def onConstraintReset(self):
-        """Reset Constraint window to default"""
+        """Reset Constraint window to default."""
         self.constraint.clearConstraints()
         self.constraint.variableTable.setUncheckToAllCheckBoxes()
         self.constraint.variableTable.prPoints.setText("100")
@@ -622,7 +676,7 @@ class DesignWindow(QDialog, Ui_Shape2SAS, Perspective):
         self.constraint.createPlugin.setEnabled(False)
 
     def onClickingClose(self):
-        """Close Shape2SAS GUI"""
+        """Close Shape2SAS GUI."""
 
         self.close()
         self.constraint.onClosingConstraints()
@@ -634,29 +688,29 @@ class DesignWindow(QDialog, Ui_Shape2SAS, Perspective):
 
     @staticmethod
     def ifNoCondition(name: str, names: list[str], **kwargs):
-        """condition method. Append"""
+        """Condition method. Append without any condition."""
         names.append(name)
 
     @staticmethod
     def ifEmptyName(name: str, names: list[str], **kwargs):
-        """condition method. Append if not empty"""
+        """Condition method. Append if not empty."""
 
         if name:
             names.append(name)
 
     def getTableName(self, column: int, row: int) -> str:
-        """Get the parameter name of a cell in the subunit table"""
+        """Get the parameter name of a cell in the subunit table."""
 
-        name = re.match(r'^[^\s=]+', self.subunitTable.model.item(row, column).text())
+        name = re.match(r"^[^\s=]+", self.subunitTable.model.item(row, column).text())
         if name:
             return name.group()
 
     def getTableNames(self, condition: MethodType, column: int, **kwargs) -> list[str]:
-        """Get the parameter names of a column in the subunit table"""
+        """Get the parameter names of a column in the subunit table."""
 
         names = []
         layout = list(OptionLayout)
-        layout.remove(OptionLayout.Colour) #TODO: features may be in another Enum
+        layout.remove(OptionLayout.Colour)  # TODO: features may be in another Enum
 
         for name in layout:
             layoutName = self.getTableName(column, OptionLayout.get_position(name))
@@ -665,7 +719,7 @@ class DesignWindow(QDialog, Ui_Shape2SAS, Perspective):
         return names
 
     def getAllTableNames(self, condition: MethodType, **kwargs) -> list[list[str]]:
-        """Get all parameter names in the subunit table"""
+        """Get all parameter names in the subunit table."""
         names = []
         columns = self.subunitTable.model.columnCount()
 
@@ -675,17 +729,16 @@ class DesignWindow(QDialog, Ui_Shape2SAS, Perspective):
         return names
 
     def getFitParameters(self) -> list[str]:
-        """return names of the chosen fit parameters"""
+        """Return names of the chosen fit parameters."""
 
         return self.constraint.variableTable.getCheckedTableNamesVariables()
 
     def getPluginModel(self):
-        """Generating a plugin model and sends it to
-        the Plugin Models folder in SasView"""
+        """Generating a plugin model and sends it to the Plugin Models folder in SasView."""
 
         logger.info("Generating plugin model.")
-        #no subunits inputted
-        columns = self.subunitTable.model.columnCount() #TODO: maybe give a warning to output texteditor
+        # No subunits inputted
+        columns = self.subunitTable.model.columnCount()  # TODO: maybe give a warning to output texteditor
         if not self.subunitTable.model.item(1, columns - 1):
             return
 
@@ -696,36 +749,32 @@ class DesignWindow(QDialog, Ui_Shape2SAS, Perspective):
         checkedPars = self.checkedVariables()
         parVals = self.getStandardReadOfTableData()
 
-        #get chosen fit parameters
+        # Get chosen fit parameters
         fitPar = self.getFitParameters()
 
         logger.info("Retrieving and verifying constraints.")
-        #get parameters constraints
+        # Get parameters constraints
         usertext, checkedPars = self.checkStateOfConstraints(fitPar, parNames, parVals, checkedPars)
 
         logger.info("Retrieving Model.")
-        #conditional subunit table parameters
+        # Conditional subunit table parameters
         modelProfile = self.getModelProfile(self.ifFitPar, conditionBool=checkedPars, conditionFitPar=parNames)
 
         model_str, full_path = generate_plugin(
-            modelProfile,
-            [parNames, parVals],
-            usertext,
-            fitPar,
-            Npoints,
-            prPoints,
-            modelName
+            modelProfile, [parNames, parVals], usertext, fitPar, Npoints, prPoints, modelName
         )
 
-        #Write file to plugin model folder
+        # Write file to plugin model folder
         TabbedModelEditor.writeFile(full_path, model_str)
         self.communicator.customModelDirectoryChanged.emit()
         logger.info(f"Successfully generated model {modelName}!")
-        self.constraint.log_embedded(f"Plugin model {modelName} has been generated and is now available in the Fit panel.")
+        self.constraint.log_embedded(
+            f"Plugin model {modelName} has been generated and is now available in the Fit panel."
+        )
         self.constraint.createPlugin.setEnabled(False)
 
     def onCheckingInput(self, input: str, default: str) -> str:
-        """Check if the input not None. Otherwise, return default value"""
+        """Check if the input not None. Otherwise, return default value."""
 
         if not input.text():
             return default
@@ -733,18 +782,17 @@ class DesignWindow(QDialog, Ui_Shape2SAS, Perspective):
             return input.text()
 
     def plotSimulatedSAXSData(self):
-        """Plotting simulated SAXS data in the Virtual SAXS Experiment tab"""
+        """Plotting simulated SAXS data in the Virtual SAXS Experiment tab."""
         self.scatteringProf
 
     def getSimulatedSAXSData(self):
-        """Generating simulated data and sends it to
-        the Data Explorer in SasView"""
+        """Generating simulated data and sends it to the Data Explorer in SasView."""
 
         columns = self.subunitTable.model.columnCount()
         if not self.subunitTable.model.item(1, columns - 1):
             return
 
-        #Calculations
+        # Calculations
         qmin = float(self.onCheckingInput(self.qMin, "0.001"))
         qmax = float(self.onCheckingInput(self.qMax, "0.5"))
 
@@ -752,11 +800,9 @@ class DesignWindow(QDialog, Ui_Shape2SAS, Perspective):
         Npr = int(self.onCheckingInput(self.Npr, "100"))
         N = int(self.onCheckingInput(self.NSimPoints, "3000"))
 
-        #name = self.onCheckingInput(self.modelName, "Model_1")
-
         par = self.getStructureFactorValues()
 
-        #SAXS parameters
+        # SAXS parameters
         Stype = self.structureFactor.currentText()
 
         sigma_r = float(self.onCheckingInput(self.interfaceRoughness, "0.0"))
@@ -764,7 +810,7 @@ class DesignWindow(QDialog, Ui_Shape2SAS, Perspective):
         conc = float(self.onCheckingInput(self.volumeFraction, "0.02"))
         exposure = float(self.onCheckingInput(self.exposureTime, "500"))
 
-        #Generate simulated data
+        # Generate simulated data
         q = Qsampling.onQsampling(qmin, qmax, Nq)
         Sim_par = SimulationParameters(q=q, prpoints=Npr, Npoints=N)
         Profile = self.getModelProfile(self.ifEmptyValue)
@@ -772,35 +818,26 @@ class DesignWindow(QDialog, Ui_Shape2SAS, Perspective):
         Distr = getPointDistribution(Profile, N)
 
         model = ModelSystem(
-            PointDistribution=Distr,
-            Stype=Stype, par=par,
-            polydispersity=polydispersity,
-            conc=conc,
-            sigma_r=sigma_r
+            PointDistribution=Distr, Stype=Stype, par=par, polydispersity=polydispersity, conc=conc, sigma_r=sigma_r
         )
 
-        Theo_I = getTheoreticalScattering(
-            TheoreticalScatteringCalculation(
-                System=model,
-                Calculation=Sim_par
-            )
-        )
+        Theo_I = getTheoreticalScattering(TheoreticalScatteringCalculation(System=model, Calculation=Sim_par))
         Sim_calc = SimulateScattering(q=Theo_I.q, I0=Theo_I.I0, I=Theo_I.I, exposure=exposure)
         Sim_SAXS = getSimulatedScattering(Sim_calc)
 
         return Sim_SAXS
 
     def showSimulatedSAXSData(self):
-        """Plotting simulated SAXS data in the Virtual SAXS Experiment tab"""
+        """Plotting simulated SAXS data in the Virtual SAXS Experiment tab."""
 
-        #check if subunit table is empty
+        # Check if subunit table is empty
         columns = self.subunitTable.model.columnCount()
         if not self.subunitTable.model.item(1, columns - 1):
             return
 
         self.sendSimToSasView.setEnabled(True)
 
-        #Clear layout for last plot
+        # Clear layout for last plot
         if self.scatteringScene.count():
             widget = self.scatteringScene.takeAt(0).widget()
             if widget:
@@ -819,8 +856,8 @@ class DesignWindow(QDialog, Ui_Shape2SAS, Perspective):
         self.setFig.set_ylabel("I(q)")
         self.setFig.errorbar(simSAXS.q, simSAXS.I_sim, yerr=simSAXS.I_err, color="black", label="I(q)")
 
-        self.setFig.set_xscale('log')
-        self.setFig.set_yscale('log')
+        self.setFig.set_xscale("log")
+        self.setFig.set_yscale("log")
 
         self.setFig.legend()
         self.setFig.grid(True)
@@ -829,14 +866,14 @@ class DesignWindow(QDialog, Ui_Shape2SAS, Perspective):
         self.canvas.draw_idle()
 
     def sendSimulatedSAXSToDataExplorer(self):
-        """Send simulated data to the Data Explorer in SasView"""
+        """Send simulated data to the Data Explorer in SasView."""
 
         name = self.onCheckingInput(self.modelName, "Model_1")
         sim = self.getSimulatedSAXSData()
         if sim is not None:
             dataClass = Data1D(x=sim.q, y=sim.I_sim, dy=sim.I_err)
 
-            #Send data to SasView Data Explorer
+            # Send data to SasView Data Explorer
             data = createModelItemWithPlot(dataClass, name)
             self.communicator.updateModelFromPerspectiveSignal.emit(data)
         else:

--- a/src/sas/qtgui/Calculators/Shape2SAS/DesignWindow.py
+++ b/src/sas/qtgui/Calculators/Shape2SAS/DesignWindow.py
@@ -11,6 +11,7 @@ from PySide6.QtWidgets import (
     QLineEdit,
     QPushButton,
     QSizePolicy,
+    QSplitter,
     QTabWidget,
     QVBoxLayout,
     QWidget,
@@ -61,6 +62,9 @@ class DesignWindow(QDialog, Ui_Shape2SAS, Perspective):
 
         self._manager = parent
         self.communicator = communicator
+
+        self.setMinimumSize(1200, 650)
+        self.resize(1200, 650)
 
         ############ Building GUI ##############
         # Create build model tab
@@ -179,12 +183,22 @@ class DesignWindow(QDialog, Ui_Shape2SAS, Perspective):
         # Perform the initial widget placement
         self.onPlotTabChanged(self.plotTabs.currentIndex())
 
-        # Left-hand table and right-hand tabs
-        modelHbox.addWidget(self.subunitTable)
-        modelHbox.addWidget(self.plotTabs)
+        # Moveable divider between the table and plots
+        self.modelSplitter = QSplitter(Qt.Orientation.Horizontal)
 
-        modelHbox.setStretch(0, 1)
-        modelHbox.setStretch(1, 2)
+        self.modelSplitter.addWidget(self.subunitTable)
+        self.modelSplitter.addWidget(self.plotTabs)
+
+        # Initial relative sizing: 40% table, 60% plots
+        self.modelSplitter.setStretchFactor(0, 2)
+        self.modelSplitter.setStretchFactor(1, 3)
+        # self.modelSplitter.setSizes([500, 750])
+
+        # Prevent either side from being completely collapsed
+        self.modelSplitter.setCollapsible(0, False)
+        self.modelSplitter.setCollapsible(1, False)
+
+        modelHbox.addWidget(self.modelSplitter)
 
         modelSection.setLayout(modelHbox)
         modelSection.setSizePolicy(
@@ -192,11 +206,8 @@ class DesignWindow(QDialog, Ui_Shape2SAS, Perspective):
             QSizePolicy.Policy.Expanding,
         )
 
-        modelVbox.addWidget(modelSection, stretch=1)
-        modelVbox.addWidget(
-            self.modelTabButtonOptions,
-            stretch=0,
-        )
+        modelVbox.addWidget(modelSection)
+        modelVbox.addWidget(self.modelTabButtonOptions)
 
         self.model.setLayout(modelVbox)
 

--- a/src/sas/qtgui/Calculators/Shape2SAS/DesignWindow.py
+++ b/src/sas/qtgui/Calculators/Shape2SAS/DesignWindow.py
@@ -190,6 +190,8 @@ class DesignWindow(QDialog, Ui_Shape2SAS, Perspective):
         # Moveable divider between the table and plots
         self.modelSplitter = QSplitter(Qt.Orientation.Horizontal)
 
+        self.subunitTable.setMinimumWidth(650)
+
         self.modelSplitter.addWidget(self.subunitTable)
         self.modelSplitter.addWidget(self.plotTabs)
         self.modelSplitter.setStretchFactor(0, 2)

--- a/src/sas/qtgui/Calculators/Shape2SAS/DesignWindow.py
+++ b/src/sas/qtgui/Calculators/Shape2SAS/DesignWindow.py
@@ -294,9 +294,7 @@ class DesignWindow(QDialog, Ui_Shape2SAS, Perspective):
 
     def onTheoreticalScatteringChanged(self, checked: bool):
         """Handle changes to the 'Include Scattering' checkbox."""
-        print(f"Checkbox state changed: {checked}")
         if checked:
-            print("Include Scattering checked")
             self.plotTabs.setTabEnabled(1, True)
             self.plotTabs.setTabEnabled(2, True)
             self.plotTabs.setCurrentWidget(self.combinedTab)
@@ -304,7 +302,6 @@ class DesignWindow(QDialog, Ui_Shape2SAS, Perspective):
             # Replot to ensure the scattering profile is generated when the checkbox is checked
             self.onClickingPlot()
         else:
-            print("Include Scattering unchecked")
             self.plotTabs.setTabEnabled(1, False)
             self.plotTabs.setTabEnabled(2, False)
             self.plotTabs.setCurrentWidget(self.viewerTab)

--- a/src/sas/qtgui/Calculators/Shape2SAS/ViewerModel.py
+++ b/src/sas/qtgui/Calculators/Shape2SAS/ViewerModel.py
@@ -3,7 +3,7 @@ from matplotlib.backends.backend_qtagg import FigureCanvasQTAgg as FigureCanvas
 from matplotlib.figure import Figure
 from PySide6.QtCore import QSize
 from PySide6.QtDataVisualization import Q3DScatter, QScatter3DSeries, QScatterDataItem, QValue3DAxis
-from PySide6.QtGui import QColor, QVector3D, Qt
+from PySide6.QtGui import QColor, Qt, QVector3D
 from PySide6.QtWidgets import QGraphicsScene, QGraphicsView, QLabel, QSizePolicy, QSpacerItem, QVBoxLayout, QWidget
 
 from sas.qtgui.Calculators.Shape2SAS.PlotAspects.plotAspects import ViewerPlotDesign

--- a/src/sas/qtgui/Calculators/Shape2SAS/ViewerModel.py
+++ b/src/sas/qtgui/Calculators/Shape2SAS/ViewerModel.py
@@ -3,7 +3,7 @@ from matplotlib.backends.backend_qtagg import FigureCanvasQTAgg as FigureCanvas
 from matplotlib.figure import Figure
 from PySide6.QtCore import QSize
 from PySide6.QtDataVisualization import Q3DScatter, QScatter3DSeries, QScatterDataItem, QValue3DAxis
-from PySide6.QtGui import QColor, QVector3D
+from PySide6.QtGui import QColor, QVector3D, Qt
 from PySide6.QtWidgets import QGraphicsScene, QGraphicsView, QLabel, QSizePolicy, QSpacerItem, QVBoxLayout, QWidget
 
 from sas.qtgui.Calculators.Shape2SAS.PlotAspects.plotAspects import ViewerPlotDesign
@@ -12,6 +12,36 @@ from sas.qtgui.Calculators.Shape2SAS.PlotAspects.plotAspects import ViewerPlotDe
 from sas.qtgui.Calculators.Shape2SAS.ViewerAllOptions import ViewerButtons, ViewerModelRadius
 from sas.sascalc.shape2sas.Models import ModelPointDistribution
 from sas.sascalc.shape2sas.TheoreticalScattering import TheoreticalScattering
+
+
+class ResponsiveGraphicsView(QGraphicsView):
+    """QGraphicsView that keeps its scene fitted to the available area."""
+
+    def fitScene(self):
+        """Fit the scene to the view, keeping the aspect ratio."""
+        
+        scene = self.scene()
+
+        if scene is None:
+            return
+
+        # Get the bounding rectangle of all items in the scene
+        scene_rect = scene.itemsBoundingRect()
+
+        if scene_rect.isEmpty():
+            return
+
+        # Set the scene rectangle and fit it to the view
+        self.setSceneRect(scene_rect)
+        self.fitInView(
+            scene_rect,
+            Qt.AspectRatioMode.KeepAspectRatio,
+        )
+
+    def resizeEvent(self, event):
+        """Handle the resize event to keep the scene fitted."""
+        super().resizeEvent(event)
+        self.fitScene()
 
 
 class ViewerModel(QWidget):
@@ -65,9 +95,11 @@ class ViewerModel(QWidget):
         self.viewerModelRadius.doubleSpinBox.valueChanged.connect(self.setZoom)
 
         #2D plot of P(q)
-        self.scattering = QGraphicsView()
+        self.scattering = ResponsiveGraphicsView()
         self.scattering.setMinimumSize(QSize(271, 271))
         self.scattering.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Expanding)
+        self.scattering.setHorizontalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAlwaysOff)
+        self.scattering.setVerticalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAlwaysOff)
         self.scattering.setBackgroundBrush(QColor(255, 255, 255))
         self.scene = QGraphicsScene()
         self.scattering.setScene(self.scene)
@@ -97,6 +129,12 @@ class ViewerModel(QWidget):
         self.scene.clear()
 
         figure = Figure()
+        figure.subplots_adjust(
+            left=0.16,
+            right=0.96,
+            top=0.90,
+            bottom=0.15,
+        )
         ax = figure.add_subplot(111)
         ax.set_title("P(q) plot")
         ax.set_xlabel("q")
@@ -111,9 +149,11 @@ class ViewerModel(QWidget):
 
 
         canvas = FigureCanvas(figure)
+        canvas.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Expanding)
+        canvas.updateGeometry()
         self.scene.addWidget(canvas)
-        self.scattering.fitInView(self.scene.sceneRect())
-        self.scatter.show()
+        self.scattering.fitScene()
+        canvas.draw_idle()
 
     def initialiseAxis(self):
         """Initialise axis for the model"""

--- a/src/sas/qtgui/Calculators/Shape2SAS/ViewerModel.py
+++ b/src/sas/qtgui/Calculators/Shape2SAS/ViewerModel.py
@@ -3,8 +3,8 @@ from matplotlib.backends.backend_qtagg import FigureCanvasQTAgg as FigureCanvas
 from matplotlib.figure import Figure
 from PySide6.QtCore import QSize
 from PySide6.QtDataVisualization import Q3DScatter, QScatter3DSeries, QScatterDataItem, QValue3DAxis
-from PySide6.QtGui import QColor, Qt, QVector3D
-from PySide6.QtWidgets import QGraphicsScene, QGraphicsView, QLabel, QSizePolicy, QSpacerItem, QVBoxLayout, QWidget
+from PySide6.QtGui import QVector3D
+from PySide6.QtWidgets import QLabel, QSizePolicy, QSpacerItem, QVBoxLayout, QWidget
 
 from sas.qtgui.Calculators.Shape2SAS.PlotAspects.plotAspects import ViewerPlotDesign
 
@@ -14,34 +14,39 @@ from sas.sascalc.shape2sas.Models import ModelPointDistribution
 from sas.sascalc.shape2sas.TheoreticalScattering import TheoreticalScattering
 
 
-class ResponsiveGraphicsView(QGraphicsView):
-    """QGraphicsView that keeps its scene fitted to the available area."""
+class SquarePlotContainer(QWidget):
+    """Container that keeps its child canvas square and centred."""
 
-    def fitScene(self):
-        """Fit the scene to the view, keeping the aspect ratio."""
+    def __init__(self, canvas, parent=None):
+        super().__init__(parent)
 
-        scene = self.scene()
+        self.canvas = canvas
+        self.canvas.setParent(self)
 
-        if scene is None:
-            return
-
-        # Get the bounding rectangle of all items in the scene
-        scene_rect = scene.itemsBoundingRect()
-
-        if scene_rect.isEmpty():
-            return
-
-        # Set the scene rectangle and fit it to the view
-        self.setSceneRect(scene_rect)
-        self.fitInView(
-            scene_rect,
-            Qt.AspectRatioMode.KeepAspectRatio,
+        self.setSizePolicy(
+            QSizePolicy.Policy.Expanding,
+            QSizePolicy.Policy.Expanding,
         )
 
+        # Prevent the combined layout from crushing the plot completely.
+        self.setMinimumSize(QSize(250, 250))
+
     def resizeEvent(self, event):
-        """Handle the resize event to keep the scene fitted."""
+        """Resize the canvas to be square and centred within the container."""
         super().resizeEvent(event)
-        self.fitScene()
+
+        width = self.width()
+        height = self.height()
+
+        # Use whichever available dimension is smaller.
+        side = min(width, height)
+
+        # Centre the square canvas inside the container.
+        x = (width - side) // 2
+        y = (height - side) // 2
+
+        self.canvas.setGeometry(x, y, side, side)
+        self.canvas.draw_idle()
 
 
 class ViewerModel(QWidget):
@@ -96,14 +101,24 @@ class ViewerModel(QWidget):
         self.viewerModelRadius.doubleSpinBox.valueChanged.connect(self.setZoom)
 
         # 2D plot of P(q)
-        self.scattering = ResponsiveGraphicsView()
-        self.scattering.setMinimumSize(QSize(271, 271))
-        self.scattering.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Expanding)
-        self.scattering.setHorizontalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAlwaysOff)
-        self.scattering.setVerticalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAlwaysOff)
-        self.scattering.setBackgroundBrush(QColor(255, 255, 255))
-        self.scene = QGraphicsScene()
-        self.scattering.setScene(self.scene)
+        self.scatteringFigure = Figure(dpi=120)
+        self.scatteringFigure.subplots_adjust(
+            left=0.16,
+            right=0.96,
+            top=0.90,
+            bottom=0.15,
+        )
+
+        self.scatteringAxes = self.scatteringFigure.add_subplot(111)
+
+        self.scattering = FigureCanvas(self.scatteringFigure)
+        self.scattering.setSizePolicy(
+            QSizePolicy.Policy.Expanding,
+            QSizePolicy.Policy.Expanding,
+        )
+
+        # Create a container to keep the scattering plot square and centered
+        self.scatteringContainer = SquarePlotContainer(self.scattering)
 
         ###Layout for GUI
         layout = QVBoxLayout()
@@ -117,43 +132,26 @@ class ViewerModel(QWidget):
         layout.addWidget(self.viewerModelRadius)
         layout.addItem(spacer)
         layout.addWidget(subunitTableLabel)
-        layout.addWidget(self.scattering)
-
-        self.setLayout(layout)
-
-        self.Viewmodel_modul = QWidget()
-        self.Viewmodel_modul.setLayout(layout)
 
     def setScatteringPlot(self, theo: TheoreticalScattering):
-        """Set the scattering plot"""
+        """Set the scattering plot."""
 
-        self.scene.clear()
+        ax = self.scatteringAxes
+        ax.clear()
 
-        figure = Figure()
-        figure.subplots_adjust(
-            left=0.16,
-            right=0.96,
-            top=0.90,
-            bottom=0.15,
-        )
-        ax = figure.add_subplot(111)
         ax.set_title("P(q) plot")
         ax.set_xlabel("q")
         ax.set_ylabel("P(q)")
+
         ax.plot(theo.q, theo.I, "-k", label="P(q)")
 
         ax.set_xscale("log")
         ax.set_yscale("log")
 
-        ax.legend()
         ax.grid(True)
 
-        canvas = FigureCanvas(figure)
-        canvas.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Expanding)
-        canvas.updateGeometry()
-        self.scene.addWidget(canvas)
-        self.scattering.fitScene()
-        canvas.draw_idle()
+        # Redraw at the canvas's current widget size.
+        self.scattering.draw_idle()
 
     def initialiseAxis(self):
         """Initialise axis for the model"""
@@ -279,7 +277,8 @@ class ViewerModel(QWidget):
 
     def setClearScatteringPlot(self):
         """Clear the Scattering plot"""
-        self.scene.clear()
+        self.scatteringAxes.clear()
+        self.scattering.draw_idle()
 
     def setClearModelPlot(self):
         """Clear the model plot"""
@@ -290,7 +289,6 @@ class ViewerModel(QWidget):
             series.dataProxy().resetArray(data)
 
         # reset view
-        self.scene.clear()
         self.scatter.scene().activeCamera().setCameraPosition(0, 0, 110)
 
         # reset axis

--- a/src/sas/qtgui/Calculators/Shape2SAS/ViewerModel.py
+++ b/src/sas/qtgui/Calculators/Shape2SAS/ViewerModel.py
@@ -19,7 +19,7 @@ class ResponsiveGraphicsView(QGraphicsView):
 
     def fitScene(self):
         """Fit the scene to the view, keeping the aspect ratio."""
-        
+
         scene = self.scene()
 
         if scene is None:
@@ -46,6 +46,7 @@ class ResponsiveGraphicsView(QGraphicsView):
 
 class ViewerModel(QWidget):
     """Graphics view of designed model"""
+
     def __init__(self, parent=None):
         super().__init__()
 
@@ -83,7 +84,7 @@ class ViewerModel(QWidget):
 
         self.initialiseAxis()
 
-        #General controls
+        # General controls
         ### xy, xz, yz buttons (Class ViewerButtons)
         self.viewerButtons = ViewerButtons()
         self.viewerModelRadius = ViewerModelRadius()
@@ -94,7 +95,7 @@ class ViewerModel(QWidget):
         self.scatter.scene().activeCamera().zoomLevelChanged.connect(self.onZoomChanged)
         self.viewerModelRadius.doubleSpinBox.valueChanged.connect(self.setZoom)
 
-        #2D plot of P(q)
+        # 2D plot of P(q)
         self.scattering = ResponsiveGraphicsView()
         self.scattering.setMinimumSize(QSize(271, 271))
         self.scattering.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Expanding)
@@ -106,7 +107,7 @@ class ViewerModel(QWidget):
 
         ###Layout for GUI
         layout = QVBoxLayout()
-        layout.setContentsMargins(0, 10, 0, 0)#remove margins
+        layout.setContentsMargins(0, 10, 0, 0)  # remove margins
 
         spacer = QSpacerItem(271, 20, QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Fixed)
         subunitTableLabel = QLabel("Scattering of P(q)")
@@ -141,12 +142,11 @@ class ViewerModel(QWidget):
         ax.set_ylabel("P(q)")
         ax.plot(theo.q, theo.I, "-k", label="P(q)")
 
-        ax.set_xscale('log')
-        ax.set_yscale('log')
+        ax.set_xscale("log")
+        ax.set_yscale("log")
 
         ax.legend()
         ax.grid(True)
-
 
         canvas = FigureCanvas(figure)
         canvas.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Expanding)
@@ -199,7 +199,7 @@ class ViewerModel(QWidget):
         max_range = max(x_max - x_min, y_max - y_min, z_max - z_min)
 
         # Add some padding
-        half_range = (max_range*1.1) / 2
+        half_range = (max_range * 1.1) / 2
 
         # Set equal ranges for all axes centered on their respective centers
         self.X_ax.setRange(x_center - half_range, x_center + half_range)
@@ -216,8 +216,8 @@ class ViewerModel(QWidget):
         colours = design.colour
 
         for series in self.dict_series.values():
-           data = []
-           series.dataProxy().resetArray(data)
+            data = []
+            series.dataProxy().resetArray(data)
 
         # Check if we have any data at all
         if not distr.x or len(distr.x) == 0:
@@ -230,9 +230,7 @@ class ViewerModel(QWidget):
         for subunit in range(len(colours)):
             # Skip empty subunits - handle numpy arrays properly
             try:
-                if (subunit >= len(distr.x)
-                        or not hasattr(distr.x[subunit], '__len__')
-                        or len(distr.x[subunit]) == 0):
+                if subunit >= len(distr.x) or not hasattr(distr.x[subunit], "__len__") or len(distr.x[subunit]) == 0:
                     continue
             except (ValueError, TypeError):
                 # Handle numpy array comparison issues
@@ -241,7 +239,11 @@ class ViewerModel(QWidget):
             series = self.dict_series[colours[subunit]]
             data = []
             for index in range(len(distr.x[subunit])):
-                data.append(QScatterDataItem(QVector3D(distr.x[subunit][index], distr.y[subunit][index], distr.z[subunit][index])))
+                data.append(
+                    QScatterDataItem(
+                        QVector3D(distr.x[subunit][index], distr.y[subunit][index], distr.z[subunit][index])
+                    )
+                )
 
             minx = min(minx, min(distr.x[subunit]))
             maxx = max(maxx, max(distr.x[subunit]))
@@ -282,14 +284,14 @@ class ViewerModel(QWidget):
     def setClearModelPlot(self):
         """Clear the model plot"""
 
-        #reset model
+        # reset model
         for series in self.dict_series.values():
             data = []
             series.dataProxy().resetArray(data)
 
-        #reset view
+        # reset view
         self.scene.clear()
         self.scatter.scene().activeCamera().setCameraPosition(0, 0, 110)
 
-        #reset axis
+        # reset axis
         self.setAxis((-10, 10), (-10, 10), (-10, 10))


### PR DESCRIPTION
## Description

Changes the layout of plots in the tool window to be tabbed instead of vertically stacked to give plots more space.

Also reformats and cleans up some of the code in the changed files.

Fixes #4044 

## How Has This Been Tested?

Manually tested.

## Review Checklist:

**Documentation**
- [ ] There is **nothing** that needs documenting
- [x] Documentation changes are **in this PR** -- will add as final commit after design finalised.
- [ ] There is an **issue** open for the documentation

**Installers**
- [ ] There is a chance this will affect the **installers**, if so
  - [ ] **Windows** installer (GH artifact) has been tested (installed and worked) 
  - [ ] **MacOSX** installer (GH artifact) has been tested (installed and worked)
  - [ ] **Wheels** installer (GH artifact) has been tested (installed and worked)

**Licensing**
- [x] The introduced changes comply with SasView license (BSD 3-Clause)

