### PR TITLE
4064: Fix call to setSlicer post API change

### DIFF
--- a/src/sas/qtgui/Plotting/SlicerParameters.py
+++ b/src/sas/qtgui/Plotting/SlicerParameters.py
@@ -740,7 +740,7 @@ class SlicerParameters(QtWidgets.QDialog, Ui_SlicerParametersUI):
         if slicer is None:
             plotter.onClearSlicer()
             return
-        plotter.setSlicer(slicer=slicer, reset=False)
+        plotter.setSlicer(slicer=slicer)
         # override slicer model
         plotter.slicer._model = self.model
         # force conversion model->parameters in slicer


### PR DESCRIPTION
## Description

`Plotter2d.setSlicer()` was changed when multi slicers were added, but a call to the method from within the `SlicerParameter` widget was not updated to match the new method signature. This caused an issue in batch slicing, which this PR should fix.

Fixes #4064

## How Has This Been Tested?

Tested locally, from source, and batch slicing seems to work again.

## Review Checklist:

**Documentation** (check at least one)
- [x] There is **nothing** that needs documenting
- [ ] Documentation changes are **in this PR**
- [ ] There is an **issue** open for the documentation (link?)

**Installers**
- [ ] There is a chance this will affect the **installers**, if so
  - [ ] **Windows** installer (GH artifact) has been tested (installed and worked) 
  - [ ] **MacOSX** installer (GH artifact) has been tested (installed and worked)
  - [ ] **Wheels** installer (GH artifact) has been tested (installed and worked)

**Licensing** (untick if necessary)
- [x] The introduced changes comply with SasView license (BSD 3-Clause)

