### PR TITLE
fix the fit_started flag enablement. #3949

### DIFF
--- a/src/sas/qtgui/Perspectives/Fitting/ConstraintWidget.py
+++ b/src/sas/qtgui/Perspectives/Fitting/ConstraintWidget.py
@@ -393,12 +393,14 @@ class ConstraintWidget(QtWidgets.QWidget, Ui_ConstraintWidgetUI):
         """
         if not self.is_running:
             return
-        self.is_running = False
+        # stop the fit thread
+        self.calc_fit.stop()
+
         #re-enable the Fit button
         self.cmdFit.setStyleSheet(BG_DEFAULT)
         self.cmdFit.setText("Fit")
-        # stop the fit thread
-        self.calc_fit.stop()
+
+        self.is_running = False
         # re-enable the fit pages participating in the fit
         self.parent.fittingStoppedSignal.emit(self.getTabsForFit())
         self.parent.communicator.statusBarUpdateSignal.emit("Fitting cancelled.")

--- a/src/sas/qtgui/Perspectives/Fitting/ConstraintWidget.py
+++ b/src/sas/qtgui/Perspectives/Fitting/ConstraintWidget.py
@@ -292,12 +292,7 @@ class ConstraintWidget(QtWidgets.QWidget, Ui_ConstraintWidgetUI):
         """
         # Stop if we're running
         if self.is_running:
-            self.is_running = False
-            #re-enable the Fit button
-            self.cmdFit.setStyleSheet(BG_DEFAULT)
-            self.cmdFit.setText("Fit")
-            # stop the fitpages
-            self.calc_fit.stop()
+            self.stopFit()
             return
 
         # Find out all tabs to fit
@@ -391,6 +386,22 @@ class ConstraintWidget(QtWidgets.QWidget, Ui_ConstraintWidgetUI):
         self.cmdFit.setText('Stop fit')
         self.parent.communicator.statusBarUpdateSignal.emit('Fitting started...')
         self.is_running = True
+
+    def stopFit(self):
+        """
+        Attempt to stop the running constrained/simultaneous fit
+        """
+        if not self.is_running:
+            return
+        self.is_running = False
+        #re-enable the Fit button
+        self.cmdFit.setStyleSheet(BG_DEFAULT)
+        self.cmdFit.setText("Fit")
+        # stop the fit thread
+        self.calc_fit.stop()
+        # re-enable the fit pages participating in the fit
+        self.parent.fittingStoppedSignal.emit(self.getTabsForFit())
+        self.parent.communicator.statusBarUpdateSignal.emit("Fitting cancelled.")
 
     def onHelp(self):
         """

--- a/src/sas/qtgui/Perspectives/Fitting/FittingWidget.py
+++ b/src/sas/qtgui/Perspectives/Fitting/FittingWidget.py
@@ -1478,6 +1478,11 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
             self.stopFit()
             return
 
+        # If this page takes part in a running constrained/simultaneous fit,
+        # the button reads 'Stop fit', so stop that fit instead of starting a new one
+        if self.stopConstrainedFit():
+            return
+
         # initialize fitter constants
         handler = None
         batch_inputs = {}
@@ -1530,6 +1535,22 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
 
         # Disable some elements
         self.disableInteractiveElements()
+
+    def stopConstrainedFit(self) -> bool:
+        """
+        Stop the constrained/simultaneous fit this page takes part in, if any.
+        Returns True if a running constrained fit was stopped.
+        """
+        if self.parent is None:
+            return False
+        constraint_tab = self.parent.perspective().getConstraintTab()
+        if constraint_tab is None or not constraint_tab.is_running:
+            return False
+        page_name = "Page%s" % self.tab_id
+        if not any(page_name in tab for tab in constraint_tab.getTabsForFit()):
+            return False
+        constraint_tab.stopFit()
+        return True
 
     def stopFit(self) -> None:
         """


### PR DESCRIPTION
## Description

When a constrained fit starts, ConstraintWidget emits `fittingStartedSignal`, and the perspective calls `disableInteractiveElements()` on each participating fit page but never set that page's `fit_started` flag.
Clicking "Stop fit" on the M2 page ran FittingWidget.onFit(). Since fit_started was set to False, it started a brand-new single-page fit while the constrained fit was still running...

`FittingWidget.onFit` now checks whether the page is running C/S fit
If so, it delegates the stop to the constraint tab instead of launching a new fit.

Fixes #3949

## How Has This Been Tested?

Locally on win11

## Review Checklist:

[if using the editor, use `[x]` in place of `[ ]` to check a box]

**Documentation** (check at least one)
- [X] There is **nothing** that needs documenting
- [ ] Documentation changes are **in this PR**
- [ ] There is an **issue** open for the documentation (link?)

**Installers**
- [ ] There is a chance this will affect the **installers**, if so
  - [ ] **Windows** installer (GH artifact) has been tested (installed and worked) 
  - [ ] **MacOSX** installer (GH artifact) has been tested (installed and worked)
  - [ ] **Wheels** installer (GH artifact) has been tested (installed and worked)

**Licensing** (untick if necessary)
- [x] The introduced changes comply with SasView license (BSD 3-Clause)

