### PR TITLE
Don't calculate magnetic models if magnetism is not toggled.

### DIFF
--- a/src/sas/qtgui/Perspectives/Fitting/FittingWidget.py
+++ b/src/sas/qtgui/Perspectives/Fitting/FittingWidget.py
@@ -1391,7 +1391,7 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         category = self.cbCategory.currentText()
         # Check if the user chose "Choose category entry"
         if category == CATEGORY_DEFAULT:
-            # if the previous category was not the default, keep it.
+            # if the previous  was not the default, keep it.
             # Otherwise, just return
             if self._previous_category_index != 0:
                 # We need to block signals, or else state changes on perceived unchanged conditions
@@ -1412,8 +1412,16 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         if self.model_data is not None:
             # Store any old parameters before switching to a new category
             self.page_parameters = self.getParameterDict()
-        # Wipe out the parameter model
+        # Wipe out the parameter model and related sub-models
         self._model_model.clear()
+        # Clear polydispersity state
+        self.polydispersity_widget.poly_model.clear()
+        self.polydispersity_widget.poly_params = {}
+        self.polydispersity_widget.poly_params_to_fit = []
+        # Clear magnetism state
+        self.magnetism_widget._magnet_model.clear()
+        self.magnetism_widget.magnet_params = {}
+        self.magnetism_widget.magnet_params_to_fit = []
         # Safely clear and enable the model combo
         self.cbModel.blockSignals(True)
         self.cbModel.clear()

--- a/src/sas/qtgui/Perspectives/Fitting/MagnetismWidget.py
+++ b/src/sas/qtgui/Perspectives/Fitting/MagnetismWidget.py
@@ -75,7 +75,10 @@ class MagnetismWidget(QtWidgets.QWidget, Ui_MagnetismWidgetUI):
         if not self.logic.model_parameters:
             return
         self._magnet_model.clear()
-        # default initial value
+        # Add the magnetic parameters to the table.
+        # 2026-08-13 PAK: Initialize M0 values with defaults from the model (typically zero).
+        # The previous code initialized them to 0.5, 1.0, 1.5, etc., though this was
+        # not obvious since magnetic theta defaulted to zero.
         for param in self.logic.model_parameters.call_parameters:
             if param.type == 'magnetic':
                 self.addCheckedMagneticListToModel(param, param.default)

--- a/src/sas/qtgui/Perspectives/Fitting/MagnetismWidget.py
+++ b/src/sas/qtgui/Perspectives/Fitting/MagnetismWidget.py
@@ -76,16 +76,9 @@ class MagnetismWidget(QtWidgets.QWidget, Ui_MagnetismWidgetUI):
             return
         self._magnet_model.clear()
         # default initial value
-        m0 = 0.5
         for param in self.logic.model_parameters.call_parameters:
-            if param.type != 'magnetic':
-                continue
-            if "M0" in param.name:
-                m0 += 0.5
-                value = m0
-            else:
-                value = param.default
-            self.addCheckedMagneticListToModel(param, value)
+            if param.type == 'magnetic':
+                self.addCheckedMagneticListToModel(param, param.default)
 
         FittingUtilities.addHeadersToModel(self._magnet_model)
 
@@ -154,10 +147,12 @@ class MagnetismWidget(QtWidgets.QWidget, Ui_MagnetismWidgetUI):
             self.updateDataSignal.emit()
 
     def updateModel(self, model: Any | None = None) -> None:
-        # add magnetic parameters if asked
-        if self.isActive and self._magnet_model.rowCount() > 0:
+        """
+        Set model magnetism parameters from widget if magnetism is active, otherwise zero them.
+        """
+        if self._magnet_model.rowCount() > 0:
             for key, value in self.magnet_params.items():
-                model.setParam(key, value)
+                model.setParam(key, value if self.isActive else 0.)
 
     def toggleMagnetism(self, isChecked: bool) -> None:
         """


### PR DESCRIPTION
## Description

Leaves the M0 values as their default (zero) when initializing the model.

Sets the magnetic parameters in the model to zero if magnetism is not active. This causes sasmodels to use Iqxy rather than Imagnetic to compute the 2D models.

This incidentally fixes the problem with a mixed magnetic and pure python model, which otherwise failed in sasmodels because the pure python model don't yet handle magnetism.

Fixes #4071

## How Has This Been Tested?

Start sasview with a sphere model, toggle 2D and plot. Verify that there is no asymmetry.

Toggle magnetism and check that M0 are all zero.

Set sld_M0 to 10, set sld_mtheta to 90 and plot. Shows asymmetry.

Toggle magnetism and plot. Shows no asymmetry.

Toggle magnetism and plot. Shows asymmetry again from values stored in the magnetism widget.

Load 2d magnetic data set and send to fitting.

Toggle radius and scale fit.

Toggle magnetism, and toggle sld_M0 and sld_mphi fit.

Start the fit. Verify that radius, scale, sld_M0 and sld_mphi are being updated.

Stop the fit, toggle magnetism and plot. No asymmetry.

Save analysis as non magnetic.

Toggle magnetism and save analysis as magnetic.

Restart sasview and load nonmagnetic analysis. Plot shows no asymmetry.

Toggle magnetism and plot. Shows asymmetry.

Restart sasview and load magnetic analysis. Plot shows asymmetry.

## Review Checklist:

[if using the editor, use `[x]` in place of `[ ]` to check a box]

**Documentation** (check at least one)
- [ ] There is **nothing** that needs documenting
- [ ] Documentation changes are **in this PR**
- [ ] There is an **issue** open for the documentation (link?)

**Installers**
- [ ] There is a chance this will affect the **installers**, if so
  - [ ] **Windows** installer (GH artifact) has been tested (installed and worked) 
  - [ ] **MacOSX** installer (GH artifact) has been tested (installed and worked)
  - [ ] **Wheels** installer (GH artifact) has been tested (installed and worked)

**Licensing** (untick if necessary)
- [x] The introduced changes comply with SasView license (BSD 3-Clause)

