### PR TITLE
Metadata tweaks

### DIFF
--- a/build_tools/application_metadata/org.sasview.sasview.desktop
+++ b/build_tools/application_metadata/org.sasview.sasview.desktop
@@ -5,7 +5,7 @@ GenericName=Small Angle Scattering Analysis
 Comment=Small Angle Scattering Analysis
 Exec=sasview
 # TRANSLATORS: Search terms to find this application. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
-Keywords=SAS;SANS;SAXS;scattering;neutron scattering;X-ray scattering;physics
+Keywords=SAS;SANS;SAXS;scattering;neutron scattering;X-ray scattering;physics;
 Icon=org.sasview.sasview
 Terminal=false
 Type=Application

--- a/build_tools/application_metadata/org.sasview.sasview.metainfo.xml
+++ b/build_tools/application_metadata/org.sasview.sasview.metainfo.xml
@@ -5,7 +5,7 @@
   <name>SasView</name>
   <project_license>BSD-3-Clause</project_license>
   <metadata_license>CC0</metadata_license>
-  <summary> SasView is a Small Angle Scattering Analysis Software Package</summary>
+  <summary>Small Angle Scattering Analysis</summary>
   <developer id="org.sasview">
     <name>SasView Developers</name>
   </developer>
@@ -27,7 +27,7 @@
   <provides>org.sasview.sasview.desktop</provides>
 
   <description>
-    <p>SasView is an open source Small Angle Scattering (SAS) analysis package used to analyze 1D and 2D scattering data in inverse space. Originally focused on neutron data (SANS), the package has been extended for X-ray scattering and correlation space methods such as SESANS and Interferometry. SasView includes a number of other features, include PrView to invert SAS data to P(r), a resolution calculator, and a scattering length density calculator, to name a few. The package also has a simple plugin mechanism for users to add custom models.</p>
+    <p>An open source Small Angle Scattering (SAS) analysis package used to analyze 1D and 2D scattering data in inverse space. Originally focused on neutron data (SANS), the package has been extended for X-ray scattering and correlation space methods such as SESANS and Interferometry. SasView includes a number of other features, include PrView to invert SAS data to P(r), a resolution calculator, and a scattering length density calculator, to name a few. The package also has a simple plugin mechanism for users to add custom models.</p>
   </description>
 
   <screenshots>


### PR DESCRIPTION
## Description

Makes some minor improvements to the metadata of the application which is displayed on the Flathub page.

One change affected the the summary line, which has been made shorter so that it fits better onto the page (the old one was too long).

I have labeled this as a draft PR because I am not sure which branch this should be merged in. It might be best to wait until the release branch is merged into main, and then I can rebase this.

## How Has This Been Tested?

There are no code changes in this PR.

## Review Checklist:

[if using the editor, use `[x]` in place of `[ ]` to check a box]

**Documentation** (check at least one)
- [x] There is **nothing** that needs documenting
- [ ] Documentation changes are **in this PR**
- [ ] There is an **issue** open for the documentation (link?)

**Installers**
- [ ] There is a chance this will affect the **installers**, if so
  - [ ] **Windows** installer (GH artifact) has been tested (installed and worked) 
  - [ ] **MacOSX** installer (GH artifact) has been tested (installed and worked)
  - [ ] **Wheels** installer (GH artifact) has been tested (installed and worked)

**Licensing** (untick if necessary)
- [x] The introduced changes comply with SasView license (BSD 3-Clause)

