### PR TITLE
Fix polydispersity plots

### DIFF
--- a/src/sas/qtgui/Perspectives/Fitting/FittingUtilities.py
+++ b/src/sas/qtgui/Perspectives/Fitting/FittingUtilities.py
@@ -661,7 +661,7 @@ def plotPolydispersities(model):
         data1d.yaxis(r'\rm{probability}', 'normalized')
         data1d.scale = 'linear'
         data1d.symbol = 'Line'
-        data1d.name = f"{name} polydispersity"
+        data1d.name = f"{name}"
         data1d.id = data1d.name # placeholder, has to be completed later
         data1d.plot_role = DataRole.ROLE_POLYDISPERSITY
         plots.append(data1d)

--- a/src/sas/qtgui/Perspectives/Fitting/FittingWidget.py
+++ b/src/sas/qtgui/Perspectives/Fitting/FittingWidget.py
@@ -76,6 +76,7 @@ if not hasattr(SasviewModel, 'get_weights'):
     SasviewModel.get_weights = get_weights
 
 logger = logging.getLogger(__name__)
+polydispersity_plot_name = "{} {} polydispersity {}"
 
 class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
     """
@@ -684,6 +685,7 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         self.polydispersity_widget.cmdFitSignal.connect(lambda: self.cmdFit.setEnabled(self.haveParamsToFit()))
         self.polydispersity_widget.updateDataSignal.connect(lambda: self.updateData())
         self.polydispersity_widget.iterateOverModelSignal.connect(lambda: self.iterateOverModel(self.updateFunctionCaption))
+        self.polydispersity_widget.deletePlotSignal.connect(self.setPlotDeletable)
         self.polydispersity_widget.toggledSignal.connect(self.onPolyToggled)
         self.magnetism_widget.cmdFitSignal.connect(lambda: self.cmdFit.setEnabled(self.haveParamsToFit()))
         self.magnetism_widget.updateDataSignal.connect(lambda: self.updateData())
@@ -712,7 +714,7 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         """
         Returns model name, by default M<tab#>, e.g. M1, M2
         """
-        return "M%i" % self.tab_id
+        return f"M{self.tab_id}"
 
     def nameForFittedData(self, name: str) -> str:
         """
@@ -720,7 +722,7 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         """
         if self.is2D:
             name += "2d"
-        name = "%s [%s]" % (self.modelName(), name)
+        name = f"{self.modelName()} [{name}]"
         return name
 
     def showModelContextMenu(self, position: QtCore.QPoint) -> None:
@@ -1687,14 +1689,23 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         chi2_repr = GuiUtils.formatNumber(self.chi2, high=True)
         self.lblChi2Value.setText(chi2_repr)
 
-    def preparePlotsForDeletion(self, redundant_role):
+    def preparePlotsForDeletion(self, redundant_role: DataRole):
         """If plots with a particular role are no longer required, change their role to ROLE_DELETABLE."""
         item_model = self.all_data[self.data_index].model()
-        plots = GuiUtils.plotsFromDisplayName(self.data.name, item_model)
-        plot_items = plots.items()
-        for _, plot in plot_items:
+        plots = GuiUtils.plotsFromDisplayName(self.data.name, item_model).values()
+        for plot in plots:
             if plot.plot_role == redundant_role:
                 plot.plot_role = DataRole.ROLE_DELETABLE
+
+    def setPlotDeletable(self, parameter_name: str) -> None:
+        """Set the plot role to ROLE_DELETABLE for the polydispersity plot with the given parameter name."""
+        item_model = self.all_data[self.data_index].model()
+        plots = GuiUtils.plotsFromDisplayName(self.data.name, item_model).values()
+        data_name = self.nameForFittedData(self.data.name).split()
+        poly_plot_name = polydispersity_plot_name.format(data_name[0], parameter_name, " ".join(data_name[1:]))
+        poly_plots = [plot for plot in plots if plot.name == poly_plot_name]
+        for plot in poly_plots:
+            plot.plot_role = DataRole.ROLE_DELETABLE
 
     def prepareFitters(self, fitter: Fit | None = None, fit_id: int = 0, weight_increase: int = 1) -> tuple[list[Fit], int]:
         """
@@ -2532,9 +2543,9 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         """
         for plot in FittingUtilities.plotPolydispersities(return_data.get('model', None)):
             data_id = fitted_data.id.split()
-            plot.id = "{} [{}] {}".format(data_id[0], plot.name, " ".join(data_id[1:]))
+            plot.id = "{} [{} polydispersity] {}".format(data_id[0], plot.name, " ".join(data_id[1:]))
             data_name = fitted_data.name.split()
-            plot.name = " ".join([data_name[0], plot.name] + data_name[1:])
+            plot.name = polydispersity_plot_name.format(data_name[0], plot.name, " ".join(data_name[1:]))
             self.createNewIndex(plot)
             new_plots.append(plot)
 

--- a/src/sas/qtgui/Perspectives/Fitting/FittingWidget.py
+++ b/src/sas/qtgui/Perspectives/Fitting/FittingWidget.py
@@ -564,6 +564,7 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         # Check if any parameters are ready for fitting
         self.cmdFit.setEnabled(self.haveParamsToFit())
         self.polydispersity_widget.togglePoly(isChecked)
+        self.updateData()
 
     def onPolyToggled(self, isChecked: bool) -> None:
         """
@@ -1675,6 +1676,10 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
 
         self.magnetism_widget.updateMagnetModelFromList(param_dict)
 
+        # Clean up polydispersity plots if polydispersity has been disabled
+        if not self.chkPolydispersity.isChecked():
+            self.preparePlotsForDeletion(DataRole.ROLE_POLYDISPERSITY)
+
         # update charts
         self.onPlot()
 
@@ -1682,6 +1687,14 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         chi2_repr = GuiUtils.formatNumber(self.chi2, high=True)
         self.lblChi2Value.setText(chi2_repr)
 
+    def preparePlotsForDeletion(self, redundant_role):
+        """If plots with a particular role are no longer required, change their role to ROLE_DELETABLE."""
+        item_model = self.all_data[self.data_index].model()
+        plots = GuiUtils.plotsFromDisplayName(self.data.name, item_model)
+        plot_items = plots.items()
+        for _, plot in plot_items:
+            if plot.plot_role == redundant_role:
+                plot.plot_role = DataRole.ROLE_DELETABLE
 
     def prepareFitters(self, fitter: Fit | None = None, fit_id: int = 0, weight_increase: int = 1) -> tuple[list[Fit], int]:
         """

--- a/src/sas/qtgui/Perspectives/Fitting/FittingWidget.py
+++ b/src/sas/qtgui/Perspectives/Fitting/FittingWidget.py
@@ -2543,7 +2543,7 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         """
         for plot in FittingUtilities.plotPolydispersities(return_data.get('model', None)):
             data_id = fitted_data.id.split()
-            plot.id = "{} [{} polydispersity] {}".format(data_id[0], plot.name, " ".join(data_id[1:]))
+            plot.id = f"{data_id[0]} [{plot.name} polydispersity] {' '.join(data_id[1:])}"
             data_name = fitted_data.name.split()
             plot.name = polydispersity_plot_name.format(data_name[0], plot.name, " ".join(data_name[1:]))
             self.createNewIndex(plot)

--- a/src/sas/qtgui/Perspectives/Fitting/PolydispersityWidget.py
+++ b/src/sas/qtgui/Perspectives/Fitting/PolydispersityWidget.py
@@ -24,6 +24,7 @@ class PolydispersityWidget(QtWidgets.QWidget, Ui_PolydispersityWidgetUI):
     cmdFitSignal = QtCore.Signal()
     updateDataSignal = QtCore.Signal()
     iterateOverModelSignal = QtCore.Signal()
+    deletePlotSignal = QtCore.Signal(str)
     toggledSignal = QtCore.Signal(bool)  # Signal when polydispersity is enabled/disabled
 
     def __init__(self, parent: QtWidgets.QWidget | None = None) -> None:
@@ -165,6 +166,13 @@ class PolydispersityWidget(QtWidgets.QWidget, Ui_PolydispersityWidgetUI):
             except TypeError:
                 # Can't be converted properly, bring back the old value and exit
                 return
+
+            # If the polydispersity is changed to zero, prepare to delete an existing plot
+            if (model_column == delegate.poly_pd and
+                self.poly_params[f"{parameter_name}.width"] != 0.0 and
+                value == 0.0
+                ):
+                self.deletePlotSignal.emit(parameter_name)
 
             # Update the sasmodel
             # PD[ratio] -> width, npts -> npts, nsigs -> nsigmas


### PR DESCRIPTION
## Description

The routine `FittingUtilities.plotPolydispersities` correctly ignores polydispersity plots if there is no polydispersity for the parameter in question. However, this causes the bug outlined in #4066 when polydispersity is set to zero, or disabled, as the previous plots persist. This PR acts to set the plots are DELETABLE when these circumstances arise, resulting in them being cleaned up by exisiting code.

Fixes #4066

## How Has This Been Tested?

Follows procedure in #4066, results are as expected.

## Review Checklist:

[if using the editor, use `[x]` in place of `[ ]` to check a box]

**Documentation** (check at least one)
- [x] There is **nothing** that needs documenting
- [ ] Documentation changes are **in this PR**
- [ ] There is an **issue** open for the documentation (link?)

**Installers**
- [ ] There is a chance this will affect the **installers**, if so
  - [ ] **Windows** installer (GH artifact) has been tested (installed and worked) 
  - [ ] **MacOSX** installer (GH artifact) has been tested (installed and worked)
  - [ ] **Wheels** installer (GH artifact) has been tested (installed and worked)

**Licensing** (untick if necessary)
- [x] The introduced changes comply with SasView license (BSD 3-Clause)

