### PR TITLE
Fitting SASBDB auto-fill and CorMap support

### DIFF
--- a/src/sas/qtgui/Perspectives/Fitting/FittingPerspective.py
+++ b/src/sas/qtgui/Perspectives/Fitting/FittingPerspective.py
@@ -645,6 +645,16 @@ class FittingWindow(QtWidgets.QTabWidget, Perspective):
         fitting_widget = self.currentFittingWidget
         return None if fitting_widget is None else fitting_widget.getReport()
 
+    def getSASBDBData(self):
+        """ Get SASBDB export data from the current tab"""
+        fitting_widget = self.currentFittingWidget
+        if fitting_widget is None:
+            return None
+        # Check if the widget has the method (it should if it's a FittingWidget)
+        if hasattr(fitting_widget, 'getSASBDBData'):
+            return fitting_widget.getSASBDBData()
+        return None
+
     @property
     def supports_fitting_menu(self) -> bool:
         return True

--- a/src/sas/qtgui/Perspectives/Fitting/FittingWidget.py
+++ b/src/sas/qtgui/Perspectives/Fitting/FittingWidget.py
@@ -102,9 +102,6 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         # Which tab is this widget displayed in?
         self.tab_id = tab_id
 
-        import sys
-        sys.excepthook = self.info
-
         # Globals
         self.initializeGlobals()
 
@@ -188,9 +185,6 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         new_font = 'font-family: -apple-system, "Helvetica Neue", "Ubuntu";'
         self.label_17.setStyleSheet(new_font)
         self.label_19.setStyleSheet(new_font)
-
-    def info(self, type: Any, value: Any, tb: Any) -> None:
-        logger.error("".join(traceback.format_exception(type, value, tb)))
 
     @property
     def logic(self) -> FittingLogic:

--- a/src/sas/qtgui/Perspectives/Fitting/FittingWidget.py
+++ b/src/sas/qtgui/Perspectives/Fitting/FittingWidget.py
@@ -102,6 +102,9 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         # Which tab is this widget displayed in?
         self.tab_id = tab_id
 
+        import sys
+        sys.excepthook = self.info
+
         # Globals
         self.initializeGlobals()
 
@@ -185,6 +188,9 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         new_font = 'font-family: -apple-system, "Helvetica Neue", "Ubuntu";'
         self.label_17.setStyleSheet(new_font)
         self.label_19.setStyleSheet(new_font)
+
+    def info(self, type: Any, value: Any, tb: Any) -> None:
+        logger.error("".join(traceback.format_exception(type, value, tb)))
 
     @property
     def logic(self) -> FittingLogic:
@@ -2036,7 +2042,9 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
             self.logic.model_parameters = kernel_module.model_info.parameters
 
         elif hasattr(kernel_module, 'parameters'):
-            # built-in and custom models
+            # Built-in and custom models. Use make_model_info so the UI
+            # parameter table matches the kernel (e.g. sasmodels >= 1.1
+            # omits magnetism for pure-Python models).
             info = modelinfo.make_model_info(kernel_module)
             self.logic.model_parameters = info.parameters
 
@@ -3137,6 +3145,157 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
                                        params=params+poly_params+magnet_params)
 
         return report_logic.reportList()
+
+    def getSASBDBData(self):
+        """
+        Create and return SASBDB export data from fitting results
+        Similar to getReport() but returns SASBDBExportData instead
+        """
+        from sas.qtgui.Utilities.SASBDB.sasbdb_data_collector import SASBDBDataCollector
+
+        collector = SASBDBDataCollector()
+        export_data = collector.export_data
+
+        # Check if we have data and a model
+        if self.data is None or self.logic.kernel_module is None:
+            return None
+
+        # Collect sample data and instrument information from the data object
+        sample, instrument = collector.collect_from_data(self.data)
+
+        # Add instrument to export data if available
+        if instrument:
+            export_data.instruments.append(instrument)
+
+        # Collect fit information
+        fit_data = {}
+        model_name = None
+        optimizer_name = None
+
+        # Extract chi2 from fit results (same way as ReportPageLogic does)
+        if hasattr(self, 'chi2') and self.chi2 is not None:
+            fit_data['chi2'] = self.chi2
+
+        # Get model name (same way as ReportPageLogic does)
+        if self.logic.kernel_module:
+            model_name = getattr(self.logic.kernel_module, 'id', None)
+            if not model_name:
+                model_name = getattr(self.logic.kernel_module, 'name', None)
+
+        # Get optimizer name (same way as ReportPageLogic does)
+        try:
+            from bumps import options
+            if hasattr(options, 'FIT_CONFIG') and hasattr(options.FIT_CONFIG, 'selected_fitter'):
+                optimizer_name = options.FIT_CONFIG.selected_fitter.name
+        except (ImportError, AttributeError):
+            pass
+
+        # Get model parameters (same way as ReportPageLogic does)
+        model_parameters = []
+        if self.logic.kernel_module:
+            from sas.qtgui.Perspectives.Fitting import FittingUtilities
+            params = FittingUtilities.getStandardParam(self._model_model)
+            poly_params = []
+            magnet_params = []
+            if self.chkPolydispersity.isChecked() and self.polydispersity_widget.poly_model.rowCount() > 0:
+                poly_params = FittingUtilities.getStandardParam(self.polydispersity_widget.poly_model)
+            if self.chkMagnetism.isChecked() and self.canHaveMagnetism() and self.magnetism_widget._magnet_model.rowCount() > 0:
+                magnet_params = FittingUtilities.getStandardParam(self.magnetism_widget._magnet_model)
+            model_parameters = params + poly_params + magnet_params
+
+        # Calculate CorMap p-value if we have both data and model
+        if (self.data is not None and
+            self.logic.kernel_module is not None and
+            hasattr(self.data, '__class__') and
+            self.data.__class__.__name__ == 'Data1D'):
+            try:
+                import numpy as np
+                from freesas.cormap import gof
+
+                # Get experimental data
+                exp_q = np.array(self.data.x)
+                exp_I = np.array(self.data.y)
+
+                # Filter valid data points
+                valid_mask = np.isfinite(exp_q) & np.isfinite(exp_I) & (exp_I > 0) & (exp_q > 0)
+                if np.any(valid_mask):
+                    exp_q_valid = exp_q[valid_mask]
+                    exp_I_valid = exp_I[valid_mask]
+
+                    # Calculate model curve at experimental q values
+                    # Use the kernel_module to calculate model intensity
+                    try:
+                        model_I_result = self.logic.kernel_module.calculate_Iq(exp_q_valid)
+                        # Handle tuple return (some models return (Iq, intermediate_results))
+                        if isinstance(model_I_result, tuple):
+                            model_I = model_I_result[0]
+                        else:
+                            model_I = model_I_result
+
+                        # Ensure model_I is a numpy array
+                        model_I = np.array(model_I)
+
+                        # Ensure both arrays have the same length
+                        min_len = min(len(exp_I_valid), len(model_I))
+                        if min_len > 10:  # Need at least 10 points for meaningful CorMap
+                            exp_I_final = exp_I_valid[:min_len]
+                            model_I_final = model_I[:min_len]
+
+                            # Filter out any remaining invalid values
+                            final_mask = (np.isfinite(exp_I_final) &
+                                         np.isfinite(model_I_final) &
+                                         (exp_I_final > 0) &
+                                         (model_I_final > 0))
+
+                            if np.sum(final_mask) > 10:
+                                exp_I_final = exp_I_final[final_mask]
+                                model_I_final = model_I_final[final_mask]
+
+                                # Prepare data for FreeSAS gof function
+                                # gof expects numpy arrays, can be 2D with shape (n, 1) or 1D
+                                exp_data = exp_I_final.reshape(-1, 1) if exp_I_final.ndim == 1 else exp_I_final
+                                model_data = model_I_final.reshape(-1, 1) if model_I_final.ndim == 1 else model_I_final
+
+                                # Calculate CorMap
+                                gof_result = gof(exp_data, model_data)
+
+                                # Extract p-value (P attribute from GOF object)
+                                if hasattr(gof_result, 'P') and gof_result.P is not None:
+                                    fit_data['cormap_pvalue'] = float(gof_result.P)
+                    except Exception as calc_error:
+                        logger.debug(f"Model calculation failed for CorMap: {calc_error}")
+
+            except ImportError:
+                logger.warning("FreeSAS not available, skipping CorMap calculation")
+            except Exception as e:
+                logger.warning(f"CorMap calculation failed: {e}")
+                import traceback
+                logger.debug(traceback.format_exc())
+
+        # Create fit entry if we have fit information
+        if fit_data.get('chi2') is not None or model_name or optimizer_name or fit_data.get('cormap_pvalue') is not None:
+            fit = collector.collect_from_fit(fit_data, model_name, optimizer_name, model_parameters)
+            # Update angular units from sample
+            if sample.angular_units:
+                fit.angular_units = sample.angular_units
+
+            sample.fits.append(fit)
+
+        # Guinier: not auto-filled here; user runs FreeSAS from SASBDB dialog if desired
+
+        # Add default molecule and buffer if not present
+        if sample.molecule is None:
+            sample.molecule = collector.create_default_molecule()
+        if sample.buffer is None:
+            sample.buffer = collector.create_default_buffer()
+
+        export_data.samples.append(sample)
+
+        # Create default project if not set
+        if export_data.project is None:
+            export_data.project = collector.create_default_project()
+
+        return export_data
 
     def loadPageStateCallback(self, state: Any | None = None, datainfo: Any | None = None, format: Any | None = None) -> None:
         """

--- a/src/sas/qtgui/Perspectives/Fitting/MagnetismWidget.py
+++ b/src/sas/qtgui/Perspectives/Fitting/MagnetismWidget.py
@@ -314,7 +314,8 @@ class MagnetismWidget(QtWidgets.QWidget, Ui_MagnetismWidgetUI):
 
         self.magnet_params[param.name] = value
         # Also update the kernel_module to keep values in sync
-        if self.logic.kernel_module is not None:
+        if (self.logic.kernel_module is not None
+                and param.name in self.logic.kernel_module.params):
             self.logic.kernel_module.setParam(param.name, value)
 
         FittingUtilities.addCheckedListToModel(self._magnet_model, checked_list)

--- a/src/sas/qtgui/Perspectives/Fitting/UnitTesting/FittingWidgetTest.py
+++ b/src/sas/qtgui/Perspectives/Fitting/UnitTesting/FittingWidgetTest.py
@@ -274,8 +274,8 @@ class FittingWidgetTest:
         # Try to change back to default
         widget.cbCategory.setCurrentIndex(0)
 
-        # Observe no such luck
-        assert widget.cbCategory.currentIndex() == 8
+        # Restores the previous category index (not a fixed combo position).
+        assert widget.cbCategory.currentIndex() == category_index
         assert widget.cbModel.count() == 29
 
         # Set the structure factor
@@ -656,7 +656,7 @@ class FittingWidgetTest:
         Test the magnetic model setup
         """
         widget.show()
-        # Change the category index so we have a model available
+        # Use a compiled model with magnetism (pure-Python models omit it)
         category_index = widget.cbCategory.findText("Sphere")
         widget.cbCategory.setCurrentIndex(category_index)
         model_index = widget.cbModel.findText("core_shell_sphere")
@@ -739,7 +739,7 @@ class FittingWidgetTest:
         # Change the category index so we have a model available
         category_index = widget.cbCategory.findText("Sphere")
         widget.cbCategory.setCurrentIndex(category_index)
-        model_index = widget.cbModel.findText("adsorbed_layer")
+        model_index = widget.cbModel.findText("sphere")
         widget.cbModel.setCurrentIndex(model_index)
 
         # Check the enablement/text

--- a/src/sas/qtgui/Perspectives/perspective.py
+++ b/src/sas/qtgui/Perspectives/perspective.py
@@ -111,6 +111,11 @@ class Perspective(metaclass=PerspectiveMeta):
         """ A string containing the HTML to be shown in the report"""
         raise NotImplementedError(f"Report not implemented for {self.name}")
 
+    def getSASBDBData(self) -> 'SASBDBExportData | None':
+        """ Get SASBDB export data from this perspective (optional)"""
+        # Import here to avoid circular dependencies
+        return None  # Default implementation returns None
+
 
     #
     # Window behavior


### PR DESCRIPTION
## Summary
- Split from draft PR #3912: Fitting **`getSASBDBData()`** auto-fill for SASBDB export, optional FreeSAS **CorMap** p-value, and related magnetism param-table fixes.
- Depends on #4077 (`sasbdb-core`). Complements the dialog PR (`sasbdb-dialog`) but can merge independently after core.

## Stack
- Base: `sasbdb-core` (PR #4077) — retarget to `main` after #4077 merges
- Sibling: dialog/menu PR (`sasbdb-dialog`)
- Part of split of #3912

## Test plan
- [ ] Fit a 1D dataset; open SASBDB export (with dialog PR) and confirm fields auto-populate
- [ ] CorMap p-value present when FreeSAS installed; graceful skip otherwise
- [ ] Fitting magnetism / `core_shell_sphere` tests still pass (`FittingWidgetTest`)
