### PR TITLE
attempting to fix #4047

### DIFF
--- a/src/sas/qtgui/Perspectives/Fitting/FittingWidget.py
+++ b/src/sas/qtgui/Perspectives/Fitting/FittingWidget.py
@@ -2048,7 +2048,11 @@ class FittingWidget(QtWidgets.QWidget, Ui_FittingWidgetUI):
         if kernel_module is None:
             # mismatch between "name" attribute and actual filename.
             curr_model = self.models[model_name]
-            name, _ = os.path.splitext(os.path.basename(curr_model.filename))
+            filename = getattr(curr_model, 'filename', None)
+            if filename is None:
+                logger.error("Can't find the model file for %s", model_name)
+                return
+            name, _ = os.path.splitext(os.path.basename(filename))
             try:
                 kernel_module = generate.load_kernel_module(name)
             except ModuleNotFoundError as ex:

--- a/src/sas/qtgui/Perspectives/Fitting/UnitTesting/FittingWidgetTest.py
+++ b/src/sas/qtgui/Perspectives/Fitting/UnitTesting/FittingWidgetTest.py
@@ -247,6 +247,27 @@ class FittingWidgetTest:
         #Test what is current text in the combobox
         assert fittingWindow.cbCategory.currentText(), "None"
 
+    def testSelectModelWithoutFilename(self, widget, mocker, caplog):
+        """
+        Selecting a model whose class carries no filename (e.g. a mixture
+        model built programmatically with make_model_from_info) must log an
+        error instead of raising TypeError in os.path.basename(None).
+        Regression test for issue #4047.
+        """
+        class DummyMixtureModel:
+            name = "dummy_mixture"
+            filename = None
+
+        widget.models["dummy_mixture"] = DummyMixtureModel
+        # force the name-based lookup to fail so the filename fallback runs
+        mocker.patch.object(FittingWidget.generate, 'load_kernel_module',
+                            side_effect=ModuleNotFoundError("dummy_mixture"))
+
+        with caplog.at_level(logging.ERROR):
+            widget.fromModelToQModel("dummy_mixture")
+
+        assert "Can't find the model file for dummy_mixture" in caplog.text
+
     def testSignals(self, widget):
         """
         Test the widget emitted signals

--- a/src/sas/sascalc/fit/models.py
+++ b/src/sas/sascalc/fit/models.py
@@ -155,6 +155,13 @@ def find_plugin_models():
             path = os.path.abspath(os.path.join(plugins_dir, filename))
             try:
                 model = load_custom_model(path)
+                # Mixture models given a custom name (e.g. built with
+                # load_model_info('A+B') and make_model_from_info) have
+                # filename set to None. We need to point it back at the plugin
+                # file so the model can be reloaded when the model name
+                # does not match the file name.
+                if getattr(model, 'filename', None) is None:
+                    model.filename = path
                 # TODO: add [plug-in] tag to model name in sasview_model
                 #if not model.name.startswith(PLUGIN_NAME_BASE):
                 #    model.name = PLUGIN_NAME_BASE + model.name


### PR DESCRIPTION
## Description

Mixture/composite model infos are created in memory, not read from a file, so `model_info.filename` is None.
`make_model_from_info` copies that None onto the generated class.
The fix proposed: in `find_plugin_models()`, after loading each plugin, fill `model.filename` with the actual plugin file path when it's None.

Fixes #4074 

## How Has This Been Tested?

Local Win11

## Review Checklist:

[if using the editor, use `[x]` in place of `[ ]` to check a box]

**Documentation** (check at least one)
- [X] There is **nothing** that needs documenting
- [ ] Documentation changes are **in this PR**
- [ ] There is an **issue** open for the documentation (link?)

**Installers**
- [ ] There is a chance this will affect the **installers**, if so
  - [ ] **Windows** installer (GH artifact) has been tested (installed and worked) 
  - [ ] **MacOSX** installer (GH artifact) has been tested (installed and worked)
  - [ ] **Wheels** installer (GH artifact) has been tested (installed and worked)

**Licensing** (untick if necessary)
- [x] The introduced changes comply with SasView license (BSD 3-Clause)

