### PR TITLE
Refactor What's New widget to avoid manually updating the config

### DIFF
--- a/src/sas/qtgui/Utilities/NewVersion/NewVersionAvailable.py
+++ b/src/sas/qtgui/Utilities/NewVersion/NewVersionAvailable.py
@@ -24,12 +24,20 @@ from sas.system.version import __version__ as current_version_string
 
 logger = logging.getLogger("NewVersionAvailable")
 
+
 class NewVersionAvailable(QDialog):
     """
     Dialog to say that a new version is available
 
     """
-    def __init__(self, current_version: str, latest_version: str, url: str = 'http://www.sasview.org/#downloadsection', parent=None):
+
+    def __init__(
+        self,
+        current_version: str,
+        latest_version: str,
+        url: str = "http://www.sasview.org/#downloadsection",
+        parent=None,
+    ):
         super().__init__(parent)
 
         self.latest_version = latest_version
@@ -45,9 +53,9 @@ class NewVersionAvailable(QDialog):
 
         self.setLayout(vertical_layout)
 
-        text = QLabel("<p>A new version of sasview is available.</p>"
-                       ""
-                       "<p><center>Visit the download page?</centre></p><p/>")
+        text = QLabel(
+            "<p>A new version of sasview is available.</p><p><center>Visit the download page?</centre></p><p/>"
+        )
 
         vertical_layout.addWidget(text)
 
@@ -71,7 +79,7 @@ class NewVersionAvailable(QDialog):
 
         button_layout.addWidget(cancel)
         button_layout.addWidget(self.dont_show)
-        button_layout.addSpacerItem(QSpacerItem(50,10))
+        button_layout.addSpacerItem(QSpacerItem(50, 10))
         button_layout.addWidget(accept)
 
     def go(self):
@@ -84,7 +92,7 @@ class NewVersionAvailable(QDialog):
 
 
 def get_current_release_version() -> tuple[str, str, Version] | None:
-    """ Get the current version from the server """
+    """Get the current version from the server"""
     try:
         response = requests.get(web.update_url, timeout=config.UPDATE_TIMEOUT)
         # Will throw Exception if the HTTP status code returned isn't success
@@ -103,12 +111,10 @@ def get_current_release_version() -> tuple[str, str, Version] | None:
         return None
 
 
-
 def maybe_prompt_new_version_download() -> QDialog | None:
-    """ If a new version is available, and Show a dialog prompting the user to download """
+    """If a new version is available, and Show a dialog prompting the user to download"""
 
     try:
-
         # Check the config to see if we should show
         # The last dismissed version needs to be at least as old as this version
         last_dismissed_string = config.LAST_UPDATE_DISMISSED_VERSION
@@ -140,24 +146,20 @@ def maybe_prompt_new_version_download() -> QDialog | None:
         latest_string, url, latest = latest_string_and_tuple
 
         if latest > comparison:
-
             app = QApplication([])
             new_version = NewVersionAvailable(current_version_string, latest_string, url)
             new_version.show()
 
             app.exec()
-            app.shutdown() # Of course!
-
-
-
-
+            app.shutdown()  # Of course!
 
     except Exception as ex:
         logger.info("Error getting latest sasview version %s", ex)
         return None
 
+
 def main():
-    """ Demo/testing window"""
+    """Demo/testing window"""
 
     maybe_prompt_new_version_download()
 

--- a/src/sas/qtgui/Utilities/WhatsNew/WhatsNew.py
+++ b/src/sas/qtgui/Utilities/WhatsNew/WhatsNew.py
@@ -27,6 +27,7 @@ def whats_new_messages():
 
     return out
 
+
 class WhatsNewBrowser(QTextBrowser):
     def __init__(self, parent=None):
         super().__init__(parent)
@@ -35,12 +36,11 @@ class WhatsNewBrowser(QTextBrowser):
         self.css_data = "<style>\n" + css + "</style>"
 
     def setHtml(self, text: str) -> None:
-        """ Overriden to inject CSS into HTML files - very, very ugly"""
+        """Overriden to inject CSS into HTML files - very, very ugly"""
         super().setHtml(text.replace("<!-- INJECT CSS HERE -->", self.css_data))
 
     def loadResource(self, kind: int, url: QUrl | str):
-
-        """ Override the resource discovery to get the images we need """
+        """Override the resource discovery to get the images we need"""
 
         if isinstance(url, QUrl):
             name = url.toString()
@@ -48,7 +48,6 @@ class WhatsNewBrowser(QTextBrowser):
             name = url
 
         if kind == 2:
-
             # This is pretty nasty, there's probably a better way
             if name.startswith("whatsnew/"):
                 parts = name.split("/")[1:]
@@ -66,14 +65,14 @@ class WhatsNewBrowser(QTextBrowser):
 
 
 class WhatsNewWidget(QDialog, Ui_WhatsNewUI):
-
-    """ What's New window: displays messages about what is new in this version of SasView
+    """What's New window: displays messages about what is new in this version of SasView
 
     It will find all files in messages.[version] if [version] is newer than the last time
     the "don't show me again" option was chosen
 
     To add new messages, just dump a (self-contained) html file into the appropriate folder
     """
+
     def __init__(self, parent=None, only_recent=True):
         """
         Parent here is the GUI Manager. Required for access to
@@ -133,18 +132,17 @@ class WhatsNewWidget(QDialog, Ui_WhatsNewUI):
         self.set_page_label()
 
         self.setMinimumSize(800, 400)
-        #self.resize(800, 600)
         self.setModal(True)
 
     def next_file(self):
-        """ Show the next available file (increment counter, show)"""
+        """Show the next available file (increment counter, show)"""
         self.current_index += 1
         self.current_index %= self.max_index
         self.show_file()
         self.set_page_label()
 
     def prev_file(self):
-        """ Go to next file"""
+        """Go to next file"""
         self.current_index -= 1
         if self.current_index < 0:
             self.current_index = self.max_index - 1
@@ -153,12 +151,10 @@ class WhatsNewWidget(QDialog, Ui_WhatsNewUI):
 
     def set_page_label(self):
         """Set the appropriate page number."""
-        self.lblPage.setText(
-            f"{self.current_index + 1} / {self.max_index}"
-        )
+        self.lblPage.setText(f"{self.current_index + 1} / {self.max_index}")
 
     def show_file(self):
-        """ Set the text of the window to the file with the current index"""
+        """Set the text of the window to the file with the current index"""
         if len(self.all_messages) > 0:
             filename = self.all_messages[self.current_index]
             with open(filename) as fid:
@@ -168,7 +164,7 @@ class WhatsNewWidget(QDialog, Ui_WhatsNewUI):
             self.browser.setHtml("<html><body><h1>You should not see this!!!</h1></body></html>")
 
     def close_me(self):
-        """ Close action, needs to save the state for showing """
+        """Close action, needs to save the state for showing"""
         if self.showAgain is not None:
             if not self.showAgain.isChecked():
                 # We choose the newest, for backwards compatability, i.e. we never reduce the last version
@@ -177,13 +173,12 @@ class WhatsNewWidget(QDialog, Ui_WhatsNewUI):
         self.close()
 
     def has_new_messages(self) -> bool:
-        """ Should the window be shown? """
+        """Should the window be shown?"""
         return bool(self.all_messages)
 
 
 def main():
-    """ Demo/testing window"""
-
+    """Demo/testing window"""
 
     app = QtWidgets.QApplication([])
 

--- a/src/sas/qtgui/Utilities/WhatsNew/WhatsNew.py
+++ b/src/sas/qtgui/Utilities/WhatsNew/WhatsNew.py
@@ -12,36 +12,18 @@ from sas.system import config
 from sas.system.version import __version__ as sasview_version
 
 
-def whats_new_messages(only_recent=True):
-    """ Accumulate all files that are newer than the value in the config
-
-    :param only_recent: require strictly newer stuff, strictness is needed for showing new things
-                           when there is an update, non-strictness is needed for the menu access.
-    """
+def whats_new_messages():
+    """Accumulate all files in the messages directory."""
 
     out = defaultdict(list)
     message_dir = resources.files("sas.qtgui.Utilities.WhatsNew.messages")
     for child_dir in message_dir.iterdir():
         # Get short filename
         if child_dir.is_dir():
-
-            newer = False
-
-            try:
-                if only_recent:
-                    newer = strictly_newer_than(child_dir.name, config.LAST_WHATS_NEW_HIDDEN_VERSION)
-                else:
-                    # Include current version
-                    newer = strictly_newer_than(child_dir.name, "0.0.0")
-
-            except ValueError:
-                pass
-
-            if newer:
-                for file in child_dir.iterdir():
-                    if file.name.endswith(".html"):
-                        out[child_dir.name].append(file)
-
+            dir_name = child_dir.name
+            for file in child_dir.iterdir():
+                if file.name.endswith(".html"):
+                    out[dir_name].append(file)
 
     return out
 
@@ -113,7 +95,6 @@ class WhatsNewWidget(QDialog, Ui_WhatsNewUI):
         self.browser.setOpenExternalLinks(True)
 
         if strictly_newer_than(sasview_version, config.LAST_WHATS_NEW_HIDDEN_VERSION):
-
             self.showAgain.setVisible(True)
             self.showAgain.setChecked(True)
         else:
@@ -124,16 +105,21 @@ class WhatsNewWidget(QDialog, Ui_WhatsNewUI):
         self.groupBox.layout().setContentsMargins(5, 5, 5, 5)
         self.groupBox.layout().addWidget(self.browser)
 
-
         # Callbacks
         self.closeButton.clicked.connect(self.close_me)
         self.prevButton.clicked.connect(self.prev_file)
         self.nextButton.clicked.connect(self.next_file)
 
-        # # Gather new files
-        new_messages = whats_new_messages(only_recent=only_recent)
+        # Gather new files
+        new_messages = whats_new_messages()
         new_message_directories = [key for key in new_messages]
         new_message_directories.sort(key=reduced_version, reverse=True)
+
+        if only_recent:
+            if strictly_newer_than(sasview_version, config.LAST_WHATS_NEW_HIDDEN_VERSION):
+                new_message_directories = new_message_directories[:1]
+            else:
+                new_message_directories = []
 
         self.all_messages = []
 

--- a/src/sas/system/config/config.py
+++ b/src/sas/system/config/config.py
@@ -1,4 +1,4 @@
-r""" Configuration class - stores configuration information for SasView
+r"""Configuration class - stores configuration information for SasView
 
 
 ..
@@ -139,30 +139,28 @@ from sas.system.config.config_meta import ConfigBase, ConfigMeta
 
 
 class Config(ConfigBase, metaclass=ConfigMeta):
-
     def __init__(self):
         super().__init__()
 
-
         # edit the list of file state your plugin can read
-        self.APPLICATION_WLIST = 'SasView files (*.svs)|*.svs'
-        self.APPLICATION_STATE_EXTENSION = '.svs'
-        self.PLUGIN_STATE_EXTENSIONS = ['.fitv', '.inv', '.prv', '.crf']
+        self.APPLICATION_WLIST = "SasView files (*.svs)|*.svs"
+        self.APPLICATION_STATE_EXTENSION = ".svs"
+        self.PLUGIN_STATE_EXTENSIONS = [".fitv", ".inv", ".prv", ".crf"]
         self.PLUGINS_WLIST = [
-            'Fitting files (*.fitv)|*.fitv',
-            'Invariant files (*.inv)|*.inv',
-            'P(r) files (*.prv)|*.prv',
-            'Corfunc files (*.crf)|*.crf']
+            "Fitting files (*.fitv)|*.fitv",
+            "Invariant files (*.inv)|*.inv",
+            "P(r) files (*.prv)|*.prv",
+            "Corfunc files (*.crf)|*.crf",
+        ]
 
         self.ANALYSIS_TYPES = [
-            'Fitting files (*.fitv)',
-            'Invariant files (*.inv)',
-            'P(r) files (*.prv)',
-            'Corfunc files (*.crf)']
+            "Fitting files (*.fitv)",
+            "Invariant files (*.inv)",
+            "P(r) files (*.prv)",
+            "Corfunc files (*.crf)",
+        ]
 
         self.SHOW_WELCOME_PANEL = False
-
-
 
         # OpenCL option - should be a string, either, "none", a number, or pair of form "A:B"
         self.SAS_OPENCL = "none"
@@ -205,7 +203,7 @@ class Config(ConfigBase, metaclass=ConfigMeta):
         self.USE_MATPLOTLIB_TOOLBAR = True
 
         # Default fitting optimizer
-        self.FITTING_DEFAULT_OPTIMIZER = 'lm'
+        self.FITTING_DEFAULT_OPTIMIZER = "lm"
 
         # Last version that the "What's New" menu was dismissed for
         self.LAST_WHATS_NEW_HIDDEN_VERSION = "0.0.0"
@@ -222,7 +220,6 @@ class Config(ConfigBase, metaclass=ConfigMeta):
         # securing the class, and for setting up reading/writing files
         #
         self.finalise()
-
 
 
 config = Config()

--- a/src/sas/system/config/config.py
+++ b/src/sas/system/config/config.py
@@ -207,11 +207,11 @@ class Config(ConfigBase, metaclass=ConfigMeta):
         # Default fitting optimizer
         self.FITTING_DEFAULT_OPTIMIZER = 'lm'
 
-        # What's New variables - this should refer to the previous minor version
-        self.LAST_WHATS_NEW_HIDDEN_VERSION = "6.1.3"
+        # Last version that the "What's New" menu was dismissed for
+        self.LAST_WHATS_NEW_HIDDEN_VERSION = "0.0.0"
 
         # Last version that the update prompt was dismissed for
-        self.LAST_UPDATE_DISMISSED_VERSION = "5.0.0"
+        self.LAST_UPDATE_DISMISSED_VERSION = "0.0.0"
 
         # Stack plots when using slicers
         # If true, plots generated when using slicers will be on the same canvas


### PR DESCRIPTION
## Description

The issue set out in #3985 arises because the `config.py` must be manually updated with the previous version for the what's new menu to display the correct set of cards. This PR refactors the widget so it does not depend on the default value of `config.LAST_WHATS_NEW_HIDDEN_VERSION` (as opposed to that set in the user's config) and hence it is set to `0.0.0` so it can be clearly understood that this is a default and does not need maintaining. The same applies for the config option `config.LAST_UPDATE_DISMISSED_VERSION`.

I have also taken the opportunity to reformat the files, note that the changes to `NewVersionAvailable.py` are only formatting changes.

I will close the previous PR #4046. I am satisfied with the points I raised there, in particular, it is expected behaviour that all cards are included when accessing the "What's New" menu from the help.

Fixes #3985 

## How Has This Been Tested?

Tested manually, including by modifying my own user config file.

## Review Checklist:

[if using the editor, use `[x]` in place of `[ ]` to check a box]

**Documentation** (check at least one)
- [x] There is **nothing** that needs documenting
- [ ] Documentation changes are **in this PR**
- [ ] There is an **issue** open for the documentation (link?)

**Installers**
- [ ] There is a chance this will affect the **installers**, if so
  - [ ] **Windows** installer (GH artifact) has been tested (installed and worked) 
  - [ ] **MacOSX** installer (GH artifact) has been tested (installed and worked)
  - [ ] **Wheels** installer (GH artifact) has been tested (installed and worked)

**Licensing** (untick if necessary)
- [x] The introduced changes comply with SasView license (BSD 3-Clause)

