### PR TITLE
Fix/utf8 encoding

### DIFF
--- a/src/sas/qtgui/Calculators/SAXSPluginModelGenerator.py
+++ b/src/sas/qtgui/Calculators/SAXSPluginModelGenerator.py
@@ -22,7 +22,7 @@ def write_plugin_model(structure_path: str):
 
     path = Path(find_plugins_dir()) / "ausaxs_saxs_plugin.py"
     text = get_model_text(structure_path)
-    with open(path, 'w') as f:
+    with open(path, 'w', encoding="utf-8") as f:
         f.write(text)
 
 def get_model_text(structure_path: str) -> str:

--- a/src/sas/qtgui/Utilities/ModelEditors/AddMultEditor/AddMultEditor.py
+++ b/src/sas/qtgui/Utilities/ModelEditors/AddMultEditor/AddMultEditor.py
@@ -253,7 +253,7 @@ class AddMultEditor(QtWidgets.QDialog, Ui_AddMultEditorUI):
                                      operator=operator,
                                      desc_line=desc_line)
 
-        with open(fname, 'w') as out_f:
+        with open(fname, 'w', encoding="utf-8") as out_f:
             out_f.write(output)
 
     def updateModels(self):

--- a/src/sas/qtgui/Utilities/ModelEditors/ReparamEditor/ReparameterizationEditor.py
+++ b/src/sas/qtgui/Utilities/ModelEditors/ReparamEditor/ReparameterizationEditor.py
@@ -628,7 +628,7 @@ class ReparameterizationEditor(QtWidgets.QDialog, Ui_ReparameterizationEditor):
         :param model_text: str of the model text to write
         """
         try:
-            with open(output_file_path, 'w') as f:
+            with open(output_file_path, 'w', encoding="utf-8") as f:
                 f.write(model_text)
         except Exception as ex:
             logger.error("Error writing model to file: %s" % ex)


### PR DESCRIPTION
## Description

I added the encoding="utf-8" argument so that model source files are explicitly read as UTF-8.

This fixes the UnicodeDecodeError that occurs when building plugin models on Windows systems using a non-UTF-8 locale, such as the Japanese locale.
Fixes #4095 

## How Has This Been Tested?

Tested the change on Windows with a Japanese locale by building the plugin models.
The build completed successfully without the UnicodeDecodeError using https://github.com/SasView/sasmodels/pull/754.

## Review Checklist:

[if using the editor, use `[x]` in place of `[ ]` to check a box]

**Documentation** (check at least one)
- [x] There is **nothing** that needs documenting
- [ ] Documentation changes are **in this PR**
- [ ] There is an **issue** open for the documentation (link?)

**Installers**
- [ ] There is a chance this will affect the **installers**, if so
  - [ ] **Windows** installer (GH artifact) has been tested (installed and worked) 
  - [ ] **MacOSX** installer (GH artifact) has been tested (installed and worked)
  - [ ] **Wheels** installer (GH artifact) has been tested (installed and worked)

**Licensing** (untick if necessary)
- [x] The introduced changes comply with SasView license (BSD 3-Clause)

