### PR TITLE
VarStats.name -> VarStats.label

### DIFF
--- a/src/sas/qtgui/Utilities/PlotView.py
+++ b/src/sas/qtgui/Utilities/PlotView.py
@@ -131,7 +131,7 @@ class CorrelationTable(QtWidgets.QWidget):
             if parsed:
                 # Use parse_var to extract all values, then format them for display
                 row_data = [
-                    parsed.name,
+                    parsed.label,
                     f"{parsed.mean:.6g}",
                     f"{parsed.median:.6g}",
                     f"{parsed.best:.6g}",


### PR DESCRIPTION
## Description

This ensures the deprecated name parameter in the bumps VarStats class uses the appropriate label parameter.

Fixes #3977

## Review Checklist:

**Documentation** (check at least one)
- [ ] There is **nothing** that needs documenting
- [ ] Documentation changes are **in this PR**
- [ ] There is an **issue** open for the documentation (link?)

**Installers**
- [ ] There is a chance this will affect the **installers**, if so
  - [ ] **Windows** installer (GH artifact) has been tested (installed and worked) 
  - [ ] **MacOSX** installer (GH artifact) has been tested (installed and worked)
  - [ ] **Wheels** installer (GH artifact) has been tested (installed and worked)

**Licensing** (untick if necessary)
- [x] The introduced changes comply with SasView license (BSD 3-Clause)

