### PR TITLE
Be able to create trends on the data explorer.

### DIFF
--- a/build_tools/requirements.txt
+++ b/build_tools/requirements.txt
@@ -25,7 +25,7 @@ pyparsing
 PySide6
 pytools
 qtconsole
-sasdata @ git+https://github.com/SasView/sasdata.git@refactor_24
+sasdata @ git+https://github.com/SasView/sasdata.git@refactor_24_trend_new
 sasmodels
 scipy
 siphash24

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ requires = [
     "periodictable",
     "pyopengl",
     "pyside6",
-    "sasdata @ git+https://github.com/SasView/sasdata.git@refactor_24",
+    "sasdata @ git+https://github.com/SasView/sasdata.git@refactor_24_trend_new",
     "sasmodels",
     "twisted",
     "uncertainties",

--- a/src/sas/data_explorer_menu.py
+++ b/src/sas/data_explorer_menu.py
@@ -12,12 +12,12 @@ from sas.refactored import Perspective
 # should not be None?
 @dataclass
 class DataExplorerMenuAction:
-    action: Literal["remove", "send_to", "view_data"]
+    action: Literal["remove", "send_to", "view_data", "make_trend"]
     action_data: Perspective | None = None
 
 
 class DataExplorerMenu(QMenu):
-    def __init__(self, parent: QWidget, data_manager: NewDataManager, send_to: bool, view_data: bool):
+    def __init__(self, parent: QWidget, data_manager: NewDataManager, send_to: bool, view_data: bool, make_trend: bool):
         super().__init__(parent)
 
         remove_action = QAction("Remove", parent)
@@ -38,3 +38,8 @@ class DataExplorerMenu(QMenu):
             view_data_action = QAction("View Data", parent)
             view_data_action.setData(DataExplorerMenuAction("view_data"))
             self.addAction(view_data_action)
+
+        if make_trend:
+            make_trend_action = QAction("Make Trend", parent)
+            make_trend_action.setData(DataExplorerMenuAction("make_trend"))
+            self.addAction(make_trend_action)

--- a/src/sas/data_explorer_tree.py
+++ b/src/sas/data_explorer_tree.py
@@ -146,7 +146,10 @@ class DataExplorerTree(QTreeWidget):
             box.show()
 
     def showViewData(self):
-        viewer = DataViewer(self.currentTrackedDatum)
+        associated = self._data_manager.get_association(self.currentTrackedDatum)
+        if isinstance(associated, Trend):
+            trend = associated
+        viewer = DataViewer(self.currentTrackedDatum, trend)
         viewer.exec()
 
     @property

--- a/src/sas/data_explorer_tree.py
+++ b/src/sas/data_explorer_tree.py
@@ -24,6 +24,9 @@ from sas.refactored import Perspective
 def tracked_data_name(data: TrackedData) -> str:
     if isinstance(data, SasData):
         return data.name
+    if isinstance(data, Trend):
+        # TODO: This is temporary. We need a way for a Trend to represent itself.
+        return 'Trend'
     else:
         return data.formatName
 

--- a/src/sas/data_explorer_tree.py
+++ b/src/sas/data_explorer_tree.py
@@ -143,7 +143,7 @@ class DataExplorerTree(QTreeWidget):
                         errors.append(err)
             case "make_trend":
                 trend_data = cast(list[SasData], self.currentTrackedData)
-                trend_creation_dialog = TrendCreation(trend_data, self._data_manager.default_trend_name)
+                trend_creation_dialog = TrendCreation(trend_data, self._data_manager.default_new_trend_name)
                 creation_result = trend_creation_dialog.exec()
                 if creation_result == QDialog.DialogCode.Accepted:
                     self._data_manager.register_trend(trend_creation_dialog.proposed_trend)

--- a/src/sas/data_explorer_tree.py
+++ b/src/sas/data_explorer_tree.py
@@ -133,6 +133,9 @@ class DataExplorerTree(QTreeWidget):
                         self._data_manager.make_association(to_perspective, datum)
                     except ValueError as err:
                         errors.append(err)
+            case "make_trend":
+                trend_data = cast(list[SasData], self.currentTrackedData)
+                self._data_manager.make_trend(trend_data)
         if len(errors):
             box = DataExplorerErrorMessage(self, errors)
             box.show()

--- a/src/sas/data_explorer_tree.py
+++ b/src/sas/data_explorer_tree.py
@@ -141,7 +141,7 @@ class DataExplorerTree(QTreeWidget):
                 creation_result = trend_creation_dialog.exec()
                 if creation_result == QDialog.DialogCode.Accepted:
                     # TODO: Need to pass in axes
-                    self._data_manager.register_trend(trend_creation_dialog.trend)
+                    self._data_manager.register_trend(trend_creation_dialog.proposed_trend)
         if len(errors):
             box = DataExplorerErrorMessage(self, errors)
             box.show()

--- a/src/sas/data_explorer_tree.py
+++ b/src/sas/data_explorer_tree.py
@@ -137,7 +137,7 @@ class DataExplorerTree(QTreeWidget):
                         errors.append(err)
             case "make_trend":
                 trend_data = cast(list[SasData], self.currentTrackedData)
-                trend_creation_dialog = TrendCreation()
+                trend_creation_dialog = TrendCreation(trend_data)
                 creation_result = trend_creation_dialog.exec()
                 if creation_result == QDialog.DialogCode.Accepted:
                     # TODO: Need to pass in axes

--- a/src/sas/data_explorer_tree.py
+++ b/src/sas/data_explorer_tree.py
@@ -13,7 +13,7 @@ from sasdata.data import SasData
 
 from sas.data_explorer_error_message import DataExplorerErrorMessage
 from sas.data_explorer_menu import DataExplorerMenu, DataExplorerMenuAction
-from sas.data_manager import NewDataManager as DataManager
+from sas.data_manager import NewDataManager as DataManager 
 from sas.data_manager import TrackedData
 from sas.qtgui.MainWindow.DataViewer import DataViewer
 from sas.refactored import Perspective
@@ -105,6 +105,7 @@ class DataExplorerTree(QTreeWidget):
     def showContextMenu(self):
         send_to = all([isinstance(datum, SasData) for datum in self.currentTrackedData])
         view_data = len(self.currentTrackedData) == 1 and isinstance(self.currentTrackedData[0], SasData)
+        make_trend = len(self.currentTrackedData) > 1 and all([isinstance_fix for datum in self.currentTrackedData])
         menu = DataExplorerMenu(self, self._data_manager, send_to, view_data)
         action = menu.exec(QCursor.pos())
         # Result will be None if the user exited the menu without selecting anything.

--- a/src/sas/data_explorer_tree.py
+++ b/src/sas/data_explorer_tree.py
@@ -149,6 +149,8 @@ class DataExplorerTree(QTreeWidget):
         associated = self._data_manager.get_association_or_none(self.currentTrackedDatum)
         if isinstance(associated, Trend):
             trend = associated
+        else:
+            trend = None
         viewer = DataViewer(self.currentTrackedDatum, trend)
         viewer.exec()
 

--- a/src/sas/data_explorer_tree.py
+++ b/src/sas/data_explorer_tree.py
@@ -17,6 +17,7 @@ from sas.data_explorer_menu import DataExplorerMenu, DataExplorerMenuAction
 from sas.data_manager import NewDataManager as DataManager, isinstance_fix 
 from sas.data_manager import TrackedData
 from sas.qtgui.MainWindow.DataViewer import DataViewer
+from sas.qtgui.MainWindow.TrendCreation import TrendCreation
 from sas.refactored import Perspective
 
 
@@ -135,6 +136,9 @@ class DataExplorerTree(QTreeWidget):
                         errors.append(err)
             case "make_trend":
                 trend_data = cast(list[SasData], self.currentTrackedData)
+                trend_creation_dialog = TrendCreation()
+                trend_creation_dialog.exec()
+                # TODO: Do something with the dialog that was just launched.
                 self._data_manager.make_trend(trend_data)
         if len(errors):
             box = DataExplorerErrorMessage(self, errors)

--- a/src/sas/data_explorer_tree.py
+++ b/src/sas/data_explorer_tree.py
@@ -7,6 +7,7 @@ from PySide6.QtWidgets import (
     QTreeWidget,
     QTreeWidgetItem,
     QWidget,
+    QDialog
 )
 
 from sasdata.data import SasData
@@ -137,9 +138,10 @@ class DataExplorerTree(QTreeWidget):
             case "make_trend":
                 trend_data = cast(list[SasData], self.currentTrackedData)
                 trend_creation_dialog = TrendCreation()
-                trend_creation_dialog.exec()
-                # TODO: Do something with the dialog that was just launched.
-                self._data_manager.make_trend(trend_data)
+                creation_result = trend_creation_dialog.exec()
+                if creation_result == QDialog.DialogCode.Accepted:
+                    # TODO: Need to pass in axes
+                    self._data_manager.make_trend(trend_data)
         if len(errors):
             box = DataExplorerErrorMessage(self, errors)
             box.show()

--- a/src/sas/data_explorer_tree.py
+++ b/src/sas/data_explorer_tree.py
@@ -140,7 +140,6 @@ class DataExplorerTree(QTreeWidget):
                 trend_creation_dialog = TrendCreation(trend_data)
                 creation_result = trend_creation_dialog.exec()
                 if creation_result == QDialog.DialogCode.Accepted:
-                    # TODO: Need to pass in axes
                     self._data_manager.register_trend(trend_creation_dialog.proposed_trend)
         if len(errors):
             box = DataExplorerErrorMessage(self, errors)

--- a/src/sas/data_explorer_tree.py
+++ b/src/sas/data_explorer_tree.py
@@ -106,7 +106,7 @@ class DataExplorerTree(QTreeWidget):
     def showContextMenu(self):
         send_to = all([isinstance(datum, SasData) for datum in self.currentTrackedData])
         view_data = len(self.currentTrackedData) == 1 and isinstance(self.currentTrackedData[0], SasData)
-        make_trend = len(self.currentTrackedData) > 1 and all([isinstance_fix(datum, Trend) for datum in self.currentTrackedData])
+        make_trend = len(self.currentTrackedData) > 1 and all([isinstance_fix(datum, SasData) for datum in self.currentTrackedData])
         menu = DataExplorerMenu(self, self._data_manager, send_to, view_data, make_trend)
         action = menu.exec(QCursor.pos())
         # Result will be None if the user exited the menu without selecting anything.

--- a/src/sas/data_explorer_tree.py
+++ b/src/sas/data_explorer_tree.py
@@ -10,10 +10,11 @@ from PySide6.QtWidgets import (
 )
 
 from sasdata.data import SasData
+from sasdata.trend import Trend
 
 from sas.data_explorer_error_message import DataExplorerErrorMessage
 from sas.data_explorer_menu import DataExplorerMenu, DataExplorerMenuAction
-from sas.data_manager import NewDataManager as DataManager 
+from sas.data_manager import NewDataManager as DataManager, isinstance_fix 
 from sas.data_manager import TrackedData
 from sas.qtgui.MainWindow.DataViewer import DataViewer
 from sas.refactored import Perspective

--- a/src/sas/data_explorer_tree.py
+++ b/src/sas/data_explorer_tree.py
@@ -141,7 +141,7 @@ class DataExplorerTree(QTreeWidget):
                 creation_result = trend_creation_dialog.exec()
                 if creation_result == QDialog.DialogCode.Accepted:
                     # TODO: Need to pass in axes
-                    self._data_manager.make_trend(trend_data)
+                    self._data_manager.register_trend(trend_creation_dialog.trend)
         if len(errors):
             box = DataExplorerErrorMessage(self, errors)
             box.show()

--- a/src/sas/data_explorer_tree.py
+++ b/src/sas/data_explorer_tree.py
@@ -1,26 +1,20 @@
+import logging
 from typing import cast
 
 from PySide6.QtCore import Qt, Signal
 from PySide6.QtGui import QCursor
-from PySide6.QtWidgets import (
-    QAbstractItemView,
-    QTreeWidget,
-    QTreeWidgetItem,
-    QWidget,
-    QDialog
-)
+from PySide6.QtWidgets import QAbstractItemView, QDialog, QTreeWidget, QTreeWidgetItem, QWidget
 
 from sasdata.data import SasData
 from sasdata.trend import Trend
 
 from sas.data_explorer_error_message import DataExplorerErrorMessage
 from sas.data_explorer_menu import DataExplorerMenu, DataExplorerMenuAction
-from sas.data_manager import NewDataManager as DataManager, isinstance_fix 
-from sas.data_manager import TrackedData
+from sas.data_manager import NewDataManager as DataManager
+from sas.data_manager import TrackedData, isinstance_fix
 from sas.qtgui.MainWindow.DataViewer import DataViewer
 from sas.qtgui.MainWindow.TrendCreation import TrendCreation
-from sas.refactored import Perspective, NamedTrend
-import logging
+from sas.refactored import NamedTrend, Perspective
 
 
 # TODO: Is this the right place for this?

--- a/src/sas/data_explorer_tree.py
+++ b/src/sas/data_explorer_tree.py
@@ -19,16 +19,22 @@ from sas.data_manager import NewDataManager as DataManager, isinstance_fix
 from sas.data_manager import TrackedData
 from sas.qtgui.MainWindow.DataViewer import DataViewer
 from sas.qtgui.MainWindow.TrendCreation import TrendCreation
-from sas.refactored import Perspective
+from sas.refactored import Perspective, NamedTrend
+import logging
 
 
 # TODO: Is this the right place for this?
 def tracked_data_name(data: TrackedData) -> str:
     if isinstance(data, SasData):
         return data.name
-    if isinstance(data, Trend):
-        # TODO: This is temporary. We need a way for a Trend to represent itself.
-        return 'Trend'
+    elif isinstance(data, NamedTrend):
+        return data.name
+    elif isinstance(data, Trend):
+        # Trends created in the data explorer should be named trends. If they're
+        # not, that indicates something has gone wrong. We won't fail here, but
+        # instead log a warning.
+        logging.warning("Trend doesn't have a name. This shouldn't be happening.")
+        return 'Unnamed Trend'
     else:
         return data.formatName
 

--- a/src/sas/data_explorer_tree.py
+++ b/src/sas/data_explorer_tree.py
@@ -105,8 +105,8 @@ class DataExplorerTree(QTreeWidget):
     def showContextMenu(self):
         send_to = all([isinstance(datum, SasData) for datum in self.currentTrackedData])
         view_data = len(self.currentTrackedData) == 1 and isinstance(self.currentTrackedData[0], SasData)
-        make_trend = len(self.currentTrackedData) > 1 and all([isinstance_fix for datum in self.currentTrackedData])
-        menu = DataExplorerMenu(self, self._data_manager, send_to, view_data)
+        make_trend = len(self.currentTrackedData) > 1 and all([isinstance_fix(datum, Trend) for datum in self.currentTrackedData])
+        menu = DataExplorerMenu(self, self._data_manager, send_to, view_data, make_trend)
         action = menu.exec(QCursor.pos())
         # Result will be None if the user exited the menu without selecting anything.
         if action is None:

--- a/src/sas/data_explorer_tree.py
+++ b/src/sas/data_explorer_tree.py
@@ -146,7 +146,7 @@ class DataExplorerTree(QTreeWidget):
             box.show()
 
     def showViewData(self):
-        associated = self._data_manager.get_association(self.currentTrackedDatum)
+        associated = self._data_manager.get_association_or_none(self.currentTrackedDatum)
         if isinstance(associated, Trend):
             trend = associated
         viewer = DataViewer(self.currentTrackedDatum, trend)

--- a/src/sas/data_explorer_tree.py
+++ b/src/sas/data_explorer_tree.py
@@ -143,7 +143,7 @@ class DataExplorerTree(QTreeWidget):
                         errors.append(err)
             case "make_trend":
                 trend_data = cast(list[SasData], self.currentTrackedData)
-                trend_creation_dialog = TrendCreation(trend_data)
+                trend_creation_dialog = TrendCreation(trend_data, self._data_manager.default_trend_name)
                 creation_result = trend_creation_dialog.exec()
                 if creation_result == QDialog.DialogCode.Accepted:
                     self._data_manager.register_trend(trend_creation_dialog.proposed_trend)

--- a/src/sas/data_manager.py
+++ b/src/sas/data_manager.py
@@ -111,14 +111,10 @@ class NewDataManager(QObject):
     def get_all_associations(self, data: TrackedData) -> list[TrackedData]:
         return [assoc[0] if assoc[0] != data else assoc[1] for assoc in self.associations if data in assoc]
 
-    def make_trend(self, data: list[SasData]):
-        # TODO: This trend axes value is a placeholder, and the user should be
-        # ale to select it in a dialog.
-        trend_axis = {"field": ["magnetic", "applied_magnetic_field"]}
-        new_trend = Trend(data=data, trend_axes=trend_axis)
-        self.add_data(new_trend)
-        for datum in data:
-            self.make_association(new_trend, datum)
+    def register_trend(self, trend: Trend):
+        self.add_data(trend)
+        for datum in trend.data:
+            self.make_association(trend, datum)
 
     @property
     def all_data(self) -> list[TrackedData]:

--- a/src/sas/data_manager.py
+++ b/src/sas/data_manager.py
@@ -102,11 +102,18 @@ class NewDataManager(QObject):
         self.associations.append(proposed_assoc)
         self.new_association.emit(data_1, data_2)
 
-    def get_association(self, data: TrackedData) -> TrackedData:
+    def get_association_or_none(self, data: TrackedData) -> TrackedData | None:
         for assoc in self.associations:
             if data in assoc:
                 return assoc[0] if assoc[0] != data else assoc[1]
-        raise ValueError('Association not found.')
+        return None
+
+    def get_association(self, data: TrackedData) -> TrackedData:
+        association = self.get_association_or_none
+        if association:
+            return association
+        else:
+            raise ValueError("Association not found")
 
     def get_all_associations(self, data: TrackedData) -> list[TrackedData]:
         return [assoc[0] if assoc[0] != data else assoc[1] for assoc in self.associations if data in assoc]

--- a/src/sas/data_manager.py
+++ b/src/sas/data_manager.py
@@ -111,6 +111,15 @@ class NewDataManager(QObject):
     def get_all_associations(self, data: TrackedData) -> list[TrackedData]:
         return [assoc[0] if assoc[0] != data else assoc[1] for assoc in self.associations if data in assoc]
 
+    def make_trend(self, data: list[SasData]):
+        # TODO: This trend axes value is a placeholder, and the user should be
+        # ale to select it in a dialog.
+        trend_axis = {"field": ["magnetic", "applied_magnetic_field"]}
+        new_trend = Trend(data=data, trend_axes=trend_axis)
+        self.add_data(new_trend)
+        for datum in data:
+            self.make_association(new_trend, datum)
+
     @property
     def all_data(self) -> list[TrackedData]:
         return self._all_data_entries

--- a/src/sas/data_manager.py
+++ b/src/sas/data_manager.py
@@ -1,3 +1,4 @@
+from sasdata.trend import Trend
 from PySide6.QtCore import QObject, Signal
 from PySide6.QtWidgets import QDialog
 
@@ -10,7 +11,8 @@ TrackedData = SasData | Perspective
 
 # TODO: Probably want to handle order, if that is even relevant.
 valid_associations: list[tuple[str | type, str | type]] = [
-    ('Perspective', SasData)
+    ('Perspective', SasData),
+    (Trend, SasData)
     # TODO: Include plots
 ]
 

--- a/src/sas/data_manager.py
+++ b/src/sas/data_manager.py
@@ -1,8 +1,8 @@
-from sasdata.trend import Trend
 from PySide6.QtCore import QObject, Signal
 from PySide6.QtWidgets import QDialog
 
 from sasdata.data import SasData
+from sasdata.trend import Trend
 
 from sas.refactored import Perspective
 

--- a/src/sas/data_manager.py
+++ b/src/sas/data_manager.py
@@ -124,7 +124,7 @@ class NewDataManager(QObject):
             self.make_association(trend, datum)
 
     @property
-    def default_trend_name(self) -> str:
+    def default_new_trend_name(self) -> str:
         trend_number = sum(isinstance_fix(obj, Trend) for obj in self._all_data_entries) + 1
         return f"Trend #{trend_number}"
 

--- a/src/sas/data_manager.py
+++ b/src/sas/data_manager.py
@@ -7,7 +7,7 @@ from sasdata.data import SasData
 from sas.refactored import Perspective
 
 # TODO: Add plots to this type.
-TrackedData = SasData | Perspective
+TrackedData = SasData | Perspective | Trend
 
 # TODO: Probably want to handle order, if that is even relevant.
 valid_associations: list[tuple[str | type, str | type]] = [

--- a/src/sas/data_manager.py
+++ b/src/sas/data_manager.py
@@ -109,7 +109,7 @@ class NewDataManager(QObject):
         return None
 
     def get_association(self, data: TrackedData) -> TrackedData:
-        association = self.get_association_or_none
+        association = self.get_association_or_none(data)
         if association:
             return association
         else:

--- a/src/sas/data_manager.py
+++ b/src/sas/data_manager.py
@@ -124,6 +124,11 @@ class NewDataManager(QObject):
             self.make_association(trend, datum)
 
     @property
+    def default_trend_name(self) -> str:
+        trend_number = sum(isinstance_fix(obj, Trend) for obj in self._all_data_entries) + 1
+        return f"Trend #{trend_number}"
+
+    @property
     def all_data(self) -> list[TrackedData]:
         return self._all_data_entries
 

--- a/src/sas/qtgui/MainWindow/DataViewer.py
+++ b/src/sas/qtgui/MainWindow/DataViewer.py
@@ -1,4 +1,3 @@
-from sasdata.trend import Trend, get_metadatum_from_path
 from PySide6.QtWidgets import (
     QDialog,
     QGridLayout,
@@ -10,6 +9,7 @@ from PySide6.QtWidgets import (
 )
 
 from sasdata.data import SasData
+from sasdata.trend import Trend, get_metadatum_from_path
 
 from sas.qtgui.MainWindow.MetadataExplorer import MetadataExplorer
 

--- a/src/sas/qtgui/MainWindow/DataViewer.py
+++ b/src/sas/qtgui/MainWindow/DataViewer.py
@@ -67,12 +67,14 @@ class DataViewer(QDialog):
     def buildTrendTable(self):
         # This shouldn't really happen, but it makes type checkers happy that
         # associated_trend is definitely not None.
+        self.trendTable.setEditTriggers(QTableWidget.EditTrigger.NoEditTriggers)
         if self.associated_trend is None:
             raise ValueError("Associated trend should not be None.")
         self.trendTable.setEditTriggers(QTableWidget.EditTrigger.NoEditTriggers)
         self.trendTable.setColumnCount(2)
         self.trendTable.setRowCount(len(self.associated_trend.trend_axes))
         self.trendTable.setHorizontalHeaderLabels(["Axis", "Value"])
+        self.trendTable.horizontalHeader().setSectionResizeMode(QHeaderView.ResizeMode.Stretch)
 
         for index, (axis_name, axis_path) in enumerate(
             zip(self.associated_trend.axis_names, self.associated_trend.trend_axes.values())

--- a/src/sas/qtgui/MainWindow/DataViewer.py
+++ b/src/sas/qtgui/MainWindow/DataViewer.py
@@ -42,10 +42,13 @@ class DataViewer(QDialog):
         self.layout.addWidget(self.viewMetadataButton, 0, 1, 1, 1)
         self.layout.addWidget(self.dataTypeLabel, 1, 0, 1, 1)
         if self.associated_trend:
-            self.layout.addWidget(self.trendLabel)
-            self.layout.addWidget(self.trendTable)
-        self.layout.addWidget(self.dataTable, 2, 0, 1, 2)
-        self.layout.addWidget(self.closeButton, 3, 0, 1, 2)
+            self.layout.addWidget(self.trendLabel, 2, 0, 1, 2)
+            self.layout.addWidget(self.trendTable, 3, 0, 1, 2)
+            data_table_row = 4
+        else:
+            data_table_row = 2
+        self.layout.addWidget(self.dataTable, data_table_row, 0, 1, 2)
+        self.layout.addWidget(self.closeButton, data_table_row + 1, 0, 1, 2)
 
     def buildTable(self):
         # Make the table readonly

--- a/src/sas/qtgui/MainWindow/DataViewer.py
+++ b/src/sas/qtgui/MainWindow/DataViewer.py
@@ -1,4 +1,4 @@
-from sasdata.trend import Trend
+from sasdata.trend import Trend, get_metadatum_from_path
 from PySide6.QtWidgets import (
     QDialog,
     QGridLayout,
@@ -54,19 +54,32 @@ class DataViewer(QDialog):
         self.dataTable.setColumnCount(len(columns))
         # NOTE: Assumes each column has the same amount of rows, which should be
         # the case, although perhaps we should validate this.
-        self.dataTable.setRowCount(
-            len(next(iter(self.to_view._data_contents.values())).value)
-        )
+        self.dataTable.setRowCount(len(next(iter(self.to_view._data_contents.values())).value))
         self.dataTable.setHorizontalHeaderLabels(columns)
-        self.dataTable.horizontalHeader().setSectionResizeMode(
-            QHeaderView.ResizeMode.Stretch
-        )
+        self.dataTable.horizontalHeader().setSectionResizeMode(QHeaderView.ResizeMode.Stretch)
         for i, data in enumerate(self.to_view._data_contents.values()):
             for j, datum in enumerate(data.value):
                 self.dataTable.setItem(j, i, QTableWidgetItem(str(datum)))
 
     def buildTrendTable(self):
-        raise NotImplementedError()
+        # This shouldn't really happen, but it makes type checkers happy that
+        # associated_trend is definitely not None.
+        if self.associated_trend is None:
+            raise ValueError("Associated trend should not be None.")
+        self.trendTable.setEditTriggers(QTableWidget.EditTrigger.NoEditTriggers)
+        self.trendTable.setColumnCount(2)
+        self.trendTable.setRowCount(len(self.associated_trend.trend_axes))
+        self.trendTable.setHorizontalHeaderLabels(["Axis", "Value"])
+
+        for index, (axis_name, axis_path) in enumerate(
+            zip(self.associated_trend.axis_names, self.associated_trend.trend_axes.values())
+        ):
+            name_item = QTableWidgetItem(axis_name)
+            # TODO: I think really Trend should have a method for doing this.
+            axis_value = get_metadatum_from_path(self.to_view, axis_path)
+            value_item = QTableWidgetItem(str(axis_value))
+            self.trendTable.setItem(index, 0, name_item)
+            self.trendTable.setItem(index, 1, value_item)
 
     def openMetadataExplorer(self):
         explorer = MetadataExplorer(self.to_view.metadata, self.to_view.name)

--- a/src/sas/qtgui/MainWindow/DataViewer.py
+++ b/src/sas/qtgui/MainWindow/DataViewer.py
@@ -1,3 +1,4 @@
+from sasdata.trend import Trend
 from PySide6.QtWidgets import (
     QDialog,
     QGridLayout,
@@ -14,10 +15,11 @@ from sas.qtgui.MainWindow.MetadataExplorer import MetadataExplorer
 
 
 class DataViewer(QDialog):
-    def __init__(self, to_view: SasData):
+    def __init__(self, to_view: SasData, associated_trend: Trend | None = None):
         super().__init__()
         self.to_view = to_view
         self.layout = QGridLayout(self)
+        self.associated_trend = associated_trend
 
         self.nameLabel = QLabel(f"Name: {self.to_view.name}")
         self.viewMetadataButton = QPushButton("View Metadata")
@@ -25,6 +27,10 @@ class DataViewer(QDialog):
         self.dataTypeLabel = QLabel(
             f"Type: {self.to_view.dataset_type.name}"
         )  # TODO: Probably a better way of printing this
+        if self.associated_trend:
+            self.trend_label = QLabel("Trend")
+            self.trend_table = QTableWidget()
+            self.buildTrendTable()
         self.dataTable = QTableWidget()
         self.dataTable.setMinimumHeight(345)
         self.buildTable()
@@ -35,6 +41,9 @@ class DataViewer(QDialog):
         self.layout.addWidget(self.nameLabel, 0, 0, 1, 1)
         self.layout.addWidget(self.viewMetadataButton, 0, 1, 1, 1)
         self.layout.addWidget(self.dataTypeLabel, 1, 0, 1, 1)
+        if self.associated_trend:
+            self.layout.addWidget(self.trend_label)
+            self.layout.addWidget(self.trend_table)
         self.layout.addWidget(self.dataTable, 2, 0, 1, 2)
         self.layout.addWidget(self.closeButton, 3, 0, 1, 2)
 
@@ -55,6 +64,9 @@ class DataViewer(QDialog):
         for i, data in enumerate(self.to_view._data_contents.values()):
             for j, datum in enumerate(data.value):
                 self.dataTable.setItem(j, i, QTableWidgetItem(str(datum)))
+
+    def buildTrendTable(self):
+        raise NotImplementedError()
 
     def openMetadataExplorer(self):
         explorer = MetadataExplorer(self.to_view.metadata, self.to_view.name)

--- a/src/sas/qtgui/MainWindow/DataViewer.py
+++ b/src/sas/qtgui/MainWindow/DataViewer.py
@@ -28,8 +28,8 @@ class DataViewer(QDialog):
             f"Type: {self.to_view.dataset_type.name}"
         )  # TODO: Probably a better way of printing this
         if self.associated_trend:
-            self.trend_label = QLabel("Trend")
-            self.trend_table = QTableWidget()
+            self.trendLabel = QLabel("Trend")
+            self.trendTable = QTableWidget()
             self.buildTrendTable()
         self.dataTable = QTableWidget()
         self.dataTable.setMinimumHeight(345)
@@ -42,8 +42,8 @@ class DataViewer(QDialog):
         self.layout.addWidget(self.viewMetadataButton, 0, 1, 1, 1)
         self.layout.addWidget(self.dataTypeLabel, 1, 0, 1, 1)
         if self.associated_trend:
-            self.layout.addWidget(self.trend_label)
-            self.layout.addWidget(self.trend_table)
+            self.layout.addWidget(self.trendLabel)
+            self.layout.addWidget(self.trendTable)
         self.layout.addWidget(self.dataTable, 2, 0, 1, 2)
         self.layout.addWidget(self.closeButton, 3, 0, 1, 2)
 

--- a/src/sas/qtgui/MainWindow/MetadataExplorer.py
+++ b/src/sas/qtgui/MainWindow/MetadataExplorer.py
@@ -9,7 +9,7 @@ from PySide6.QtWidgets import (
     QTreeWidgetItem,
     QVBoxLayout, QHBoxLayout,
 )
-
+from PySide6.QtCore import Qt
 from sasdata.metadata import Metadata, MetaNode
 from sasdata.quantities.quantity import Quantity
 from sasdata.temp_xml_reader import load_data
@@ -111,6 +111,15 @@ class MetadataExplorer(QDialog):
                     node_item = QTreeWidgetItem([key, str(value.contents)])
                     table_root.addChild(node_item)
 
+    @property
+    def getSelectedPaths(self) -> list[str]:
+        return_value: list[str] = []
+        for selected in self.metadataTreeWidget.selectedItems():
+            current_item = selected
+            while current_item is not None:
+                return_value.append(current_item.data(0, Qt.ItemDataRole.DisplayRole))
+                current_item = current_item.parent()
+        return return_value
 
 if __name__ == "__main__":
     app = QApplication([])

--- a/src/sas/qtgui/MainWindow/MetadataExplorer.py
+++ b/src/sas/qtgui/MainWindow/MetadataExplorer.py
@@ -124,7 +124,7 @@ class MetadataExplorer(QDialog):
                 current_path.append(get_data(current_item))
                 current_item = current_item.parent()
             return_value.append(current_path)
-        return return_value
+        return return_value[::-1]
 
 if __name__ == "__main__":
     app = QApplication([])

--- a/src/sas/qtgui/MainWindow/MetadataExplorer.py
+++ b/src/sas/qtgui/MainWindow/MetadataExplorer.py
@@ -60,6 +60,7 @@ class MetadataExplorer(QDialog):
         if selection_mode:
             self.closeButton = QPushButton("Cancel")
             self.selectButton = QPushButton("Select")
+            self.selectButton.clicked.connect(self.accept)
             self.button_row.addWidget(self.closeButton)
             self.button_row.addWidget(self.selectButton)
         else:

--- a/src/sas/qtgui/MainWindow/MetadataExplorer.py
+++ b/src/sas/qtgui/MainWindow/MetadataExplorer.py
@@ -124,7 +124,7 @@ class MetadataExplorer(QDialog):
                 current_path.append(get_data(current_item))
                 current_item = current_item.parent()
             return_value.append(current_path)
-        return return_value[::-1]
+        return return_value
 
 if __name__ == "__main__":
     app = QApplication([])

--- a/src/sas/qtgui/MainWindow/MetadataExplorer.py
+++ b/src/sas/qtgui/MainWindow/MetadataExplorer.py
@@ -112,13 +112,15 @@ class MetadataExplorer(QDialog):
                     table_root.addChild(node_item)
 
     @property
-    def getSelectedPaths(self) -> list[str]:
-        return_value: list[str] = []
+    def getSelectedPaths(self) -> list[list[str]]:
+        return_value: list[list[str]] = []
         for selected in self.metadataTreeWidget.selectedItems():
             current_item = selected
+            current_path: list[str] = []
             while current_item is not None:
-                return_value.append(current_item.data(0, Qt.ItemDataRole.DisplayRole))
+                current_path.append(current_item.data(0, Qt.ItemDataRole.DisplayRole))
                 current_item = current_item.parent()
+            return_value.append(current_path)
         return return_value
 
 if __name__ == "__main__":

--- a/src/sas/qtgui/MainWindow/MetadataExplorer.py
+++ b/src/sas/qtgui/MainWindow/MetadataExplorer.py
@@ -72,7 +72,7 @@ class MetadataExplorer(QDialog):
         self.setMinimumSize(800, 430)
 
     def closeEvent(self, event):
-        self.close()
+        self.reject()
 
     def buildTree(
         self,

--- a/src/sas/qtgui/MainWindow/MetadataExplorer.py
+++ b/src/sas/qtgui/MainWindow/MetadataExplorer.py
@@ -113,12 +113,15 @@ class MetadataExplorer(QDialog):
 
     @property
     def getSelectedPaths(self) -> list[list[str]]:
+        def get_data(item: QTreeWidgetItem):
+            return item.data(0, Qt.ItemDataRole.DisplayRole)
+
         return_value: list[list[str]] = []
         for selected in self.metadataTreeWidget.selectedItems():
             current_item = selected
             current_path: list[str] = []
-            while current_item is not None:
-                current_path.append(current_item.data(0, Qt.ItemDataRole.DisplayRole))
+            while current_item is not None and get_data(current_item) not in ["raw", "root", "Metadata"]:
+                current_path.append(get_data(current_item))
                 current_item = current_item.parent()
             return_value.append(current_path)
         return return_value

--- a/src/sas/qtgui/MainWindow/MetadataExplorer.py
+++ b/src/sas/qtgui/MainWindow/MetadataExplorer.py
@@ -123,7 +123,7 @@ class MetadataExplorer(QDialog):
             while current_item is not None and get_data(current_item) not in ["raw", "root", "Metadata"]:
                 current_path.append(get_data(current_item))
                 current_item = current_item.parent()
-            return_value.append(current_path)
+            return_value.append(current_path[::-1])
         return return_value
 
 if __name__ == "__main__":

--- a/src/sas/qtgui/MainWindow/MetadataExplorer.py
+++ b/src/sas/qtgui/MainWindow/MetadataExplorer.py
@@ -7,7 +7,7 @@ from PySide6.QtWidgets import (
     QPushButton,
     QTreeWidget,
     QTreeWidgetItem,
-    QVBoxLayout,
+    QVBoxLayout, QHBoxLayout,
 )
 
 from sasdata.metadata import Metadata, MetaNode
@@ -51,13 +51,22 @@ class MetadataExplorer(QDialog):
             self.metadataTreeWidget.setSelectionMode(QTreeWidget.SelectionMode.MultiSelection)
 
 
-        self.closeButton = QPushButton("Close")
-        self.closeButton.clicked.connect(self.closeEvent)
 
         self.layout = QVBoxLayout(self)
         self.layout.addWidget(self.filenameLabel)
         self.layout.addWidget(self.metadataTreeWidget)
-        self.layout.addWidget(self.closeButton)
+
+        self.button_row = QHBoxLayout()
+        if selection_mode:
+            self.closeButton = QPushButton("Cancel")
+            self.selectButton = QPushButton("Select")
+            self.button_row.addWidget(self.closeButton)
+            self.button_row.addWidget(self.selectButton)
+        else:
+            self.closeButton = QPushButton("Close")
+            self.button_row.addWidget(self.closeButton)
+        self.closeButton.clicked.connect(self.closeEvent)
+        self.layout.addLayout(self.button_row)
 
         self.setWindowTitle("Metadata Explorer")
         self.setMinimumSize(800, 430)

--- a/src/sas/qtgui/MainWindow/MetadataExplorer.py
+++ b/src/sas/qtgui/MainWindow/MetadataExplorer.py
@@ -35,7 +35,7 @@ def metadata_as_dict(to_convert: object):
 
 
 class MetadataExplorer(QDialog):
-    def __init__(self, metadata: Metadata, filename: str | None):
+    def __init__(self, metadata: Metadata, filename: str | None, selection_mode: bool = False):
         super().__init__()
         self.metadata_dict = metadata_as_dict(metadata)
 
@@ -45,6 +45,11 @@ class MetadataExplorer(QDialog):
         self.metadataTreeWidget = QTreeWidget()
         self.buildTree()
         self.metadataTreeWidget.header().setDefaultSectionSize(350)
+
+        self.selection_mode = selection_mode
+        if self.selection_mode:
+            self.metadataTreeWidget.setSelectionMode(QTreeWidget.SelectionMode.MultiSelection)
+
 
         self.closeButton = QPushButton("Close")
         self.closeButton.clicked.connect(self.closeEvent)

--- a/src/sas/qtgui/MainWindow/MetadataExplorer.py
+++ b/src/sas/qtgui/MainWindow/MetadataExplorer.py
@@ -1,15 +1,17 @@
 from sys import argv
 
+from PySide6.QtCore import Qt
 from PySide6.QtWidgets import (
     QApplication,
     QDialog,
+    QHBoxLayout,
     QLabel,
     QPushButton,
     QTreeWidget,
     QTreeWidgetItem,
-    QVBoxLayout, QHBoxLayout,
+    QVBoxLayout,
 )
-from PySide6.QtCore import Qt
+
 from sasdata.metadata import Metadata, MetaNode
 from sasdata.quantities.quantity import Quantity
 from sasdata.temp_xml_reader import load_data

--- a/src/sas/qtgui/MainWindow/TrendCreation.py
+++ b/src/sas/qtgui/MainWindow/TrendCreation.py
@@ -69,4 +69,7 @@ class TrendCreation(QDialog):
         metadata_dialog = MetadataExplorer(self.target_data[0].metadata, "New Trend", True)
         result = metadata_dialog.exec()
         if result == QDialog.DialogCode.Accepted:
-            pass  # TODO: Update proposed axes.
+            for axis_path in metadata_dialog.getSelectedPaths:
+                # TODO: perhaps have a better way of choosing names. Maybe make them customisable?
+                self.proposed_trend_axes.append(ProposedTrendAxis(axis_name=axis_path[-1], axis_path=axis_path))
+                

--- a/src/sas/qtgui/MainWindow/TrendCreation.py
+++ b/src/sas/qtgui/MainWindow/TrendCreation.py
@@ -1,7 +1,8 @@
 from sasdata.data import SasData
+from sasdata.trend import Trend
 from sas.qtgui.MainWindow.MetadataExplorer import MetadataExplorer
 from dataclasses import dataclass
-from PySide6.QtWidgets import QDialog, QVBoxLayout, QLabel, QTableWidget, QHBoxLayout, QPushButton, QTableWidgetItem, QHeaderView
+from PySide6.QtWidgets import QDialog, QVBoxLayout, QLabel, QTableWidget, QHBoxLayout, QPushButton, QTableWidgetItem, QHeaderView, QMessageBox
 
 
 @dataclass
@@ -75,4 +76,12 @@ class TrendCreation(QDialog):
                 # TODO: perhaps have a better way of choosing names. Maybe make them customisable?
                 self.proposed_trend_axes.append(ProposedTrendAxis(axis_name=axis_path[-1], axis_path=axis_path))
                 self.update_table()
+
+    def make_trend(self):
+        """Try to make the proposed Trend, and error if it fails."""
+        try:
+            # TODO: Fill in the dictionary
+            _ = Trend(self.target_data, {})
+        except ValueError as e:
+            QMessageBox.critical(None, "Trend cannot be created", e)
                 

--- a/src/sas/qtgui/MainWindow/TrendCreation.py
+++ b/src/sas/qtgui/MainWindow/TrendCreation.py
@@ -11,6 +11,9 @@ class ProposedTrendAxis:
     axis_path: list[str]
 
 
+def proposed_axes_as_dict(proposed_axes: list[ProposedTrendAxis]) -> dict[str, list[str]]:
+    return {axis.axis_name: axis.axis_path for axis in proposed_axes}
+
 class TrendCreation(QDialog):
     def __init__(self, target_data: list[SasData]):
         super().__init__()

--- a/src/sas/qtgui/MainWindow/TrendCreation.py
+++ b/src/sas/qtgui/MainWindow/TrendCreation.py
@@ -2,7 +2,7 @@ from sasdata.data import SasData
 from sasdata.trend import Trend
 from sas.qtgui.MainWindow.MetadataExplorer import MetadataExplorer
 from dataclasses import dataclass
-from PySide6.QtWidgets import QDialog, QVBoxLayout, QLabel, QTableWidget, QHBoxLayout, QPushButton, QTableWidgetItem, QHeaderView, QMessageBox
+from PySide6.QtWidgets import QDialog, QVBoxLayout, QLabel, QTableWidget, QHBoxLayout, QPushButton, QTableWidgetItem, QHeaderView, QMessageBox, QTextEdit
 
 
 @dataclass
@@ -25,6 +25,9 @@ class TrendCreation(QDialog):
 
         self.layout = QVBoxLayout(self)
 
+        self.trend_name_label = QLabel("Trend Name:")
+        self.trend_name_entry = QTextEdit()
+
         self.header_label = QLabel("The below table shows the axes that are selected for this trend.")
         self.table = QTableWidget()
         self.update_table()
@@ -39,6 +42,8 @@ class TrendCreation(QDialog):
         self.button_row.addWidget(self.cancel_button)
         self.button_row.addWidget(self.make_button)
 
+        self.layout.addWidget(self.trend_name_label)
+        self.layout.addWidget(self.trend_name_entry)
         self.layout.addWidget(self.header_label)
         self.layout.addWidget(self.add_axes_button)
         self.layout.addWidget(self.table)

--- a/src/sas/qtgui/MainWindow/TrendCreation.py
+++ b/src/sas/qtgui/MainWindow/TrendCreation.py
@@ -80,11 +80,15 @@ class TrendCreation(QDialog):
                 self.proposed_trend_axes.append(ProposedTrendAxis(axis_name=axis_path[-1], axis_path=axis_path))
                 self.update_table()
 
+    @property
+    def selected_proposed_trend_axes_as_dict(self) -> dict[str, list[str]]:
+        return proposed_axes_as_dict(self.proposed_trend_axes)
+
     def make_trend(self):
         """Try to make the proposed Trend, and error if it fails."""
         try:
             # TODO: Fill in the dictionary
-            _ = Trend(self.target_data, proposed_axes_as_dict(self.proposed_trend_axes))
+            _ = Trend(self.target_data, self.selected_proposed_trend_axes_as_dict)
             self.accept()
         except ValueError as e:
             QMessageBox.critical(None, "Trend cannot be created", str(e))

--- a/src/sas/qtgui/MainWindow/TrendCreation.py
+++ b/src/sas/qtgui/MainWindow/TrendCreation.py
@@ -16,11 +16,11 @@ def proposed_axes_as_dict(proposed_axes: list[ProposedTrendAxis]) -> dict[str, l
     return {axis.axis_name: axis.axis_path for axis in proposed_axes}
 
 class TrendCreation(QDialog):
-    def __init__(self, target_data: list[SasData]):
+    def __init__(self, target_data: list[SasData], default_name: str):
         super().__init__()
 
         self.proposed_trend_axes: list[ProposedTrendAxis] = []
-        self.proposed_name = ""
+        self.proposed_name = default_name
         self.target_data = target_data
 
         self.setWindowTitle("Trend Creation")

--- a/src/sas/qtgui/MainWindow/TrendCreation.py
+++ b/src/sas/qtgui/MainWindow/TrendCreation.py
@@ -19,6 +19,7 @@ class TrendCreation(QDialog):
         super().__init__()
 
         self.proposed_trend_axes: list[ProposedTrendAxis] = []
+        self.proposed_name = ""
         self.target_data = target_data
 
         self.setWindowTitle("Trend Creation")
@@ -27,6 +28,7 @@ class TrendCreation(QDialog):
 
         self.trend_name_label = QLabel("Trend Name:")
         self.trend_name_entry = QLineEdit()
+        self.trend_name_entry.textChanged.connect(self.on_new_proposed_name)
 
         self.header_label = QLabel("The below table shows the axes that are selected for this trend.")
         self.table = QTableWidget()
@@ -48,6 +50,9 @@ class TrendCreation(QDialog):
         self.layout.addWidget(self.add_axes_button)
         self.layout.addWidget(self.table)
         self.layout.addLayout(self.button_row)
+
+    def on_new_proposed_name(self):
+        self.proposed_name = self.trend_name_entry.text()
 
     def update_table(self):
         self.table.clear()

--- a/src/sas/qtgui/MainWindow/TrendCreation.py
+++ b/src/sas/qtgui/MainWindow/TrendCreation.py
@@ -25,6 +25,7 @@ class TrendCreation(QDialog):
         self.table = QTableWidget()
         self.update_table()
         self.add_axes_button = QPushButton("Add Axes")
+        self.add_axes_button.clicked.connect(self.handle_add_axes)
 
         self.button_row = QHBoxLayout()
         self.cancel_button = QPushButton("Cancel")

--- a/src/sas/qtgui/MainWindow/TrendCreation.py
+++ b/src/sas/qtgui/MainWindow/TrendCreation.py
@@ -85,6 +85,7 @@ class TrendCreation(QDialog):
         try:
             # TODO: Fill in the dictionary
             _ = Trend(self.target_data, proposed_axes_as_dict(self.proposed_trend_axes))
+            self.accept()
         except ValueError as e:
             QMessageBox.critical(None, "Trend cannot be created", str(e))
                 

--- a/src/sas/qtgui/MainWindow/TrendCreation.py
+++ b/src/sas/qtgui/MainWindow/TrendCreation.py
@@ -84,6 +84,10 @@ class TrendCreation(QDialog):
     def selected_proposed_trend_axes_as_dict(self) -> dict[str, list[str]]:
         return proposed_axes_as_dict(self.proposed_trend_axes)
 
+    @property
+    def proposed_trend(self) -> Trend:
+        return Trend(self.target_data, self.selected_proposed_trend_axes_as_dict)
+
     def make_trend(self):
         """Try to make the proposed Trend, and error if it fails."""
         try:

--- a/src/sas/qtgui/MainWindow/TrendCreation.py
+++ b/src/sas/qtgui/MainWindow/TrendCreation.py
@@ -24,7 +24,7 @@ class TrendCreation(QDialog):
         self.add_axes_button = QPushButton("Add Axes")
 
         self.button_row = QHBoxLayout()
-        self.cancel_button = QPushButton("Cance ")
+        self.cancel_button = QPushButton("Cancel")
         self.make_button = QPushButton("Make Trend")
         self.button_row.addWidget(self.cancel_button)
         self.button_row.addWidget(self.make_button)

--- a/src/sas/qtgui/MainWindow/TrendCreation.py
+++ b/src/sas/qtgui/MainWindow/TrendCreation.py
@@ -72,4 +72,5 @@ class TrendCreation(QDialog):
             for axis_path in metadata_dialog.getSelectedPaths:
                 # TODO: perhaps have a better way of choosing names. Maybe make them customisable?
                 self.proposed_trend_axes.append(ProposedTrendAxis(axis_name=axis_path[-1], axis_path=axis_path))
+                self.update_table()
                 

--- a/src/sas/qtgui/MainWindow/TrendCreation.py
+++ b/src/sas/qtgui/MainWindow/TrendCreation.py
@@ -35,7 +35,7 @@ class TrendCreation(QDialog):
         self.cancel_button = QPushButton("Cancel")
         self.cancel_button.clicked.connect(self.reject)
         self.make_button = QPushButton("Make Trend")
-        self.make_button.clicked.connect(self.accept)
+        self.make_button.clicked.connect(self.make_trend)
         self.button_row.addWidget(self.cancel_button)
         self.button_row.addWidget(self.make_button)
 

--- a/src/sas/qtgui/MainWindow/TrendCreation.py
+++ b/src/sas/qtgui/MainWindow/TrendCreation.py
@@ -1,7 +1,7 @@
 from sasdata.data import SasData
 from sas.qtgui.MainWindow.MetadataExplorer import MetadataExplorer
 from dataclasses import dataclass
-from PySide6.QtWidgets import QDialog, QVBoxLayout, QLabel, QTableWidget, QHBoxLayout, QPushButton, QTableWidgetItem
+from PySide6.QtWidgets import QDialog, QVBoxLayout, QLabel, QTableWidget, QHBoxLayout, QPushButton, QTableWidgetItem, QHeaderView
 
 
 @dataclass
@@ -46,6 +46,8 @@ class TrendCreation(QDialog):
         self.table.setRowCount(len(self.proposed_trend_axes))
         self.table.setColumnCount(2)
         self.table.setHorizontalHeaderLabels(["Axis Name", "Axis Metadata"])
+        self.table.horizontalHeader().setSectionResizeMode(0, QHeaderView.ResizeMode.ResizeToContents)
+        self.table.horizontalHeader().setSectionResizeMode(1, QHeaderView.ResizeMode.Stretch)
 
         row_index = 0
         for axis in self.proposed_trend_axes:

--- a/src/sas/qtgui/MainWindow/TrendCreation.py
+++ b/src/sas/qtgui/MainWindow/TrendCreation.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from PySide6.QtWidgets import QDialog, QVBoxLayout, QLabel, QTableWidget, QHBoxLayout, QPushButton
+from PySide6.QtWidgets import QDialog, QVBoxLayout, QLabel, QTableWidget, QHBoxLayout, QPushButton, QTableWidgetItem
 
 
 @dataclass
@@ -20,7 +20,7 @@ class TrendCreation(QDialog):
 
         self.header_label = QLabel("The below table shows the axes that are selected for this trend.")
         self.table = QTableWidget()
-        self.table.setHorizontalHeaderLabels(["Axis Name", "Axis Metadata"])
+        self.update_table()
         self.add_axes_button = QPushButton("Add Axes")
 
         self.button_row = QHBoxLayout()
@@ -33,3 +33,19 @@ class TrendCreation(QDialog):
         self.layout.addWidget(self.add_axes_button)
         self.layout.addWidget(self.table)
         self.layout.addLayout(self.button_row)
+
+    def update_table(self):
+        self.table.clear()
+
+        self.table.setRowCount(len(self.proposed_trend_axes))
+        self.table.setHorizontalHeaderLabels(["Axis Name", "Axis Metadata"])
+
+        row_index = 0
+        for axis in self.proposed_trend_axes:
+            name_item = QTableWidgetItem(axis.axis_name)
+            path_item = QTableWidgetItem(", ".join(axis.axis_path))
+            self.table.setItem(row_index, 0, name_item)
+            self.table.setItem(row_index, 1, path_item)
+            row_index += 1
+
+        self.table.show()

--- a/src/sas/qtgui/MainWindow/TrendCreation.py
+++ b/src/sas/qtgui/MainWindow/TrendCreation.py
@@ -12,6 +12,7 @@ class TrendCreation(QDialog):
         self.header_label = QLabel("The below table shows the axes that are selected for this trend.")
         self.table = QTableWidget()
         self.table.setHorizontalHeaderLabels(["Axis Name", "Axis Metadata"])
+        self.add_axes_button = QPushButton("Add Axes")
 
         self.button_row = QHBoxLayout()
         self.cancel_button = QPushButton("Cance ")
@@ -20,5 +21,6 @@ class TrendCreation(QDialog):
         self.button_row.addWidget(self.make_button)
 
         self.layout.addWidget(self.header_label)
+        self.layout.addWidget(self.add_axes_button)
         self.layout.addWidget(self.table)
         self.layout.addLayout(self.button_row)

--- a/src/sas/qtgui/MainWindow/TrendCreation.py
+++ b/src/sas/qtgui/MainWindow/TrendCreation.py
@@ -1,3 +1,5 @@
+from sasdata.data import SasData
+from sas.qtgui.MainWindow.MetadataExplorer import MetadataExplorer
 from dataclasses import dataclass
 from PySide6.QtWidgets import QDialog, QVBoxLayout, QLabel, QTableWidget, QHBoxLayout, QPushButton, QTableWidgetItem
 
@@ -53,3 +55,17 @@ class TrendCreation(QDialog):
             row_index += 1
 
         self.table.show()
+
+    def handle_add_axes(self):
+        # TODO: This is assuming all the data in target data has the same
+        # metadata, but this of course is not guaranteed. I see two ways of
+        # resolving this:
+        #
+        # 1. Validate that the objects do share all the same metadata.
+        # 2. Only show metadata in the explorer which the data objects share.
+        # This is probably trickier to implement but would also be the most
+        # flexible.
+        metadata_dialog = MetadataExplorer(self.target_data[0].metadata, "New Trend", True)
+        result = metadata_dialog.exec()
+        if result == QDialog.DialogCode.Accepted:
+            pass  # TODO: Update proposed axes.

--- a/src/sas/qtgui/MainWindow/TrendCreation.py
+++ b/src/sas/qtgui/MainWindow/TrendCreation.py
@@ -1,9 +1,18 @@
+from dataclasses import dataclass
 from PySide6.QtWidgets import QDialog, QVBoxLayout, QLabel, QTableWidget, QHBoxLayout, QPushButton
+
+
+@dataclass
+class ProposedTrendAxis:
+    axis_name: str
+    axis_path: list[str]
 
 
 class TrendCreation(QDialog):
     def __init__(self):
         super().__init__()
+
+        self.proposed_trend_axes: list[ProposedTrendAxis] = []
 
         self.setWindowTitle("Trend Creation")
 

--- a/src/sas/qtgui/MainWindow/TrendCreation.py
+++ b/src/sas/qtgui/MainWindow/TrendCreation.py
@@ -84,7 +84,7 @@ class TrendCreation(QDialog):
         """Try to make the proposed Trend, and error if it fails."""
         try:
             # TODO: Fill in the dictionary
-            _ = Trend(self.target_data, {})
+            _ = Trend(self.target_data, proposed_axes_as_dict(self.proposed_trend_axes))
         except ValueError as e:
             QMessageBox.critical(None, "Trend cannot be created", e)
                 

--- a/src/sas/qtgui/MainWindow/TrendCreation.py
+++ b/src/sas/qtgui/MainWindow/TrendCreation.py
@@ -38,6 +38,7 @@ class TrendCreation(QDialog):
         self.table.clear()
 
         self.table.setRowCount(len(self.proposed_trend_axes))
+        self.table.setColumnCount(2)
         self.table.setHorizontalHeaderLabels(["Axis Name", "Axis Metadata"])
 
         row_index = 0

--- a/src/sas/qtgui/MainWindow/TrendCreation.py
+++ b/src/sas/qtgui/MainWindow/TrendCreation.py
@@ -25,7 +25,9 @@ class TrendCreation(QDialog):
 
         self.button_row = QHBoxLayout()
         self.cancel_button = QPushButton("Cancel")
+        self.cancel_button.clicked.connect(self.reject)
         self.make_button = QPushButton("Make Trend")
+        self.make_button.clicked.connect(self.accept)
         self.button_row.addWidget(self.cancel_button)
         self.button_row.addWidget(self.make_button)
 

--- a/src/sas/qtgui/MainWindow/TrendCreation.py
+++ b/src/sas/qtgui/MainWindow/TrendCreation.py
@@ -2,7 +2,7 @@ from sasdata.data import SasData
 from sasdata.trend import Trend
 from sas.qtgui.MainWindow.MetadataExplorer import MetadataExplorer
 from dataclasses import dataclass
-from PySide6.QtWidgets import QDialog, QVBoxLayout, QLabel, QTableWidget, QHBoxLayout, QPushButton, QTableWidgetItem, QHeaderView, QMessageBox, QTextEdit
+from PySide6.QtWidgets import QDialog, QVBoxLayout, QLabel, QTableWidget, QHBoxLayout, QPushButton, QTableWidgetItem, QHeaderView, QMessageBox, QLineEdit
 
 
 @dataclass
@@ -26,7 +26,7 @@ class TrendCreation(QDialog):
         self.layout = QVBoxLayout(self)
 
         self.trend_name_label = QLabel("Trend Name:")
-        self.trend_name_entry = QTextEdit()
+        self.trend_name_entry = QLineEdit()
 
         self.header_label = QLabel("The below table shows the axes that are selected for this trend.")
         self.table = QTableWidget()

--- a/src/sas/qtgui/MainWindow/TrendCreation.py
+++ b/src/sas/qtgui/MainWindow/TrendCreation.py
@@ -1,0 +1,24 @@
+from PySide6.QtWidgets import QDialog, QVBoxLayout, QLabel, QTableWidget, QHBoxLayout, QPushButton
+
+
+class TrendCreation(QDialog):
+    def __init__(self):
+        super().__init__()
+
+        self.setWindowTitle("Trend Creation")
+
+        self.layout = QVBoxLayout(self)
+
+        self.header_label = QLabel("The below table shows the axes that are selected for this trend.")
+        self.table = QTableWidget()
+        self.table.setHorizontalHeaderLabels(["Axis Name", "Axis Metadata"])
+
+        self.button_row = QHBoxLayout()
+        self.cancel_button = QPushButton("Cance ")
+        self.make_button = QPushButton("Make Trend")
+        self.button_row.addWidget(self.cancel_button)
+        self.button_row.addWidget(self.make_button)
+
+        self.layout.addWidget(self.header_label)
+        self.layout.addWidget(self.table)
+        self.layout.addLayout(self.button_row)

--- a/src/sas/qtgui/MainWindow/TrendCreation.py
+++ b/src/sas/qtgui/MainWindow/TrendCreation.py
@@ -9,10 +9,11 @@ class ProposedTrendAxis:
 
 
 class TrendCreation(QDialog):
-    def __init__(self):
+    def __init__(self, target_data: list[SasData]):
         super().__init__()
 
         self.proposed_trend_axes: list[ProposedTrendAxis] = []
+        self.target_data = target_data
 
         self.setWindowTitle("Trend Creation")
 

--- a/src/sas/qtgui/MainWindow/TrendCreation.py
+++ b/src/sas/qtgui/MainWindow/TrendCreation.py
@@ -28,7 +28,7 @@ class TrendCreation(QDialog):
         self.layout = QVBoxLayout(self)
 
         self.trend_name_label = QLabel("Trend Name:")
-        self.trend_name_entry = QLineEdit()
+        self.trend_name_entry = QLineEdit(self.proposed_name)
         self.trend_name_entry.textChanged.connect(self.on_new_proposed_name)
 
         self.header_label = QLabel("The below table shows the axes that are selected for this trend.")

--- a/src/sas/qtgui/MainWindow/TrendCreation.py
+++ b/src/sas/qtgui/MainWindow/TrendCreation.py
@@ -1,9 +1,22 @@
-from sas.refactored import NamedTrend
-from sasdata.data import SasData
-from sasdata.trend import Trend
-from sas.qtgui.MainWindow.MetadataExplorer import MetadataExplorer
 from dataclasses import dataclass
-from PySide6.QtWidgets import QDialog, QVBoxLayout, QLabel, QTableWidget, QHBoxLayout, QPushButton, QTableWidgetItem, QHeaderView, QMessageBox, QLineEdit
+
+from PySide6.QtWidgets import (
+    QDialog,
+    QHBoxLayout,
+    QHeaderView,
+    QLabel,
+    QLineEdit,
+    QMessageBox,
+    QPushButton,
+    QTableWidget,
+    QTableWidgetItem,
+    QVBoxLayout,
+)
+
+from sasdata.data import SasData
+
+from sas.qtgui.MainWindow.MetadataExplorer import MetadataExplorer
+from sas.refactored import NamedTrend
 
 
 @dataclass
@@ -106,4 +119,4 @@ class TrendCreation(QDialog):
             self.accept()
         except ValueError as e:
             QMessageBox.critical(None, "Trend cannot be created", str(e))
-                
+

--- a/src/sas/qtgui/MainWindow/TrendCreation.py
+++ b/src/sas/qtgui/MainWindow/TrendCreation.py
@@ -86,5 +86,5 @@ class TrendCreation(QDialog):
             # TODO: Fill in the dictionary
             _ = Trend(self.target_data, proposed_axes_as_dict(self.proposed_trend_axes))
         except ValueError as e:
-            QMessageBox.critical(None, "Trend cannot be created", e)
+            QMessageBox.critical(None, "Trend cannot be created", str(e))
                 

--- a/src/sas/qtgui/MainWindow/TrendCreation.py
+++ b/src/sas/qtgui/MainWindow/TrendCreation.py
@@ -49,7 +49,7 @@ class TrendCreation(QDialog):
 
         self.table.setRowCount(len(self.proposed_trend_axes))
         self.table.setColumnCount(2)
-        self.table.setHorizontalHeaderLabels(["Axis Name", "Axis Metadata"])
+        self.table.setHorizontalHeaderLabels(["Axis Name", "Metadata Path"])
         self.table.horizontalHeader().setSectionResizeMode(0, QHeaderView.ResizeMode.ResizeToContents)
         self.table.horizontalHeader().setSectionResizeMode(1, QHeaderView.ResizeMode.Stretch)
 

--- a/src/sas/qtgui/MainWindow/TrendCreation.py
+++ b/src/sas/qtgui/MainWindow/TrendCreation.py
@@ -103,7 +103,7 @@ class TrendCreation(QDialog):
         """Try to make the proposed Trend, and error if it fails."""
         try:
             # TODO: Fill in the dictionary
-            _ = Trend(self.target_data, self.selected_proposed_trend_axes_as_dict)
+            _ = self.proposed_trend
             self.accept()
         except ValueError as e:
             QMessageBox.critical(None, "Trend cannot be created", str(e))

--- a/src/sas/qtgui/MainWindow/TrendCreation.py
+++ b/src/sas/qtgui/MainWindow/TrendCreation.py
@@ -102,7 +102,6 @@ class TrendCreation(QDialog):
     def make_trend(self):
         """Try to make the proposed Trend, and error if it fails."""
         try:
-            # TODO: Fill in the dictionary
             _ = self.proposed_trend
             self.accept()
         except ValueError as e:

--- a/src/sas/qtgui/MainWindow/TrendCreation.py
+++ b/src/sas/qtgui/MainWindow/TrendCreation.py
@@ -1,3 +1,4 @@
+from sas.refactored import NamedTrend
 from sasdata.data import SasData
 from sasdata.trend import Trend
 from sas.qtgui.MainWindow.MetadataExplorer import MetadataExplorer
@@ -95,8 +96,8 @@ class TrendCreation(QDialog):
         return proposed_axes_as_dict(self.proposed_trend_axes)
 
     @property
-    def proposed_trend(self) -> Trend:
-        return Trend(self.target_data, self.selected_proposed_trend_axes_as_dict)
+    def proposed_trend(self) -> NamedTrend:
+        return NamedTrend(self.target_data, self.selected_proposed_trend_axes_as_dict, self.proposed_name)
 
     def make_trend(self):
         """Try to make the proposed Trend, and error if it fails."""

--- a/src/sas/refactored.py
+++ b/src/sas/refactored.py
@@ -84,5 +84,7 @@ class NamedTrend(Trend):
     name: str
 
     def __init__(self, data: list[SasData], trend_axes: dict[str, list[str] | list], name: str):
+        if name.strip() == "":
+            raise ValueError("A named trend cannot have an empty name.")
         super().__init__(data=data, trend_axes=trend_axes)
         self.name = name

--- a/src/sas/refactored.py
+++ b/src/sas/refactored.py
@@ -1,7 +1,5 @@
-from sasdata.trend import Trend
 import logging
 from abc import abstractmethod
-from dataclasses import dataclass
 
 # This is ugly but necessary to avoid a cyclic dependency
 from typing import TYPE_CHECKING, cast
@@ -9,6 +7,7 @@ from typing import TYPE_CHECKING, cast
 from PySide6.QtWidgets import QDialog, QWidget
 
 from sasdata.data import SasData
+from sasdata.trend import Trend
 
 if TYPE_CHECKING:
     from sas.data_manager import NewDataManager as DataManager

--- a/src/sas/refactored.py
+++ b/src/sas/refactored.py
@@ -1,5 +1,7 @@
+from sasdata.trend import Trend
 import logging
 from abc import abstractmethod
+from dataclasses import dataclass
 
 # This is ugly but necessary to avoid a cyclic dependency
 from typing import TYPE_CHECKING, cast
@@ -77,3 +79,10 @@ class Theory:
     # at the current SasView codebase, it seems they are all just Data1Ds with
     # nothing else special.
     pass
+
+class NamedTrend(Trend):
+    name: str
+
+    def __init__(self, data: list[SasData], trend_axes: dict[str, list[str] | list], name: str):
+        super().__init__(data=data, trend_axes=trend_axes)
+        self.name = name


### PR DESCRIPTION
## Description

This PR makes it possible to create trends on the data explorer.

## How Has This Been Tested?

You need to load some data with metadata. I have been using the Mumag data.

- Go to File -> Advanced Load
- Make sure you've set the 'Dataset Type' to '1 D I vs Q'
- Click on 'Select File', and load some Mumag data. If you've got sasdata cloned on the 'refactor_24_trend_new' branch, you can go to 'test/mumag', and load the data in one of the files.
- Click on 'Edit Metadata', and scroll down to the magnetic metadata. The Mumag data files in that directory follow the format [counting_index]\_[applied_magnetic_field]\_[saturation_magnetization]\_[demagnetizing_field]. Make sure to select the right part of the file for each metadata.
- Click 'Save', and then click 'Done' to load the files.
- Select all the files you just loaded, right click, and select 'Make Trend'. (This option should always appear when you've selected more than one data object.)
- Click on 'Add Axes'.
- Expand 'raw', 'root', 'magnetic', and select all of the metadata under 'magnetic'.
- Click 'Select', and then click 'Make Trend'
- You should now see the trend created on the data explorer.
- For each individual data item in the trend, you should be able to right click on it, click 'View Data', and it will show the values for the trend axes (only if its in a trend, which is a good way to test this has all worked).

You can't actually do anything with a trend yet, but my plan next is to work on integration of the Mumag tool as a perspective which will take advantage of the work here.