### PR TITLE
attempt at fixing #4105

### DIFF
--- a/src/sas/qtgui/Perspectives/Fitting/PolydispersityWidget.py
+++ b/src/sas/qtgui/Perspectives/Fitting/PolydispersityWidget.py
@@ -70,7 +70,9 @@ class PolydispersityWidget(QtWidgets.QWidget, Ui_PolydispersityWidgetUI):
         self.poly_model.clear()
         self.poly_params = {}
 
-        parameters = self.logic.model_parameters.form_volume_parameters
+        # Copy: '+=' would append the orientation parameters to the sasmodels
+        # ParameterTable itself, duplicating rows on every subsequent call.
+        parameters = list(self.logic.model_parameters.form_volume_parameters)
         if self.is2D:
             parameters += self.logic.model_parameters.orientation_parameters
 
@@ -523,14 +525,17 @@ class PolydispersityWidget(QtWidgets.QWidget, Ui_PolydispersityWidgetUI):
             # Nsigs
             param_repr = GuiUtils.formatNumber(param_dict[param_name][5+ioffset], high=True)
             self.poly_model.item(row, 5+joffset).setText(param_repr)
-            # Function
+            # Function: the combobox index widget is the only source of truth.
+            # Never write the name into the underlying item - the delegate
+            # paints it under the combobox and it bleeds through on some
+            # platforms/styles (#4105).
             param_repr = param_dict[param_name][6+ioffset]
-            self.poly_model.item(row, 6+joffset).setText(param_repr)
             index = self.poly_model.index(row, 6+joffset)
             widget = self.lstPoly.indexWidget(index)
             if widget is not None and isinstance(widget, QtWidgets.QComboBox):
                 func_index = widget.findText(param_repr)
-                widget.setCurrentIndex(func_index)
+                if func_index >= 0:
+                    widget.setCurrentIndex(func_index)
 
             self.setFocus()
 


### PR DESCRIPTION
## Description

`updateFullPolyModel`: drop the setText on the function column; the combobox is the only source of captiojn (since `gatherPolyParams` already reads the widget).

Fixes #4105 

(also, a ninja bug fix for silent sasmodels `ParameterTable` mutation)

## How Has This Been Tested?

Local Win11 check

## Review Checklist:

[if using the editor, use `[x]` in place of `[ ]` to check a box]

**Documentation** (check at least one)
- [X] There is **nothing** that needs documenting
- [ ] Documentation changes are **in this PR**
- [ ] There is an **issue** open for the documentation (link?)

**Installers**
- [ ] There is a chance this will affect the **installers**, if so
  - [ ] **Windows** installer (GH artifact) has been tested (installed and worked) 
  - [ ] **MacOSX** installer (GH artifact) has been tested (installed and worked)
  - [ ] **Wheels** installer (GH artifact) has been tested (installed and worked)

**Licensing** (untick if necessary)
- [x] The introduced changes comply with SasView license (BSD 3-Clause)

