### PR TITLE
be very careful with app-wide event filters. #4109

### DIFF
--- a/src/sas/qtgui/Utilities/ModelEditors/TabbedEditor/PluginDefinition.py
+++ b/src/sas/qtgui/Utilities/ModelEditors/TabbedEditor/PluginDefinition.py
@@ -353,11 +353,12 @@ class PluginDefinition(QtWidgets.QDialog, Ui_PluginDefinition):
         :param widget: The widget to search from
         :return: The parent table widget if found, None otherwise
         """
-        parent = widget
-        while parent is not None:
-            if parent is self.tblParams or parent is self.tblParamsPD:
-                return parent  # type: ignore[return-value]
-            parent = parent.parent()
+        # Note: use isAncestorOf() rather than walking widget.parent(), since
+        # unrelated widgets in the application may shadow QObject.parent with
+        # an attribute of their own.
+        for table in (self.tblParams, self.tblParamsPD):
+            if widget is table or table.isAncestorOf(widget):
+                return table
         return None
 
     def _commitEditorData(self, table: QtWidgets.QTableWidget, editor_widget: QtWidgets.QWidget):
@@ -418,6 +419,11 @@ class PluginDefinition(QtWidgets.QDialog, Ui_PluginDefinition):
         if event.type() != QtCore.QEvent.KeyPress:
             return super(PluginDefinition, self).eventFilter(obj, event)
 
+        # The filter is application-wide, so ignore everything unless this
+        # editor is actually on screen.
+        if not self.isVisible():
+            return super(PluginDefinition, self).eventFilter(obj, event)
+
         # Handle Enter/Return key press
         if event.key() not in (QtCore.Qt.Key_Return, QtCore.Qt.Key_Enter):
             return super(PluginDefinition, self).eventFilter(obj, event)
@@ -440,6 +446,15 @@ class PluginDefinition(QtWidgets.QDialog, Ui_PluginDefinition):
 
         # Swallow the event so default handling doesn't also run
         return True
+
+    def closeEvent(self, event: QtCore.QEvent):
+        """
+        Stop filtering application events once the editor is closed
+        """
+        app = QtWidgets.QApplication.instance()
+        if app is not None:
+            app.removeEventFilter(self)
+        super(PluginDefinition, self).closeEvent(event)
 
     def getModel(self) -> dict:
         """

--- a/src/sas/qtgui/Utilities/ModelEditors/TabbedEditor/TabbedModelEditor.py
+++ b/src/sas/qtgui/Utilities/ModelEditors/TabbedEditor/TabbedModelEditor.py
@@ -142,6 +142,9 @@ class TabbedModelEditor(QtWidgets.QDialog, Ui_TabbedModelEditor):
         """
         if self.is_modified and self.saveClose():
             return
+        app = QtWidgets.QApplication.instance()
+        if app is not None:
+            app.removeEventFilter(self)
         event.accept()
 
     def eventFilter(self, obj: QtCore.QObject, event: QtCore.QEvent) -> bool:
@@ -150,11 +153,13 @@ class TabbedModelEditor(QtWidgets.QDialog, Ui_TabbedModelEditor):
         """
         if event.type() != QtCore.QEvent.KeyPress:
             return super(TabbedModelEditor, self).eventFilter(obj, event)
-        if event.key() == QtCore.Qt.Key_Escape:
-            if isinstance(obj, QtWidgets.QDialog) and (obj == self or self.isAncestorOf(obj)):
-                return True
-            else:
-                return False
+        if event.key() != QtCore.Qt.Key_Escape:
+            return super(TabbedModelEditor, self).eventFilter(obj, event)
+        # The filter is application-wide, so only swallow Escape for widgets
+        # belonging to this editor.
+        if isinstance(obj, QtWidgets.QDialog) and (obj is self or self.isAncestorOf(obj)):
+            return True
+        return super(TabbedModelEditor, self).eventFilter(obj, event)
 
     def onLoad(self, at_launch: bool = False):
         """

--- a/src/sas/qtgui/Utilities/UnitTesting/PluginDefinitionTest.py
+++ b/src/sas/qtgui/Utilities/UnitTesting/PluginDefinitionTest.py
@@ -1,5 +1,7 @@
 import pytest
-from PySide6.QtWidgets import QTableWidgetItem
+from PySide6.QtCore import QEvent, Qt
+from PySide6.QtGui import QKeyEvent
+from PySide6.QtWidgets import QApplication, QLineEdit, QTableWidgetItem, QWidget
 
 from sas.qtgui.UnitTesting.TestUtils import QtSignalSpy
 
@@ -156,3 +158,28 @@ class PluginDefinitionTest:
 
         # model dict updated
         assert widget.model['func_text'] == new_model.rstrip()
+
+    def testFindParentTable(self, widget):
+        """The parameter tables must be recognized, and nothing else"""
+        # A widget inside one of the tables
+        assert widget._findParentTable(widget.tblParams) == widget.tblParams
+        assert widget._findParentTable(widget.tblParams.viewport()) == widget.tblParams
+        assert widget._findParentTable(widget.tblParamsPD.viewport()) == widget.tblParamsPD
+
+        # An unrelated widget, in a hierarchy where 'parent' is shadowed by a
+        # non-callable attribute, as done in e.g. the fitting perspective
+        outsider = QWidget()
+        outsider.parent = "not callable"
+        inner = QLineEdit(outsider)
+        assert widget._findParentTable(inner) is None
+
+    def testEventFilterOnForeignWidget(self, widget, mocker):
+        """Enter presses outside the plugin editor must be passed through"""
+        outsider = QWidget()
+        outsider.parent = "not callable"
+        inner = QLineEdit(outsider)
+        mocker.patch.object(QApplication, 'focusWidget', return_value=inner)
+        widget.show()
+
+        event = QKeyEvent(QEvent.KeyPress, Qt.Key_Return, Qt.NoModifier)
+        assert not widget.eventFilter(inner, event)


### PR DESCRIPTION
## Description

Walking up the parentage hierarchy while the app-wide event filter is active is not healthy.
This PR fixes this in PluginDefinitions

Fixes #4109 

## How Has This Been Tested?

Local Win11 test

## Review Checklist:

[if using the editor, use `[x]` in place of `[ ]` to check a box]

**Documentation** (check at least one)
- [X] There is **nothing** that needs documenting
- [ ] Documentation changes are **in this PR**
- [ ] There is an **issue** open for the documentation (link?)

**Installers**
- [ ] There is a chance this will affect the **installers**, if so
  - [ ] **Windows** installer (GH artifact) has been tested (installed and worked) 
  - [ ] **MacOSX** installer (GH artifact) has been tested (installed and worked)
  - [ ] **Wheels** installer (GH artifact) has been tested (installed and worked)

**Licensing** (untick if necessary)
- [x] The introduced changes comply with SasView license (BSD 3-Clause)

